### PR TITLE
fix: center placeholder text and input content vertically in composer input

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -1516,9 +1516,9 @@ export function FloatingComposer({
           <textarea
             ref={draft.textareaRef}
             rows={1}
-            className={`ds-no-drag block min-w-0 resize-none break-words bg-transparent px-1 py-0.5 text-[15px] leading-[1.45] text-ds-ink placeholder:text-ds-faint focus:outline-none [overflow-wrap:anywhere] ${
+            className={`ds-no-drag block min-w-0 resize-none break-words bg-transparent px-1 py-2.5 text-[15px] leading-[1.45] text-ds-ink placeholder:text-ds-faint focus:outline-none [overflow-wrap:anywhere] ${
               canCompose ? '' : 'opacity-80'
-            } ${compact ? 'text-[14px]' : 'min-h-[40px]'}`}
+            } ${compact ? 'text-[14px] py-2' : 'min-h-[40px]'}`}
             placeholder={placeholder}
             value={input}
             disabled={!canCompose}


### PR DESCRIPTION
## Summary

This PR fixes the vertical alignment issue in the chat composer input field. The placeholder text ('Ask the agent...') and user input content were not properly centered vertically within the input area, resulting in a misaligned and visually inconsistent user experience.

## Problem

The composer input textarea had insufficient vertical padding ( = 2px top/bottom), causing:
- Placeholder text positioned too close to the top edge
- Input content not vertically centered within the input area
- Inconsistent visual alignment with surrounding UI elements

## Solution

Increased the vertical padding of the textarea element to provide better vertical centering:

**File modified:** 

- **Default mode:** Changed  to  (10px top/bottom padding)
- **Compact mode:** Changed  to  (8px top/bottom padding)

This ensures both the placeholder text and user input content are properly centered within the input field's height.

## Testing

- [x] Verify placeholder text is vertically centered in the input field
- [x] Verify user input content is vertically centered while typing
- [x] Test in both default and compact composer modes
- [x] Ensure the input field maintains proper height and doesn't clip content
- [x] Test with multi-line input to ensure proper expansion behavior