### PR TITLE
fix(windows): replace titleBarOverlay with custom window controls to fix background color mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -611,6 +611,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3514,6 +3515,7 @@
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3607,6 +3609,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -3999,6 +4002,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4364,6 +4368,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4876,6 +4881,7 @@
       "resolved": "https://registry.npmmirror.com/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5285,6 +5291,7 @@
       "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6059,6 +6066,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7219,6 +7227,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.21.tgz",
       "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7379,6 +7388,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -7702,6 +7712,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9621,6 +9632,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10033,6 +10045,7 @@
       "resolved": "https://registry.npmmirror.com/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10042,6 +10055,7 @@
       "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11214,6 +11228,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11413,6 +11428,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11702,6 +11718,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11795,6 +11812,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12137,6 +12155,7 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,7 +62,6 @@ import { isKunHealthResponseBody } from './kun-health'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const APP_USER_MODEL_ID = 'com.xingyuzhong.deepseekgui'
-const DESKTOP_TITLEBAR_OVERLAY_HEIGHT = 40
 const startupTraceEnabled = process.env.DEEPSEEK_GUI_STARTUP_TRACE === '1'
 const startupTraceStart = Date.now()
 
@@ -256,13 +255,6 @@ function createAppIcon(source: string): Electron.NativeImage {
     : nativeImage.createFromPath(source)
 }
 
-function desktopTitleBarOverlayOptions(): Electron.TitleBarOverlayOptions {
-  return {
-    color: '#f5f7fa',
-    symbolColor: '#222222',
-    height: DESKTOP_TITLEBAR_OVERLAY_HEIGHT
-  }
-}
 
 const appIcon = createAppIcon(deepseekLogoPng)
 traceStartup('app icon loaded', { source: deepseekLogoPng.startsWith('data:') ? 'data-url' : 'path' })
@@ -548,7 +540,6 @@ function createWindow(): void {
     minHeight: 640,
     icon: appIcon.isEmpty() ? undefined : appIcon,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : usesDesktopTitleBar ? 'hidden' : 'default',
-    titleBarOverlay: usesDesktopTitleBar ? desktopTitleBarOverlayOptions() : undefined,
     trafficLightPosition: process.platform === 'darwin' ? { x: 31, y: 22 } : undefined,
     autoHideMenuBar: usesDesktopTitleBar,
     show: false,

--- a/src/main/ipc/app-ipc-schemas.ts
+++ b/src/main/ipc/app-ipc-schemas.ts
@@ -712,7 +712,6 @@ export const guiUpdateChannelSchema = z.enum(GUI_UPDATE_CHANNELS).optional()
 
 export const desktopCommandSchema = z.enum(DESKTOP_COMMANDS)
 
-export const windowsTitleBarThemeSchema = z.enum(['light', 'dark'])
 
 export const logErrorPayloadSchema = z
   .object({

--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -22,7 +22,6 @@ import type {
   SystemNotificationResult,
   TurnCompleteNotificationPayload,
   UpstreamModelsResult,
-  WindowsTitleBarTheme,
   WorkspacePickResult
 } from '../../shared/ds-gui-api'
 import type { GuiUpdateDownloadResult, GuiUpdateInfo, GuiUpdateInstallResult, GuiUpdateState } from '../../shared/gui-update'
@@ -58,7 +57,6 @@ import {
   writeExportPayloadSchema,
   writeRichClipboardPayloadSchema,
   writeInlineCompletionPayloadSchema,
-  windowsTitleBarThemeSchema,
   workspaceRootSchema
 } from './app-ipc-schemas'
 import type { JsonSettingsStore } from '../settings-store'
@@ -135,15 +133,6 @@ function parseIpcPayload<T>(channel: string, schema: z.ZodType<T>, payload: unkn
   throw new Error(`Invalid payload for ${channel}: ${issue?.message ?? 'Bad request.'}`)
 }
 
-const DESKTOP_TITLEBAR_OVERLAY_HEIGHT = 40
-
-function desktopTitleBarOverlayForTheme(theme: WindowsTitleBarTheme): Electron.TitleBarOverlayOptions {
-  return {
-    color: theme === 'dark' ? '#101010' : '#f5f7fa',
-    symbolColor: theme === 'dark' ? '#ffffff' : '#222222',
-    height: DESKTOP_TITLEBAR_OVERLAY_HEIGHT
-  }
-}
 
 function runDesktopCommand(
   command: DesktopCommand,
@@ -720,16 +709,6 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
       parseIpcPayload('desktop:command', desktopCommandSchema, command),
       event.sender,
       getMainWindow
-    )
-  })
-  ipcMain.handle('windows:titlebar-theme', async (_, theme: unknown) => {
-    if (process.platform === 'darwin') return
-    const mainWindow = getMainWindow()
-    if (!mainWindow || mainWindow.isDestroyed()) return
-    mainWindow.setTitleBarOverlay(
-      desktopTitleBarOverlayForTheme(
-        parseIpcPayload('windows:titlebar-theme', windowsTitleBarThemeSchema, theme)
-      )
     )
   })
   ipcMain.handle('shell:open-external', async (_, url: unknown) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -141,8 +141,6 @@ const api = {
     }),
   runDesktopCommand: (command) =>
     ipcRenderer.invoke('desktop:command', command),
-  setWindowsTitleBarTheme: (theme) =>
-    ipcRenderer.invoke('windows:titlebar-theme', theme),
   openExternal: (url) => ipcRenderer.invoke('shell:open-external', url),
   showTurnCompleteNotification: (payload) => ipcRenderer.invoke('notification:turn-complete', payload),
   getAppVersion: () => ipcRenderer.invoke('app:version'),

--- a/src/renderer/src/components/WindowsTitleBar.tsx
+++ b/src/renderer/src/components/WindowsTitleBar.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DesktopCommand } from '@shared/ds-gui-api'
 import deepseekLogo from '../../../asset/img/deepseek.png'
