### PR TITLE
fix(kun/memory): use atomic write for FileMemoryStore (supersedes #83)

### DIFF
--- a/kun/src/memory/memory-store.ts
+++ b/kun/src/memory/memory-store.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { MemoryCapabilityConfig } from '../contracts/capabilities.js'
+import { atomicWriteFile } from '../adapters/file/atomic-write.js'
 import {
   MemoryDiagnostics,
   MemoryRecord,
@@ -131,7 +132,10 @@ export class FileMemoryStore implements MemoryStore {
   }
 
   private write(record: MemoryRecord): Promise<void> {
-    return writeFile(join(this.options.rootDir, `${record.id}.json`), JSON.stringify(record, null, 2), 'utf8')
+    return atomicWriteFile(
+      join(this.options.rootDir, `${record.id}.json`),
+      JSON.stringify(record, null, 2)
+    )
   }
 
   private now(): string {

--- a/kun/tests/memory-store.test.ts
+++ b/kun/tests/memory-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -163,6 +163,23 @@ describe('Memory store and recall', () => {
     const finalInstructions = seenRequests.at(-1)?.contextInstructions?.join('\n') ?? ''
     expect(finalInstructions).not.toContain(memory.id)
     expect(finalInstructions).toContain('Shell runtime:')
+  })
+
+  it('writes memory records atomically (no .tmp file left on success)', async () => {
+    const store = createStore()
+    await store.create({ content: 'atomic test memory' })
+
+    // Final file present and parseable.
+    const finalContents = await readFile(
+      join(dir, 'memory', 'mem_1.json'),
+      'utf8'
+    )
+    expect(finalContents.length).toBeGreaterThan(0)
+    expect(JSON.parse(finalContents).content).toBe('atomic test memory')
+
+    // No .tmp leftover from the atomic write.
+    const entries = await readdir(join(dir, 'memory'))
+    expect(entries.filter((entry) => entry.includes('.tmp'))).toEqual([])
   })
 
   function createStore(overrides: Partial<MemoryCapabilityConfig> = {}) {


### PR DESCRIPTION
## Summary

`fix(kun/memory): use atomic write for FileMemoryStore`

Supersedes #83. #83 was based on master, this is the same fix rebased onto `develop` to satisfy the project's branch policy (PRs target `develop`, not `master`).

## Why

`FileMemoryStore.write()` wrote memory record JSON files with a direct `writeFile`. If the process was killed mid-write, the file could be left truncated. Because `MemoryRecord` parsing in `readAll()` silently swallows parse errors (`.catch(() => null)` on the JSON.parse line), a truncated file becomes **silently invisible** — the memory appears to be deleted without ever being explicitly removed.

The project already has `atomicWriteFile` (`kun/src/adapters/file/atomic-write.ts`) and uses it for #17 / #59 and for the settings-store path (rebased #82). This commit migrates the memory-store write to the same helper.

## What changed

- `kun/src/memory/memory-store.ts`:
  - Replace direct `writeFile` with `atomicWriteFile` in `FileMemoryStore.write()`
- `kun/tests/memory-store.test.ts`:
  - New test `writes memory records atomically (no .tmp file left on success)` appended using the existing `createStore()` helper, asserts the write path leaves no `.tmp` leftover

## Validation

- `npm run typecheck` ✓
- `npm run build:kun` ✓
- `cd kun && npx vitest run tests/memory-store.test.ts` — 5/5 tests pass (including the new atomic-write test)

## Supersedes #83

The original #83 was opened from `master` and is now closed. The commit is identical (`5f5b1ec2` → `8904f91` after the develop rebase); only the base branch and the parent SHA changed.

## Related

- #82 / #119: same `atomicWriteFile` pattern for `JsonSettingsStore`
- #17 / #59: original `atomicWriteFile` introduction in the kun layer
