### PR TITLE
Restore unfinished SDD drafts / 恢复未完成的新建需求

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -43,7 +43,7 @@ import { composeWritePrompt } from '../write/quoted-selection'
 import { useWriteWorkspaceStore } from '../write/write-workspace-store'
 import { isWriteThreadId } from '../write/write-thread-registry'
 import { createSddDraft, forgetRememberedSddDraft, useSddDraftStore } from '../sdd/sdd-draft-store'
-import type { SddDraft } from '../sdd/sdd-draft-store'
+import type { SddDraft, SddDraftSaveStatus } from '../sdd/sdd-draft-store'
 import { saveActiveSddDraftToDisk } from '../sdd/sdd-draft-actions'
 import { restoreRememberedSddDraft } from '../sdd/sdd-draft-restore'
 import { composeSddAssistantPrompt } from '../sdd/sdd-assistant-prompt'
@@ -374,6 +374,8 @@ export function Workbench(): ReactElement {
   const draftByThread = useRef<Record<string, string>>({})
   const prevThreadId = useRef<string | null>(null)
   const inputRef = useRef('')
+  const dismissedSddDraftWorkspacesRef = useRef<Set<string>>(new Set())
+  const restoredSddDraftWorkspaceRef = useRef('')
   const sddUpgradeInFlightRef = useRef(false)
   const sddUpgradeTargetRef = useRef<PendingSddPlanTarget | null>(null)
   const timelineBlocks = blocks
@@ -858,16 +860,58 @@ export function Workbench(): ReactElement {
     return createSddAssistantThreadForDraft(draft)
   }
 
-  const openSddRequirementDraft = async (draft: SddDraft, content: string): Promise<boolean> => {
-    useSddDraftStore.getState().setActiveDraft(draft, content)
+  const openSddRequirementDraft = async (
+    draft: SddDraft,
+    content: string,
+    options: {
+      lastSavedContent?: string
+      saveStatus?: SddDraftSaveStatus
+      openAssistant?: boolean
+    } = {}
+  ): Promise<boolean> => {
+    useSddDraftStore.getState().setActiveDraft(draft, content, {
+      lastSavedContent: options.lastSavedContent,
+      saveStatus: options.saveStatus
+    })
+    dismissedSddDraftWorkspacesRef.current.delete(normalizeWorkspaceRoot(draft.workspaceRoot))
     setInput('')
     setMode('agent')
     setRoute('chat')
-    setRightSidebarWidth((width) => Math.max(width, 420))
-    const sddThreadId = await ensureSddAssistantThreadForDraft(draft)
-    if (!sddThreadId) return false
-    setRightPanelMode('sdd-ai')
+    if (options.openAssistant ?? runtimeConnection === 'ready') {
+      setRightSidebarWidth((width) => Math.max(width, 420))
+      const sddThreadId = await ensureSddAssistantThreadForDraft(draft)
+      if (sddThreadId) {
+        setRightPanelMode('sdd-ai')
+      } else {
+        setRightPanelMode(null)
+      }
+    } else {
+      setRightPanelMode(null)
+    }
     return true
+  }
+
+  const dismissActiveSddDraft = (options: { closeAssistant?: boolean } = {}): void => {
+    const draft = useSddDraftStore.getState().activeDraft
+    if (draft) {
+      dismissedSddDraftWorkspacesRef.current.add(normalizeWorkspaceRoot(draft.workspaceRoot))
+      void saveActiveSddDraftToDisk()
+      useSddDraftStore.getState().clearActiveDraft()
+    }
+    if (options.closeAssistant && rightPanelMode === 'sdd-ai') setRightPanelMode(null)
+  }
+
+  const toggleSddAssistantPanel = async (): Promise<void> => {
+    if (rightPanelMode === 'sdd-ai') {
+      setRightPanelMode(null)
+      return
+    }
+    const draft = useSddDraftStore.getState().activeDraft
+    if (!draft) return
+    setRightSidebarWidth((width) => Math.max(width, 420))
+    const threadId = await ensureSddAssistantThreadForDraft(draft)
+    if (!threadId) return
+    setRightPanelMode('sdd-ai')
   }
 
   const startNewSddRequirement = async (): Promise<void> => {
@@ -888,7 +932,10 @@ export function Workbench(): ReactElement {
       readWorkspaceFile: window.dsGui.readWorkspaceFile
     })
     if (restored.kind === 'restored') {
-      await openSddRequirementDraft(restored.draft, restored.content)
+      await openSddRequirementDraft(restored.draft, restored.content, {
+        lastSavedContent: restored.lastSavedContent,
+        saveStatus: restored.saveStatus
+      })
       return
     }
 
@@ -916,6 +963,39 @@ export function Workbench(): ReactElement {
     const activeDraft = { ...draft, absolutePath: result.path }
     await openSddRequirementDraft(activeDraft, initialContent)
   }
+
+  useEffect(() => {
+    if (activeSddDraft) return
+    const activeCodeWorkspace = activeThreadId
+      ? normalizeWorkspaceRoot(codeThreads.find((thread) => thread.id === activeThreadId)?.workspace ?? '')
+      : ''
+    const targetWorkspace = activeCodeWorkspace || normalizeWorkspaceRoot(workspaceRoot)
+    if (!targetWorkspace || dismissedSddDraftWorkspacesRef.current.has(targetWorkspace)) return
+    if (restoredSddDraftWorkspaceRef.current === targetWorkspace) return
+
+    let cancelled = false
+    restoredSddDraftWorkspaceRef.current = targetWorkspace
+    void restoreRememberedSddDraft({
+      workspaceRoot: targetWorkspace,
+      readWorkspaceFile: window.dsGui.readWorkspaceFile
+    }).then((restored) => {
+      if (cancelled || restored.kind !== 'restored') return
+      if (useSddDraftStore.getState().activeDraft) return
+      useSddDraftStore.getState().setActiveDraft(restored.draft, restored.content, {
+        lastSavedContent: restored.lastSavedContent,
+        saveStatus: restored.saveStatus
+      })
+      dismissedSddDraftWorkspacesRef.current.delete(targetWorkspace)
+      setInput('')
+      setMode('agent')
+      setRoute('chat')
+      setRightPanelMode(null)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeSddDraft, activeThreadId, codeThreads, setRightPanelMode, setRoute, workspaceRoot])
 
   const sendSddAssistantPrompt = async (value: string): Promise<void> => {
     const v = value.trim()
@@ -1290,30 +1370,21 @@ export function Workbench(): ReactElement {
   }
 
   const openThread = (id: string): void => {
-    if (activeSddDraft) {
-      void saveActiveSddDraftToDisk()
-      useSddDraftStore.getState().clearActiveDraft()
-    }
+    if (activeSddDraft) dismissActiveSddDraft({ closeAssistant: true })
     setConnectPhoneSidebarOpen(false)
     setRoute('chat')
     void selectThread(id)
   }
 
   const startNewChat = (): void => {
-    if (activeSddDraft) {
-      void saveActiveSddDraftToDisk()
-      useSddDraftStore.getState().clearActiveDraft()
-    }
+    if (activeSddDraft) dismissActiveSddDraft({ closeAssistant: true })
     setConnectPhoneSidebarOpen(false)
     setRoute('chat')
     void createThread()
   }
 
   const startNewChatInWorkspace = (workspaceRoot: string): void => {
-    if (activeSddDraft) {
-      void saveActiveSddDraftToDisk()
-      useSddDraftStore.getState().clearActiveDraft()
-    }
+    if (activeSddDraft) dismissActiveSddDraft({ closeAssistant: true })
     setConnectPhoneSidebarOpen(false)
     setRoute('chat')
     void createThread({ workspaceRoot })
@@ -1340,11 +1411,7 @@ export function Workbench(): ReactElement {
   }
 
   const toggleConnectPhone = (): void => {
-    if (activeSddDraft) {
-      void saveActiveSddDraftToDisk()
-      useSddDraftStore.getState().clearActiveDraft()
-      if (rightPanelMode === 'sdd-ai') setRightPanelMode(null)
-    }
+    if (activeSddDraft) dismissActiveSddDraft({ closeAssistant: true })
     openClaw()
     setConnectPhoneSidebarOpen((open) => !open)
   }
@@ -1620,13 +1687,9 @@ export function Workbench(): ReactElement {
               leftSidebarCollapsed={leftSidebarCollapsed}
               assistantOpen={rightPanelMode === 'sdd-ai'}
               onToggleLeftSidebar={toggleLeftSidebar}
-              onToggleAssistant={() => toggleRightPanelMode('sdd-ai')}
+              onToggleAssistant={() => void toggleSddAssistantPanel()}
               onNext={() => void handleSddNextStep()}
-              onClose={() => {
-                void saveActiveSddDraftToDisk()
-                useSddDraftStore.getState().clearActiveDraft()
-                if (rightPanelMode === 'sdd-ai') setRightPanelMode(null)
-              }}
+              onClose={() => dismissActiveSddDraft({ closeAssistant: true })}
               nextDisabled={busy || runtimeConnection !== 'ready' || sddDraftOperationStatus === 'upgrading'}
             />
           ) : (

--- a/src/renderer/src/sdd/sdd-draft-restore.test.ts
+++ b/src/renderer/src/sdd/sdd-draft-restore.test.ts
@@ -22,12 +22,14 @@ function createMemoryStorage(): Storage {
 
 describe('sdd-draft-restore', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     vi.stubGlobal('localStorage', createMemoryStorage())
     vi.stubGlobal('window', { localStorage })
     useSddDraftStore.getState().clearActiveDraft()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     useSddDraftStore.getState().clearActiveDraft()
   })
@@ -64,6 +66,67 @@ describe('sdd-draft-restore', () => {
         workspaceRoot: '/tmp/app',
         absolutePath: '/tmp/app/.kunsdd/draft/123e4567-e89b-12d3-a456-426614174000/requirement.md'
       }
+    })
+  })
+
+  it('restores newer unsaved local content when disk autosave did not finish before restart', async () => {
+    const draft = createSddDraft({
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      workspaceRoot: '/tmp/app/',
+      now: 1
+    })
+    useSddDraftStore.getState().setActiveDraft(draft, '# Disk draft')
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-02T03:04:05.000Z'))
+    useSddDraftStore.getState().setContent('# Disk draft\n\nUnsaved local line')
+    useSddDraftStore.getState().clearActiveDraft()
+    const readWorkspaceFile = vi.fn().mockResolvedValue({
+      ok: true,
+      path: '/tmp/app/.kunsdd/draft/123e4567-e89b-12d3-a456-426614174000/requirement.md',
+      content: '# Disk draft',
+      size: 12,
+      truncated: false
+    })
+
+    const result = await restoreRememberedSddDraft({
+      workspaceRoot: '/tmp/app',
+      readWorkspaceFile
+    })
+
+    expect(result).toMatchObject({
+      kind: 'restored',
+      content: '# Disk draft\n\nUnsaved local line',
+      lastSavedContent: '# Disk draft',
+      saveStatus: 'dirty'
+    })
+  })
+
+  it('does not let a clean local snapshot override newer disk content', async () => {
+    const draft = createSddDraft({
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      workspaceRoot: '/tmp/app/',
+      now: 1
+    })
+    useSddDraftStore.getState().setActiveDraft(draft, '# Previous')
+    useSddDraftStore.getState().clearActiveDraft()
+    const readWorkspaceFile = vi.fn().mockResolvedValue({
+      ok: true,
+      path: '/tmp/app/.kunsdd/draft/123e4567-e89b-12d3-a456-426614174000/requirement.md',
+      content: '# Updated on disk',
+      size: 17,
+      truncated: false
+    })
+
+    const result = await restoreRememberedSddDraft({
+      workspaceRoot: '/tmp/app',
+      readWorkspaceFile
+    })
+
+    expect(result).toMatchObject({
+      kind: 'restored',
+      content: '# Updated on disk',
+      lastSavedContent: '# Updated on disk',
+      saveStatus: 'saved'
     })
   })
 

--- a/src/renderer/src/sdd/sdd-draft-restore.ts
+++ b/src/renderer/src/sdd/sdd-draft-restore.ts
@@ -1,14 +1,18 @@
 import type { WorkspaceFileReadResult, WorkspaceFileTarget } from '@shared/workspace-file'
 import {
   forgetRememberedSddDraft,
+  readRememberedSddDraftContent,
   readRememberedSddDraft,
-  type SddDraft
+  type SddDraft,
+  type SddDraftSaveStatus
 } from './sdd-draft-store'
 
 export type RestoredSddDraft = {
   kind: 'restored'
   draft: SddDraft
   content: string
+  lastSavedContent: string
+  saveStatus: SddDraftSaveStatus
 }
 
 export type UnrestorableSddDraft =
@@ -20,6 +24,11 @@ export type RestoreRememberedSddDraftResult = RestoredSddDraft | UnrestorableSdd
 type RestoreRememberedSddDraftOptions = {
   workspaceRoot: string
   readWorkspaceFile: (options: WorkspaceFileTarget) => Promise<WorkspaceFileReadResult>
+}
+
+function timestampMs(value: string): number {
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : 0
 }
 
 export async function restoreRememberedSddDraft({
@@ -38,9 +47,19 @@ export async function restoreRememberedSddDraft({
     return { kind: 'unreadable', draft: remembered, message: result.message }
   }
 
+  const contentSnapshot = readRememberedSddDraftContent(remembered)
+  const snapshotLooksNewer =
+    contentSnapshot &&
+    contentSnapshot.content !== contentSnapshot.lastSavedContent &&
+    contentSnapshot.content !== result.content &&
+    timestampMs(contentSnapshot.updatedAt) > timestampMs(remembered.updatedAt)
+  const content = snapshotLooksNewer ? contentSnapshot.content : result.content
+
   return {
     kind: 'restored',
     draft: { ...remembered, absolutePath: result.path },
-    content: result.content
+    content,
+    lastSavedContent: result.content,
+    saveStatus: content === result.content ? 'saved' : 'dirty'
   }
 }

--- a/src/renderer/src/sdd/sdd-draft-store.test.ts
+++ b/src/renderer/src/sdd/sdd-draft-store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createSddDraft,
   forgetRememberedSddDraft,
+  readRememberedSddDraftContent,
   readRememberedSddDraft,
   useSddDraftStore
 } from './sdd-draft-store'
@@ -147,6 +148,49 @@ describe('sdd-draft-store', () => {
     expect(state.saveStatus).toBe('saved')
     expect(state.error).toBe('image missing')
     expect(readRememberedSddDraft('/tmp/app')?.updatedAt).toBe('2026-01-02T03:04:05.000Z')
+  })
+
+  it('persists unsaved draft content for restart recovery', () => {
+    const draft = createSddDraft({
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      workspaceRoot: '/tmp/app',
+      now: 1
+    })
+    useSddDraftStore.getState().setActiveDraft(draft, '# Draft')
+
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-02T03:04:05.000Z'))
+    useSddDraftStore.getState().setContent('# Draft\n\nUnsaved line')
+
+    expect(readRememberedSddDraftContent(draft)).toEqual({
+      draftId: draft.id,
+      content: '# Draft\n\nUnsaved line',
+      lastSavedContent: '# Draft',
+      updatedAt: '2026-01-02T03:04:05.000Z'
+    })
+  })
+
+  it('opens a restored dirty draft with separate saved baseline', () => {
+    const draft = createSddDraft({
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      workspaceRoot: '/tmp/app',
+      now: 1
+    })
+
+    useSddDraftStore.getState().setActiveDraft(draft, '# Local unsaved draft', {
+      lastSavedContent: '# Disk draft',
+      saveStatus: 'dirty'
+    })
+
+    expect(useSddDraftStore.getState()).toMatchObject({
+      content: '# Local unsaved draft',
+      lastSavedContent: '# Disk draft',
+      saveStatus: 'dirty'
+    })
+    expect(readRememberedSddDraftContent(draft)).toMatchObject({
+      content: '# Local unsaved draft',
+      lastSavedContent: '# Disk draft'
+    })
   })
 
   it('saves the active draft to disk and updates clean state', async () => {

--- a/src/renderer/src/sdd/sdd-draft-store.ts
+++ b/src/renderer/src/sdd/sdd-draft-store.ts
@@ -18,6 +18,14 @@ type PersistedSddDraftRegistry = {
   version: 1
   activeByWorkspace: Record<string, string>
   drafts: Record<string, SddDraft>
+  contentByDraft: Record<string, SddDraftContentSnapshot>
+}
+
+export type SddDraftContentSnapshot = {
+  draftId: string
+  content: string
+  lastSavedContent: string
+  updatedAt: string
 }
 
 export type SddDraftState = {
@@ -27,7 +35,14 @@ export type SddDraftState = {
   saveStatus: SddDraftSaveStatus
   operationStatus: SddDraftOperationStatus
   error: string | null
-  setActiveDraft: (draft: SddDraft, content: string) => void
+  setActiveDraft: (
+    draft: SddDraft,
+    content: string,
+    options?: {
+      lastSavedContent?: string
+      saveStatus?: SddDraftSaveStatus
+    }
+  ) => void
   setContent: (content: string) => void
   setSaveStatus: (status: SddDraftSaveStatus, error?: string | null) => void
   markSaved: (content: string) => void
@@ -53,6 +68,19 @@ function draftId(workspaceRoot: string, relativePath: string): string {
   return `${normalizeWorkspaceRoot(workspaceRoot)}:${normalizeSddRelativePath(relativePath)}`
 }
 
+function normalizeContentSnapshot(raw: unknown, fallbackDraftId = ''): SddDraftContentSnapshot | null {
+  if (!isRecord(raw)) return null
+  const draftId = normalizeText(raw.draftId) || normalizeText(fallbackDraftId)
+  if (!draftId || typeof raw.content !== 'string') return null
+  const lastSavedContent = typeof raw.lastSavedContent === 'string' ? raw.lastSavedContent : raw.content
+  return {
+    draftId,
+    content: raw.content,
+    lastSavedContent,
+    updatedAt: normalizeText(raw.updatedAt) || new Date(0).toISOString()
+  }
+}
+
 function normalizeDraft(raw: unknown, fallbackId = ''): SddDraft | null {
   if (!isRecord(raw)) return null
   const id = normalizeText(raw.id) || normalizeText(fallbackId)
@@ -73,7 +101,7 @@ function normalizeDraft(raw: unknown, fallbackId = ''): SddDraft | null {
 }
 
 function emptyRegistry(): PersistedSddDraftRegistry {
-  return { version: 1, activeByWorkspace: {}, drafts: {} }
+  return { version: 1, activeByWorkspace: {}, drafts: {}, contentByDraft: {} }
 }
 
 function readRegistry(storage = browserStorage()): PersistedSddDraftRegistry {
@@ -101,7 +129,16 @@ function readRegistry(storage = browserStorage()): PersistedSddDraftRegistry {
         }
       }
     }
-    return { version: 1, activeByWorkspace, drafts }
+    const contentByDraft: Record<string, SddDraftContentSnapshot> = {}
+    if (isRecord(parsed.contentByDraft)) {
+      for (const [id, value] of Object.entries(parsed.contentByDraft)) {
+        const snapshot = normalizeContentSnapshot(value, id)
+        if (snapshot && drafts[snapshot.draftId]) {
+          contentByDraft[snapshot.draftId] = snapshot
+        }
+      }
+    }
+    return { version: 1, activeByWorkspace, drafts, contentByDraft }
   } catch {
     return emptyRegistry()
   }
@@ -145,6 +182,24 @@ export function rememberSddDraft(draft: SddDraft): void {
   writeRegistry(registry)
 }
 
+export function rememberSddDraftContent(
+  draft: Pick<SddDraft, 'id'>,
+  content: string,
+  lastSavedContent = content
+): void {
+  const draftId = normalizeText(draft.id)
+  if (!draftId) return
+  const registry = readRegistry()
+  if (!registry.drafts[draftId]) return
+  registry.contentByDraft[draftId] = {
+    draftId,
+    content,
+    lastSavedContent,
+    updatedAt: new Date().toISOString()
+  }
+  writeRegistry(registry)
+}
+
 export function readRememberedSddDraft(workspaceRoot: string): SddDraft | null {
   const registry = readRegistry()
   const workspace = normalizeWorkspaceRoot(workspaceRoot)
@@ -153,11 +208,21 @@ export function readRememberedSddDraft(workspaceRoot: string): SddDraft | null {
   return draft && normalizeWorkspaceRoot(draft.workspaceRoot) === workspace ? draft : null
 }
 
+export function readRememberedSddDraftContent(
+  draft: Pick<SddDraft, 'id'>
+): SddDraftContentSnapshot | null {
+  const draftId = normalizeText(draft.id)
+  if (!draftId) return null
+  const registry = readRegistry()
+  return registry.contentByDraft[draftId] ?? null
+}
+
 export function forgetRememberedSddDraft(draft: Pick<SddDraft, 'id' | 'workspaceRoot'>): void {
   const normalizedId = normalizeText(draft.id)
   if (!normalizedId) return
   const registry = readRegistry()
   delete registry.drafts[normalizedId]
+  delete registry.contentByDraft[normalizedId]
   for (const [key, activeId] of Object.entries(registry.activeByWorkspace)) {
     if (activeId === normalizedId) {
       delete registry.activeByWorkspace[key]
@@ -174,24 +239,32 @@ export const useSddDraftStore = create<SddDraftState>((set) => ({
   operationStatus: 'idle',
   error: null,
 
-  setActiveDraft: (draft, content) => {
+  setActiveDraft: (draft, content, options = {}) => {
+    const lastSavedContent = options.lastSavedContent ?? content
+    const saveStatus = options.saveStatus ?? (content === lastSavedContent ? 'saved' : 'dirty')
     rememberSddDraft(draft)
+    rememberSddDraftContent(draft, content, lastSavedContent)
     set({
       activeDraft: draft,
       content,
-      lastSavedContent: content,
-      saveStatus: 'saved',
+      lastSavedContent,
+      saveStatus,
       operationStatus: 'idle',
       error: null
     })
   },
 
   setContent: (content) =>
-    set((state) => ({
-      content,
-      saveStatus: content === state.lastSavedContent ? 'saved' : 'dirty',
-      error: state.saveStatus === 'error' ? null : state.error
-    })),
+    set((state) => {
+      if (state.activeDraft) {
+        rememberSddDraftContent(state.activeDraft, content, state.lastSavedContent)
+      }
+      return {
+        content,
+        saveStatus: content === state.lastSavedContent ? 'saved' : 'dirty',
+        error: state.saveStatus === 'error' ? null : state.error
+      }
+    }),
 
   setSaveStatus: (status, error = null) => set({ saveStatus: status, error }),
 
@@ -201,6 +274,7 @@ export const useSddDraftStore = create<SddDraftState>((set) => ({
         ? { ...state.activeDraft, updatedAt: new Date().toISOString() }
         : state.activeDraft
       if (activeDraft) rememberSddDraft(activeDraft)
+      if (activeDraft) rememberSddDraftContent(activeDraft, content, content)
       return {
         activeDraft,
         content,


### PR DESCRIPTION
## Summary
- persist active SDD draft content snapshots for restart recovery
- auto-reopen remembered unfinished requirement drafts when returning to a workspace
- keep restored dirty content separate from the last saved disk baseline

## Test Plan
- npm.cmd test -- src/renderer/src/sdd/sdd-draft-store.test.ts src/renderer/src/sdd/sdd-draft-restore.test.ts
- npm.cmd run typecheck
- npm.cmd run lint (passes with existing hook warnings in ConnectPhone/ClawDialog)