### PR TITLE
fix(timeline): land on the latest message when switching threads

### DIFF
--- a/src/renderer/src/components/chat/use-timeline-scroll.ts
+++ b/src/renderer/src/components/chat/use-timeline-scroll.ts
@@ -138,6 +138,14 @@ export function useTimelineScroll({
   }, [contentKey, endRef, streaming])
 
   // Hard reset on thread switch.
+  //
+  // Streamdown markdown is lazy-loaded, so the timeline keeps growing
+  // for a few frames after the new turns mount. A single scrollIntoView
+  // at this point lands on the pre-settle height and the viewport ends
+  // up above the latest message. Pin the scroll to the bottom while the
+  // inner content grows, then let go as soon as either the height
+  // settles or a short grace window elapses — so we never fight the
+  // user the moment they start scrolling.
   useEffect(() => {
     stickToBottomRef.current = true
     historyExpansionRequestedRef.current = false
@@ -147,8 +155,25 @@ export function useTimelineScroll({
       window.cancelAnimationFrame(scrollFrameRef.current)
       scrollFrameRef.current = null
     }
-    endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
-  }, [activeThreadId, endRef])
+    const el = containerRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+    const inner = el.firstElementChild as HTMLElement | null
+    if (!inner) return
+    const SETTLE_WINDOW_MS = 1200
+    const observer = new ResizeObserver(() => {
+      if (!stickToBottomRef.current) return
+      const node = containerRef.current
+      if (!node) return
+      node.scrollTop = node.scrollHeight
+    })
+    observer.observe(inner)
+    const timer = window.setTimeout(() => observer.disconnect(), SETTLE_WINDOW_MS)
+    return () => {
+      observer.disconnect()
+      window.clearTimeout(timer)
+    }
+  }, [activeThreadId, containerRef])
 
   // Cleanup any pending rAF on unmount.
   useEffect(


### PR DESCRIPTION
## Summary

Switching to a thread used to call `scrollIntoView({ block: 'end' })` once, right after `activeThreadId` changed. `Streamdown` markdown is `React.lazy`-loaded, so the timeline keeps growing for several frames after the new turns mount. That single scroll lands on the pre-settle height and the viewport ends up parked above the latest message, making the thread look like it opens at the top.

Replace the one-shot scroll with a `ResizeObserver` guarded by `stickToBottomRef`:

- pin scroll to the bottom while the inner content keeps growing (lazy markdown / images settling in)
- release the moment the user scrolls — the existing scroll listener flips `stickToBottomRef` to `false` and the observer becomes a no-op
- disconnect after a short grace window (1.2s) so it never fights the user later

## 摘要

切换线程时,代码原本是在 `activeThreadId` 变化后调用一次 `scrollIntoView({ block: 'end' })`。但 `Streamdown` 是 `React.lazy` 异步加载的,新的 turn 挂载之后,timeline 还会继续撑高几帧。这一次性 scroll 滚到的是"未落位的底",视口最终停在最新消息上面,看起来像每次开会话都从顶部开始。

把这次一次性 scroll 换成一个由 `stickToBottomRef` 守护的 `ResizeObserver`:

- 内容区域高度还在长就持续 pin 到底部(markdown / 图片 lazy 落位的过程)
- 一旦用户开始滚动,scroll listener 把 `stickToBottomRef` 置 `false`,observer 变成 no-op,不抢
- 1.2s 短窗口后自动 disconnect,后续完全交给原有的 stick-to-bottom 流式机制

## Files changed / 改动文件

- `src/renderer/src/components/chat/use-timeline-scroll.ts` — "Hard reset on thread switch" effect 改成 ResizeObserver + stickToBottomRef + 1.2s 窗口

## Test plan / 测试清单

- [x] 打开有较长历史的线程 → 直接停在最新一条消息
- [x] 切换线程后立刻往上滚 → 不被弹回底部
- [x] 流式输出仍然实时跟到底
- [x] 空线程 / 只有一条消息的线程 → 不出错
- [x] 快速来回切换多个线程 → 观察 observer 是否正确清理(无内存泄漏)