### PR TITLE
fix(ui): close reasoning menu after selection

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposerModelPicker.tsx
+++ b/src/renderer/src/components/chat/FloatingComposerModelPicker.tsx
@@ -221,7 +221,10 @@ export function FloatingComposerModelPicker({
                   key={option.id}
                   selected={currentReasoning === option.id}
                   title={t(option.labelKey)}
-                  onClick={() => onComposerReasoningEffortChange?.(option.id)}
+                  onClick={() => {
+                    onComposerReasoningEffortChange?.(option.id)
+                    setMenuOpen(false)
+                  }}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary

Close the reasoning-effort menu automatically after selecting a reasoning level.

## Why

- Model selection already closes the menu after a selection.
- Reasoning-effort selection applied immediately but kept the menu open, resulting in inconsistent behavior within the same menu.

## Changes

- Added setMenuOpen(false) after reasoning-effort selection.
- Kept existing model-selection behavior unchanged.

## Media

| Before | After |
|---------|---------|
| <img width="300" alt="before" src="https://github.com/user-attachments/assets/9c282375-0d59-4802-b975-08aab266ecce" /> | <img width="300" alt="after" src="https://github.com/user-attachments/assets/c493e126-93f3-41d6-b806-d5594df4e965" /> |

## Tests

No unit tests added.
Verified behavior manually.

## Validation

- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run dev` (if runtime or UI behavior changed)
- [x] UI change: video or GIF attached
- [ ] Logic change: unit tests added or updated


