### PR TITLE
fix: update default API endpoint to stable production URL

### DIFF
--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -19,7 +19,7 @@ export type ClawScheduleKind = ScheduleKind
 export type ClawTaskStatus = ScheduleTaskStatus
 export type ClawModel = ScheduleModel
 
-export const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/beta'
+export const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com'
 export const DEFAULT_CLAW_MODEL = 'auto'
 export const CLAW_MODEL_IDS = ['auto', 'deepseek-v4-pro', 'deepseek-v4-flash'] as const
 export const DEFAULT_SCHEDULE_MODEL = DEFAULT_CLAW_MODEL


### PR DESCRIPTION
## Summary

This PR updates the default DeepSeek API base URL from the beta endpoint to the stable production endpoint.

## Problem

The application was configured to use the beta API endpoint by default:

- Default URL: `https://api.deepseek.com/beta`
- This endpoint may have different rate limits, stability characteristics, or feature availability
- New users would connect to the beta endpoint without explicit choice

## Solution

**File modified:** `src/shared/app-settings-types.ts`

Updated the `DEFAULT_DEEPSEEK_BASE_URL` constant:

```typescript
// Before
export const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/beta'

// After
export const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com'
```

This change affects:
- New installations with default settings
- Reset-to-default scenarios
- The initial configuration shown in Settings > General

## Impact

- **New users:** Will connect to the stable production API by default
- **Existing users:** No change (their saved settings are preserved)
- **Manual configuration:** Users can still manually set any API endpoint

## Testing

- [x] Perform a fresh installation or reset settings to default
- [x] Navigate to Settings > General
- [x] Verify the API base URL field shows `https://api.deepseek.com`
- [x] Test API connectivity with the new default URL
- [x] Verify existing manual configurations are not affected
