### PR TITLE
fix: center placeholder text and input content vertically in composer input

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -1543,9 +1543,9 @@ export function FloatingComposer({
           <textarea
             ref={draft.textareaRef}
             rows={1}
-            className={`ds-no-drag block min-w-0 resize-none break-words bg-transparent px-1 py-0.5 text-[15px] leading-[1.45] text-ds-ink placeholder:text-ds-faint focus:outline-none [overflow-wrap:anywhere] ${
+            className={`ds-no-drag block min-w-0 resize-none break-words bg-transparent px-1 py-2.5 text-[15px] leading-[1.45] text-ds-ink placeholder:text-ds-faint focus:outline-none [overflow-wrap:anywhere] ${
               canCompose ? '' : 'opacity-80'
-            } ${compact ? 'text-[14px]' : 'min-h-[40px]'}`}
+            } ${compact ? 'text-[14px] py-2' : 'min-h-[40px]'}`}
             placeholder={placeholder}
             value={input}
             disabled={!canCompose}


### PR DESCRIPTION
## Summary

Re-apply the fix from PR #53 (reverted in PR #108) to vertically center placeholder text and input content in the composer textarea.

## Problem

The textarea padding was too small (py-0.5), causing placeholder text and input content to appear near the top of the input area.

## Solution

Adjust textarea padding to vertically center the content:
- Normal mode: py-0.5 → py-2.5
- Compact mode: add py-2

## Changes

- Increase textarea padding for better vertical centering
- Adjust compact mode padding for consistent visual balance

## Testing

- Verify placeholder text is vertically centered in the composer
- Verify input content is vertically centered
- Verify compact mode has appropriate padding