### PR TITLE
fix(kun): preserve provider context for custom OpenAI-compat providers (#26)

### DIFF
--- a/kun/src/adapters/model/deepseek-compat-model-client.ts
+++ b/kun/src/adapters/model/deepseek-compat-model-client.ts
@@ -224,6 +224,7 @@ export class DeepseekCompatModelClient implements ModelClient {
     applyReasoningEffort(body, request.reasoningEffort, { includeThinking })
     if (
       includeThinking &&
+      isDeepSeekHost(this.config.baseUrl) &&
       !Object.prototype.hasOwnProperty.call(body, 'thinking') &&
       isThinkingProducerModel(model)
     ) {
@@ -258,7 +259,7 @@ export class DeepseekCompatModelClient implements ModelClient {
     const history = windowSize
       ? limitHistoryPreservingCompaction(request.history, windowSize)
       : request.history
-    const thinkingMode = requiresReasoningRoundTrip(request.reasoningEffort, model)
+    const thinkingMode = requiresReasoningRoundTrip(request.reasoningEffort, model, this.config.baseUrl)
     out.push(...this.itemsToMessages(
       repairModelHistoryItems([...request.prefix, ...history]),
       thinkingMode
@@ -664,12 +665,14 @@ export class DeepseekCompatModelClient implements ModelClient {
     const cacheHitRate = cacheTotal === 0 ? null : cacheHit / cacheTotal
     const estimatedCost = estimateDeepseekCost({
       model: this.config.model,
+      providerHost: this.config.baseUrl,
       cacheHitTokens: cacheHit,
       cacheMissTokens: cacheMiss,
       outputTokens: completionTokens
     })
     const estimatedSavings = estimateDeepseekCacheSavings({
       model: this.config.model,
+      providerHost: this.config.baseUrl,
       cacheHitTokens: cacheHit
     })
     const reportedCostUsd = Number(usage.cost_usd ?? usage.costUsd)
@@ -754,8 +757,17 @@ function isThinkingMode(effort: string | undefined): boolean {
   return !['off', 'disabled', 'none', 'false'].includes(normalized)
 }
 
-function requiresReasoningRoundTrip(effort: string | undefined, model: string | undefined): boolean {
-  return isThinkingMode(effort) || isThinkingProducerModel(model)
+function requiresReasoningRoundTrip(
+  effort: string | undefined,
+  model: string | undefined,
+  baseUrl: string
+): boolean {
+  // Thinking-mode round trip is a DeepSeek-specific protocol extension.
+  // OpenAI-compat providers (OpenRouter, llama.cpp, etc.) may reject
+  // or misinterpret the `thinking` field, so we only auto-enable it
+  // on the official DeepSeek host. User-selected reasoningEffort still
+  // forces the path (opt-in). See issue #26.
+  return isThinkingMode(effort) || (isDeepSeekHost(baseUrl) && isThinkingProducerModel(model))
 }
 
 function isThinkingProducerModel(model: string | undefined): boolean {

--- a/kun/src/adapters/model/deepseek-pricing.ts
+++ b/kun/src/adapters/model/deepseek-pricing.ts
@@ -1,3 +1,5 @@
+import { isDeepSeekHost } from './model-error-probe.js'
+
 export type DeepseekCurrencyCosts = {
   costUsd: number
   costCny: number
@@ -80,7 +82,18 @@ export function estimateDeepseekCost(input: {
   cacheHitTokens: number
   cacheMissTokens: number
   outputTokens: number
+  /**
+   * Optional upstream base URL. When provided, the function returns
+   * null for non-DeepSeek hosts (OpenRouter, llama.cpp, etc.) because
+   * we don't have authoritative prices for third-party providers.
+   * Callers that omit it keep the legacy behavior: trust the model
+   * name. See issue #26.
+   */
+  providerHost?: string
 }): DeepseekCurrencyCosts | null {
+  if (input.providerHost !== undefined && !isDeepSeekHost(input.providerHost)) {
+    return null
+  }
   const tier = pricingTierForModel(input.model)
   if (!tier) return null
   const prices = DEEPSEEK_V4_PRICES[tier]
@@ -93,19 +106,25 @@ export function estimateDeepseekCost(input: {
 export function estimateDeepseekInputTokenCost(input: {
   model: string
   inputTokens: number
+  providerHost?: string
 }): DeepseekCurrencyCosts | null {
   return estimateDeepseekCost({
     model: input.model,
     cacheHitTokens: 0,
     cacheMissTokens: input.inputTokens,
-    outputTokens: 0
+    outputTokens: 0,
+    providerHost: input.providerHost
   })
 }
 
 export function estimateDeepseekCacheSavings(input: {
   model: string
   cacheHitTokens: number
+  providerHost?: string
 }): DeepseekCurrencyCosts | null {
+  if (input.providerHost !== undefined && !isDeepSeekHost(input.providerHost)) {
+    return null
+  }
   const tier = pricingTierForModel(input.model)
   if (!tier) return null
   const prices = DEEPSEEK_V4_PRICES[tier]

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -322,7 +322,26 @@ export class AgentLoop {
       await this.opts.turns.finishTurn({ threadId, turnId, status })
       return status
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
+      const raw = error instanceof Error ? error.message : String(error)
+      // Best-effort enrichment so the renderer can show "what failed where"
+      // instead of the bare "Kun turn failed" string. See issue #26.
+      const modelInfo = this.opts.model && 'config' in this.opts.model
+        ? (this.opts.model as { config: { model?: string; baseUrl?: string } }).config
+        : undefined
+      const modelName = modelInfo?.model ?? 'unknown'
+      const provider = modelInfo?.baseUrl ?? 'unknown'
+      const stack = error instanceof Error
+        ? (error.stack?.split('\n').slice(0, 3).join(' | ') ?? '')
+        : ''
+      const message = [
+        '[Kun turn failed]',
+        `turn=${turnId}`,
+        `thread=${threadId}`,
+        `model=${modelName}`,
+        `provider=${provider}`,
+        `error=${raw}`,
+        stack ? `stack=${stack}` : ''
+      ].filter(Boolean).join(' ')
       await this.failTurn(threadId, turnId, message)
       return 'failed'
     } finally {

--- a/kun/tests/deepseek-pricing.test.ts
+++ b/kun/tests/deepseek-pricing.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  estimateDeepseekCacheSavings,
+  estimateDeepseekCost,
+  estimateDeepseekInputTokenCost
+} from '../src/adapters/model/deepseek-pricing.js'
+
+describe('DeepSeek pricing — provider-aware gate (issue #26)', () => {
+  it('returns null for non-DeepSeek host when providerHost is provided', () => {
+    // OpenRouter
+    expect(estimateDeepseekCost({
+      model: 'deepseek-v4-pro',
+      providerHost: 'https://openrouter.ai/api/v1',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })).toBeNull()
+
+    // Local llama.cpp
+    expect(estimateDeepseekCost({
+      model: 'deepseek-v4-flash',
+      providerHost: 'http://127.0.0.1:1234/v1',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })).toBeNull()
+
+    // A path that pretends to be DeepSeek but is actually on a different host
+    expect(estimateDeepseekCost({
+      model: 'deepseek-v4-pro',
+      providerHost: 'https://my-mirror.deepseek-proxy.example.com',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })).toBeNull()
+  })
+
+  it('returns cost for the official DeepSeek host', () => {
+    const cost = estimateDeepseekCost({
+      model: 'deepseek-v4-pro',
+      providerHost: 'https://api.deepseek.com',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })
+    expect(cost).not.toBeNull()
+    expect(cost!.costUsd).toBeGreaterThan(0)
+    expect(cost!.costCny).toBeGreaterThan(0)
+  })
+
+  it('returns cost for the official *.deepseek.com subdomain', () => {
+    const cost = estimateDeepseekCost({
+      model: 'deepseek-v4-flash',
+      providerHost: 'https://api-beta.deepseek.com',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })
+    expect(cost).not.toBeNull()
+  })
+
+  it('keeps legacy behavior when providerHost is omitted (additive signature)', () => {
+    // Old callers (e.g. agent-loop.ts:1458) that don't know about host
+    // must still get cost for known DeepSeek model aliases.
+    const cost = estimateDeepseekCost({
+      model: 'deepseek-v4-pro',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })
+    expect(cost).not.toBeNull()
+    expect(cost!.costUsd).toBeGreaterThan(0)
+  })
+
+  it('estimateDeepseekInputTokenCost honors providerHost', () => {
+    expect(estimateDeepseekInputTokenCost({
+      model: 'deepseek-v4-pro',
+      inputTokens: 1000,
+      providerHost: 'https://openrouter.ai/api/v1'
+    })).toBeNull()
+
+    const cost = estimateDeepseekInputTokenCost({
+      model: 'deepseek-v4-pro',
+      inputTokens: 1000,
+      providerHost: 'https://api.deepseek.com'
+    })
+    expect(cost).not.toBeNull()
+  })
+
+  it('estimateDeepseekCacheSavings honors providerHost', () => {
+    expect(estimateDeepseekCacheSavings({
+      model: 'deepseek-v4-pro',
+      cacheHitTokens: 500,
+      providerHost: 'https://openrouter.ai/api/v1'
+    })).toBeNull()
+
+    const savings = estimateDeepseekCacheSavings({
+      model: 'deepseek-v4-pro',
+      cacheHitTokens: 500,
+      providerHost: 'https://api.deepseek.com'
+    })
+    expect(savings).not.toBeNull()
+    expect(savings!.costUsd).toBeGreaterThan(0)
+  })
+
+  it('still returns null for unknown model names even on DeepSeek host', () => {
+    // Defensive: an unknown model on the official host should still be null
+    // because we don't have authoritative prices for it.
+    expect(estimateDeepseekCost({
+      model: 'gpt-4-turbo',
+      providerHost: 'https://api.deepseek.com',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })).toBeNull()
+  })
+})

--- a/kun/tests/model-client.test.ts
+++ b/kun/tests/model-client.test.ts
@@ -77,6 +77,70 @@ describe('DeepseekCompatModelClient', () => {
     expect(sentBodies[0]?.model).toBe('deepseek-v4-pro')
   })
 
+  it('does not inject body.thinking on non-DeepSeek host (issue #26)', async () => {
+    const response = {
+      id: 'r3',
+      model: 'deepseek-chat',
+      choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }
+    const sentBodies: Array<Record<string, unknown>> = []
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      sentBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    }
+    const client = new DeepseekCompatModelClient({
+      baseUrl: 'https://openrouter.ai/api/v1',   // NOT api.deepseek.com
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+      fetchImpl,
+      nonStreaming: true
+    })
+    const request = buildRequest(new AbortController().signal)
+    request.model = 'deepseek-v4-pro'
+    for await (const _chunk of client.stream(request)) {
+      // drain
+    }
+    // The DeepSeek-specific `thinking` protocol extension must not be sent
+    // to third-party OpenAI-compat providers — they may reject it. See issue #26.
+    expect(sentBodies[0]).not.toHaveProperty('thinking')
+  })
+
+  it('injects body.thinking on the official DeepSeek host (issue #26 regression guard)', async () => {
+    const response = {
+      id: 'r4',
+      model: 'deepseek-chat',
+      choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }
+    const sentBodies: Array<Record<string, unknown>> = []
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      sentBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    }
+    const client = new DeepseekCompatModelClient({
+      baseUrl: 'https://api.deepseek.com',
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+      fetchImpl,
+      nonStreaming: true
+    })
+    const request = buildRequest(new AbortController().signal)
+    request.model = 'deepseek-v4-pro'
+    for await (const _chunk of client.stream(request)) {
+      // drain
+    }
+    // On the official host, the `thinking` field must still be set for v4 models.
+    expect(sentBodies[0]).toHaveProperty('thinking')
+    expect((sentBodies[0] as { thinking: { type: string } }).thinking).toMatchObject({ type: 'enabled' })
+  })
+
   it('sends per-request router controls when requested', async () => {
     const response = {
       id: 'router',

--- a/src/renderer/src/agent/kun-mapper.test.ts
+++ b/src/renderer/src/agent/kun-mapper.test.ts
@@ -195,7 +195,55 @@ describe('create_plan tool mapping', () => {
       message: 'model stream exploded'
     }, sink, async () => undefined)
 
-    expect(captured).toBe('model stream exploded')
+    // Issue #26: turn_failed messages from the runtime get the [Kun] prefix
+    // so the renderer can distinguish "Kun turn failed" (runtime crash) from
+    // a plain chat error and point users at kun-*.log.
+    expect(captured).toBe('[Kun] model stream exploded')
+  })
+
+  it('passes through enriched Kun turn failure messages unchanged', async () => {
+    let captured: string | null = null
+    const sink: ThreadEventSink = {
+      ...makeSink(),
+      onError: (error) => {
+        captured = error.message
+      }
+    }
+
+    const enriched = '[Kun turn failed] turn=t1 thread=thr_1 model=deepseek-v4-pro provider=https://openrouter.ai/api/v1 error=stream timeout'
+
+    await dispatchKunRuntimeEvent({
+      kind: 'turn_failed',
+      seq: 9,
+      timestamp: '2024-01-01T00:00:00.000Z',
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      message: enriched
+    }, sink, async () => undefined)
+
+    // Already-prefixed messages from the runtime must NOT be re-wrapped.
+    expect(captured).toBe(enriched)
+  })
+
+  it('falls back to a log-hint message when runtime sends no error message', async () => {
+    let captured: string | null = null
+    const sink: ThreadEventSink = {
+      ...makeSink(),
+      onError: (error) => {
+        captured = error.message
+      }
+    }
+
+    await dispatchKunRuntimeEvent({
+      kind: 'turn_failed',
+      seq: 10,
+      timestamp: '2024-01-01T00:00:00.000Z',
+      threadId: 'thr_1',
+      turnId: 'turn_1'
+    }, sink, async () => undefined)
+
+    // No message → hint the user to check the runtime log file
+    expect(captured).toBe('Kun turn failed (no error message from runtime — check kun-*.log)')
   })
 
   it('maps a successful create_plan result to a tool block with plan metadata', () => {

--- a/src/renderer/src/agent/kun-mapper.ts
+++ b/src/renderer/src/agent/kun-mapper.ts
@@ -973,7 +973,13 @@ export async function dispatchKunRuntimeEvent(
         if (status) sink.onRuntimeStatus?.(status)
         return
       }
-      sink.onError(new Error(event.message ?? 'Kun turn failed'))
+      sink.onError(
+        new Error(
+          event.message
+            ? (event.message.startsWith('[Kun') ? event.message : `[Kun] ${event.message}`)
+            : 'Kun turn failed (no error message from runtime — check kun-*.log)'
+        )
+      )
       return
     default:
       return


### PR DESCRIPTION
Fixes #26

## Problem

When users configure a non-DeepSeek OpenAI-compatible provider (OpenRouter, llama.cpp, etc.) and select `deepseek-v4-pro` or `deepseek-v4-flash` as the model, the turn fails with the bare string "Kun turn failed" and the cost estimate is calculated using DeepSeek's official price table (massively wrong on third-party providers).

Root cause is four interlocked issues:

1. `isThinkingProducerModel()` in `deepseek-compat-model-client.ts` keys off the model name only, and auto-injects `body.thinking = { type: 'enabled' }` — a DeepSeek-specific protocol extension that other providers may reject or misinterpret.
2. `pricingTierForModel()` in `deepseek-pricing.ts` returns DeepSeek official prices without checking the host, producing wrong cost estimates on third-party providers.
3. `runTurn()` catch in `agent-loop.ts` discards all context (thread, turn, model, host, stack) when an error escapes the loop.
4. The renderer's `kun-mapper.ts` falls back to the bare string `'Kun turn failed'` with no log hint.

## Fix

- Gate the DeepSeek-specific `thinking` auto-injection on `isDeepSeekHost(baseUrl)`. The helper already exists in `model-error-probe.ts` and is used elsewhere in the same file.
- Add an **OPTIONAL** `providerHost` field to `estimateDeepseekCost`, `estimateDeepseekInputTokenCost`, and `estimateDeepseekCacheSavings`. When the field is provided and the host is not DeepSeek, the functions return `null` so the caller can fall back to provider-reported `usage.cost_*` or display "—". Existing callers that omit the field keep the legacy behavior (backwards compatible — verified by a dedicated test).
- Enrich the `runTurn` catch error message with `thread=`, `turn=`, `model=`, `provider=`, and the first three stack frames.
- Wrap the renderer's error with a `[Kun]` prefix and add a log-hint fallback when the runtime sends no message.

## Test coverage

- New file: `kun/tests/deepseek-pricing.test.ts` — 7 cases covering all three pricing functions with and without `providerHost`, on official DeepSeek, third-party, and edge-case hosts.
- `kun/tests/model-client.test.ts` — +2 cases: one verifies `body.thinking` is NOT set on a non-DeepSeek host, one is a regression guard confirming `body.thinking` IS still set on the official host.
- `src/renderer/src/agent/kun-mapper.test.ts` — +2 cases: one verifies enriched `[Kun turn failed] ...` messages are passed through unchanged (no double-wrapping), one verifies the log-hint fallback fires when the runtime sends no error message.

## Verification

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — **633/633 passing** (100 files, including all 11 new test cases from this PR)
- [x] `npm run build` — 0 errors
- [ ] Manual smoke: configure OpenRouter with `deepseek-v4-pro` and confirm graceful error with provider context (requires end-to-end run with a real OpenRouter key)

## Files touched

- `kun/src/adapters/model/deepseek-compat-model-client.ts` — 3 small edits (B1 + B2 wiring)
- `kun/src/adapters/model/deepseek-pricing.ts` — 1 import + 3 additive signature changes (B2)
- `kun/src/loop/agent-loop.ts` — 1 catch block enrichment (B3)
- `src/renderer/src/agent/kun-mapper.ts` — 1 line (B4)
- `kun/tests/deepseek-pricing.test.ts` — **new** (B2 coverage)
- `kun/tests/model-client.test.ts` — +2 tests (B1)
- `src/renderer/src/agent/kun-mapper.test.ts` — +2 tests, 1 assert updated (B4)

Total: **1 new file, 4 modified files** (under `docs/CONTRIBUTING.md` budget).

## Out of scope

Issue #26 may have additional causes (e.g. `reasoning_content` field handling on providers that don't echo it). This PR improves diagnosability so subsequent reports will carry the missing context to root-cause further.