### PR TITLE
fix: show runtime errors in offline hero

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -1540,6 +1540,7 @@ export function Workbench(): ReactElement {
               live={timelineLiveAssistant}
               activeThreadId={activeThreadId}
               runtimeConnection={runtimeConnection}
+              runtimeError={error}
               onRetryConnection={() => void probeRuntime('user')}
               onOpenSettings={() => openSettings('agents')}
               onSelectSuggestion={(text) => setInput(text)}

--- a/src/renderer/src/components/chat/MessageTimeline.initial-heatmap.test.ts
+++ b/src/renderer/src/components/chat/MessageTimeline.initial-heatmap.test.ts
@@ -8,12 +8,14 @@ function renderHero(options: {
   route?: 'chat' | 'claw'
   ready?: boolean
   hasWorkspace?: boolean
+  runtimeError?: string | null
 } = {}): string {
   return renderToStaticMarkup(
     createElement(MessageTimelineEmptyHero, {
       route: options.route ?? 'chat',
       ready: options.ready ?? true,
       hasWorkspace: options.hasWorkspace ?? true,
+      runtimeError: options.runtimeError ?? null,
       activeClawChannel: null,
       onPickWorkspace: () => undefined,
       onRetry: () => undefined,
@@ -46,5 +48,14 @@ describe('MessageTimeline initial heatmap empty hero routing', () => {
     expect(clawHtml).toContain('ds-claw-empty-whale-logo')
     expect(clawHtml).toContain('ds-work-logo')
     expect(clawHtml).not.toContain('Kun usage')
+  })
+
+  it('shows the runtime error in the offline hero when one is available', () => {
+    const html = renderHero({
+      ready: false,
+      runtimeError: i18n.t('common:runtimePortConflict')
+    })
+
+    expect(html).toContain('The runtime port is already in use.')
   })
 })

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -28,6 +28,7 @@ type Props = {
   live: string
   activeThreadId: string | null
   runtimeConnection: RuntimeConnectionStatus
+  runtimeError?: string | null
   onRetryConnection: () => void
   onOpenSettings: () => void
   onSelectSuggestion?: (prompt: string) => void
@@ -49,6 +50,7 @@ export function MessageTimeline({
   live,
   activeThreadId,
   runtimeConnection,
+  runtimeError,
   onRetryConnection,
   onOpenSettings,
   onSelectSuggestion,
@@ -120,6 +122,7 @@ export function MessageTimeline({
             route={heroRoute}
             ready={runtimeConnection === 'ready'}
             hasWorkspace={!!workspaceRoot}
+            runtimeError={runtimeError}
             activeClawChannel={activeClawChannel}
             onPickWorkspace={() => void chooseWorkspace()}
             onRetry={onRetryConnection}

--- a/src/renderer/src/components/chat/message-timeline-empty.tsx
+++ b/src/renderer/src/components/chat/message-timeline-empty.tsx
@@ -68,13 +68,16 @@ function ClawEmptyHero({
 }
 
 function RuntimeWakeHero({
+  runtimeError,
   onRetry,
   onOpenSettings
 }: {
+  runtimeError?: string | null
   onRetry: () => void
   onOpenSettings: () => void
 }): ReactElement {
   const { t } = useTranslation('common')
+  const detail = runtimeError?.trim() || t('runtimeOfflineHeroSub')
 
   return (
     <div className="ds-runtime-wake-hero ds-no-drag px-6 pb-8 pt-12 text-center md:pt-16">
@@ -87,7 +90,7 @@ function RuntimeWakeHero({
         {t('runtimeOfflineHeroTitle')}
       </h1>
       <p className="mt-3 max-w-[620px] text-[15px] leading-7 text-ds-muted">
-        {t('runtimeOfflineHeroSub')}
+        {detail}
       </p>
       <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
         <button
@@ -115,6 +118,7 @@ export function MessageTimelineEmptyHero({
   route,
   ready,
   hasWorkspace,
+  runtimeError,
   activeClawChannel,
   onPickWorkspace,
   onRetry,
@@ -124,6 +128,7 @@ export function MessageTimelineEmptyHero({
   route: 'chat' | 'claw'
   ready: boolean
   hasWorkspace: boolean
+  runtimeError?: string | null
   activeClawChannel: ClawImChannelV1 | null
   onPickWorkspace: () => void
   onRetry: () => void
@@ -133,7 +138,7 @@ export function MessageTimelineEmptyHero({
   const { t } = useTranslation('common')
 
   if (!ready) {
-    return <RuntimeWakeHero onRetry={onRetry} onOpenSettings={onOpenSettings} />
+    return <RuntimeWakeHero runtimeError={runtimeError} onRetry={onRetry} onOpenSettings={onOpenSettings} />
   }
 
   if (!hasWorkspace) {


### PR DESCRIPTION
## Summary

- Show concrete runtime startup errors in the offline runtime hero.

## Why

- When the runtime fails to start because of a known issue such as a port conflict, the UI currently falls back to a generic offline message.
- Showing the actual runtime error makes the failure easier to understand and act on.

## Changes

- Pass `runtimeError` from `Workbench` into `MessageTimeline`.
- Render the runtime error in the offline hero when available.
- Keep the existing generic offline message as the fallback.
- Add a regression test for the runtime port conflict message.

## Media

- Not attached. This is a small text-state UI change covered by a regression test.

## Tests

- Added `MessageTimeline` regression coverage for showing `common:runtimePortConflict` in the offline hero.

## Validation

- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run dev` (if runtime or UI behavior changed)
- [ ] UI change: video or GIF attached
- [x] Logic change: unit tests added or updated

## 中文说明

这个 PR 让离线 runtime 提示区域在有具体启动错误时显示实际错误信息，例如端口已被占用，而不是只显示通用的离线提示。

改动范围保持很小：只把 `runtimeError` 从 `Workbench` 透传到 `MessageTimeline`，并在离线提示中优先显示该错误；没有错误时仍使用原来的默认文案。同时补了一个回归测试，覆盖端口冲突错误能正确显示。

已验证 `npm run test`、`npm run typecheck`、`npm run build` 和 `npm run dev`。另外 `npm run lint` 也通过，只有 7 个项目已有 warning，和本次改动无关。


## Notes

- `npm run lint` also passes with 0 errors and 7 existing warnings unrelated to this change.
- `npm run dev` started successfully; local renderer used `http://localhost:5174/` because `5173` was already in use.