### PR TITLE
fix: preserve sidebar chat history when viewing scheduled tasks

### DIFF
--- a/src/renderer/src/components/chat/Sidebar.tsx
+++ b/src/renderer/src/components/chat/Sidebar.tsx
@@ -193,11 +193,31 @@ export function Sidebar({
           t={t}
         />
       ) : activeView === 'schedule' ? (
-        <div className="ds-no-drag flex min-h-0 flex-1 flex-col px-2 pt-1">
-          <div className="px-1 text-[13px] font-normal text-ds-faint">
-            {t('schedule')}
-          </div>
-        </div>
+        <SidebarProjectsSection
+          threads={threads}
+          activeView="chat"
+          activeThreadId={activeThreadId}
+          runtimeReady={runtimeReady}
+          searchQuery={threadSearch}
+          showArchived={showArchivedThreads}
+          workspaceRoot={workspaceRoot}
+          workspaceRoots={codeWorkspaceRoots}
+          busy={busy}
+          watchTurnCompletion={watchTurnCompletion}
+          unreadThreadIds={unreadThreadIds}
+          locale={i18n.language}
+          onPickWorkspace={() => void chooseWorkspace()}
+          onRemoveWorkspace={deleteWorkspace}
+          onCreateThreadInWorkspace={onNewChatInWorkspace}
+          onSelectThread={onSelectThread}
+          onRenameThread={onRenameThread}
+          onArchiveThread={onArchiveThread}
+          onDeleteThread={onDeleteThread}
+          onRestoreThread={onRestoreThread}
+          onSearchQueryChange={onThreadSearchChange}
+          onShowArchivedChange={onShowArchivedThreadsChange}
+          t={t}
+        />
       ) : (
       <SidebarProjectsSection
         threads={threads}


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where clicking the "Scheduled Tasks" button in the left sidebar causes the chat history and other sidebar content to disappear.

## Problem

When users click on the "Scheduled Tasks" navigation item in the left sidebar, the sidebar content switches to a minimal view that only displays the text "Scheduled Tasks" without showing the chat history. This results in:

- Loss of visibility into existing chat threads
- Inability to navigate back to previous conversations
- Poor user experience when switching between features

## Root Cause

In `src/renderer/src/components/chat/Sidebar.tsx`, the component conditionally renders content based on the `activeView` prop:

- When `activeView === 'schedule'`, it rendered a minimal placeholder div instead of the actual sidebar content
- The chat history (`SidebarProjectsSection`) was only rendered when `activeView` was neither 'claw' nor 'schedule'

## Solution

**File modified:** `src/renderer/src/components/chat/Sidebar.tsx`

Modified the conditional rendering logic to display the chat history even when the scheduled tasks view is active:

- Replaced the minimal placeholder div with the full `SidebarProjectsSection` component
- Set `activeView="chat"` for the sidebar section to ensure proper thread rendering
- Maintained all existing functionality for thread selection, renaming, archiving, and deletion

## Testing

- [x] Click "Scheduled Tasks" in the left sidebar
- [x] Verify chat history remains visible in the sidebar
- [x] Verify scheduled tasks view is displayed in the main content area
- [x] Test clicking on a chat thread from the sidebar while in scheduled tasks view
- [x] Verify navigation between different views works correctly
- [x] Test sidebar collapse/expand functionality