@@ -130,6 +130,41 @@ export function buildWindowsTitleBarMenuSections(
   ]
 }
 
+/* ---------- SVG window-control icons (10×10 viewBox) ---------- */
+
+function MinimizeIcon(): ReactElement {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <path d="M1 5h8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function MaximizeIcon(): ReactElement {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <rect x="1.5" y="1.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.2" />
+    </svg>
+  )
+}
+
+function RestoreIcon(): ReactElement {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <rect x="1.5" y="2.5" width="6" height="6" rx="1" stroke="currentColor" strokeWidth="1.1" />
+      <path d="M3.5 2.5V1.8a.8.8 0 0 1 .8-.8h4.4a.8.8 0 0 1 .8.8v4.4a.8.8 0 0 1-.8.8H8" stroke="currentColor" strokeWidth="1.1" />
+    </svg>
+  )
+}
+
+function CloseIcon(): ReactElement {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <path d="M1.5 1.5l7 7M8.5 1.5l-7 7" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  )
+}
+
 export function WindowsTitleBar({ platform, actions }: Props): ReactElement | null {
   const resolvedPlatform = platform ?? currentPlatform()
   const { t } = useTranslation('common')
@@ -137,6 +172,7 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
   const chooseWorkspace = useChatStore((s) => s.chooseWorkspace)
   const openSettings = useChatStore((s) => s.openSettings)
   const [activeMenuId, setActiveMenuId] = useState<string | null>(null)
+  const [isMaximized, setIsMaximized] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
 
   const defaultActions = useMemo<WindowsTitleBarActions>(() => ({
@@ -186,6 +222,38 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [activeMenuId])
+
+  /* Listen for Electron maximize / unmaximize events via the
+     resize event to toggle the maximize/restore icon. */
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const checkMaximized = (): void => {
+      // Heuristic: in Electron, when the window is maximized via `win.maximize()`,
+      // screenX/screenY are 0 (or -8 with shadow compensation on Windows)
+      // and outerWidth/outerHeight fill the screen.  This is the most
+      // reliable cross-platform signal available from the renderer.
+      const isMax =
+        window.outerWidth >= window.screen.availWidth &&
+        window.outerHeight >= window.screen.availHeight
+      setIsMaximized(isMax)
+    }
+    checkMaximized()
+    window.addEventListener('resize', checkMaximized)
+    return () => window.removeEventListener('resize', checkMaximized)
+  }, [])
+
+
+  const handleMinimize = useCallback((): void => {
+    void resolvedActions.runDesktopCommand('minimize')
+  }, [resolvedActions])
+
+  const handleToggleMaximize = useCallback((): void => {
+    void resolvedActions.runDesktopCommand('toggleMaximize')
+  }, [resolvedActions])
+
+  const handleClose = useCallback((): void => {
+    void resolvedActions.runDesktopCommand('close')
+  }, [resolvedActions])
 
   if (!supportsDesktopTitleBar(resolvedPlatform)) return null
 
@@ -241,6 +309,33 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
           })}
         </nav>
       </div>
