### PR TITLE
Deduplicate repeated file change summaries / 合并重复文件改动摘要

### DIFF
--- a/src/renderer/src/components/chat/derive-turn-sections.test.ts
+++ b/src/renderer/src/components/chat/derive-turn-sections.test.ts
@@ -103,6 +103,53 @@ describe('deriveTurnSections', () => {
     ])
   })
 
+  it('merges repeated file changes for the same displayed path', () => {
+    const firstPatch = [
+      'diff --git a/.kunsdd/draft/plan/requirement.md b/.kunsdd/draft/plan/requirement.md',
+      '--- a/.kunsdd/draft/plan/requirement.md',
+      '+++ b/.kunsdd/draft/plan/requirement.md',
+      '@@ -1,1 +1,1 @@',
+      '-old title',
+      '+new title'
+    ].join('\n')
+    const secondPatch = [
+      'diff --git a/.kunsdd/draft/plan/requirement.md b/.kunsdd/draft/plan/requirement.md',
+      '--- a/.kunsdd/draft/plan/requirement.md',
+      '+++ b/.kunsdd/draft/plan/requirement.md',
+      '@@ -4,1 +4,2 @@',
+      ' context',
+      '+new detail'
+    ].join('\n')
+    const result = sections([
+      {
+        kind: 'tool',
+        id: 'tool_first_edit',
+        summary: 'Edit requirement',
+        status: 'success',
+        toolKind: 'file_change',
+        filePath: '/tmp/.kunsdd/draft/plan/requirement.md',
+        detail: firstPatch
+      },
+      {
+        kind: 'tool',
+        id: 'tool_second_edit',
+        summary: 'Edit requirement again',
+        status: 'success',
+        toolKind: 'file_change',
+        filePath: '/tmp/.kunsdd/draft/plan/requirement.md',
+        detail: secondPatch
+      }
+    ])
+
+    expect(result.turnFileChanges).toHaveLength(1)
+    expect(result.turnFileChanges[0]).toMatchObject({
+      id: 'tool_first_edit',
+      filePath: '.kunsdd/draft/plan/requirement.md'
+    })
+    expect(result.turnFileChanges[0]?.detail).toContain('+new title')
+    expect(result.turnFileChanges[0]?.detail).toContain('+new detail')
+  })
+
   it('renders live assistant output inside the active process timeline', () => {
     const result = processingSections({
       liveProcessText: 'private reasoning',

--- a/src/renderer/src/components/chat/derive-turn-sections.ts
+++ b/src/renderer/src/components/chat/derive-turn-sections.ts
@@ -19,12 +19,44 @@ export type TurnSections = {
   turnFileChanges: ToolBlock[]
 }
 
+type ResolvedFileChangeBlock = ToolBlock & {
+  detail: string
+  filePath: string
+}
+
 type DeriveTurnSectionsInput = {
   turn: Turn
   isProcessing: boolean
   liveProcessText: string
   liveContent: string
   workspaceRoot: string
+}
+
+function fileChangeGroupKey(filePath: string): string {
+  return filePath.trim().replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+function mergeFileChangeBlocks(changes: ResolvedFileChangeBlock[]): ToolBlock[] {
+  const merged: ResolvedFileChangeBlock[] = []
+  const indexByPath = new Map<string, number>()
+
+  for (const change of changes) {
+    const key = fileChangeGroupKey(change.filePath)
+    const existingIndex = indexByPath.get(key)
+    if (existingIndex === undefined) {
+      indexByPath.set(key, merged.length)
+      merged.push(change)
+      continue
+    }
+
+    const existing = merged[existingIndex]
+    merged[existingIndex] = {
+      ...existing,
+      detail: [existing.detail, change.detail].filter(Boolean).join('\n\n')
+    }
+  }
+
+  return merged
 }
 
 /**
@@ -96,7 +128,7 @@ export function deriveTurnSections({
 
   const turnFileChanges: ToolBlock[] = isProcessing
     ? []
-    : turn.blocks.flatMap((block): ToolBlock[] => {
+    : mergeFileChangeBlocks(turn.blocks.flatMap((block): ResolvedFileChangeBlock[] => {
         if (
           !(block.kind === 'tool' && block.toolKind === 'file_change' && block.status === 'success')
         ) {
@@ -113,7 +145,7 @@ export function deriveTurnSections({
         if (!resolvedFilePath) return []
 
         return [{ ...block, detail: detailText, filePath: resolvedFilePath }]
-      })
+      }))
 
   return { processBlocks, assistantContentBlocks, turnFileChanges }
 }


### PR DESCRIPTION
﻿## Summary / 概要

English:
- Merge repeated successful `file_change` blocks that point to the same displayed path.
- Keep the first tool block identity while concatenating later diff details, so review still shows the full set of edits.
- Add a regression test for repeated edits to the same `.kunsdd/draft/plan/requirement.md` file.

中文：
- 合并同一个显示路径上的重复 `file_change` 成一条文件改动记录。
- 保留第一条 tool block 的身份，同时把后续 diff 详情拼接进去，避免审查时丢失实际改动。
- 增加同一个 `.kunsdd/draft/plan/requirement.md` 被多次编辑时只显示一条记录的回归测试。

Fixes #101

## Verification / 验证

- `npm.cmd test -- src/renderer/src/components/chat/derive-turn-sections.test.ts src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts`
- `npm.cmd run typecheck`
- `git diff --check upstream/develop..HEAD`
