### PR TITLE
feat(composer): insert dropped file paths into chat input

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import type { DsGuiApi } from '../shared/ds-gui-api'
 
 const api = {
@@ -161,7 +161,8 @@ const api = {
   logError: (category, message, detail) =>
     ipcRenderer.invoke('log:error', { category, message, detail }),
   getLogPath: () => ipcRenderer.invoke('log:get-path'),
-  openLogDir: () => ipcRenderer.invoke('log:open-dir')
+  openLogDir: () => ipcRenderer.invoke('log:open-dir'),
+  getPathForFile: (file: File) => webUtils.getPathForFile(file)
 } satisfies DsGuiApi
 
 contextBridge.exposeInMainWorld('dsGui', api)

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -1174,17 +1174,59 @@ export function FloatingComposer({
   }
 
   const handleComposerDragOver = (event: ReactDragEvent<HTMLDivElement>): void => {
-    if (!canPickAttachment || !imageTransferHasImages(event.dataTransfer)) return
+    const dataTransferTypes = Array.from(event.dataTransfer.types ?? [])
+    const canAcceptImages = canPickAttachment && imageTransferHasImages(event.dataTransfer)
+    if (!dataTransferTypes.includes('Files') && !canAcceptImages) return
     event.preventDefault()
     event.dataTransfer.dropEffect = 'copy'
   }
 
+  const insertTextAtComposerCursor = (text: string): void => {
+    if (!text) return
+    const textarea = draft.textareaRef.current
+    const currentValue = input
+    const selectionStart = textarea?.selectionStart ?? composerCursor ?? currentValue.length
+    const selectionEnd = textarea?.selectionEnd ?? selectionStart
+    const before = currentValue.slice(0, selectionStart)
+    const after = currentValue.slice(selectionEnd)
+    const leadingPad = before.length > 0 && !/\s$/.test(before) ? ' ' : ''
+    const trailingPad = after.length > 0 && !/^\s/.test(after) ? ' ' : ''
+    const insertion = `${leadingPad}${text}${trailingPad}`
+    const nextInput = `${before}${insertion}${after}`
+    const nextCursor = before.length + insertion.length - trailingPad.length
+    setInput(nextInput)
+    window.requestAnimationFrame(() => {
+      const el = draft.textareaRef.current
+      if (!el) return
+      el.focus()
+      el.setSelectionRange(nextCursor, nextCursor)
+      setComposerCursor(nextCursor)
+    })
+  }
+
   const handleComposerDrop = (event: ReactDragEvent<HTMLDivElement>): void => {
-    if (!canPickAttachment || !onPickAttachments) return
-    const files = imageFilesFromTransfer(event.dataTransfer)
-    if (files.length === 0) return
+    const imageFiles = canPickAttachment ? imageFilesFromTransfer(event.dataTransfer) : []
+    const rawFiles = Array.from(event.dataTransfer.files ?? [])
+    const isImageLike = (file: File): boolean =>
+      isImageMimeType(file.type) || Boolean(imageMimeTypeFromFileName(file.name))
+    const pathFiles = rawFiles.filter((file) => !isImageLike(file))
+    if (imageFiles.length === 0 && pathFiles.length === 0) return
     event.preventDefault()
-    onPickAttachments(files)
+    if (imageFiles.length > 0 && onPickAttachments) {
+      onPickAttachments(imageFiles)
+    }
+    if (pathFiles.length > 0) {
+      const paths: string[] = []
+      for (const file of pathFiles) {
+        try {
+          const path = window.dsGui.getPathForFile(file)
+          if (path) paths.push(path)
+        } catch {
+          // ignore files we cannot resolve a filesystem path for
+        }
+      }
+      if (paths.length > 0) insertTextAtComposerCursor(paths.join(' '))
+    }
     draft.focusComposer()
   }
 

--- a/src/shared/ds-gui-api.ts
+++ b/src/shared/ds-gui-api.ts
@@ -222,4 +222,5 @@ export type DsGuiApi = {
   logError: (category: string, message: string, detail?: unknown) => Promise<void>
   getLogPath: () => Promise<string>
   openLogDir: () => Promise<{ ok: boolean; message?: string }>
+  getPathForFile: (file: File) => string
 }


### PR DESCRIPTION
## 摘要

把文件从 Finder / 资源管理器拖到「向智能体提问」输入框时,目前是静默丢弃(drop handler 只接受图片 MIME 且没有 `preventDefault`)。

这个 PR 让 textarea 在光标位置插入文件的绝对路径,多个文件用空格分隔,图片仍然走原有附件上传流程。

## 行为

- 非图片文件 → 取绝对路径,空格分隔插入到光标位置;前后字符不是空白则自动补空格,光标停在路径末尾
- 图片(`image/*` 或常见图片后缀)→ 仍走 `onPickAttachments` 附件上传,出现缩略图
- 文件夹 → 插入文件夹自身的绝对路径,不展开里面的文件
- Electron 32+ 移除了 renderer 直接读 `File.path` 的能力,所以绝对路径走 preload 暴露的 `webUtils.getPathForFile`

## 改动

- `src/preload/index.ts` / `src/shared/ds-gui-api.ts` — 暴露 `getPathForFile(file: File): string`
- `src/renderer/src/components/chat/FloatingComposer.tsx`
  - `handleComposerDragOver` 允许任何 `Files` 类型 drag(原先只允许图片,导致 drop 根本不会触发)
  - 新增 `insertTextAtComposerCursor` 处理光标插入和前后空白
  - `handleComposerDrop` 按 MIME / 后缀切分图片和非图片,分别走附件流程或路径插入

## Test plan

- [x] 拖一个 `.ts` 文件 → 光标位置出现绝对路径
- [x] 拖多个文件 → 路径之间用空格分隔
- [x] 拖一个文件夹 → 出现文件夹的绝对路径,不展开内部文件
- [x] 拖 png/jpg → 走附件流程出现缩略图,不插入路径
- [x] 在已有文本中间拖入 → 路径前后自动补空格,光标停在路径末尾
- [x] 在空输入框拖入 → 路径前后不强加空格