### PR TITLE
fix: preserve sidebar chat history when viewing scheduled tasks

### DIFF
--- a/src/renderer/src/components/chat/Sidebar.tsx
+++ b/src/renderer/src/components/chat/Sidebar.tsx
@@ -193,11 +193,31 @@ export function Sidebar({
           t={t}
         />
       ) : activeView === 'schedule' ? (
-        <div className="ds-no-drag flex min-h-0 flex-1 flex-col px-2 pt-1">
-          <div className="px-1 text-[13px] font-normal text-ds-faint">
-            {t('schedule')}
-          </div>
-        </div>
+        <SidebarProjectsSection
+          threads={threads}
+          activeView="chat"
+          activeThreadId={activeThreadId}
+          runtimeReady={runtimeReady}
+          searchQuery={threadSearch}
+          showArchived={showArchivedThreads}
+          workspaceRoot={workspaceRoot}
+          workspaceRoots={codeWorkspaceRoots}
+          busy={busy}
+          watchTurnCompletion={watchTurnCompletion}
+          unreadThreadIds={unreadThreadIds}
+          locale={i18n.language}
+          onPickWorkspace={() => void chooseWorkspace()}
+          onRemoveWorkspace={deleteWorkspace}
+          onCreateThreadInWorkspace={onNewChatInWorkspace}
+          onSelectThread={onSelectThread}
+          onRenameThread={onRenameThread}
+          onArchiveThread={onArchiveThread}
+          onDeleteThread={onDeleteThread}
+          onRestoreThread={onRestoreThread}
+          onSearchQueryChange={onThreadSearchChange}
+          onShowArchivedChange={onShowArchivedThreadsChange}
+          t={t}
+        />
       ) : (
       <SidebarProjectsSection
         threads={threads}


### PR DESCRIPTION
## Summary

Re-apply the fix from PR #55 (reverted in PR #107) to show sidebar chat history when viewing scheduled tasks.

## Problem

When the schedule view is active, the sidebar shows an empty div with just the 'schedule' text label, hiding all chat history.

## Solution

Show the SidebarProjectsSection component when the schedule view is active, so users can still see and access their chat history while viewing scheduled tasks.

## Changes

- Replace empty div in schedule view with SidebarProjectsSection component
- Maintain all existing functionality for chat and write views

## Testing

- Verify sidebar shows chat history when schedule view is active
- Verify sidebar still works correctly for chat and write views