### PR TITLE
fix: scale Windows titlebar overlay with UI font size

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -59,6 +59,7 @@ import {
 } from './weixin-bridge-runtime'
 import { webhookUrl } from './claw-runtime-helpers'
 import { isKunHealthResponseBody } from './kun-health'
+import { uiFontScaleFactor } from '../shared/ui-font-scale'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const APP_USER_MODEL_ID = 'com.xingyuzhong.deepseekgui'
@@ -146,6 +147,7 @@ if (!runningClawScheduleMcpServer && process.platform === 'win32') {
 
 let mainWindow: BrowserWindow | null = null
 let store: JsonSettingsStore
+let currentAppSettings: AppSettingsV1 | null = null
 let logDir = ''
 let clawRuntime: ClawRuntime | null = null
 let scheduleRuntime: ScheduleRuntime | null = null
@@ -256,11 +258,15 @@ function createAppIcon(source: string): Electron.NativeImage {
     : nativeImage.createFromPath(source)
 }
 
-function desktopTitleBarOverlayOptions(): Electron.TitleBarOverlayOptions {
+function desktopTitleBarOverlayHeight(uiFontScale: AppSettingsV1['uiFontScale']): number {
+  return Math.round(DESKTOP_TITLEBAR_OVERLAY_HEIGHT * uiFontScaleFactor(uiFontScale))
+}
+
+function desktopTitleBarOverlayOptions(uiFontScale: AppSettingsV1['uiFontScale']): Electron.TitleBarOverlayOptions {
   return {
     color: '#f5f7fa',
     symbolColor: '#222222',
-    height: DESKTOP_TITLEBAR_OVERLAY_HEIGHT
+    height: desktopTitleBarOverlayHeight(uiFontScale)
   }
 }
 
@@ -285,7 +291,7 @@ type TurnCompleteNotificationPayload = {
 
 function revealMainWindow(): void {
   if (!mainWindow) {
-    createWindow()
+    createWindow(currentAppSettings ?? undefined)
   }
   if (!mainWindow) return
   if (mainWindow.isMinimized()) mainWindow.restore()
@@ -537,7 +543,7 @@ async function ensureKunRuntime(settings: AppSettingsV1): Promise<void> {
   }
 }
 
-function createWindow(): void {
+function createWindow(settings: Pick<AppSettingsV1, 'uiFontScale'> = { uiFontScale: 'small' }): void {
   traceStartup('createWindow:start')
   const preloadPath = resolvePreloadPath()
   const usesDesktopTitleBar = process.platform === 'win32' || process.platform === 'linux'
@@ -548,7 +554,7 @@ function createWindow(): void {
     minHeight: 640,
     icon: appIcon.isEmpty() ? undefined : appIcon,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : usesDesktopTitleBar ? 'hidden' : 'default',
-    titleBarOverlay: usesDesktopTitleBar ? desktopTitleBarOverlayOptions() : undefined,
+    titleBarOverlay: usesDesktopTitleBar ? desktopTitleBarOverlayOptions(settings.uiFontScale) : undefined,
     trafficLightPosition: process.platform === 'darwin' ? { x: 31, y: 22 } : undefined,
     autoHideMenuBar: usesDesktopTitleBar,
     show: false,
@@ -700,6 +706,7 @@ app.whenReady().then(async () => {
   store = new JsonSettingsStore(app.getPath('userData'))
   traceStartup('settings load:start')
   const initial = await store.load()
+  currentAppSettings = initial
   traceStartup('settings load:done')
   await syncClawScheduleMcpConfig(initial, getClawScheduleMcpLaunchConfig()).catch((error) => {
     console.error('[claw-schedule-mcp] failed to sync config on startup:', error)
@@ -761,6 +768,7 @@ app.whenReady().then(async () => {
     if (prev.guiUpdate.channel !== saved.guiUpdate.channel && guiUpdaterModulePromise) {
       void guiUpdaterModulePromise.then((module) => module.setGuiUpdateChannel(saved.guiUpdate.channel))
     }
+    currentAppSettings = saved
     queueRuntimeSettingsApply(prev, saved)
     scheduleRuntime?.sync(saved)
     clawRuntime?.sync(saved)
@@ -805,7 +813,7 @@ app.whenReady().then(async () => {
   registerRuntimeSseIpc({ ipcMain, store, ensureRuntime, logError })
   traceStartup('ipc registration:done')
 
-  createWindow()
+  createWindow(initial)
   traceStartup('createWindow:returned')
 
   void pruneOnStartup().catch((err) => {
@@ -828,7 +836,7 @@ app.whenReady().then(async () => {
   })
 
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+    if (BrowserWindow.getAllWindows().length === 0) createWindow(currentAppSettings ?? undefined)
   })
 }).catch((error) => {
   const message = error instanceof Error ? error.message : String(error)

--- a/src/main/ipc/register-app-ipc-handlers.test.ts
+++ b/src/main/ipc/register-app-ipc-handlers.test.ts
@@ -120,6 +120,35 @@ describe('registerAppIpcHandlers', () => {
     expect(applySettingsPatch).toHaveBeenCalledWith(payload)
   })
 
+  it('uses the saved UI font scale for the Windows titlebar overlay height', async () => {
+    const { registerAppIpcHandlers } = await import('./register-app-ipc-handlers')
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const savedSettings = { ...settings(), uiFontScale: 'medium' as const }
+    const setTitleBarOverlay = vi.fn()
+    const mainWindow = {
+      isDestroyed: vi.fn(() => false),
+      setTitleBarOverlay
+    }
+
+    try {
+      registerAppIpcHandlers(registerOptions({
+        store: { load: vi.fn(async () => savedSettings) } as never,
+        getMainWindow: () => mainWindow as never
+      }))
+
+      const handler = handlers.get('windows:titlebar-theme')
+      await handler?.({}, 'dark')
+
+      expect(setTitleBarOverlay).toHaveBeenCalledWith({
+        color: '#101010',
+        symbolColor: '#ffffff',
+        height: 35
+      })
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
   it('passes schedule settings patches through to applySettingsPatch', async () => {
     const { registerAppIpcHandlers } = await import('./register-app-ipc-handlers')
     const applySettingsPatch = vi.fn(async (partial: AppSettingsPatch) => ({

--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -90,6 +90,7 @@ import {
 } from '../services/write-inline-completion-service'
 import { copyWriteDocumentAsRichText, exportWriteDocument } from '../services/write-export-service'
 import { listGuiSkills } from '../services/skill-service'
+import { uiFontScaleFactor } from '../../shared/ui-font-scale'
 
 type GuiUpdaterModule = typeof import('../gui-updater')
 
@@ -137,11 +138,18 @@ function parseIpcPayload<T>(channel: string, schema: z.ZodType<T>, payload: unkn
 
 const DESKTOP_TITLEBAR_OVERLAY_HEIGHT = 40
 
-function desktopTitleBarOverlayForTheme(theme: WindowsTitleBarTheme): Electron.TitleBarOverlayOptions {
+function desktopTitleBarOverlayHeight(uiFontScale: AppSettingsV1['uiFontScale']): number {
+  return Math.round(DESKTOP_TITLEBAR_OVERLAY_HEIGHT * uiFontScaleFactor(uiFontScale))
+}
+
+function desktopTitleBarOverlayForTheme(
+  theme: WindowsTitleBarTheme,
+  uiFontScale: AppSettingsV1['uiFontScale']
+): Electron.TitleBarOverlayOptions {
   return {
     color: theme === 'dark' ? '#101010' : '#f5f7fa',
     symbolColor: theme === 'dark' ? '#ffffff' : '#222222',
-    height: DESKTOP_TITLEBAR_OVERLAY_HEIGHT
+    height: desktopTitleBarOverlayHeight(uiFontScale)
   }
 }
 
@@ -724,12 +732,12 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
   })
   ipcMain.handle('windows:titlebar-theme', async (_, theme: unknown) => {
     if (process.platform === 'darwin') return
+    const parsedTheme = parseIpcPayload('windows:titlebar-theme', windowsTitleBarThemeSchema, theme)
     const mainWindow = getMainWindow()
     if (!mainWindow || mainWindow.isDestroyed()) return
+    const settings = await store.load()
     mainWindow.setTitleBarOverlay(
-      desktopTitleBarOverlayForTheme(
-        parseIpcPayload('windows:titlebar-theme', windowsTitleBarThemeSchema, theme)
-      )
+      desktopTitleBarOverlayForTheme(parsedTheme, settings.uiFontScale)
     )
   })
   ipcMain.handle('shell:open-external', async (_, url: unknown) => {

--- a/src/renderer/src/lib/apply-theme.ts
+++ b/src/renderer/src/lib/apply-theme.ts
@@ -1,5 +1,8 @@
+import type { UiFontScale } from '../../../shared/app-settings'
+import { uiFontScaleFactor } from '../../../shared/ui-font-scale'
+
 export type ThemePreference = 'system' | 'light' | 'dark'
-export type UiFontScale = 'small' | 'medium' | 'large'
+export type { UiFontScale } from '../../../shared/app-settings'
 
 let removeSystemListener: (() => void) | null = null
 
@@ -44,11 +47,5 @@ export function applyTheme(pref: ThemePreference): void {
 
 export function applyUiFontScale(scale: UiFontScale): void {
   const root = document.documentElement
-  const factor =
-    scale === 'small'
-      ? '0.82'
-      : scale === 'large'
-        ? '1'
-        : '0.88'
-  root.style.setProperty('--ds-ui-scale', factor)
+  root.style.setProperty('--ds-ui-scale', String(uiFontScaleFactor(scale)))
 }

--- a/src/shared/ui-font-scale.ts
+++ b/src/shared/ui-font-scale.ts
@@ -1,0 +1,7 @@
+import type { UiFontScale } from './app-settings-types'
+
+export function uiFontScaleFactor(scale: UiFontScale): number {
+  if (scale === 'small') return 0.82
+  if (scale === 'large') return 1
+  return 0.88
+}


### PR DESCRIPTION
```md
## Summary

- Fixes Windows titlebar overlay sizing so native caption controls follow the configured UI font scale.

## Why

- The renderer UI is scaled with `--ds-ui-scale`, but Electron's native Windows titlebar overlay height was fixed at `40px`.
- This caused the custom titlebar/menu area and native minimize/maximize/close controls to look misaligned at different UI font sizes.

## Changes

- Added a shared `uiFontScaleFactor` helper for `small`, `medium`, and `large`.
- Updated initial `titleBarOverlay.height` to use the saved `uiFontScale`.
- Updated Windows titlebar theme refresh to preserve scaled overlay height.
- Kept renderer `body` zoom behavior unchanged.
- Added coverage for scaled titlebar overlay height.


## Media

[![Windows titlebar fixed - 1]()](https://github.com/user-attachments/assets/21f08b2b-149f-41dd-a4a1-0c4afa956714)
![Windows titlebar fixed - 2](https://github.com/user-attachments/assets/704d51c2-2885-4b63-8e37-bd5e5ed9bc8b)

## Tests

- Added/updated `src/main/ipc/register-app-ipc-handlers.test.ts`.

## Validation

- [ ] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] `npm run dev` (if runtime or UI behavior changed)
- [x] UI change: video or GIF attached
- [x] Logic change: unit tests added or updated

## Notes

- `npm run test` currently fails on unrelated Windows path-separator expectations.
- Focused test passed: `npx vitest run src/main/ipc/register-app-ipc-handlers.test.ts`
```