### PR TITLE
fix(kun): preserve provider context for custom OpenAI-compat providers (closes #26, supersedes #69)

### DIFF
--- a/kun/src/adapters/model/deepseek-compat-model-client.ts
+++ b/kun/src/adapters/model/deepseek-compat-model-client.ts
@@ -224,6 +224,7 @@ export class DeepseekCompatModelClient implements ModelClient {
     applyReasoningEffort(body, request.reasoningEffort, { includeThinking })
     if (
       includeThinking &&
+      isDeepSeekHost(this.config.baseUrl) &&
       !Object.prototype.hasOwnProperty.call(body, 'thinking') &&
       isThinkingProducerModel(model)
     ) {
@@ -258,7 +259,7 @@ export class DeepseekCompatModelClient implements ModelClient {
     const history = windowSize
       ? limitHistoryPreservingCompaction(request.history, windowSize)
       : request.history
-    const thinkingMode = requiresReasoningRoundTrip(request.reasoningEffort, model)
+    const thinkingMode = requiresReasoningRoundTrip(request.reasoningEffort, model, this.config.baseUrl)
     out.push(...this.itemsToMessages(
       repairModelHistoryItems([...request.prefix, ...history]),
       thinkingMode
@@ -664,12 +665,14 @@ export class DeepseekCompatModelClient implements ModelClient {
     const cacheHitRate = cacheTotal === 0 ? null : cacheHit / cacheTotal
     const estimatedCost = estimateDeepseekCost({
       model: this.config.model,
+      providerHost: this.config.baseUrl,
       cacheHitTokens: cacheHit,
       cacheMissTokens: cacheMiss,
       outputTokens: completionTokens
     })
     const estimatedSavings = estimateDeepseekCacheSavings({
       model: this.config.model,
+      providerHost: this.config.baseUrl,
       cacheHitTokens: cacheHit
     })
     const reportedCostUsd = Number(usage.cost_usd ?? usage.costUsd)
@@ -754,8 +757,17 @@ function isThinkingMode(effort: string | undefined): boolean {
   return !['off', 'disabled', 'none', 'false'].includes(normalized)
 }
 
-function requiresReasoningRoundTrip(effort: string | undefined, model: string | undefined): boolean {
-  return isThinkingMode(effort) || isThinkingProducerModel(model)
+function requiresReasoningRoundTrip(
+  effort: string | undefined,
+  model: string | undefined,
+  baseUrl: string
+): boolean {
+  // Thinking-mode round trip is a DeepSeek-specific protocol extension.
+  // OpenAI-compat providers (OpenRouter, llama.cpp, etc.) may reject
+  // or misinterpret the `thinking` field, so we only auto-enable it
+  // on the official DeepSeek host. User-selected reasoningEffort still
+  // forces the path (opt-in). See issue #26.
+  return isThinkingMode(effort) || (isDeepSeekHost(baseUrl) && isThinkingProducerModel(model))
 }
 
 function isThinkingProducerModel(model: string | undefined): boolean {

--- a/kun/src/adapters/model/deepseek-pricing.ts
+++ b/kun/src/adapters/model/deepseek-pricing.ts
@@ -1,3 +1,5 @@
+import { isDeepSeekHost } from './model-error-probe.js'
+
 export type DeepseekCurrencyCosts = {
   costUsd: number
   costCny: number
@@ -80,7 +82,18 @@ export function estimateDeepseekCost(input: {
   cacheHitTokens: number
   cacheMissTokens: number
   outputTokens: number
+  /**
+   * Optional upstream base URL. When provided, the function returns
+   * null for non-DeepSeek hosts (OpenRouter, llama.cpp, etc.) because
+   * we don't have authoritative prices for third-party providers.
+   * Callers that omit it keep the legacy behavior: trust the model
+   * name. See issue #26.
+   */
+  providerHost?: string
 }): DeepseekCurrencyCosts | null {
+  if (input.providerHost !== undefined && !isDeepSeekHost(input.providerHost)) {
+    return null
+  }
   const tier = pricingTierForModel(input.model)
   if (!tier) return null
   const prices = DEEPSEEK_V4_PRICES[tier]
@@ -93,19 +106,25 @@ export function estimateDeepseekCost(input: {
 export function estimateDeepseekInputTokenCost(input: {
   model: string
   inputTokens: number
+  providerHost?: string
 }): DeepseekCurrencyCosts | null {
   return estimateDeepseekCost({
     model: input.model,
     cacheHitTokens: 0,
     cacheMissTokens: input.inputTokens,
-    outputTokens: 0
+    outputTokens: 0,
+    providerHost: input.providerHost
   })
 }
 
 export function estimateDeepseekCacheSavings(input: {
   model: string
   cacheHitTokens: number
+  providerHost?: string
 }): DeepseekCurrencyCosts | null {
+  if (input.providerHost !== undefined && !isDeepSeekHost(input.providerHost)) {
+    return null
+  }
   const tier = pricingTierForModel(input.model)
   if (!tier) return null
   const prices = DEEPSEEK_V4_PRICES[tier]

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -322,7 +322,26 @@ export class AgentLoop {
       await this.opts.turns.finishTurn({ threadId, turnId, status })
       return status
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
+      const raw = error instanceof Error ? error.message : String(error)
+      // Best-effort enrichment so the renderer can show "what failed where"
+      // instead of the bare "Kun turn failed" string. See issue #26.
+      const modelInfo = this.opts.model && 'config' in this.opts.model
+        ? (this.opts.model as { config: { model?: string; baseUrl?: string } }).config
+        : undefined
+      const modelName = modelInfo?.model ?? 'unknown'
+      const provider = modelInfo?.baseUrl ?? 'unknown'
+      const stack = error instanceof Error
+        ? (error.stack?.split('\n').slice(0, 3).join(' | ') ?? '')
+        : ''
+      const message = [
+        '[Kun turn failed]',
+        `turn=${turnId}`,
+        `thread=${threadId}`,
+        `model=${modelName}`,
+        `provider=${provider}`,
+        `error=${raw}`,
+        stack ? `stack=${stack}` : ''
+      ].filter(Boolean).join(' ')
       await this.failTurn(threadId, turnId, message)
       return 'failed'
     } finally {

--- a/kun/tests/deepseek-pricing.test.ts
+++ b/kun/tests/deepseek-pricing.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  estimateDeepseekCacheSavings,
+  estimateDeepseekCost,
+  estimateDeepseekInputTokenCost
+} from '../src/adapters/model/deepseek-pricing.js'
+
+describe('DeepSeek pricing — provider-aware gate (issue #26)', () => {
+  it('returns null for non-DeepSeek host when providerHost is provided', () => {
+    // OpenRouter
+    expect(estimateDeepseekCost({
+      model: 'deepseek-v4-pro',
+      providerHost: 'https://openrouter.ai/api/v1',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })).toBeNull()
+
+    // Local llama.cpp
+    expect(estimateDeepseekCost({
+      model: 'deepseek-v4-flash',
+      providerHost: 'http://127.0.0.1:1234/v1',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })).toBeNull()
+
+    // A path that pretends to be DeepSeek but is actually on a different host
+    expect(estimateDeepseekCost({
+      model: 'deepseek-v4-pro',
+      providerHost: 'https://my-mirror.deepseek-proxy.example.com',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })).toBeNull()
+  })
+
+  it('returns cost for the official DeepSeek host', () => {
+    const cost = estimateDeepseekCost({
+      model: 'deepseek-v4-pro',
+      providerHost: 'https://api.deepseek.com',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })
+    expect(cost).not.toBeNull()
+    expect(cost!.costUsd).toBeGreaterThan(0)
+    expect(cost!.costCny).toBeGreaterThan(0)
+  })
+
+  it('returns cost for the official *.deepseek.com subdomain', () => {
+    const cost = estimateDeepseekCost({
+      model: 'deepseek-v4-flash',
+      providerHost: 'https://api-beta.deepseek.com',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })
+    expect(cost).not.toBeNull()
+  })
+
+  it('keeps legacy behavior when providerHost is omitted (additive signature)', () => {
+    // Old callers (e.g. agent-loop.ts:1458) that don't know about host
+    // must still get cost for known DeepSeek model aliases.
+    const cost = estimateDeepseekCost({
+      model: 'deepseek-v4-pro',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })
+    expect(cost).not.toBeNull()
+    expect(cost!.costUsd).toBeGreaterThan(0)
+  })
+
+  it('estimateDeepseekInputTokenCost honors providerHost', () => {
+    expect(estimateDeepseekInputTokenCost({
+      model: 'deepseek-v4-pro',
+      inputTokens: 1000,
+      providerHost: 'https://openrouter.ai/api/v1'
+    })).toBeNull()
+
+    const cost = estimateDeepseekInputTokenCost({
+      model: 'deepseek-v4-pro',
+      inputTokens: 1000,
+      providerHost: 'https://api.deepseek.com'
+    })
+    expect(cost).not.toBeNull()
+  })
+
+  it('estimateDeepseekCacheSavings honors providerHost', () => {
+    expect(estimateDeepseekCacheSavings({
+      model: 'deepseek-v4-pro',
+      cacheHitTokens: 500,
+      providerHost: 'https://openrouter.ai/api/v1'
+    })).toBeNull()
+
+    const savings = estimateDeepseekCacheSavings({
+      model: 'deepseek-v4-pro',
+      cacheHitTokens: 500,
+      providerHost: 'https://api.deepseek.com'
+    })
+    expect(savings).not.toBeNull()
+    expect(savings!.costUsd).toBeGreaterThan(0)
+  })
+
+  it('still returns null for unknown model names even on DeepSeek host', () => {
+    // Defensive: an unknown model on the official host should still be null
+    // because we don't have authoritative prices for it.
+    expect(estimateDeepseekCost({
+      model: 'gpt-4-turbo',
+      providerHost: 'https://api.deepseek.com',
+      cacheHitTokens: 0, cacheMissTokens: 1000, outputTokens: 500
+    })).toBeNull()
+  })
+})

--- a/kun/tests/model-client.test.ts
+++ b/kun/tests/model-client.test.ts
@@ -77,6 +77,70 @@ describe('DeepseekCompatModelClient', () => {
     expect(sentBodies[0]?.model).toBe('deepseek-v4-pro')
   })
 
+  it('does not inject body.thinking on non-DeepSeek host (issue #26)', async () => {
+    const response = {
+      id: 'r3',
+      model: 'deepseek-chat',
+      choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }
+    const sentBodies: Array<Record<string, unknown>> = []
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      sentBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    }
+    const client = new DeepseekCompatModelClient({
+      baseUrl: 'https://openrouter.ai/api/v1',   // NOT api.deepseek.com
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+      fetchImpl,
+      nonStreaming: true
+    })
+    const request = buildRequest(new AbortController().signal)
+    request.model = 'deepseek-v4-pro'
+    for await (const _chunk of client.stream(request)) {
+      // drain
+    }
+    // The DeepSeek-specific `thinking` protocol extension must not be sent
+    // to third-party OpenAI-compat providers — they may reject it. See issue #26.
+    expect(sentBodies[0]).not.toHaveProperty('thinking')
+  })
+
+  it('injects body.thinking on the official DeepSeek host (issue #26 regression guard)', async () => {
+    const response = {
+      id: 'r4',
+      model: 'deepseek-chat',
+      choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }
+    const sentBodies: Array<Record<string, unknown>> = []
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      sentBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    }
+    const client = new DeepseekCompatModelClient({
+      baseUrl: 'https://api.deepseek.com',
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+      fetchImpl,
+      nonStreaming: true
+    })
+    const request = buildRequest(new AbortController().signal)
+    request.model = 'deepseek-v4-pro'
+    for await (const _chunk of client.stream(request)) {
+      // drain
+    }
+    // On the official host, the `thinking` field must still be set for v4 models.
+    expect(sentBodies[0]).toHaveProperty('thinking')
+    expect((sentBodies[0] as { thinking: { type: string } }).thinking).toMatchObject({ type: 'enabled' })
+  })
+
   it('sends per-request router controls when requested', async () => {
     const response = {
       id: 'router',
@@ -268,7 +332,7 @@ describe('DeepseekCompatModelClient', () => {
         headers: { 'content-type': 'application/json' }
       })
     const client = new DeepseekCompatModelClient({
-      baseUrl: 'https://example.com/beta',
+      baseUrl: 'https://api.deepseek.com',
       apiKey: 'k',
       model: 'deepseek-chat',
       fetchImpl,
@@ -373,7 +437,7 @@ describe('DeepseekCompatModelClient', () => {
         headers: { 'content-type': 'application/json' }
       })
     const client = new DeepseekCompatModelClient({
-      baseUrl: 'https://example.com/beta',
+      baseUrl: 'https://api.deepseek.com',
       apiKey: 'k',
       model: 'deepseek-chat',
       fetchImpl,
@@ -782,7 +846,7 @@ describe('DeepseekCompatModelClient', () => {
       })
     }
     const client = new DeepseekCompatModelClient({
-      baseUrl: 'https://example.com/beta',
+      baseUrl: 'https://api.deepseek.com',
       apiKey: 'k',
       model: 'deepseek-chat',
       fetchImpl,


### PR DESCRIPTION
## Summary

`fix(kun): preserve provider context for custom OpenAI-compat providers (#26)`

Re-applies the kun-side fixes from the original #69 (upstream commit `1986cc7c`) on top of the current `develop` branch. Three of the original four interlocked issues in `1986cc7c` have been partially or fully resolved on develop since the original PR was opened; this PR re-applies the parts that are still needed and drops the parts whose work is now done by a different module.

## Why

When users configure a non-DeepSeek OpenAI-compatible provider (OpenRouter, llama.cpp, etc.) and select `deepseek-v4-pro`/`flash` as the model:

- The DeepSeek-specific `body.thinking = { type: 'enabled' }` protocol extension is auto-injected even on third-party hosts, which they may reject.
- The cost estimate is calculated using DeepSeek's official price table, producing wildly wrong numbers on third-party providers.

The original #69 was based on `master` and is now closed.

## What changed

- `kun/src/adapters/model/deepseek-compat-model-client.ts`:
  - Gate the thinking auto-injection on `isDeepSeekHost(this.config.baseUrl)`.
  - Pass `providerHost: this.config.baseUrl` to `estimateDeepseekCost` and `estimateDeepseekCacheSavings`.
- `kun/src/adapters/model/deepseek-pricing.ts`:
  - Add an OPTIONAL `providerHost` field to `estimateDeepseekCost`, `estimateDeepseekInputTokenCost`, and `estimateDeepseekCacheSavings`. When the host is not DeepSeek, return `null` so the caller can fall back to provider-reported `usage.cost_*` or `—`. Existing callers that omit the field keep legacy behavior.
- `kun/src/loop/agent-loop.ts`:
  - Re-apply 1986cc7c's runTurn catch enrichment (`[Kun turn failed] turn=… thread=… model=… provider=… error=… stack=…`). The renderer's `format-runtime-error.ts` does not currently parse the `[Kun]` prefix, so this enrichment is forward-compatible rather than user-visible today.
- `kun/tests/deepseek-pricing.test.ts` (new, 7 cases):
  - Cover the `providerHost` branch in `estimateDeepseek*` and the legacy branch when the field is omitted.
- `kun/tests/model-client.test.ts`:
  - +2 cases asserting the `isDeepSeekHost` gate is applied to `body.thinking` injection.
  - 3 baseUrl corrections: `https://example.com/beta` → `https://api.deepseek.com` in three pre-existing client configs that were already implicitly assuming a DeepSeek host. These three tests started failing once 1986cc7c's pricing gate was added; the original test author intended `api.deepseek.com`.

## Intentionally NOT re-applied (from 1986cc7c)

- `src/renderer/src/agent/kun-mapper.ts` and `kun-mapper.test.ts` changes (the `[Kun]` prefix and log-hint fallback). develop now routes runtime errors through `format-runtime-error.ts` + `runtimeErrorFromEvent` + `errorForRuntimeEvent`, which is a different architecture. Re-applying the old renderer code on top would either no-op or reintroduce the conflicts that blocked the original cherry-pick.

## Validation

- `npm run typecheck` (web + node) ✓
- `npm run build:kun` ✓
- `cd kun && npx vitest run` — 35/35 affected tests pass (including the 7 new pricing tests, 2 new thinking-gate tests, and 3 previously-failing baseUrl tests)
- `npx vitest run` (root) — 668/669 pass; the single remaining failure is the pre-existing `resolveAppIconPath / Windows path handling` issue in `src/main/index.test.ts` that is unrelated to this change.

## Supersedes #69

The original #69 was opened from `master` and is now closed. The kun-side core fixes are preserved; only the parts already absorbed by develop are dropped.

Refs: closes #26 (the issue's report; #69 was the PR).

## Base branch policy

This PR targets `develop` per `docs/CONTRIBUTING.md` ("Open pull requests into `develop` unless maintainers explicitly direct otherwise"). The base=master on the original #69 was a mistake; this re-open fixes it.
