### PR TITLE
Stabilize message timeline rendering / 稳定长会话消息渲染

### DIFF
--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -13,7 +13,9 @@ import { ProcessSectionRow, groupProcessSections } from './message-timeline-proc
 import { AnimatedWorkLogo } from './AnimatedWorkLogo'
 import {
   groupTurns,
+  sameTurnContent,
   splitThink,
+  stableTurnKey,
   turnHasPendingRuntimeWork,
   type Turn
 } from './message-timeline-turns'
@@ -42,6 +44,27 @@ type Props = {
 
 const TURN_PAGE_SIZE = 18
 const AUTO_COLLAPSE_THRESHOLD = 24
+
+function blockScrollStamp(block: ChatBlock | undefined): string {
+  if (!block) return ''
+  switch (block.kind) {
+    case 'user':
+    case 'assistant':
+    case 'reasoning':
+    case 'system':
+      return `${block.id}:${block.kind}:${block.text.length}`
+    case 'tool':
+      return `${block.id}:${block.kind}:${block.status}:${block.summary.length}:${block.detail?.length ?? 0}`
+    case 'review':
+      return `${block.id}:${block.kind}:${block.status}:${block.reviewText?.length ?? 0}`
+    case 'approval':
+    case 'user_input':
+    case 'compaction':
+      return `${block.id}:${block.kind}:${block.status}`
+    default:
+      return ''
+  }
+}
 
 export function MessageTimeline({
   blocks,
@@ -78,6 +101,15 @@ export function MessageTimeline({
   const containerRef = useRef<HTMLDivElement>(null)
 
   const turns = useMemo(() => groupTurns(blocks), [blocks])
+  const latestBlock = blocks[blocks.length - 1]
+  const scrollContentKey = [
+    activeThreadId ?? '',
+    turns.length,
+    blocks.length,
+    blockScrollStamp(latestBlock),
+    live.length,
+    liveReasoning.length
+  ].join(':')
   const {
     visibleTurnCount,
     hiddenTurnCount,
@@ -91,7 +123,10 @@ export function MessageTimeline({
     autoCollapseThreshold: AUTO_COLLAPSE_THRESHOLD,
     totalTurns: turns.length,
     busy,
-    scrollDeps: { blocks, live, liveReasoning }
+    scrollDeps: {
+      contentKey: scrollContentKey,
+      streaming: Boolean(live.trim() || liveReasoning.trim())
+    }
   })
   const visibleTurns = useMemo(
     () => (hiddenTurnCount > 0 ? turns.slice(hiddenTurnCount) : turns),
@@ -167,7 +202,7 @@ export function MessageTimeline({
           const showForkPoint =
             forkBoundaryTurnCount !== undefined && absoluteTurnIndex === forkBoundaryTurnCount
           return (
-            <Fragment key={userId ?? `turn-${index}`}>
+            <Fragment key={stableTurnKey(turn, absoluteTurnIndex)}>
               {showForkPoint ? <ThreadForkPoint parentTitle={forkedFromTitle} /> : null}
               <MemoMessageTurn
                 turn={turn}
@@ -387,7 +422,7 @@ function LiveTurnProgressRow(): ReactElement {
 }
 
 const MemoMessageTurn = memo(MessageTurn, (prev, next) => (
-  prev.turn === next.turn &&
+  sameTurnContent(prev.turn, next.turn) &&
   prev.isProcessing === next.isProcessing &&
   prev.liveReasoning === next.liveReasoning &&
   prev.live === next.live &&

--- a/src/renderer/src/components/chat/message-timeline-turns.test.ts
+++ b/src/renderer/src/components/chat/message-timeline-turns.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatBlock } from '../../agent/types'
+import { groupTurns, sameTurnContent, stableTurnKey } from './message-timeline-turns'
+
+describe('message timeline turns', () => {
+  it('uses stable ids for user and assistant-only turns', () => {
+    const blocks: ChatBlock[] = [
+      { kind: 'assistant', id: 'assistant_intro', text: 'Welcome' },
+      { kind: 'user', id: 'user_1', text: 'Hello' },
+      { kind: 'assistant', id: 'assistant_1', text: 'Hi' }
+    ]
+
+    const turns = groupTurns(blocks)
+
+    expect(stableTurnKey(turns[0], 0)).toBe('assistant_intro')
+    expect(stableTurnKey(turns[1], 1)).toBe('user_1')
+  })
+
+  it('treats rebuilt turn arrays as the same content when block references are unchanged', () => {
+    const blocks: ChatBlock[] = [
+      { kind: 'user', id: 'user_1', text: 'Hello' },
+      { kind: 'assistant', id: 'assistant_1', text: 'Hi' }
+    ]
+
+    const first = groupTurns(blocks)[0]
+    const second = groupTurns(blocks)[0]
+
+    expect(first).not.toBe(second)
+    expect(sameTurnContent(first, second)).toBe(true)
+  })
+
+  it('detects updates to a block inside an otherwise stable turn', () => {
+    const firstBlocks: ChatBlock[] = [
+      { kind: 'user', id: 'user_1', text: 'Hello' },
+      { kind: 'assistant', id: 'assistant_1', text: 'Hi' }
+    ]
+    const nextBlocks: ChatBlock[] = [
+      firstBlocks[0],
+      { kind: 'assistant', id: 'assistant_1', text: 'Hi again' }
+    ]
+
+    expect(sameTurnContent(groupTurns(firstBlocks)[0], groupTurns(nextBlocks)[0])).toBe(false)
+  })
+})

--- a/src/renderer/src/components/chat/message-timeline-turns.ts
+++ b/src/renderer/src/components/chat/message-timeline-turns.ts
@@ -23,6 +23,19 @@ export function groupTurns(blocks: ChatBlock[]): Turn[] {
   return turns
 }
 
+export function stableTurnKey(turn: Turn, fallbackIndex: number): string {
+  return turn.user?.id ?? turn.blocks[0]?.id ?? `turn-${fallbackIndex}`
+}
+
+export function sameTurnContent(left: Turn, right: Turn): boolean {
+  if (left.user !== right.user) return false
+  if (left.blocks.length !== right.blocks.length) return false
+  for (let index = 0; index < left.blocks.length; index += 1) {
+    if (left.blocks[index] !== right.blocks[index]) return false
+  }
+  return true
+}
+
 export function splitThink(text: string): { think: string; content: string } {
   const match = text.match(/<think>([\s\S]*?)(?:<\/think>|$)/)
   if (!match) return { think: '', content: text }

--- a/src/renderer/src/components/chat/use-timeline-scroll.ts
+++ b/src/renderer/src/components/chat/use-timeline-scroll.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
-import type { ChatBlock } from '../../agent/types'
 
 /** Threshold (px) from the top of the scroll container that triggers
  * auto-loading earlier turns. */
@@ -17,7 +16,7 @@ type UseTimelineScrollOptions = {
   totalTurns: number
   busy: boolean
   /** Triggers stick-to-bottom snap scroll. */
-  scrollDeps: { blocks: ChatBlock[]; live: string; liveReasoning: string }
+  scrollDeps: { contentKey: string; streaming: boolean }
 }
 
 export type UseTimelineScrollResult = {
@@ -64,7 +63,7 @@ export function useTimelineScroll({
   busy,
   scrollDeps
 }: UseTimelineScrollOptions): UseTimelineScrollResult {
-  const { blocks, live, liveReasoning } = scrollDeps
+  const { contentKey, streaming } = scrollDeps
   const shouldCollapseHistory = totalTurns > autoCollapseThreshold
   const [visibleTurnCount, setVisibleTurnCount] = useState(() =>
     deriveTimelineVisibleTurnCount({
@@ -132,11 +131,11 @@ export function useTimelineScroll({
     scrollFrameRef.current = window.requestAnimationFrame(() => {
       scrollFrameRef.current = null
       endRef.current?.scrollIntoView({
-        behavior: live || liveReasoning ? 'auto' : 'smooth',
+        behavior: streaming ? 'auto' : 'smooth',
         block: 'end'
       })
     })
-  }, [blocks, endRef, live, liveReasoning])
+  }, [contentKey, endRef, streaming])
 
   // Hard reset on thread switch.
   useEffect(() => {


### PR DESCRIPTION
﻿## Summary / 概要

English:
- Stabilize message turn keys so long conversations do not fall back to index-based keys.
- Narrow timeline auto-scroll dependencies during streaming.
- Avoid broad chat UI rewrites.

中文：
- 稳定消息 turn key，避免长会话回退到 index key。
- 收窄 streaming 时自动滚动的依赖，减少历史消息被反复重渲染。
- 不重做聊天 UI，只修稳定性。

Fixes #24

## Verification / 验证

- `npm.cmd test -- src/renderer/src/components/chat/message-timeline-turns.test.ts src/renderer/src/components/chat/use-timeline-scroll.test.ts src/renderer/src/components/chat/derive-turn-sections.test.ts src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd run build`

Note: lint still reports the existing hook warnings in ConnectPhoneView/SidebarClawDialog.
