### PR TITLE
Fix onboarding setup flicker

### DIFF
--- a/src/renderer/src/components/InitialSetupDialog.tsx
+++ b/src/renderer/src/components/InitialSetupDialog.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactElement, useEffect, useState } from 'react'
+import { type ReactElement, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   getActiveAgentApiKey,
@@ -14,7 +14,6 @@ import { Eye, EyeOff, ExternalLink, Sparkles, Sun, Moon, Monitor, X } from 'luci
 
 type ThemePref = AppSettingsV1['theme']
 type SetupFormPatch = AppSettingsPatch
-type MaskedInputStyle = CSSProperties & { WebkitTextSecurity?: 'disc' }
 
 const themeOptions: { value: ThemePref; icon: typeof Sun; labelKey: string }[] = [
   { value: 'system', icon: Monitor, labelKey: 'themeSystem' },
@@ -35,15 +34,21 @@ export function InitialSetupDialog(): ReactElement {
   const [showApiKey, setShowApiKey] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const formRef = useRef<AppSettingsV1 | null>(null)
   const isPreview = initialSetupMode === 'preview'
   const provider = form ? getModelProviderSettings(form) : null
+
+  const setCurrentForm = (next: AppSettingsV1 | null): void => {
+    formRef.current = next
+    setForm(next)
+  }
 
   useEffect(() => {
     let cancelled = false
     void rendererRuntimeClient
       .getSettings({ forceRefresh: true })
       .then((s) => {
-        if (!cancelled) setForm(s)
+        if (!cancelled) setCurrentForm(s)
       })
       .catch((e: unknown) => {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e))
@@ -52,16 +57,17 @@ export function InitialSetupDialog(): ReactElement {
   }, [])
 
   const updateForm = (patch: SetupFormPatch) => {
-    if (!form) return
+    const current = formRef.current
+    if (!current) return
     const next = normalizeAppSettings({
-      ...form,
+      ...current,
       ...patch,
       provider: {
-        ...form.provider,
+        ...current.provider,
         ...(patch.provider ?? {})
       }
     } as AppSettingsV1)
-    setForm(next)
+    setCurrentForm(next)
   }
 
   const updateProvider = (patch: Partial<AppSettingsV1['provider']>): void => {
@@ -69,7 +75,7 @@ export function InitialSetupDialog(): ReactElement {
   }
 
   const handleThemeChange = (theme: ThemePref) => {
-    if (!form) return
+    if (!formRef.current) return
     updateForm({ theme })
     applyTheme(theme)
   }
@@ -86,16 +92,17 @@ export function InitialSetupDialog(): ReactElement {
   }
 
   const handleSave = async () => {
-    if (!form) return
-    if (!getActiveAgentApiKey(form).trim()) {
+    const current = formRef.current
+    if (!current) return
+    if (!getActiveAgentApiKey(current).trim()) {
       setError(t('firstRunApiKeyValidation'))
       return
     }
     setSaving(true)
     setError(null)
     try {
-      const next = await rendererRuntimeClient.setSettings(form)
-      setForm(next)
+      const next = await rendererRuntimeClient.setSettings(current)
+      setCurrentForm(next)
       await applyI18n(next.locale)
       void reloadUiSettings()
       void probeRuntime('background')
@@ -128,9 +135,6 @@ export function InitialSetupDialog(): ReactElement {
   const fieldClass =
     'w-full rounded-xl border border-slate-300/75 bg-white/88 px-4 py-3 text-[15px] text-slate-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.72)] outline-none transition focus:border-[#1388ff]/70 focus:ring-2 focus:ring-[#1388ff]/15 dark:border-white/10 dark:bg-white/[0.04] dark:text-slate-100 dark:shadow-none dark:focus:border-[#3aa0ff]/70 dark:focus:ring-[#3aa0ff]/15 dark:placeholder:text-slate-500'
   const labelClass = 'text-sm font-semibold text-slate-700 dark:text-slate-200'
-  const apiKeyMaskStyle: MaskedInputStyle | undefined =
-    !showApiKey && provider?.apiKey ? { WebkitTextSecurity: 'disc' } : undefined
-
   return (
     <div className="ds-no-drag fixed inset-0 z-50 overflow-y-auto bg-[#eef2fb]/45 p-3 backdrop-blur-[18px] dark:bg-black/62 dark:backdrop-blur-[22px] sm:p-6">
       <div className="flex min-h-full items-center justify-center">
@@ -217,7 +221,7 @@ export function InitialSetupDialog(): ReactElement {
             </label>
             <div className="relative">
               <input
-                type="text"
+                type={showApiKey ? 'text' : 'password'}
                 value={provider?.apiKey ?? ''}
                 onChange={(e) => updateProvider({ apiKey: e.target.value })}
                 placeholder="sk-..."
@@ -225,7 +229,6 @@ export function InitialSetupDialog(): ReactElement {
                 autoCorrect="off"
                 autoCapitalize="off"
                 spellCheck={false}
-                style={apiKeyMaskStyle}
                 className={`${fieldClass} pr-12 font-mono placeholder:font-sans`}
               />
               <button


### PR DESCRIPTION
Fixes #65

## Summary

Fixes the initial onboarding setup dialog by stabilizing the API key field and preserving the latest setup draft when saving.

## Why

The API key field used a text input with `WebkitTextSecurity` to mask the value. In Electron/Chromium this can repaint aggressively while typing, which makes the first-run API key page appear to flicker.

The setup dialog also saved from React state directly. When language/theme/API key updates happen right before clicking save, the save handler can observe a stale draft. Keeping a ref in sync with the form state ensures the persisted settings use the latest onboarding selection, including Chinese locale.

## Changes

- Switch the onboarding API key field to native `password` / `text` input types for show/hide behavior.
- Keep the latest onboarding form draft in a ref and save from that ref.
- Continue applying the saved locale after settings persistence.

## Media

N/A

## Tests

- `npm run typecheck`
- `npm run test -- src/renderer/src/AppShell.test.ts src/renderer/src/agent/runtime-client.test.ts`

## Validation

Verified the TypeScript build and focused renderer/runtime-client tests pass locally.
