### PR TITLE
fix(web-fetch): keep content-length guard and use streaming for unknown-length responses

### DIFF
--- a/kun/src/adapters/tool/web-tool-provider.ts
+++ b/kun/src/adapters/tool/web-tool-provider.ts
@@ -211,16 +211,11 @@ class FetchWebProvider implements WebProvider {
     try {
       const response = await fetch(request.url, { signal: controller.signal })
       if (!response.ok) throw new Error(`HTTP ${response.status}`)
-      const contentLength = response.headers.get('content-length')
-      if (contentLength && Number(contentLength) > request.maxBytes) {
-        throw new Error(`content exceeds ${request.maxBytes} byte limit`)
-      }
       const buffer = Buffer.from(await response.arrayBuffer())
-      if (buffer.length > request.maxBytes) {
-        throw new Error(`content exceeds ${request.maxBytes} byte limit`)
-      }
+      const truncated = buffer.length > request.maxBytes
+      const readableBuffer = truncated ? buffer.subarray(0, request.maxBytes) : buffer
       const contentType = response.headers.get('content-type') ?? undefined
-      const raw = buffer.toString('utf8')
+      const raw = readableBuffer.toString('utf8')
       const extracted = extractReadableText(raw, contentType)
       const finalUrl = response.url || request.url
       return {
@@ -232,7 +227,7 @@ class FetchWebProvider implements WebProvider {
         text: extracted.text,
         retrievedAt: this.nowIso(),
         byteCount: buffer.length,
-        truncated: false
+        truncated
       }
     } finally {
       clearTimeout(timeout)

--- a/kun/src/adapters/tool/web-tool-provider.ts
+++ b/kun/src/adapters/tool/web-tool-provider.ts
@@ -211,11 +211,47 @@ class FetchWebProvider implements WebProvider {
     try {
       const response = await fetch(request.url, { signal: controller.signal })
       if (!response.ok) throw new Error(`HTTP ${response.status}`)
-      const buffer = Buffer.from(await response.arrayBuffer())
-      const truncated = buffer.length > request.maxBytes
-      const readableBuffer = truncated ? buffer.subarray(0, request.maxBytes) : buffer
+
+      // Fast-fail if content-length is known and exceeds limit
+      const contentLength = response.headers.get('content-length')
+      if (contentLength && Number(contentLength) > request.maxBytes) {
+        throw new Error(`content exceeds ${request.maxBytes} byte limit`)
+      }
+
+      // Stream response body with size limit
+      const reader = response.body?.getReader()
+      if (!reader) throw new Error('response body is not readable')
+
+      const chunks: Uint8Array[] = []
+      let totalBytes = 0
+      let truncated = false
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        const remaining = request.maxBytes - totalBytes
+        if (remaining <= 0) {
+          truncated = true
+          reader.cancel()
+          break
+        }
+
+        if (value.length > remaining) {
+          chunks.push(value.subarray(0, remaining))
+          totalBytes += remaining
+          truncated = true
+          reader.cancel()
+          break
+        }
+
+        chunks.push(value)
+        totalBytes += value.length
+      }
+
+      const buffer = Buffer.concat(chunks)
       const contentType = response.headers.get('content-type') ?? undefined
-      const raw = readableBuffer.toString('utf8')
+      const raw = buffer.toString('utf8')
       const extracted = extractReadableText(raw, contentType)
       const finalUrl = response.url || request.url
       return {
@@ -226,7 +262,7 @@ class FetchWebProvider implements WebProvider {
         contentType,
         text: extracted.text,
         retrievedAt: this.nowIso(),
-        byteCount: buffer.length,
+        byteCount: totalBytes,
         truncated
       }
     } finally {

--- a/kun/tests/web-tool-provider.test.ts
+++ b/kun/tests/web-tool-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { CapabilityRegistry } from '../src/adapters/tool/capability-registry.js'
 import { LocalToolHost } from '../src/adapters/tool/local-tool-host.js'
 import { buildWebToolProviders } from '../src/adapters/tool/web-tool-provider.js'
@@ -48,6 +48,10 @@ function deterministicProvider() {
 }
 
 describe('Web tool provider', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('does not advertise web tools when web access is disabled', async () => {
     const config = KunCapabilitiesConfig.parse({})
     const built = buildWebToolProviders(config.web, { provider: deterministicProvider() })
@@ -101,6 +105,45 @@ describe('Web tool provider', () => {
         policy: 'allowed',
         provider: 'test-search',
         byteCount: 20
+      })
+    }
+  })
+
+  it('truncates oversized fetch responses instead of failing', async () => {
+    vi.stubGlobal('fetch', async () => new Response('abcdefghijklmnopqrstuvwxyz', {
+      headers: {
+        'content-length': '26',
+        'content-type': 'text/plain'
+      }
+    }))
+    const config = KunCapabilitiesConfig.parse({
+      web: {
+        enabled: true,
+        fetchEnabled: true,
+        allowDomains: ['docs.example.test']
+      }
+    })
+    const host = new LocalToolHost({
+      registry: new CapabilityRegistry(buildWebToolProviders(config.web).providers)
+    })
+
+    const result = await host.execute({
+      callId: 'call_1',
+      toolName: 'web_fetch',
+      arguments: { url: 'https://docs.example.test/large', max_bytes: 10 }
+    }, buildContext())
+
+    expect(result.item).toMatchObject({ kind: 'tool_result', isError: false })
+    if (result.item.kind === 'tool_result') {
+      expect(result.item.output).toMatchObject({
+        text: 'abcdefghij',
+        byteCount: 26,
+        truncated: true,
+        telemetry: {
+          policy: 'allowed',
+          provider: 'fetch',
+          byteCount: 26
+        }
       })
     }
   })

--- a/kun/tests/web-tool-provider.test.ts
+++ b/kun/tests/web-tool-provider.test.ts
@@ -109,10 +109,48 @@ describe('Web tool provider', () => {
     }
   })
 
-  it('truncates oversized fetch responses instead of failing', async () => {
+  it('rejects fetch responses when content-length exceeds max_bytes', async () => {
     vi.stubGlobal('fetch', async () => new Response('abcdefghijklmnopqrstuvwxyz', {
       headers: {
         'content-length': '26',
+        'content-type': 'text/plain'
+      }
+    }))
+    const config = KunCapabilitiesConfig.parse({
+      web: {
+        enabled: true,
+        fetchEnabled: true,
+        allowDomains: ['docs.example.test']
+      }
+    })
+    const host = new LocalToolHost({
+      registry: new CapabilityRegistry(buildWebToolProviders(config.web).providers)
+    })
+
+    const result = await host.execute({
+      callId: 'call_1',
+      toolName: 'web_fetch',
+      arguments: { url: 'https://docs.example.test/large', max_bytes: 10 }
+    }, buildContext())
+
+    expect(result.item).toMatchObject({ kind: 'tool_result', isError: true })
+    if (result.item.kind === 'tool_result') {
+      expect(result.item.output).toMatchObject({
+        error: {
+          code: 'fetch_failed',
+          message: expect.stringContaining('content exceeds')
+        },
+        telemetry: {
+          policy: 'allowed',
+          provider: 'fetch'
+        }
+      })
+    }
+  })
+
+  it('truncates oversized fetch responses via streaming when content-length is unknown', async () => {
+    vi.stubGlobal('fetch', async () => new Response('abcdefghijklmnopqrstuvwxyz', {
+      headers: {
         'content-type': 'text/plain'
       }
     }))
@@ -137,12 +175,12 @@ describe('Web tool provider', () => {
     if (result.item.kind === 'tool_result') {
       expect(result.item.output).toMatchObject({
         text: 'abcdefghij',
-        byteCount: 26,
+        byteCount: 10,
         truncated: true,
         telemetry: {
           policy: 'allowed',
           provider: 'fetch',
-          byteCount: 26
+          byteCount: 10
         }
       })
     }


### PR DESCRIPTION
## Summary

Address review comments on PR #58 by implementing safer web fetch truncation.

## Changes

- **Keep content-length fast-fail check**: When  header is available and exceeds , throw error immediately (preserves existing protection)
- **Streaming with size limit**: For responses without , use streaming reads and abort once  is reached
- **Memory/bandwidth protection**: Prevents downloading entire large responses before truncating
- **Updated tests**: Cover both content-length rejection and streaming truncation cases

## Review Comments Addressed

This PR addresses the review comments from @XingYu-Zhong on PR #58:

> The blocker is not the idea of truncation itself, but that the current implementation removes the existing size protection without replacing it with an equivalent safe mechanism.

This implementation:
1. Keeps the  early check when available
2. Uses streaming with abort for unknown-length responses
3. Returns  when stream was limited

## Tests

- 
> kun@0.1.0 test
> vitest run tests/web-tool-provider.test.ts


 RUN  v4.1.8 /Users/huqiantao/TRAE/deepseek-gui/kun


 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  22:13:18
   Duration  281ms (transform 117ms, setup 0ms, import 179ms, tests 19ms, environment 0ms) ✓
- 
> kun@0.1.0 typecheck
> tsc --noEmit -p tsconfig.json ✓