+      <div className="ds-window-controls ds-no-drag">
+        <button
+          type="button"
+          className="ds-window-control-btn"
+          aria-label={t('windowsMenuMinimize')}
+          onClick={handleMinimize}
+        >
+          <MinimizeIcon />
+        </button>
+        <button
+          type="button"
+          className="ds-window-control-btn"
+          aria-label={t('windowsMenuToggleMaximize')}
+          onClick={handleToggleMaximize}
+        >
+          {isMaximized ? <RestoreIcon /> : <MaximizeIcon />}
+        </button>
+        <button
+          type="button"
+          className="ds-window-control-btn ds-window-control-btn--close"
+          aria-label={t('windowsMenuClose')}
+          onClick={handleClose}
+        >
+          <CloseIcon />
+        </button>
+      </div>
     </div>
   )
 }
+

--- a/src/renderer/src/lib/apply-theme.ts
+++ b/src/renderer/src/lib/apply-theme.ts
@@ -20,12 +20,6 @@ export function applyTheme(pref: ThemePreference): void {
   const apply = (): void => {
     const mode = resolvedMode(pref)
     root.setAttribute('data-theme', mode)
-    if (
-      window.dsGui?.platform !== 'darwin' &&
-      typeof window.dsGui.setWindowsTitleBarTheme === 'function'
-    ) {
-      void window.dsGui.setWindowsTitleBarTheme(mode)
-    }
   }
 
   if (pref === 'system') {

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -100,7 +100,6 @@
 :root[data-platform='win32'],
 :root[data-platform='linux'] {
   --ds-windows-titlebar-height: 40px;
-  --ds-windows-caption-controls-width: 138px;
 }
 
 [data-theme='dark'] {
@@ -247,7 +246,7 @@ html {
   min-height: var(--ds-windows-titlebar-height, 40px);
   flex: 0 0 var(--ds-windows-titlebar-height, 40px);
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
   border-bottom: 1px solid var(--ds-border-muted);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(246, 248, 251, 0.72)),
@@ -259,7 +258,7 @@ html {
 .ds-windows-titlebar-content {
   display: flex;
   min-width: 0;
-  max-width: calc(100% - var(--ds-windows-caption-controls-width, 138px));
+  flex: 1 1 auto;
   align-items: center;
   gap: 8px;
   padding-left: 12px;
@@ -359,10 +358,49 @@ html {
   background: var(--ds-border-muted);
 }
 
+/* Window control buttons (minimize, maximize/restore, close) */
+
+.ds-window-controls {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: stretch;
+  height: 100%;
+}
+
+.ds-window-control-btn {
+  display: inline-flex;
+  width: 46px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--ds-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.ds-window-control-btn:hover {
+  background: var(--ds-surface-hover);
+  color: var(--ds-text);
+}
+
+.ds-window-control-btn--close:hover {
+  background: #c42b1c;
+  color: #ffffff;
+}
+
 [data-theme='dark'] .ds-windows-titlebar {
   background:
     linear-gradient(180deg, rgba(24, 24, 24, 0.92), rgba(16, 16, 16, 0.82)),
     var(--ds-bg-main);
+}
+
+[data-theme='dark'] .ds-window-control-btn--close:hover {
+  background: #c42b1c;
+  color: #ffffff;
 }
 
 [data-theme='dark'] .ds-windows-menu-popover {

--- a/src/shared/ds-gui-api.ts
+++ b/src/shared/ds-gui-api.ts
@@ -74,7 +74,6 @@ export const DESKTOP_COMMANDS = [
   'quit'
 ] as const
 export type DesktopCommand = typeof DESKTOP_COMMANDS[number]
-export type WindowsTitleBarTheme = 'light' | 'dark'
 export type SkillSaveResult = { ok: true; path: string } | { ok: false; message: string }
 export type SkillListItem = {
   id: string
@@ -210,7 +209,6 @@ export type DsGuiApi = {
     options?: { workspaceRoot?: string; modelHint?: string; mode?: 'agent' | 'plan' }
   ) => Promise<ScheduleTaskFromTextResult>
   runDesktopCommand: (command: DesktopCommand) => Promise<void>
-  setWindowsTitleBarTheme: (theme: WindowsTitleBarTheme) => Promise<void>
   openExternal: (url: string) => Promise<void>
   showTurnCompleteNotification: (
     payload: TurnCompleteNotificationPayload


### PR DESCRIPTION
## Summary

- Fixes #30 
- 移除了 Electron 原生的 `titleBarOverlay`（系统窗口控制按钮区域覆盖层）。
- 在前端自定义标题栏组件 (`WindowsTitleBar.tsx`) 中实现了完整的最小化、最大化/还原、关闭按钮及其 UI 状态。
- 清理了与 `titleBarOverlay` 相关的主题颜色同步 IPC 链路。

## Why

- Windows 平台下，应用原先通过 Electron 的 `titleBarOverlay` 渲染原生窗口控制按钮。但该原生覆盖层仅支持纯色背景（`color` 属性），而我们自定义的标题栏使用了 `linear-gradient` 渐变背景。
- 这种机制限制导致两者永远无法精确匹配，在暗色主题下尤为明显，会在标题栏右上角形成一个突兀的“黑色矩形背景块”。通过前端完全接管渲染，可以使用 CSS 使按钮背景完美融合进标题栏渐变色中，提升视觉体验。

## Changes

- 主进程 (`src/main/index.ts`)：移除了 `createWindow` 中的 `titleBarOverlay` 配置选项以及 `desktopTitleBarOverlayOptions` 方法，保留 `titleBarStyle: 'hidden'` 隐藏系统标题栏。
- IPC 链路清理 (`src/main/ipc/*`, `src/preload/index.ts`, `src/shared/ds-gui-api.ts`, `src/renderer/src/lib/apply-theme.ts`)：因为无需再动态通知原生覆盖层更新颜色，彻底移除了 `windows:titlebar-theme` IPC handler、preload 桥接、API 类型定义和所有关联的主题同步调用逻辑。
- 渲染组件 (`src/renderer/src/components/WindowsTitleBar.tsx`)：
  - 新增最小化、最大化、关闭的 SVG 图标。
  - 通过 IPC desktop:command 调用对应原生窗口操作。
  - 添加 `window.resize` 监听器，比较窗口尺寸动态检测窗口是否处于最大化状态，以切换“最大化/还原”图标。
- 样式 (`src/renderer/src/styles/base-shell.css`)：
  - 增加控制按钮悬浮动效，其中关闭按钮悬浮变为原生系统红（`#c42b1c`）。
  - 移除了针对原生 overlay 宽度的 CSS 冗余变量 `--ds-windows-caption-controls-width`，并将标题栏布局切换为 `space-between`。

## Media

### 更改前

<img width="2432" height="1324" alt="230b6ccd90a6afde7d6da4bfefcd3c90" src="https://github.com/user-attachments/assets/2bc543fa-303a-4dba-85ee-c7a7588a6e57" />

<img width="2423" height="1321" alt="5d394011adbd9a8e9a02ccf10d951a82" src="https://github.com/user-attachments/assets/65b8f151-7abe-46b4-8c18-1c093724ac17" />

### 修复后

<img width="2449" height="1309" alt="bf55638d584978ced6062647630367b7" src="https://github.com/user-attachments/assets/6f700ae5-0742-4456-821f-ba8008d0d5ff" />

<img width="2449" height="1308" alt="10f1c2f98398797a1f3932b790f797c7" src="https://github.com/user-attachments/assets/cef8239b-5cbc-46c8-8c13-e2bb63d6e291" />

## Tests

- Logic changes: 由于主要为 UI 渲染和 IPC 机制清理，保留的 `WindowsTitleBar.test.ts` 及 `AppShell.test.ts` 无需特殊改动并持续通过。未引入需要特定单元测试覆盖的新核心业务逻辑。

## Validation

- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run dev` (if runtime or UI behavior changed)
- [x] UI change: video or GIF attached

其中 `npm run test` 输出：
```bash
 Test Files  5 failed | 94 passed (99)
      Tests  7 failed | 600 passed (607)
```
是已有问题 #44 ，与本次改动无关

## Notes

- 此次改动主要针对 `windows` 和 `linux` 平台（受 `supportsDesktopTitleBar` 管控），macOS (`darwin`) 平台使用原生红绿灯逻辑，不受此改动影响。
