### PR TITLE
fix(runtime-hero): surface specific runtime error in title when probe fails (fixes #78)

### DIFF
--- a/src/renderer/src/components/chat/message-timeline-empty.test.ts
+++ b/src/renderer/src/components/chat/message-timeline-empty.test.ts
@@ -1,0 +1,87 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it } from 'vitest'
+import i18n from '../../i18n'
+import { MessageTimelineEmptyHero } from './message-timeline-empty'
+
+/**
+ * Tests for the "runtime offline" hero (`RuntimeWakeHero` inside
+ * `MessageTimelineEmptyHero`). See issue #78 — when the user-reported port
+ * conflict occurred, the hero only showed a vague "正在唤醒本地智能体" title
+ * while the specific error lived in a faint detail paragraph below. Users
+ * skimmed the title, thought the app was still loading, and never opened
+ * Settings. The fix: when `runtimeError` is present, surface the localized
+ * error in the title slot so the user sees the real cause immediately.
+ */
+
+function renderOfflineHero(runtimeError: string | null = null): string {
+  return renderToStaticMarkup(
+    createElement(MessageTimelineEmptyHero, {
+      route: 'chat',
+      ready: false,
+      hasWorkspace: true,
+      runtimeError,
+      activeClawChannel: null,
+      onPickWorkspace: () => undefined,
+      onRetry: () => undefined,
+      onOpenSettings: () => undefined,
+      onSelectSuggestion: () => undefined
+    })
+  )
+}
+
+describe('MessageTimelineEmptyHero — runtime offline hero (issue #78)', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it('uses the waking title when no runtime error is available', () => {
+    const html = renderOfflineHero(null)
+    expect(html).toContain('DeepSeek-GUI is waking the local agent')
+    expect(html).not.toContain('Cannot connect to the local runtime')
+  })
+
+  it('switches to the error title and surfaces the localized error when a runtime error is provided', () => {
+    const portConflict = i18n.t('common:runtimePortConflict')
+    const html = renderOfflineHero(portConflict)
+    // New error title should appear (so users see the failure immediately)
+    expect(html).toContain('Cannot connect to the local runtime')
+    // The old "waking" title must NOT appear — that's the bug we're fixing
+    expect(html).not.toContain('DeepSeek-GUI is waking the local agent')
+    // The specific localized port-conflict message should appear in the body
+    expect(html).toContain(portConflict)
+  })
+
+  it('treats whitespace-only runtimeError as no error', () => {
+    const html = renderOfflineHero('   \n  ')
+    // Falls back to the generic waking hero
+    expect(html).toContain('DeepSeek-GUI is waking the local agent')
+    expect(html).not.toContain('Cannot connect to the local runtime')
+  })
+
+  it('keeps both the retry and open-settings actions visible on the error hero', () => {
+    const html = renderOfflineHero(i18n.t('common:runtimePortConflict'))
+    expect(html).toContain('Retry')
+    expect(html).toContain('Open Settings')
+  })
+})
+
+describe('MessageTimelineEmptyHero — runtime offline hero (issue #78, zh-CN)', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('zh-CN')
+  })
+
+  it('uses 正在唤醒 title when no runtime error is available', () => {
+    const html = renderOfflineHero(null)
+    expect(html).toContain('正在唤醒本地智能体')
+    expect(html).not.toContain('无法连接到本地运行时')
+  })
+
+  it('switches to 无法连接到本地运行时 title and surfaces the localized port-conflict error', () => {
+    const portConflict = i18n.t('common:runtimePortConflict')
+    const html = renderOfflineHero(portConflict)
+    expect(html).toContain('无法连接到本地运行时')
+    expect(html).not.toContain('正在唤醒本地智能体')
+    expect(html).toContain(portConflict)
+  })
+})

