### PR TITLE
[codex] tighten write editor selection highlight

### DIFF
--- a/src/renderer/src/styles/write-editor.css
+++ b/src/renderer/src/styles/write-editor.css
@@ -127,6 +127,10 @@ summary,
   background: var(--write-selection-bg);
 }
 
+.write-codemirror-host > .cm-editor.cm-write-live-preview.cm-focused > .cm-scroller > .cm-selectionLayer {
+  display: none;
+}
+
 .write-codemirror-host > .cm-editor .cm-content::selection,
 .write-codemirror-host > .cm-editor .cm-content *::selection {
   background: var(--write-selection-bg);


### PR DESCRIPTION
## What changed

This PR tightens the Write live editor selection highlight so the selected background stays on the text itself instead of spilling into the surrounding horizontal whitespace.

## Why it changed

CodeMirror's selection layer was still rendering block-like selection rectangles in the live writing editor. In practice that made selected lines look wider than the actual text content.

## User impact

Selecting text in Write mode now looks cleaner and more precise, especially for long prose paragraphs in live editing.

## Root cause

The live editor was showing CodeMirror's drawn selection layer together with the desired text-level highlight treatment, which produced visible gutter-like highlight padding around the selected text.

## Validation

- `npm run typecheck`
