### PR TITLE
fix(persistence): use atomic write for settings-store (supersedes #82)

### DIFF
--- a/src/main/settings-store.test.ts
+++ b/src/main/settings-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -351,5 +351,28 @@ describe('JsonSettingsStore', () => {
 
     expect(channel?.threadId).toBe('reasonix-channel')
     expect(conversation?.localThreadId).toBe('reasonix-conversation')
+  })
+
+  it('saves settings atomically (no .tmp file left on success)', async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), 'ds-gui-settings-atomic-'))
+
+    try {
+      const store = new JsonSettingsStore(userDataDir)
+      const loaded = await store.load()
+      await store.save(loaded)
+
+      // Final file is present and non-empty.
+      const finalContents = await readFile(
+        join(userDataDir, 'deepseek-gui-settings.json'),
+        'utf8'
+      )
+      expect(finalContents.length).toBeGreaterThan(0)
+
+      // No .tmp leftover from the atomic write.
+      const entries = await readdir(userDataDir)
+      expect(entries.filter((entry) => entry.includes('.tmp'))).toEqual([])
+    } finally {
+      await rm(userDataDir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
+import { atomicWriteFile } from '../../kun/src/adapters/file/atomic-write.js'
 import {
   applyKunRuntimePatch,
   kunSettingsEnvelope,
@@ -317,7 +318,7 @@ export class JsonSettingsStore {
     await ensureClawChannelWorkspaceRootsExist(normalized)
     this.cache = normalized
     await mkdir(dirname(this.path), { recursive: true })
-    await writeFile(this.path, serializeSettingsForDisk(normalized), 'utf8')
+    await atomicWriteFile(this.path, serializeSettingsForDisk(normalized))
   }
 
   async patch(partial: AppSettingsPatch): Promise<AppSettingsV1> {


### PR DESCRIPTION
## Summary

`fix(persistence): use atomic write for settings-store`

Supersedes #82. #82 was based on master, this is the same fix rebased onto `develop` to satisfy the project's branch policy (PRs target `develop`, not `master`).

## Why

`JsonSettingsStore.save()` wrote the settings file with a direct `writeFile`. If the process was killed mid-write (or the user lost power), the file could be left truncated. The `load()` path already detects a corrupt file and falls back to defaults — but that fallback throws away the user's configuration, which is the failure mode this commit prevents.

The `kun` side of the project already adopted `atomicWriteFile` for the same pattern (`kun/src/adapters/file/atomic-write.ts`, also referenced by #17 / #59). This commit migrates the settings-side write to the same helper. No new code, no new dependency, no new user-visible behaviour — only a hardening fix.

## What changed

- `src/main/settings-store.ts`:
  - Import `atomicWriteFile` from `../../kun/src/adapters/file/atomic-write.js`
  - Replace `writeFile(this.path, ..., 'utf8')` with `atomicWriteFile(this.path, ...)` inside `JsonSettingsStore.save()`
- `src/main/settings-store.test.ts`:
  - New test `saves settings atomically (no .tmp file left on success)` asserts the save path leaves no `.tmp` leftover and produces a valid file

## Validation

- `npm run typecheck` ✓
- `npx vitest run src/main/settings-store.test.ts` — 16/16 tests pass (including the new atomic-write test)
- Manual: confirmed `JsonSettingsStore` no longer leaves a `.tmp` file on success and writes a valid file on disk

## Supersedes #82

The original #82 was opened from `master` and is now closed. The commit is identical (`355f416a` → `310a4cb` after the develop rebase); only the base branch and the parent SHA changed.

Refs: this is the same fix as #82; issue #82 (the kun turn failed regression for non-DeepSeek providers) is unrelated and is being handled by the rebased #69.
