### PR TITLE
feat: insert dropped file paths into composer textarea

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import type { DsGuiApi } from '../shared/ds-gui-api'
 
 const api = {
@@ -161,7 +161,8 @@ const api = {
   logError: (category, message, detail) =>
     ipcRenderer.invoke('log:error', { category, message, detail }),
   getLogPath: () => ipcRenderer.invoke('log:get-path'),
-  openLogDir: () => ipcRenderer.invoke('log:open-dir')
+  openLogDir: () => ipcRenderer.invoke('log:open-dir'),
+  getPathForFile: (file: File) => webUtils.getPathForFile(file)
 } satisfies DsGuiApi
 
 contextBridge.exposeInMainWorld('dsGui', api)

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -1174,17 +1174,59 @@ export function FloatingComposer({
   }
 
   const handleComposerDragOver = (event: ReactDragEvent<HTMLDivElement>): void => {
-    if (!canPickAttachment || !imageTransferHasImages(event.dataTransfer)) return
+    const transferHasFiles = Array.from(event.dataTransfer.types ?? []).includes('Files')
+    const canAcceptImages = canPickAttachment && imageTransferHasImages(event.dataTransfer)
+    if (!transferHasFiles && !canAcceptImages) return
     event.preventDefault()
     event.dataTransfer.dropEffect = 'copy'
   }
 
+  const insertPathsAtCursor = (paths: string[]): void => {
+    if (paths.length === 0) return
+    const textarea = draft.textareaRef.current
+    const currentValue = input
+    const selectionStart = textarea?.selectionStart ?? composerCursor ?? currentValue.length
+    const selectionEnd = textarea?.selectionEnd ?? selectionStart
+    const before = currentValue.slice(0, selectionStart)
+    const after = currentValue.slice(selectionEnd)
+    const needsLeadingSpace = before.length > 0 && !/\s$/.test(before)
+    const needsTrailingSpace = after.length > 0 && !/^\s/.test(after)
+    const insertion = `${needsLeadingSpace ? ' ' : ''}${paths.join(' ')}${needsTrailingSpace ? ' ' : ''}`
+    const nextInput = `${before}${insertion}${after}`
+    const nextCursor = before.length + insertion.length - (needsTrailingSpace ? 1 : 0)
+    setInput(nextInput)
+    window.requestAnimationFrame(() => {
+      const el = draft.textareaRef.current
+      if (!el) return
+      el.focus()
+      el.setSelectionRange(nextCursor, nextCursor)
+      setComposerCursor(nextCursor)
+    })
+  }
+
   const handleComposerDrop = (event: ReactDragEvent<HTMLDivElement>): void => {
-    if (!canPickAttachment || !onPickAttachments) return
-    const files = imageFilesFromTransfer(event.dataTransfer)
-    if (files.length === 0) return
+    const imageFiles = canPickAttachment ? imageFilesFromTransfer(event.dataTransfer) : []
+    const rawFiles = Array.from(event.dataTransfer.files ?? [])
+    const isImageLike = (file: File): boolean =>
+      isImageMimeType(file.type) || Boolean(imageMimeTypeFromFileName(file.name))
+    const pathFiles = rawFiles.filter((file) => !isImageLike(file))
+    if (imageFiles.length === 0 && pathFiles.length === 0) return
     event.preventDefault()
-    onPickAttachments(files)
+    if (imageFiles.length > 0 && onPickAttachments) {
+      onPickAttachments(imageFiles)
+    }
+    if (pathFiles.length > 0) {
+      const paths: string[] = []
+      for (const file of pathFiles) {
+        try {
+          const path = window.dsGui.getPathForFile(file)
+          if (path) paths.push(path)
+        } catch {
+          // ignore files we can't resolve a path for
+        }
+      }
+      insertPathsAtCursor(paths)
+    }
     draft.focusComposer()
   }
 

--- a/src/shared/ds-gui-api.ts
+++ b/src/shared/ds-gui-api.ts
@@ -222,4 +222,5 @@ export type DsGuiApi = {
   logError: (category: string, message: string, detail?: unknown) => Promise<void>
   getLogPath: () => Promise<string>
   openLogDir: () => Promise<{ ok: boolean; message?: string }>
+  getPathForFile: (file: File) => string
 }


### PR DESCRIPTION
## 摘要

拖拽非图片文件到「向智能体提问」输入框时被静默丢弃。这个 PR 让 textarea 在光标位置插入文件的绝对路径(图片仍走原有附件流程)。

## 改动

- `src/preload/index.ts` / `src/shared/ds-gui-api.ts` — 暴露 `getPathForFile`(Electron 32+ 移除了 `File.path`,需走 `webUtils.getPathForFile`)
- `src/renderer/src/components/chat/FloatingComposer.tsx` — `dragover` / `drop` 按 MIME 区分图片/非图片;非图片用 `getPathForFile` 取绝对路径,空格分隔插入到 textarea 光标位置,自动补两侧空格

## Test plan

- [x] 拖一个 `.ts` 文件 → 光标位置出现绝对路径
- [x] 拖多个文件 → 路径之间用空格分隔
- [x] 拖文件夹 → 出现文件夹的绝对路径,不展开内部文件
- [x] 拖 png/jpg → 仍走附件流程,出现缩略图
- [x] 拖到已有文本中间 → 路径前后自动补空格,光标停在路径末尾
- [x] 拖到空输入框 → 路径前后不强加空格