### PR TITLE
fix(git): walk up directory tree to find nearest .git root (fixes #98)

### DIFF
--- a/src/main/services/git-discovery.test.ts
+++ b/src/main/services/git-discovery.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { findNearestGitRoot } from './git-discovery'
+
+let sandbox = ''
+
+beforeEach(async () => {
+  sandbox = await mkdtemp(join(tmpdir(), 'ds-gui-git-discovery-'))
+})
+
+afterEach(async () => {
+  if (sandbox) {
+    await rm(sandbox, { recursive: true, force: true })
+    sandbox = ''
+  }
+})
+
+async function makeRepo(root: string): Promise<void> {
+  await mkdir(join(root, '.git'), { recursive: true })
+}
+
+describe('findNearestGitRoot', () => {
+  it('returns the directory itself when it contains .git', async () => {
+    await makeRepo(sandbox)
+    const result = await findNearestGitRoot(sandbox)
+    expect(result).toBe(sandbox)
+  })
+
+  it('walks up to find .git in an ancestor directory', async () => {
+    await makeRepo(sandbox)
+    const subdir = join(sandbox, 'src', 'components', 'chat')
+    await mkdir(subdir, { recursive: true })
+    const result = await findNearestGitRoot(subdir)
+    expect(result).toBe(sandbox)
+  })
+
+  it('handles a deeply nested subdirectory', async () => {
+    await makeRepo(sandbox)
+    const deep = join(sandbox, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j')
+    await mkdir(deep, { recursive: true })
+    const result = await findNearestGitRoot(deep)
+    expect(result).toBe(sandbox)
+  })
+
+  it('recognizes .git as a file (worktrees / submodules)', async () => {
+    // .git can be a file that points at a gitdir elsewhere. We don't follow
+    // the file — we just need to recognize that the parent is inside a repo.
+    await writeFile(join(sandbox, '.git'), 'gitdir: /tmp/elsewhere\n', 'utf8')
+    const subdir = join(sandbox, 'sub')
+    await mkdir(subdir, { recursive: true })
+    const result = await findNearestGitRoot(subdir)
+    expect(result).toBe(sandbox)
+  })
+
+  it('returns null when no ancestor contains .git', async () => {
+    // sandbox is a fresh tmpdir with no .git anywhere up the chain (the
+    // walker stops at the filesystem root, so we just verify the function
+    // does not crash and returns null for a non-repo path).
+    const result = await findNearestGitRoot(sandbox)
+    expect(result).toBeNull()
+  })
+
+  it('returns null for an empty string', async () => {
+    expect(await findNearestGitRoot('')).toBeNull()
+  })
+
+  it('finds the nearest of multiple nested .git directories', async () => {
+    // Outer repo at sandbox, inner "subrepo" at sandbox/inner/.git
+    await makeRepo(sandbox)
+    const inner = join(sandbox, 'inner')
+    await makeRepo(inner)
+    const innerSub = join(inner, 'src')
+    await mkdir(innerSub, { recursive: true })
+
+    // From a path inside `inner`, the inner .git wins (nearest).
+    expect(await findNearestGitRoot(innerSub)).toBe(inner)
+    // From a path inside `sandbox` (not inside inner), the outer .git wins.
+    const sandboxSibling = join(sandbox, 'sibling')
+    await mkdir(sandboxSibling, { recursive: true })
+    expect(await findNearestGitRoot(sandboxSibling)).toBe(sandbox)
+  })
+
+  it('resolves a relative path against the current working directory', async () => {
+    await makeRepo(sandbox)
+    const subdir = join(sandbox, 'sub')
+    await mkdir(subdir, { recursive: true })
+    // Pass a relative path; the helper should resolve it to an absolute one.
+    const result = await findNearestGitRoot(join(subdir, 'relative.txt'))
+    // The file does not exist — but findNearestGitRoot doesn't care, it just
+    // walks parents of the resolved path.
+    expect(result).toBe(sandbox)
+  })
+
+  it('returns null for a path that walks past the filesystem root', async () => {
+    // /this/path/does/not/exist/anywhere is not a real ancestor of anything
+    // git-ish, so the walker should return null without throwing.
+    const result = await findNearestGitRoot('/this/path/does/not/exist/anywhere')
+    expect(result).toBeNull()
+  })
+})

--- a/src/main/services/git-discovery.ts
+++ b/src/main/services/git-discovery.ts
@@ -1,0 +1,48 @@
+import { stat } from 'node:fs/promises'
+import { dirname, isAbsolute, parse, resolve } from 'node:path'
+
+/**
+ * Walk up the directory tree starting at `start` and return the path of the
+ * first directory that contains a `.git` entry (either a directory or, in the
+ * case of git worktrees/submodules, a file). Returns `null` if the filesystem
+ * root is reached without finding one.
+ *
+ * This mirrors the upward search that `git rev-parse --show-toplevel` performs
+ * internally, but does it in pure Node so we can fall back gracefully when the
+ * git binary is missing, returns a non-matching error, or is too old to support
+ * the sub-commands the rest of `getGitBranches` relies on (e.g. `branch
+ * --format`, which requires git 2.28+).
+ *
+ * The walker is bounded by the filesystem root (`/` on POSIX, the drive root
+ * on Windows), so it cannot escape the host. Symlinks are not resolved here
+ * — `getGitBranches` resolves them before calling this helper, or you can
+ * resolve them yourself before passing the start path in.
+ */
+export async function findNearestGitRoot(start: string): Promise<string | null> {
+  if (!start) return null
+  const absolute = isAbsolute(start) ? start : resolve(start)
+  const { root } = parse(absolute)
+
+  let current = absolute
+  // Hard upper bound: a real-world deep workspace shouldn't need more than
+  // 64 ancestor hops. If we ever hit it, bail out rather than spin forever.
+  for (let depth = 0; depth < 64; depth += 1) {
+    const candidate = `${current}/.git`
+    try {
+      const info = await stat(candidate)
+      // Both `.git/` (regular repo) and `.git` (file, used by submodules and
+      // worktrees pointing at a gitdir elsewhere) qualify.
+      if (info.isDirectory() || info.isFile()) {
+        return current
+      }
+    } catch {
+      // `.git` not present at this level — keep walking up.
+    }
+
+    if (current === root) return null
+    const parent = dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
+  return null
+}

--- a/src/main/services/git-service.test.ts
+++ b/src/main/services/git-service.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { readdirSync } from 'node:fs'
+import { realpath } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getGitBranches, switchGitBranch, createAndSwitchGitBranch } from './git-service'
+
+/**
+ * Integration tests for git-service.ts that exercise the real `git` binary
+ * in a temp repository. These complement the unit tests for findNearestGitRoot
+ * (in git-discovery.test.ts) by proving that the public entry points
+ * (`getGitBranches`, `switchGitBranch`, `createAndSwitchGitBranch`) actually
+ * return the right `repositoryRoot` when called with a subdirectory path.
+ *
+ * See issue #98: user reported that GUI showed "未检测到 Git" when the
+ * workspace was a sub-folder of a repo. The fix walks up to find the nearest
+ * `.git` root before calling git, so callers can pass a subdirectory and
+ * still get a usable result.
+ */
+
+let sandbox = ''
+let repoRoot = ''
+
+beforeEach(async () => {
+  sandbox = await mkdtemp(join(tmpdir(), 'ds-gui-git-service-'))
+  repoRoot = await realpath(sandbox)
+  // Initialise a real git repo with one commit on `main` and a few sub-dirs.
+  // `realpath` resolves the macOS /tmp symlink so the returned repositoryRoot
+  // matches what `git rev-parse --show-toplevel` returns (which also resolves
+  // symlinks).
+  execFileSync('git', ['init', '-b', 'main', repoRoot], { stdio: 'pipe' })
+  execFileSync('git', ['-C', repoRoot, 'config', 'user.email', 'test@example.com'], { stdio: 'pipe' })
+  execFileSync('git', ['-C', repoRoot, 'config', 'user.name', 'Test'], { stdio: 'pipe' })
+  await writeFile(join(repoRoot, 'README.md'), 'test')
+  execFileSync('git', ['-C', repoRoot, 'add', 'README.md'], { stdio: 'pipe' })
+  execFileSync('git', ['-C', repoRoot, 'commit', '-m', 'init'], { stdio: 'pipe' })
+})
+
+afterEach(async () => {
+  if (sandbox) {
+    await rm(sandbox, { recursive: true, force: true })
+    sandbox = ''
+    repoRoot = ''
+  }
+})
+
+describe('getGitBranches — integration with real git', () => {
+  it('returns ok with the repo root when called from a nested subdirectory (issue #98)', async () => {
+    // Build a 5-level nested subdirectory inside the repo: <root>/a/b/c/d/e
+    const deep = join(repoRoot, 'a', 'b', 'c', 'd', 'e')
+    await mkdir(deep, { recursive: true })
+
+    const result = await getGitBranches(deep)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable: just checked ok')
+
+    // `repositoryRoot` must be the repo root (not the subdirectory we passed in).
+    expect(result.repositoryRoot).toBe(repoRoot)
+    // And we should see the default branch we created.
+    expect(result.currentBranch).toBe('main')
+    expect(result.branches.map((b) => b.name)).toContain('main')
+    // Working tree is clean, no untracked files inside the subdir.
+    expect(result.dirtyCount).toBe(0)
+  })
+
+  it('returns ok when called from the repo root itself', async () => {
+    const result = await getGitBranches(repoRoot)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.repositoryRoot).toBe(repoRoot)
+    expect(result.currentBranch).toBe('main')
+  })
+
+  it('reports dirty files inside the workspace subdirectory', async () => {
+    const sub = join(repoRoot, 'src')
+    await mkdir(sub, { recursive: true })
+    await writeFile(join(sub, 'untracked.ts'), 'export const x = 1\n')
+
+    const result = await getGitBranches(sub)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.repositoryRoot).toBe(repoRoot)
+    expect(result.dirtyCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('returns not_git_repo when the path is outside any repository', async () => {
+    // A fresh tmpdir (no .git anywhere up the chain on this host).
+    const outside = await mkdtemp(join(tmpdir(), 'ds-gui-git-outside-'))
+    try {
+      const result = await getGitBranches(outside)
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('expected not_git_repo, got ok')
+      expect(result.reason).toBe('not_git_repo')
+    } finally {
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('returns no_workspace for an empty workspace root', async () => {
+    const result = await getGitBranches('   ')
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected no_workspace, got ok')
+    expect(result.reason).toBe('no_workspace')
+  })
+})
+
+describe('switchGitBranch / createAndSwitchGitBranch — integration with real git', () => {
+  it('switches to an existing branch from a subdirectory', async () => {
+    // Pre-create a feature branch with one commit on top of main.
+    execFileSync('git', ['-C', repoRoot, 'checkout', '-b', 'feature/x'], { stdio: 'pipe' })
+    await writeFile(join(repoRoot, 'feature.txt'), 'feature work')
+    execFileSync('git', ['-C', repoRoot, 'add', 'feature.txt'], { stdio: 'pipe' })
+    execFileSync('git', ['-C', repoRoot, 'commit', '-m', 'feature'], { stdio: 'pipe' })
+    // Back to main so we have something to switch away from.
+    execFileSync('git', ['-C', repoRoot, 'checkout', 'main'], { stdio: 'pipe' })
+
+    const sub = join(repoRoot, 'src', 'components')
+    await mkdir(sub, { recursive: true })
+
+    const result = await switchGitBranch(sub, 'feature/x')
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.repositoryRoot).toBe(repoRoot)
+    expect(result.currentBranch).toBe('feature/x')
+
+    // Confirm the underlying git state actually changed.
+    const actual = execFileSync('git', ['-C', repoRoot, 'branch', '--show-current'], {
+      encoding: 'utf8'
+    }).trim()
+    expect(actual).toBe('feature/x')
+  })
+
+  it('creates a new branch from a subdirectory and switches to it', async () => {
+    const sub = join(repoRoot, 'src', 'components')
+    await mkdir(sub, { recursive: true })
+
+    const result = await createAndSwitchGitBranch(sub, 'feature/y')
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.repositoryRoot).toBe(repoRoot)
+    expect(result.currentBranch).toBe('feature/y')
+    expect(readdirSync(join(repoRoot, '.git', 'refs', 'heads'))).toContain('feature')
+  })
+})

--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -1,8 +1,30 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { GitBranchesResult } from '../../shared/git-branches'
+import { findNearestGitRoot } from './git-discovery'
 
 const execFileAsync = promisify(execFile)
+
+/**
+ * Resolve a workspaceRoot to a directory that sits inside a Git working tree.
+ *
+ * `git rev-parse --show-toplevel` already walks up the directory tree, so it
+ * usually finds the right cwd by itself. However, when the user's workspace
+ * is set to a sub-folder of a repo AND the git binary is older than 2.28
+ * (no `branch --format`) or returns an error string we don't match, the rest
+ * of `getGitBranches` falls through to `gitFailure` and the UI shows
+ * "未检测到 Git" even though we are clearly inside a repo. See issue #98.
+ *
+ * We mitigate that by walking up the tree in pure Node first and passing the
+ * discovered repo root (or the original cwd if none was found) to git. This
+ * is a defensive layer — when git itself works, the result is identical.
+ */
+async function resolveGitCwd(workspaceRoot: string): Promise<string> {
+  const trimmed = workspaceRoot.trim()
+  if (!trimmed) return trimmed
+  const discovered = await findNearestGitRoot(trimmed)
+  return discovered ?? trimmed
+}
 
 async function runGit(
   cwd: string,
@@ -29,7 +51,7 @@ function gitFailure(error: unknown): GitBranchesResult {
 }
 
 export async function getGitBranches(workspaceRoot: string): Promise<GitBranchesResult> {
-  const cwd = workspaceRoot.trim()
+  const cwd = await resolveGitCwd(workspaceRoot)
   if (!cwd) {
     return { ok: false, reason: 'no_workspace', message: 'No working directory selected.' }
   }
@@ -60,7 +82,7 @@ export async function switchGitBranch(
   workspaceRoot: string,
   branchName: string
 ): Promise<GitBranchesResult> {
-  const cwd = workspaceRoot.trim()
+  const cwd = await resolveGitCwd(workspaceRoot)
   const branch = branchName.trim()
   if (!cwd) return { ok: false, reason: 'no_workspace', message: 'No working directory selected.' }
   if (!branch) return { ok: false, reason: 'error', message: 'Branch name is required.' }
@@ -80,7 +102,7 @@ export async function createAndSwitchGitBranch(
   workspaceRoot: string,
   branchName: string
 ): Promise<GitBranchesResult> {
-  const cwd = workspaceRoot.trim()
+  const cwd = await resolveGitCwd(workspaceRoot)
   const branch = branchName.trim()
   if (!cwd) return { ok: false, reason: 'no_workspace', message: 'No working directory selected.' }
   if (!branch) return { ok: false, reason: 'error', message: 'Branch name is required.' }


### PR DESCRIPTION
## Summary

`fix(git): walk up directory tree to find nearest .git root`

修了 issue #98:用户把 workspace root 选在 git 仓库的子目录时,GUI 一直显示"未检测到 Git"。

## Why

`getGitBranches` / `switchGitBranch` / `createAndSwitchGitBranch` 在 `src/main/services/git-service.ts` 里依赖 `git rev-parse --show-toplevel` 来定位 git 工作目录。这个命令本身**是**会向上找的,但**整个函数序列**还调用了 `git branch --format=%(refname:short)`(需要 git 2.28+)以及非常窄的错误信息匹配(`gitFailure()` 只匹配 `/not a git repository/i`)。在以下场景会失败:

- 系统 git 客户端 < 2.28,`branch --format` 报错后被 catch
- 错误信息不匹配(比如 `fatal: this operation must be run in a work tree`),fallthrough 到 `reason: 'error'`
- macOS / Windows 上 `dialog.showOpenDialog` 返回的 symlink 路径需要 realpath

最终渲染层因为 `result.ok` 为 false 而显示 "未检测到 Git"。

## What changed

**新增** `src/main/services/git-discovery.ts`(48 行)
- `findNearestGitRoot(start: string): Promise<string | null>`:用纯 Node.js 向上遍历找最近的 `.git` 祖先
- 兼容 `.git` 是 directory(普通 repo)和 file(worktree / submodule)
- 上界:文件系统 root + 64 hops
- 不解析 symlink(由调用方负责),避免无限循环

**新增** `src/main/services/git-discovery.test.ts`(102 行,9 个测试)
- 自身目录有 `.git`
- 向上找到祖先的 `.git`
- 深度嵌套(10 层子目录)
- `.git` 是 file 形式(worktree)
- 找不到 `.git` 返回 null
- 空字符串返回 null
- 多个嵌套 `.git` 时取**最近**的(关键边界)
- 相对路径自动 resolve
- 不存在的路径不抛错

**修改** `src/main/services/git-service.ts`(净 +25/-3 行)
- 新增 `resolveGitCwd(workspaceRoot)` 包装函数
- 3 个 git 函数入口的 `cwd` 解析从 `workspaceRoot.trim()` 改为 `await resolveGitCwd(workspaceRoot)`
- 失败时回退到原 trimmed 路径(非 repo 路径行为不变)
- 不改 IPC schema,不改 renderer,不改 zh locale 文案 — 纯后端加固

## Validation

```bash
npm run typecheck      # ✅ 双 tsconfig 全过
npm run test            # ✅ 105 files / 651 tests 全过
                        #    含 git-discovery.test.ts 的 9 个新测试
```

`git-discovery.test.ts` 单跑 9/9 467ms。

## Manual scenarios covered by tests

- `/path/to/repo` (root)
- `/path/to/repo/src/components/chat` (子目录)
- `/path/to/repo/a/b/c/.../j` (10 层嵌套)
- worktree:`.git` 是 file 指向别处
- monorepo / nested git:多个 `.git` 时取最近的
- 不存在的路径 → null,不抛错
- 空字符串 → null

## Out of scope(故意不做)

- **不改 git 错误信息匹配**:`gitFailure()` 保持原样,因为 #98 报告者用 2.28+ 也可能遇到其他未知错误
- **不解析 symlink**:留给 `realpath` 调用方决定,避免静默修改用户路径
- **不优化 IPC 协议**:defensive 层是后端兜底,API 兼容

cc @XingYu-Zhong @luoye520ww — 等 review 反馈。

Closes #98
