### PR TITLE
fix: resolve CJS/ESM import error with @larksuiteoapi/node-sdk

### DIFF
--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -1,13 +1,9 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { randomUUID } from 'node:crypto'
 import { URL } from 'node:url'
-import {
-  createLarkChannel,
-  Domain,
-  LoggerLevel,
-  type LarkChannel,
-  type NormalizedMessage
-} from '@larksuiteoapi/node-sdk'
+import pkg from '@larksuiteoapi/node-sdk'
+const { createLarkChannel, Domain, LoggerLevel } = pkg
+import type { LarkChannel, NormalizedMessage } from '@larksuiteoapi/node-sdk'
 import type {
   AppSettingsV1,
   ClawImChannelV1,


### PR DESCRIPTION
## Summary

The `@larksuiteoapi/node-sdk` package is a CommonJS module, but it was being imported with named ESM exports, causing Electron to crash at startup with:

```
SyntaxError: Named export 'createLarkChannel' not found. The requested module '@larksuiteoapi/node-sdk' is a CommonJS module...
```

The fix switches to CJS-compatible import pattern: default import + destructure for values, while keeping `import type` for type-only imports (which are erased at compile time).

## Test plan

- [ ] `npm run dev` no longer crashes on this import error
- [ ] Electron window opens successfully