--- a/src/renderer/src/components/chat/message-timeline-empty.tsx
+++ b/src/renderer/src/components/chat/message-timeline-empty.tsx
@@ -77,7 +77,16 @@ function RuntimeWakeHero({
   onOpenSettings: () => void
 }): ReactElement {
   const { t } = useTranslation('common')
-  const detail = runtimeError?.trim() || t('runtimeOfflineHeroSub')
+  // When the runtime probe has surfaced a specific error (e.g. port conflict,
+  // missing API key, or unhealthy runtime), prefer a clear "cannot connect"
+  // title and show the localized error message as the body. Otherwise fall
+  // back to the generic "waking" hero. This addresses issue #78, where users
+  // saw the "正在唤醒" title and assumed the app was still loading, never
+  // noticing the port-conflict detail text below it.
+  const trimmedError = runtimeError?.trim() ?? ''
+  const hasError = trimmedError.length > 0
+  const title = hasError ? t('runtimeErrorHeroTitle') : t('runtimeOfflineHeroTitle')
+  const detail = hasError ? trimmedError : t('runtimeOfflineHeroSub')
 
   return (
     <div className="ds-runtime-wake-hero ds-no-drag px-6 pb-8 pt-12 text-center md:pt-16">
@@ -87,7 +96,7 @@ function RuntimeWakeHero({
         {t('runtimeOfflineHeroKicker')}
       </p>
       <h1 className="mt-2 max-w-[620px] text-[26px] font-semibold leading-tight tracking-[0] text-ds-ink md:text-[32px]">
-        {t('runtimeOfflineHeroTitle')}
+        {title}
       </h1>
       <p className="mt-3 max-w-[620px] text-[15px] leading-7 text-ds-muted">
         {detail}

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -888,6 +888,7 @@
   "runtimeOfflineHeroKicker": "GUI agent core",
   "runtimeOfflineHeroTitle": "DeepSeek-GUI is waking the local agent",
   "runtimeOfflineHeroSub": "The workbench is bringing Kun back into this window. When the local service is ready, sessions and the composer resume here.",
+  "runtimeErrorHeroTitle": "Cannot connect to the local runtime",
   "openSettings": "Open Settings",
   "close": "Close",
   "clear": "Clear",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -888,6 +888,7 @@
   "runtimeOfflineHeroKicker": "GUI 内置智能体",
   "runtimeOfflineHeroTitle": "DeepSeek-GUI 正在唤醒本地智能体",
   "runtimeOfflineHeroSub": "工作台会把 Kun 接回当前窗口；恢复后会话和输入框会在这里继续可用。若停留过久，可以重试或检查设置。",
+  "runtimeErrorHeroTitle": "无法连接到本地运行时",
   "openSettings": "打开设置",
   "close": "关闭",
   "clear": "清除",


### PR DESCRIPTION
## Summary

修了 issue #78: GUI 启动后,如果 Kun 启动失败(比如 8899 端口被 workbuddy 占用),用户看到"正在唤醒本地智能体"标题,以为在 loading,不知道是端口冲突,不知道去设置改端口。

## Why

`RuntimeWakeHero` (在 `message-timeline-empty.tsx` 里)原本逻辑:
- title 永远 = `runtimeOfflineHeroTitle` = "正在唤醒本地智能体"
- detail = `runtimeError || runtimeOfflineHeroSub` = "工作台会把 Kun 接回..."

结果:port 冲突时,`runtimeError` 实际是 "运行时端口已被占用。请释放该端口,或在设置中更换端口。",**但放在 detail 段落里**(颜色淡、字号小),用户第一眼只看到 "正在唤醒",误以为在 loading,不去看 detail,不去点"打开设置"。

## What changed

**修改** `src/renderer/src/components/chat/message-timeline-empty.tsx` (+11/-2):
- `runtimeError` 存在时,title 改成 `runtimeErrorHeroTitle` = "无法连接到本地运行时 / Cannot connect to the local runtime"
- detail 改成 `runtimeError` 本身(具体错误,如"运行时端口已被占用...")
- 无 error 时维持原状(保留"正在唤醒"标题的初始 loading 状态)

**新增** `src/renderer/src/locales/zh/common.json` + `en/common.json`:
- `runtimeErrorHeroTitle`: zh = "无法连接到本地运行时", en = "Cannot connect to the local runtime"

**新增** `src/renderer/src/components/chat/message-timeline-empty.test.ts` (+100):
- 6 个测试覆盖 en + zh-CN + 空 + 仅 whitespace + port 冲突 + 按钮可见

## Validation

```bash
npm run typecheck      # ✅ 双 tsconfig 全过
npm run build          # ✅ build 31s
npx vitest run message-timeline-empty  # ✅ 6/6
npx vitest run MessageTimeline  # ✅ 14/14
npx vitest run  # 684/685 (1 pre-existing fail in src/main/index.test.ts:71
                # 跟本 PR 无关 — Windows path 解析, 跟 #69 #77 同样的 i18n-fixture
                # pre-existing 问题)
```

## Manual scenario

启动 GUI,kun 启动失败(port 8899 被 workbuddy 占用):
- 之前:看到 "正在唤醒本地智能体" + 模糊 detail "工作台会把 Kun 接回..." → 用户困惑,不知道去改端口
- 之后:看到 "无法连接到本地运行时" + "运行时端口已被占用。请释放该端口,或在设置中更换端口。" → 一眼知道是 port 冲突,点"打开设置"改 port

## Out of scope(故意不做)

- **不改 reclaimKunPort 逻辑**:端口冲突仍报错,不自动 fallback(那个是 #78 方案 A,风险高,跟报告者已自解决冲突)
- **不改 Settings UI**:port 字段在 SettingsView 已存在,只是普通用户不一定找得到 — 那是另一个 issue
- **不改 shouldOpenAgentsSettings 列表**:`runtime_port_conflict` 已在里面,自动跳到 settings — 这条已经工作

cc @XingYu-Zhong @luoye520ww

Closes #78