### PR TITLE
Fix Windows locked atomic writes / 修复 Windows 文件锁下的原子写入

### DIFF
--- a/kun/src/adapters/file/atomic-write.ts
+++ b/kun/src/adapters/file/atomic-write.ts
@@ -22,11 +22,19 @@ export async function atomicWriteFile(
   const tmp = `${path}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`
   try {
     await writeFile(tmp, contents, 'utf-8')
-    await renameWithRetry(tmp, path, options.renameRetry)
+    try {
+      await renameWithRetry(tmp, path, options.renameRetry)
+    } catch (error) {
+      if (!shouldFallbackToDirectWrite(error)) {
+        throw error
+      }
+      await writeFile(path, contents, 'utf-8')
+    }
   } catch (error) {
     await rm(tmp, { force: true }).catch(() => undefined)
     throw error
   }
+  await rm(tmp, { force: true }).catch(() => undefined)
 }
 
 async function renameWithRetry(
@@ -52,6 +60,10 @@ async function renameWithRetry(
 
 function isRetryableRenameError(error: unknown): boolean {
   return RETRYABLE_RENAME_ERROR_CODES.has(String((error as { code?: unknown })?.code ?? ''))
+}
+
+function shouldFallbackToDirectWrite(error: unknown): boolean {
+  return process.platform === 'win32' && isRetryableRenameError(error)
 }
 
 function delay(ms: number): Promise<void> {

--- a/kun/tests/atomic-write.test.ts
+++ b/kun/tests/atomic-write.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -26,6 +26,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   renameMock.mockReset()
+  vi.restoreAllMocks()
 })
 
 describe('atomicWriteFile', () => {
@@ -53,6 +54,56 @@ describe('atomicWriteFile', () => {
 
       expect(await readFile(path, 'utf-8')).toBe('{"ok":true}')
       expect(renameMock).toHaveBeenCalledTimes(2)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to a direct write after Windows rename retries are exhausted', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kun-atomic-'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    renameMock.mockImplementation(async () => {
+      const error = new Error('operation not permitted') as Error & { code: string }
+      error.code = 'EPERM'
+      throw error
+    })
+
+    try {
+      const path = join(dir, 'events.jsonl')
+      await atomicWriteFile(path, '{"seq":1}', {
+        renameRetry: {
+          attempts: 2,
+          baseDelayMs: 0
+        }
+      })
+
+      expect(await readFile(path, 'utf-8')).toBe('{"seq":1}')
+      expect(renameMock).toHaveBeenCalledTimes(2)
+      expect((await readdir(dir)).filter((name) => name.endsWith('.tmp'))).toEqual([])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not use the direct-write fallback for non-Windows rename failures', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kun-atomic-'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    renameMock.mockImplementation(async () => {
+      const error = new Error('operation not permitted') as Error & { code: string }
+      error.code = 'EPERM'
+      throw error
+    })
+
+    try {
+      const path = join(dir, 'events.jsonl')
+      await expect(atomicWriteFile(path, '{"seq":1}', {
+        renameRetry: {
+          attempts: 2,
+          baseDelayMs: 0
+        }
+      })).rejects.toMatchObject({ code: 'EPERM' })
+      expect(renameMock).toHaveBeenCalledTimes(2)
+      await expect(readFile(path, 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' })
     } finally {
       await rm(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
﻿## Summary / 概要

English:
- Make Kun's file atomic write path more tolerant of Windows file locks.
- Keep the existing atomic rename retry path first, then fall back only when Windows reports EPERM/EACCES/EBUSY after retries are exhausted.
- Avoid changing non-Windows behavior.

中文：
- 增强 Kun 文件写入在 Windows 文件锁场景下的处理。
- 仍然优先走原有 atomic rename retry；只有 Windows 下 EPERM/EACCES/EBUSY 重试耗尽后才回退。
- 不改非 Windows 行为。

Fixes #17

## Verification / 验证

- `npm.cmd test -- tests/atomic-write.test.ts tests/file-session-store.test.ts` in `kun`
- `npm.cmd run typecheck --if-present` in `kun`
