### PR TITLE
fix: scroll to bottom of conversation on thread switch

### DIFF
--- a/src/renderer/src/components/chat/use-timeline-scroll.ts
+++ b/src/renderer/src/components/chat/use-timeline-scroll.ts
@@ -147,7 +147,15 @@ export function useTimelineScroll({
       window.cancelAnimationFrame(scrollFrameRef.current)
       scrollFrameRef.current = null
     }
-    endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
+    // Double-rAF: defer scroll until after visibleTurnCount has been
+    // re-derived and the extra turns have been painted. A single rAF
+    // fires before the state-update from the re-derive effect commits.
+    scrollFrameRef.current = window.requestAnimationFrame(() => {
+      scrollFrameRef.current = window.requestAnimationFrame(() => {
+        scrollFrameRef.current = null
+        endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
+      })
+    })
   }, [activeThreadId, endRef])
 
   // Cleanup any pending rAF on unmount.


### PR DESCRIPTION
## Problem

When switching between conversations via the sidebar, the message timeline does not scroll to the latest messages. Instead, the viewport lands somewhere in the middle of the conversation, leaving the user disoriented.

## Root Cause

A race condition in the `useTimelineScroll` hook between two `useEffect` blocks in `src/renderer/src/components/chat/use-timeline-scroll.ts`:

1. **Hard reset effect** (triggered by `activeThreadId` change): calls `endRef.current?.scrollIntoView()` synchronously. At this point `visibleTurnCount` React state is still stale from the previous conversation — only a subset of turns are rendered in the DOM.

2. **Re-derive visible count effect** (also triggered by `activeThreadId` change): calls `setVisibleTurnCount(deriveTimelineVisibleTurnCount(...))`, which queues an async state update that re-renders with more turns prepended above the viewport.

Because the scroll fires before the visible turn count reconciles, the content area grows taller after the scroll, pushing the scroll position away from the bottom.

## Fix

Defer the `scrollIntoView` call using a double `requestAnimationFrame`, ensuring it runs after `visibleTurnCount` has been re-derived and the additional turns have been painted:

```typescript
// Before
endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })

// After — double-rAF defers until after the next paint
scrollFrameRef.current = window.requestAnimationFrame(() => {
  scrollFrameRef.current = window.requestAnimationFrame(() => {
    scrollFrameRef.current = null
    endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
  })
})
```

## Files Changed

- `src/renderer/src/components/chat/use-timeline-scroll.ts` — defer scroll in thread-switch effect (+9, -1)

## Testing

1. Open a conversation with a long message history
2. Scroll up manually, then click a different conversation in the sidebar — viewport should jump to the latest messages
3. Switch back and forth between multiple conversations — each time the view should start at the bottom
4. Verify that existing scroll behavior still works: stick-to-bottom during streaming, lazy-load earlier turns on scroll-up, and prepend-position preservation