### PR TITLE
fix(bash-tool): poll action blocks for yield_seconds

### DIFF
--- a/kun/src/adapters/tool/builtin-bash-tool.ts
+++ b/kun/src/adapters/tool/builtin-bash-tool.ts
@@ -501,7 +501,7 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
   const shellRuntime = shellRuntimeInfo()
   return LocalToolHost.defineTool({
     name: 'bash',
-    description: `Execute a shell command in the workspace using the host platform shell. Current shell: ${shellRuntime.name}. Use ${shellRuntime.syntax} syntax. Return combined stdout and stderr. Long-running commands return a session_id; use action="poll" to read more output, action="write" with input to send stdin, or action="stop" to terminate the session.`,
+    description: `Execute a shell command in the workspace using the host platform shell. Current shell: ${shellRuntime.name}. Use ${shellRuntime.syntax} syntax. Return combined stdout and stderr. Long-running commands return a session_id; use action="poll" to block up to yield_seconds (default ${DEFAULT_BASH_YIELD_SECONDS}s, max ${MAX_BASH_YIELD_SECONDS}s) waiting for more output or process exit, action="write" with input to send stdin, or action="stop" to terminate the session.`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -546,6 +546,7 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
           const payload = await sessionPayload(session, { stopSent: true })
           return { output: payload, isError: session.status === 'running' || session.status === 'failed' }
         }
+        await waitForSessionExitOrDelay(session, normalizeYieldSeconds(args.yield_seconds) * 1000)
         return { output: await sessionPayload(session), isError: session.status === 'failed' }
       }
 

--- a/kun/tests/builtin-tools.test.ts
+++ b/kun/tests/builtin-tools.test.ts
@@ -383,6 +383,51 @@ describe('Kun built-in tools', () => {
     expect(String(polled.output)).toContain('done')
   })
 
+  it('blocks the poll action for at least yield_seconds while the session keeps running', async () => {
+    const output = await executeTool(host, workspace, 'bash', {
+      command: 'echo ready; sleep 5; echo done',
+      yield_seconds: 1,
+      timeout: 10
+    })
+    expect(output.status).toBe('running')
+
+    const startedAt = Date.now()
+    const polled = await executeTool(host, workspace, 'bash', {
+      action: 'poll',
+      session_id: String(output.session_id),
+      yield_seconds: 2
+    })
+    const elapsed = Date.now() - startedAt
+    expect(elapsed).toBeGreaterThanOrEqual(1800)
+    expect(polled.status).toBe('running')
+
+    await executeTool(host, workspace, 'bash', {
+      action: 'stop',
+      session_id: String(output.session_id)
+    })
+  })
+
+  it('returns from poll early once the session exits before yield_seconds', async () => {
+    const output = await executeTool(host, workspace, 'bash', {
+      command: 'echo ready; sleep 1; echo done',
+      yield_seconds: 1,
+      timeout: 10
+    })
+    expect(output.status).toBe('running')
+
+    const startedAt = Date.now()
+    const polled = await executeTool(host, workspace, 'bash', {
+      action: 'poll',
+      session_id: String(output.session_id),
+      yield_seconds: 10
+    })
+    const elapsed = Date.now() - startedAt
+    expect(elapsed).toBeLessThan(3000)
+    expect(polled.status).toBe('completed')
+    expect(polled.exit_code).toBe(0)
+    expect(String(polled.output)).toContain('done')
+  })
+
   it('includes the active shell in bash partial updates', async () => {
     const updates: TurnItem[] = []
     const result = await host.execute(


### PR DESCRIPTION
## 摘要

`bash` 工具的 `action="poll"` 在长时运行的会话上立即返回当前快照,完全不阻塞。模型即使在思考里"等 70 秒再轮询",实际只是连续触发 poll,墙钟几乎为零,远端脚本根本来不及产出。

`write` 和 `stop` 都已经用 `waitForSessionExitOrDelay` 等了一段时间再读 payload,只有 `poll` 漏掉了这一步。补上后:

- `poll` 至多阻塞 `yield_seconds` 秒(默认 10s,上限 60s,下限 1s)
- 进程在窗口内退出则立即返回
- 工具描述同步说明 `poll` 是阻塞式

Fixes #94

## 改动

- `kun/src/adapters/tool/builtin-bash-tool.ts`
  - poll 分支返回 payload 前调用 `waitForSessionExitOrDelay(session, normalizeYieldSeconds(args.yield_seconds) * 1000)`
  - 工具描述加上 poll 的等待语义
- `kun/tests/builtin-tools.test.ts`
  - 新增"长时运行时 poll 阻塞 ≥ yield_seconds"用例
  - 新增"会话在 yield_seconds 内退出时 poll 提前返回"用例

## Test plan

- [x] `npm test` 通过(含新增两个用例)
- [x] `sleep 5 && echo done` 启动会话后立刻 `poll yield_seconds=10` → 墙钟 ≈ 5s,`status="completed"`,output 含 `done`
- [x] `sleep 60` 启动会话后 `poll yield_seconds=2` → 墙钟 ≈ 2s,`status="running"`
- [x] 复现 #94 场景:`ssh host long-running-script` 后多次 poll,模型"等 X 秒"现在真的耗墙钟时间