### PR TITLE
Prepare agent provider registry for Codex CLI

### DIFF
--- a/src/renderer/src/agent/kun-runtime.test.ts
+++ b/src/renderer/src/agent/kun-runtime.test.ts
@@ -8,7 +8,12 @@ import {
   type AppSettingsV1
 } from '@shared/app-settings'
 import { KunRuntimeProvider } from './kun-runtime'
-import { getProvider, resetProviderCacheForTests } from './registry'
+import {
+  getAgentProviderDescriptor,
+  getProvider,
+  listAgentProviderDescriptors,
+  resetProviderCacheForTests
+} from './registry'
 import { rendererRuntimeClient } from './runtime-client'
 import type { ThreadEventSink } from './types'
 
@@ -780,6 +785,26 @@ describe('KunRuntimeProvider', () => {
 })
 
 describe('registry', () => {
+  it('lists Kun and planned Codex CLI provider descriptors', () => {
+    expect(listAgentProviderDescriptors()).toEqual([
+      expect.objectContaining({
+        id: 'kun',
+        displayName: 'Kun',
+        status: 'available'
+      }),
+      expect.objectContaining({
+        id: 'codex-cli',
+        displayName: 'Codex CLI',
+        status: 'planned'
+      })
+    ])
+    expect(getAgentProviderDescriptor('codex-cli')).toMatchObject({
+      id: 'codex-cli',
+      displayName: 'Codex CLI',
+      status: 'planned'
+    })
+  })
+
   it('returns a cached provider for the kun id', () => {
     resetProviderCacheForTests()
     const first = getProvider()
@@ -787,4 +812,8 @@ describe('registry', () => {
     expect(first).toBe(second)
   })
 
+  it('keeps unimplemented providers out of the runtime path', () => {
+    resetProviderCacheForTests()
+    expect(() => getProvider('codex-cli')).toThrow('Agent provider is not implemented yet: codex-cli')
+  })
 })

--- a/src/renderer/src/agent/registry.ts
+++ b/src/renderer/src/agent/registry.ts
@@ -1,14 +1,55 @@
-import type { AgentProvider } from './types'
+import type { AgentProvider, AgentProviderId } from './types'
 import { KunRuntimeProvider } from './kun-runtime'
 
-let cachedProvider: AgentProvider | null = null
+export type AgentProviderStatus = 'available' | 'planned'
 
-export function getProvider(): AgentProvider {
+export type AgentProviderDescriptor = {
+  id: AgentProviderId
+  displayName: string
+  status: AgentProviderStatus
+  description: string
+}
+
+const agentProviderDescriptors: AgentProviderDescriptor[] = [
+  {
+    id: 'kun',
+    displayName: 'Kun',
+    status: 'available',
+    description: 'Bundled HTTP/SSE runtime used by DeepSeek-GUI.'
+  },
+  {
+    id: 'codex-cli',
+    displayName: 'Codex CLI',
+    status: 'planned',
+    description: 'External coding-agent CLI provider planned for future integration.'
+  }
+]
+
+const cachedProviders = new Map<AgentProviderId, AgentProvider>()
+
+export function listAgentProviderDescriptors(): AgentProviderDescriptor[] {
+  return agentProviderDescriptors.map((descriptor) => ({ ...descriptor }))
+}
+
+export function getAgentProviderDescriptor(providerId: AgentProviderId): AgentProviderDescriptor {
+  const descriptor = agentProviderDescriptors.find((entry) => entry.id === providerId)
+  if (!descriptor) throw new Error(`Unknown agent provider: ${providerId}`)
+  return { ...descriptor }
+}
+
+export function getProvider(providerId: AgentProviderId = 'kun'): AgentProvider {
+  const cachedProvider = cachedProviders.get(providerId)
   if (cachedProvider) return cachedProvider
-  cachedProvider = new KunRuntimeProvider()
-  return cachedProvider
+
+  if (providerId !== 'kun') {
+    throw new Error(`Agent provider is not implemented yet: ${providerId}`)
+  }
+
+  const provider = new KunRuntimeProvider()
+  cachedProviders.set(providerId, provider)
+  return provider
 }
 
 export function resetProviderCacheForTests(): void {
-  cachedProvider = null
+  cachedProviders.clear()
 }

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -362,8 +362,10 @@ export type ThreadEventSink = {
   onUsage?(usage: ThreadUsageSnapshot): void
 }
 
+export type AgentProviderId = 'kun' | 'codex-cli'
+
 export interface AgentProvider {
-  readonly id: 'kun'
+  readonly id: AgentProviderId
   readonly displayName: string
   getCapabilities(): {
     interrupt: boolean


### PR DESCRIPTION
## Summary

Prepare the renderer agent provider registry for future non-Kun providers.

Part of #66.

## Why

Codex CLI support is not just another OpenAI-compatible model provider. It needs to become an external agent provider with its own runtime/session bridge. The current renderer registry hard-codes a single cached Kun provider, and `AgentProvider.id` only allows `'kun'`, which makes incremental provider work harder to stage cleanly.

## Changes

- Add an `AgentProviderId` union with `kun` and planned `codex-cli` ids.
- Add provider descriptors for available Kun and planned Codex CLI support.
- Cache providers by provider id instead of one global singleton.
- Keep the runtime path protected by throwing if an unimplemented provider is requested.
- Add registry coverage for descriptor listing, Kun caching, and unimplemented provider handling.

## Scope

This PR does not implement the Codex CLI process/session bridge yet. It only adds the registry shape needed for follow-up Codex CLI provider PRs.

## Media

N/A

## Tests

- `npm run typecheck`
- `npm run test -- src/renderer/src/agent/kun-runtime.test.ts`

## Validation

Verified the TypeScript build and focused Kun runtime/registry tests pass locally.
