### PR TITLE
fix: refresh SDD drafts from disk

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -1512,7 +1512,9 @@ export function Workbench(): ReactElement {
           {activeSddDraft ? (
             <SddDraftEditorView
               leftSidebarCollapsed={leftSidebarCollapsed}
+              assistantOpen={rightPanelMode === 'sdd-ai'}
               onToggleLeftSidebar={toggleLeftSidebar}
+              onToggleAssistant={() => toggleRightPanelMode('sdd-ai')}
               onNext={() => void handleSddNextStep()}
               onClose={() => {
                 void saveActiveSddDraftToDisk()

--- a/src/renderer/src/components/sdd/SddDraftEditorView.test.ts
+++ b/src/renderer/src/components/sdd/SddDraftEditorView.test.ts
@@ -1,0 +1,18 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SddAssistantToggleButton } from './SddDraftEditorView'
+
+describe('SddDraftEditorView', () => {
+  it('renders a control to reopen the Requirement AI panel', () => {
+    const html = renderToStaticMarkup(
+      createElement(SddAssistantToggleButton, {
+        assistantOpen: false,
+        onToggleAssistant: () => undefined,
+        label: 'Requirement AI'
+      })
+    )
+
+    expect(html).toContain('aria-label="Requirement AI"')
+  })
+})

--- a/src/renderer/src/components/sdd/SddDraftEditorView.tsx
+++ b/src/renderer/src/components/sdd/SddDraftEditorView.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, type ReactElement } from 'react'
-import { ArrowRight, FileText, Loader2, Save, X } from 'lucide-react'
+import { ArrowRight, FileText, Loader2, Save, Sparkles, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/react/shallow'
 import { SDD_IMAGE_RELATIVE_DIR } from '@shared/sdd'
 import { useSddDraftStore } from '../../sdd/sdd-draft-store'
-import { saveActiveSddDraftToDisk } from '../../sdd/sdd-draft-actions'
+import { saveActiveSddDraftToDisk, syncActiveSddDraftFromDisk } from '../../sdd/sdd-draft-actions'
 import { useWriteWorkspaceStore } from '../../write/write-workspace-store'
+import { startWriteWorkspaceFileWatch } from '../../write/write-file-watch'
 import { WriteMarkdownEditor } from '../write/WriteMarkdownEditor'
 import { SidebarTitlebarToggleButton } from '../sidebar/SidebarPrimitives'
 
@@ -13,7 +14,9 @@ const SDD_AUTOSAVE_MS = 650
 
 type Props = {
   leftSidebarCollapsed: boolean
+  assistantOpen: boolean
   onToggleLeftSidebar: () => void
+  onToggleAssistant: () => void
   onNext: () => void
   onClose: () => void
   nextDisabled: boolean
@@ -27,9 +30,36 @@ function statusKey(saveStatus: string, operationStatus: string): string {
   return 'sddStatusSaved'
 }
 
+export function SddAssistantToggleButton({
+  assistantOpen,
+  onToggleAssistant,
+  label
+}: {
+  assistantOpen: boolean
+  onToggleAssistant: () => void
+  label: string
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onToggleAssistant}
+      className={`ds-sidebar-toggle-button ${
+        assistantOpen ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10' : ''
+      }`}
+      title={label}
+      aria-label={label}
+      aria-pressed={assistantOpen}
+    >
+      <Sparkles className="h-4 w-4" strokeWidth={1.85} />
+    </button>
+  )
+}
+
 export function SddDraftEditorView({
   leftSidebarCollapsed,
+  assistantOpen,
   onToggleLeftSidebar,
+  onToggleAssistant,
   onNext,
   onClose,
   nextDisabled
@@ -99,6 +129,36 @@ export function SddDraftEditorView({
     if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current)
     void saveActiveSddDraftToDisk()
   }, [])
+
+  const activeDraftId = activeDraft?.id
+  const activeDraftWorkspaceRoot = activeDraft?.workspaceRoot
+  const activeDraftRelativePath = activeDraft?.relativePath
+  const activeDraftAbsolutePath = activeDraft?.absolutePath
+
+  useEffect(() => {
+    if (!activeDraftId || !activeDraftWorkspaceRoot || !activeDraftRelativePath) return
+    if (
+      typeof window.dsGui?.watchWorkspaceFile !== 'function' ||
+      typeof window.dsGui?.unwatchWorkspaceFile !== 'function' ||
+      typeof window.dsGui?.onWorkspaceFileChanged !== 'function'
+    ) {
+      return
+    }
+
+    return startWriteWorkspaceFileWatch({
+      api: window.dsGui,
+      workspaceRoot: activeDraftWorkspaceRoot,
+      path: activeDraftAbsolutePath ?? activeDraftRelativePath,
+      kind: 'text',
+      onTextSnapshot: (snapshot) => {
+        void syncActiveSddDraftFromDisk(snapshot)
+      },
+      onImageChanged: () => undefined,
+      onError: (message) => {
+        useSddDraftStore.getState().setSaveStatus('error', message)
+      }
+    })
+  }, [activeDraftAbsolutePath, activeDraftId, activeDraftRelativePath, activeDraftWorkspaceRoot])
 
   if (!activeDraft) {
     return (
@@ -175,6 +235,11 @@ export function SddDraftEditorView({
               >
                 <Save className="h-4 w-4" strokeWidth={1.85} />
               </button>
+              <SddAssistantToggleButton
+                assistantOpen={assistantOpen}
+                onToggleAssistant={onToggleAssistant}
+                label={t('sddAssistant')}
+              />
               <button
                 type="button"
                 onClick={onNext}

--- a/src/renderer/src/sdd/sdd-draft-actions.ts
+++ b/src/renderer/src/sdd/sdd-draft-actions.ts
@@ -1,5 +1,65 @@
 import { useSddDraftStore } from './sdd-draft-store'
 
+type SddDraftDiskSnapshot = {
+  path?: string
+  content?: string
+  size?: number
+  truncated?: boolean
+  message?: string
+}
+
+function normalizePath(value: string): string {
+  return value.trim().replaceAll('\\', '/').replace(/\/+$/, '')
+}
+
+function snapshotMatchesActiveDraft(path: string): boolean {
+  const draft = useSddDraftStore.getState().activeDraft
+  if (!draft) return false
+  const normalized = normalizePath(path)
+  const relativePath = normalizePath(draft.relativePath)
+  const candidates = [
+    draft.absolutePath,
+    draft.relativePath,
+    `${draft.workspaceRoot}/${draft.relativePath}`
+  ]
+    .filter((value): value is string => Boolean(value))
+    .map(normalizePath)
+  return candidates.includes(normalized) || normalized.endsWith(`/${relativePath}`)
+}
+
+export async function syncActiveSddDraftFromDisk(snapshot: SddDraftDiskSnapshot): Promise<boolean> {
+  const state = useSddDraftStore.getState()
+  const draft = state.activeDraft
+  if (!draft) return false
+  if (state.saveStatus === 'dirty' || state.saveStatus === 'saving') return false
+  if (snapshot.path && !snapshotMatchesActiveDraft(snapshot.path)) return false
+
+  if (snapshot.message) {
+    useSddDraftStore.getState().setSaveStatus('error', snapshot.message)
+    return false
+  }
+
+  let content = snapshot.content
+  if (typeof content !== 'string') {
+    const result = await window.dsGui.readWorkspaceFile({
+      workspaceRoot: draft.workspaceRoot,
+      path: draft.relativePath
+    })
+    if (!result.ok) {
+      useSddDraftStore.getState().setSaveStatus('error', result.message)
+      return false
+    }
+    content = result.content
+  }
+
+  const latest = useSddDraftStore.getState()
+  if (latest.activeDraft?.id !== draft.id) return false
+  if (latest.saveStatus === 'dirty' || latest.saveStatus === 'saving') return false
+
+  latest.markSaved(content)
+  return true
+}
+
 export async function saveActiveSddDraftToDisk(): Promise<boolean> {
   const snapshot = useSddDraftStore.getState()
   const draft = snapshot.activeDraft

--- a/src/renderer/src/sdd/sdd-draft-store.test.ts
+++ b/src/renderer/src/sdd/sdd-draft-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSddDraft, readRememberedSddDraft, useSddDraftStore } from './sdd-draft-store'
-import { saveActiveSddDraftToDisk } from './sdd-draft-actions'
+import { saveActiveSddDraftToDisk, syncActiveSddDraftFromDisk } from './sdd-draft-actions'
 
 const SDD_DRAFT_REGISTRY_STORAGE_KEY = 'deepseekgui.sdd.draft.registry.v1'
 
@@ -131,6 +131,53 @@ describe('sdd-draft-store', () => {
       content: '# Draft updated',
       lastSavedContent: '# Draft updated',
       saveStatus: 'saved'
+    })
+  })
+
+  it('refreshes a clean active draft from disk changes', async () => {
+    const draft = createSddDraft({
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      workspaceRoot: '/tmp/app',
+      absolutePath: '/tmp/app/.kunsdd/draft/123e4567-e89b-12d3-a456-426614174000/requirement.md',
+      now: 1
+    })
+    useSddDraftStore.getState().setActiveDraft(draft, '# Draft')
+
+    await expect(syncActiveSddDraftFromDisk({
+      path: '/tmp/app/.kunsdd/draft/123e4567-e89b-12d3-a456-426614174000/requirement.md',
+      content: '# Draft updated by AI',
+      size: 21,
+      truncated: false
+    })).resolves.toBe(true)
+
+    expect(useSddDraftStore.getState()).toMatchObject({
+      content: '# Draft updated by AI',
+      lastSavedContent: '# Draft updated by AI',
+      saveStatus: 'saved'
+    })
+  })
+
+  it('does not overwrite unsaved draft edits with disk changes', async () => {
+    const draft = createSddDraft({
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      workspaceRoot: '/tmp/app',
+      absolutePath: '/tmp/app/.kunsdd/draft/123e4567-e89b-12d3-a456-426614174000/requirement.md',
+      now: 1
+    })
+    useSddDraftStore.getState().setActiveDraft(draft, '# Draft')
+    useSddDraftStore.getState().setContent('# Local unsaved draft')
+
+    await expect(syncActiveSddDraftFromDisk({
+      path: '/tmp/app/.kunsdd/draft/123e4567-e89b-12d3-a456-426614174000/requirement.md',
+      content: '# External draft',
+      size: 16,
+      truncated: false
+    })).resolves.toBe(false)
+
+    expect(useSddDraftStore.getState()).toMatchObject({
+      content: '# Local unsaved draft',
+      lastSavedContent: '# Draft',
+      saveStatus: 'dirty'
     })
   })
 


### PR DESCRIPTION
## Summary

- Fixes #102.
- Refresh SDD requirement drafts when the underlying file changes on disk.
- Add a visible Requirement AI button in the SDD draft toolbar so the right panel can be reopened after collapsing.

## Why

- Requirement drafts could become stale when an AI edit changed the draft file outside the editor.
- The Requirement AI panel could be collapsed, but there was no obvious control in the SDD draft view to open it again.

## Changes

- Reuse the existing workspace file watcher for active SDD drafts.
- Sync clean SDD drafts from disk changes while preserving unsaved local edits.
- Add a toolbar button to toggle the Requirement AI panel.
- Add regression tests for disk refresh behavior and the Requirement AI reopen control.

## 中文说明

修复 issue #102 里提到的两个问题：

1. 新建需求后的中间需求草稿编辑器现在会监听对应文件变化。如果AI修改了需求文件，编辑器会自动同步最新内容。
2. 右侧“需求AI”面板收起后，现在可以通过需求草稿顶部的按钮重新打开。

实现保持小范围改动：复用已有文件监听机制，不新增独立watcher；同步时不会覆盖用户本地未保存内容。

## Media

- Not attached. Small toolbar/UI state change covered by regression test.

## Tests

- Added SDD draft store tests for disk refresh and preserving unsaved local edits.
- Added SDD draft editor toolbar test for the Requirement AI reopen control.

## Validation

- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run dev`
- [ ] UI change: video or GIF attached
- [x] Logic change: unit tests added or updated

## Notes

- `npm run lint` passes with 0 errors and 7 existing warnings unrelated to this change.
- `npm run dev` started successfully at `http://localhost:5173/`.