### PR TITLE
Preserve full assistant replies split by tool output / 保留被工具输出分隔的完整回复

### DIFF
--- a/src/renderer/src/components/chat/derive-turn-sections.test.ts
+++ b/src/renderer/src/components/chat/derive-turn-sections.test.ts
@@ -58,6 +58,51 @@ describe('deriveTurnSections', () => {
     expect(result.processBlocks.map((block) => block.kind)).toEqual(['tool'])
   })
 
+  it('keeps completed assistant text that was separated by tool output', () => {
+    const result = sections([
+      { kind: 'assistant', id: 'intro', text: 'I found the likely cause.' },
+      {
+        kind: 'tool',
+        id: 'tool_read',
+        summary: 'read: source',
+        status: 'success',
+        toolKind: 'tool_call',
+        detail: 'read output'
+      },
+      {
+        kind: 'assistant',
+        id: 'analysis',
+        text: [
+          'Here is the detailed analysis:',
+          '',
+          '```txt',
+          'command output line 1',
+          'command output line 2',
+          '```'
+        ].join('\n')
+      },
+      {
+        kind: 'tool',
+        id: 'tool_issue',
+        summary: 'web_fetch: issue',
+        status: 'success',
+        toolKind: 'tool_call',
+        detail: 'https://github.com/XingYu-Zhong/DeepSeek-GUI/issues/96'
+      },
+      { kind: 'assistant', id: 'next', text: 'The issue link above should still be visible.' }
+    ])
+
+    expect(result.assistantContentBlocks.map((block) => block.id)).toEqual([
+      'intro',
+      'analysis',
+      'next'
+    ])
+    expect(result.assistantContentBlocks.map((block) => block.text).join('\n\n')).toContain(
+      'command output line 2'
+    )
+    expect(result.processBlocks.map((block) => block.id)).toEqual(['tool_read', 'tool_issue'])
+  })
+
   it('does not create assistant content from tool-only process work', () => {
     const result = sections([
       {

--- a/src/renderer/src/components/chat/derive-turn-sections.ts
+++ b/src/renderer/src/components/chat/derive-turn-sections.ts
@@ -5,7 +5,6 @@ import {
   formatFilePathForDisplay,
 } from '../../lib/diff-stats'
 import {
-  findTrailingAssistantContentStart,
   isProcessBlock,
   splitThink,
   type Turn
@@ -49,11 +48,8 @@ export function deriveTurnSections({
   const processBlocks: ChatBlock[] = []
   const assistantContentBlocks: TurnAssistantBlock[] = []
   let latestAssistantContentBlock: TurnAssistantBlock | null = null
-  const trailingAssistantContentStart = isProcessing
-    ? turn.blocks.length
-    : findTrailingAssistantContentStart(turn.blocks)
 
-  for (const [index, block] of turn.blocks.entries()) {
+  for (const block of turn.blocks) {
     if (block.kind === 'assistant') {
       const split = splitThink(block.text)
       if (split.think) {
@@ -64,7 +60,7 @@ export function deriveTurnSections({
         latestAssistantContentBlock = contentBlock
         if (isProcessing) {
           processBlocks.push(contentBlock)
-        } else if (index >= trailingAssistantContentStart) {
+        } else {
           assistantContentBlocks.push(contentBlock)
         }
       }


### PR DESCRIPTION
﻿## Summary / 概要

English:
- Preserve every completed assistant text segment in a finished turn, even when tool output appears between assistant messages.
- Keep tool/process output in the process timeline while still rendering the full assistant reply below.
- Add a regression test for assistant text split by tool output, including code/command output and issue links.

中文：
- 已完成的 turn 中，如果 assistant 文本被工具输出分隔，不再只保留最后一段 assistant 文本。
- 工具/过程输出仍然留在过程时间线里，同时完整渲染 assistant 的最终回复内容。
- 增加回归测试，覆盖“第一句话后接工具输出、代码块/命令输出和 issue 链接不可见”的场景。

Fixes #132
Refs #96

## Notes / 备注

This is intentionally small and only touches the turn-section derivation path. It does not change Streamdown rendering, virtual scroll, or SSE buffering.

这个 PR 只改消息分段派生逻辑，不改 Streamdown、虚拟滚动或 SSE buffering，方便单独 review。

## Verification / 验证

- `npm.cmd test -- src/renderer/src/components/chat/derive-turn-sections.test.ts src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts`
- `npm.cmd run typecheck`
- `git diff --check upstream/develop..HEAD`
