### PR TITLE
fix(chat): drop duplicate streaming deltas by seq

### DIFF
--- a/src/renderer/src/store/chat-store-runtime.test.ts
+++ b/src/renderer/src/store/chat-store-runtime.test.ts
@@ -101,6 +101,43 @@ describe('thread event sink binding', () => {
     expect(getState().lastSeq).toBe(9)
     expect(getState().turnReasoningFirstAtByUserId['user-current']).toEqual(expect.any(Number))
   })
+
+  it('skips reasoning deltas whose seq has already been folded in', () => {
+    const { getState, set, get } = makeSinkHarness({ activeThreadId: 'thread-current' })
+    const controller = new AbortController()
+    const sink = buildThreadEventSink(set, get, {
+      threadId: 'thread-current',
+      signal: controller.signal
+    })
+
+    sink.onDeltas([{ kind: 'agent_reasoning', text: 'The', seq: 1 }])
+    sink.onDeltas([{ kind: 'agent_reasoning', text: ' old', seq: 2 }])
+    // The same SSE event arrives again (duplicate delivery / replay overlap).
+    sink.onDeltas([{ kind: 'agent_reasoning', text: ' old', seq: 2 }])
+    sink.onDeltas([{ kind: 'agent_reasoning', text: ' code', seq: 3 }])
+
+    expect(getState().liveReasoning).toBe('The old code')
+    expect(getState().lastSeq).toBe(3)
+  })
+
+  it('skips duplicate-seq reasoning deltas within a single batch', () => {
+    const { getState, set, get } = makeSinkHarness({ activeThreadId: 'thread-current' })
+    const controller = new AbortController()
+    const sink = buildThreadEventSink(set, get, {
+      threadId: 'thread-current',
+      signal: controller.signal
+    })
+
+    sink.onDeltas([
+      { kind: 'agent_reasoning', text: 'The', seq: 1 },
+      { kind: 'agent_reasoning', text: 'The', seq: 1 },
+      { kind: 'agent_reasoning', text: ' old', seq: 2 },
+      { kind: 'agent_reasoning', text: ' old', seq: 2 }
+    ])
+
+    expect(getState().liveReasoning).toBe('The old')
+    expect(getState().lastSeq).toBe(2)
+  })
 })
 
 describe('thread event sink runtime errors', () => {

--- a/src/renderer/src/store/chat-store-runtime.ts
+++ b/src/renderer/src/store/chat-store-runtime.ts
@@ -591,7 +591,15 @@ export function buildThreadEventSink(
         let nextReasoningFirstAtByUserId = s.turnReasoningFirstAtByUserId
         let nextReasoningLastAtByUserId = s.turnReasoningLastAtByUserId
         const userId = s.currentTurnUserId
+        // Guard against the same delta arriving twice (duplicate SSE
+        // delivery, replay overlap, etc.) by skipping any delta whose
+        // seq is <= the highest seq we have already folded in.
+        let seenSeq = s.lastSeq
         for (const delta of deltas) {
+          if (typeof delta.seq === 'number') {
+            if (delta.seq <= seenSeq) continue
+            seenSeq = delta.seq
+          }
           if (delta.kind === 'agent_reasoning') {
             liveReasoning += delta.text
             if (userId) {

--- a/src/renderer/src/store/chat-store-side-actions.ts
+++ b/src/renderer/src/store/chat-store-side-actions.ts
@@ -122,7 +122,14 @@ function buildSideSink(sideId: string, ctx: SideContext): ThreadEventSink {
           const lastSeq = seqs.length > 0 ? Math.max(side.lastSeq, ...seqs) : side.lastSeq
           let liveReasoning = side.liveReasoning
           let liveAssistant = side.liveAssistant
+          // Skip deltas whose seq has already been folded in. Guards
+          // against duplicate SSE delivery / replay overlap.
+          let seenSeq = side.lastSeq
           for (const delta of deltas) {
+            if (typeof delta.seq === 'number') {
+              if (delta.seq <= seenSeq) continue
+              seenSeq = delta.seq
+            }
             if (delta.kind === 'agent_reasoning') liveReasoning += delta.text
             else liveAssistant += delta.text
           }


### PR DESCRIPTION
## 摘要

「思考中…」面板偶尔会把每个 reasoning token 在原地重复一遍("TheThe old old \`udsuds_s_sendend...\`"),视觉上每一个 SSE delta 都被立即追加了两次。这个 PR 在 store 层加一道 seq 去重防线,让重复投递的 delta 不再二次累加。

## 行为

- runtime 给每个 delta 事件都带了单调递增的 `seq`,store 用 `lastSeq` 跟踪已处理到哪。
- `onDeltas` 用 `lastSeq` 作为已处理截断:`delta.seq <= seenSeq` 直接跳过,接受后 `seenSeq` 推进到当前 seq,所以**同一批次里出现的重复 seq 也会被跳过**。
- 没带 seq 的 delta(测试桩、mock 流等)按原行为照常追加,不影响现有测试。
- 在 `chat-store-side-actions` 的侧栏对话 sink 里加同样的保护。

## 改动

- `src/renderer/src/store/chat-store-runtime.ts` — `onDeltas` 增加 seq 截断
- `src/renderer/src/store/chat-store-side-actions.ts` — 侧栏 sink 同步
- `src/renderer/src/store/chat-store-runtime.test.ts` — 两个回归用例(跨批次重复 seq、单批次重复 seq)

## 备注

这是 **renderer 层的防御性修复**。根因可能在更上游:
- main 进程 SSE 转发(`src/main/runtime-sse-ipc.ts`)是否在某些场景把同一事件 emit 两次
- 某些 DeepSeek 兼容上游同时回写 `reasoning_content` 和 `reasoning` 字段,被 `consumeStreamPayload` 转成两条 delta
- React StrictMode 下的订阅竞态(本地反复怀疑过,但用 seq 截断更稳)

不管真凶在哪里,store 层用 seq 截断都是正确的不变式:**同一个 seq 永远只能被 fold 进 liveReasoning 一次**。

## Test plan

- [ ] `npm test -- chat-store-runtime` 通过(含新加两个回归用例)
- [ ] 复现场景:模型连续输出 reasoning,UI 不再出现 "xxxx" → "xxxxxxxx" 的重复
- [ ] 正常流式输出仍然实时增量显示,不影响动画
- [ ] 切换 thread / abort 之后再 send,新一轮流式不被旧的 lastSeq 误伤