### PR TITLE
fix: bash poll action waits for output/exit (fixes #94)

### DIFF
--- a/kun/src/adapters/tool/builtin-bash-tool.ts
+++ b/kun/src/adapters/tool/builtin-bash-tool.ts
@@ -501,7 +501,7 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
   const shellRuntime = shellRuntimeInfo()
   return LocalToolHost.defineTool({
     name: 'bash',
-    description: `Execute a shell command in the workspace using the host platform shell. Current shell: ${shellRuntime.name}. Use ${shellRuntime.syntax} syntax. Return combined stdout and stderr. Long-running commands return a session_id; use action="poll" to read more output, action="write" with input to send stdin, or action="stop" to terminate the session.`,
+    description: `Execute a shell command in the workspace using the host platform shell. Current shell: ${shellRuntime.name}. Use ${shellRuntime.syntax} syntax. Return combined stdout and stderr. Long-running commands return a session_id; use action="poll" to wait up to yield_seconds (default ${DEFAULT_BASH_YIELD_SECONDS}s, max ${MAX_BASH_YIELD_SECONDS}s) for more output or process exit, action="write" with input to send stdin, or action="stop" to terminate the session.`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -546,6 +546,7 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
           const payload = await sessionPayload(session, { stopSent: true })
           return { output: payload, isError: session.status === 'running' || session.status === 'failed' }
         }
+        await waitForSessionExitOrDelay(session, normalizeYieldSeconds(args.yield_seconds) * 1000)
         return { output: await sessionPayload(session), isError: session.status === 'failed' }
       }
 

--- a/kun/tests/builtin-tools.test.ts
+++ b/kun/tests/builtin-tools.test.ts
@@ -383,6 +383,51 @@ describe('Kun built-in tools', () => {
     expect(String(polled.output)).toContain('done')
   })
 
+  it('waits for the running bash session during poll until yield_seconds elapses', async () => {
+    const output = await executeTool(host, workspace, 'bash', {
+      command: 'echo ready; sleep 5; echo done',
+      yield_seconds: 1,
+      timeout: 10
+    })
+    expect(output.status).toBe('running')
+
+    const startedAt = Date.now()
+    const polled = await executeTool(host, workspace, 'bash', {
+      action: 'poll',
+      session_id: String(output.session_id),
+      yield_seconds: 2
+    })
+    const elapsed = Date.now() - startedAt
+    expect(elapsed).toBeGreaterThanOrEqual(1800)
+    expect(polled.status).toBe('running')
+
+    await executeTool(host, workspace, 'bash', {
+      action: 'stop',
+      session_id: String(output.session_id)
+    })
+  })
+
+  it('returns early from poll when the session exits before yield_seconds', async () => {
+    const output = await executeTool(host, workspace, 'bash', {
+      command: 'echo ready; sleep 1; echo done',
+      yield_seconds: 1,
+      timeout: 10
+    })
+    expect(output.status).toBe('running')
+
+    const startedAt = Date.now()
+    const polled = await executeTool(host, workspace, 'bash', {
+      action: 'poll',
+      session_id: String(output.session_id),
+      yield_seconds: 10
+    })
+    const elapsed = Date.now() - startedAt
+    expect(elapsed).toBeLessThan(3000)
+    expect(polled.status).toBe('completed')
+    expect(polled.exit_code).toBe(0)
+    expect(String(polled.output)).toContain('done')
+  })
+
   it('includes the active shell in bash partial updates', async () => {
     const updates: TurnItem[] = []
     const result = await host.execute(


### PR DESCRIPTION
## 摘要

`bash` 工具的 `action="poll"` 没有真的等待,立即返回当前快照,所以模型说"等 70 秒再轮询"时实际上零延时连续触发,远端脚本根本来不及产出。

修成 `poll` 等待最多 `yield_seconds` 秒(默认 10s,上限 60s,下限 1s),或进程提前退出立刻返回——和 `write` / `stop` 已有的 `waitForSessionExitOrDelay` 行为一致。

Fixes #94

## 改动

- `kun/src/adapters/tool/builtin-bash-tool.ts` — `poll` 分支返回 payload 前调用 `waitForSessionExitOrDelay(session, yield_seconds * 1000)`;工具描述补上等待语义说明
- `kun/tests/builtin-tools.test.ts` — 两个回归用例:poll 阻塞 ≥ yield_seconds、会话在 yield_seconds 内退出时 poll 提前返回

## Test plan

- [x] 新增的两个 vitest 用例通过
- [x] `sleep 5 && echo done` 后立刻 `poll yield_seconds=10` → 墙钟 ≥ ~5s,`status="completed"`,output 含 `done`
- [x] `sleep 60` 后 `poll yield_seconds=2` → 墙钟 ≈ 2s,`status="running"`
- [x] 复现 #94 场景:`ssh host long-running-script` 多次 poll,"等 X 秒"真的耗墙钟时间