### PR TITLE
fix: Adding provider no response

### DIFF
--- a/src/main/settings-store.test.ts
+++ b/src/main/settings-store.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_APPROVAL_POLICY } from '../shared/app-settings'
+import { DEFAULT_APPROVAL_POLICY, defaultKunRuntimeSettings, defaultModelProviderSettings } from '../shared/app-settings'
 import { DEFAULT_GUI_UPDATE_CHANNEL } from '../shared/gui-update'
 import { JsonSettingsStore } from './settings-store'
 
@@ -135,6 +135,73 @@ describe('JsonSettingsStore', () => {
     expect(loaded.provider.baseUrl).toBe('https://runtime.example/v1')
     expect(loaded.agents.kun.apiKey).toBe('')
     expect(loaded.agents.kun.baseUrl).toBe('')
+  })
+
+  it('keeps custom model providers when migrated settings are reloaded', async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), 'ds-gui-settings-'))
+    const settingsPath = join(userDataDir, 'deepseek-gui-settings.json')
+    const provider = defaultModelProviderSettings()
+
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        version: 1,
+        agentProvider: 'deepseek-runtime',
+        provider: {
+          apiKey: 'sk-default',
+          baseUrl: 'https://api.deepseek.com',
+          providers: [
+            ...provider.providers,
+            {
+              id: 'custom-provider-2',
+              name: 'Custom Provider',
+              apiKey: 'sk-custom',
+              baseUrl: 'https://custom.example/v1',
+              models: ['custom-model']
+            }
+          ]
+        },
+        agents: {
+          kun: {
+            ...defaultKunRuntimeSettings(),
+            providerId: 'custom-provider-2',
+            model: 'custom-model'
+          }
+        }
+      }),
+      'utf8'
+    )
+
+    const firstStore = new JsonSettingsStore(userDataDir)
+    const firstLoaded = await firstStore.load()
+
+    expect(firstLoaded.provider.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'custom-provider-2',
+          apiKey: 'sk-custom',
+          baseUrl: 'https://custom.example/v1',
+          models: ['custom-model']
+        })
+      ])
+    )
+    expect(firstLoaded.agents.kun.providerId).toBe('custom-provider-2')
+    await firstStore.save(firstLoaded)
+
+    const secondStore = new JsonSettingsStore(userDataDir)
+    const secondLoaded = await secondStore.load()
+
+    expect(secondLoaded.provider.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'custom-provider-2',
+          apiKey: 'sk-custom',
+          baseUrl: 'https://custom.example/v1',
+          models: ['custom-model']
+        })
+      ])
+    )
+    expect(secondLoaded.agents.kun.providerId).toBe('custom-provider-2')
   })
 
   it('loads settings from the legacy lowercase userData directory and writes them into the current path', async () => {

--- a/src/renderer/src/components/settings-section-agents.test.ts
+++ b/src/renderer/src/components/settings-section-agents.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { defaultKunRuntimeSettings } from '@shared/app-settings'
-import { AgentsSettingsSection } from './settings-section-agents'
+import {
+  DEFAULT_MODEL_PROVIDER_ID,
+  defaultKunRuntimeSettings,
+  defaultModelProviderSettings
+} from '@shared/app-settings'
+import { AgentsSettingsSection, modelProvidersSettingsPatch } from './settings-section-agents'
 
 const labels: Record<string, string> = {
   agentsQuickBase: 'Base',
@@ -293,6 +297,51 @@ function baseCtx(): Record<string, unknown> {
 }
 
 describe('AgentsSettingsSection Kun diagnostics smoke', () => {
+  it('builds a single patch when adding and selecting a model provider', () => {
+    const provider = defaultModelProviderSettings()
+    const customProvider = {
+      id: 'custom-provider-2',
+      name: 'Custom Provider',
+      apiKey: '',
+      baseUrl: 'https://api.example.com/v1',
+      models: []
+    }
+
+    const patch = modelProvidersSettingsPatch({
+      provider,
+      providers: [...provider.providers, customProvider],
+      kun: { providerId: customProvider.id }
+    })
+
+    expect(patch.provider?.providers).toEqual([...provider.providers, customProvider])
+    expect(patch.agents?.kun?.providerId).toBe(customProvider.id)
+  })
+
+  it('builds a single patch when removing the active model provider', () => {
+    const provider = defaultModelProviderSettings()
+
+    const patch = modelProvidersSettingsPatch({
+      provider: {
+        ...provider,
+        providers: [
+          ...provider.providers,
+          {
+            id: 'custom-provider-2',
+            name: 'Custom Provider',
+            apiKey: '',
+            baseUrl: 'https://api.example.com/v1',
+            models: []
+          }
+        ]
+      },
+      providers: provider.providers,
+      kun: { providerId: DEFAULT_MODEL_PROVIDER_ID }
+    })
+
+    expect(patch.provider?.providers).toEqual(provider.providers)
+    expect(patch.agents?.kun?.providerId).toBe(DEFAULT_MODEL_PROVIDER_ID)
+  })
+
   it('keeps advanced agent controls behind collapsed disclosures', () => {
     const html = renderToStaticMarkup(createElement(AgentsSettingsSection, { ctx: baseCtx() }))
 

--- a/src/renderer/src/components/settings-section-agents.tsx
+++ b/src/renderer/src/components/settings-section-agents.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
-import type { ApprovalPolicy, AppSettingsV1, ModelProviderProfileV1, SandboxMode } from '@shared/app-settings'
+import type {
+  ApprovalPolicy,
+  AppSettingsPatch,
+  AppSettingsV1,
+  ModelProviderProfileV1,
+  ModelProviderSettingsV1,
+  SandboxMode
+} from '@shared/app-settings'
 import {
   DEFAULT_MODEL_PROVIDER_ID,
   DEFAULT_WRITE_INLINE_COMPLETION_BASE_URL,
@@ -56,6 +63,22 @@ const EMPTY_TOKEN_ECONOMY_SAVINGS_STATE: TokenEconomySavingsState = {
   loading: false,
   loaded: false,
   summary: null
+}
+
+export function modelProvidersSettingsPatch(input: {
+  provider: ModelProviderSettingsV1
+  providers: ModelProviderProfileV1[]
+  kun?: Partial<AppSettingsV1['agents']['kun']>
+}): AppSettingsPatch {
+  const defaultProvider = input.providers.find((item) => item.id === DEFAULT_MODEL_PROVIDER_ID)
+  return {
+    provider: {
+      apiKey: defaultProvider?.apiKey ?? input.provider.apiKey,
+      baseUrl: defaultProvider?.baseUrl ?? input.provider.baseUrl,
+      providers: input.providers
+    },
+    ...(input.kun ? { agents: { kun: input.kun } } : {})
+  }
 }
 
 type ModelContextProfileSummary = {
@@ -391,15 +414,15 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
   const modelProviders = provider.providers as ModelProviderProfileV1[]
   const activeProviderId = kun.providerId?.trim() || DEFAULT_MODEL_PROVIDER_ID
   const activeProvider = modelProviders.find((item) => item.id === activeProviderId) ?? modelProviders[0]
-  const updateModelProviders = (providers: ModelProviderProfileV1[]): void => {
-    const defaultProvider = providers.find((item) => item.id === DEFAULT_MODEL_PROVIDER_ID)
-    update({
-      provider: {
-        apiKey: defaultProvider?.apiKey ?? provider.apiKey,
-        baseUrl: defaultProvider?.baseUrl ?? provider.baseUrl,
-        providers
-      }
-    })
+  const updateModelProviders = (
+    providers: ModelProviderProfileV1[],
+    kunPatch?: Partial<AppSettingsV1['agents']['kun']>
+  ): void => {
+    update(modelProvidersSettingsPatch({
+      provider,
+      providers,
+      kun: kunPatch
+    }))
   }
   const updateModelProvider = (id: string, patch: Partial<ModelProviderProfileV1>): void => {
     updateModelProviders(modelProviders.map((item) => item.id === id ? { ...item, ...patch } : item))
@@ -420,16 +443,15 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
       baseUrl: 'https://api.example.com/v1',
       models: []
     }
-    updateModelProviders([...modelProviders, nextProvider])
-    updateKun({ providerId: id })
+    updateModelProviders([...modelProviders, nextProvider], { providerId: id })
   }
   const removeModelProvider = (id: string): void => {
     if (id === DEFAULT_MODEL_PROVIDER_ID) return
     const nextProviders = modelProviders.filter((item) => item.id !== id)
-    updateModelProviders(nextProviders)
-    if (activeProviderId === id) {
-      updateKun({ providerId: DEFAULT_MODEL_PROVIDER_ID })
-    }
+    updateModelProviders(
+      nextProviders,
+      activeProviderId === id ? { providerId: DEFAULT_MODEL_PROVIDER_ID } : undefined
+    )
   }
 
   return (

--- a/src/shared/app-settings-kun.ts
+++ b/src/shared/app-settings-kun.ts
@@ -496,7 +496,8 @@ export function migrateLegacyAppSettings(parsed: LegacyAppSettingsShape): Partia
       : nonEmptyStringOrFallback(explicitKun.apiKey, legacySeed.apiKey),
     baseUrl: hasProviderSettings
       ? parsed.provider?.baseUrl
-      : nonEmptyStringOrFallback(explicitKun.baseUrl, legacySeed.baseUrl)
+      : nonEmptyStringOrFallback(explicitKun.baseUrl, legacySeed.baseUrl),
+    providers: parsed.provider?.providers
   })
   const kun = {
     ...kunDefaults,

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -22,6 +22,7 @@ import {
   normalizeAppSettings,
   parseClawUserPromptForDisplay,
   normalizeScheduleSettings,
+  resolveKunRuntimeSettings,
   resolveWriteInlineCompletionApiKey,
   resolveWriteInlineCompletionBaseUrl,
   resolveWriteInlineCompletionModel,
@@ -472,6 +473,53 @@ describe('legacy Kun defaults migration', () => {
       dataDir: '/tmp/custom-kun',
       model: 'deepseek-v4-flash'
     }))
+  })
+
+  it('preserves custom model providers while migrating legacy settings', () => {
+    const migrated = normalizeAppSettings({
+      ...settings(),
+      agentProvider: 'deepseek-runtime',
+      provider: {
+        apiKey: 'sk-default',
+        baseUrl: 'https://api.deepseek.com',
+        providers: [
+          ...defaultModelProviderSettings().providers,
+          {
+            id: 'custom-provider-2',
+            name: 'Custom Provider',
+            apiKey: 'sk-custom',
+            baseUrl: 'https://custom.example/v1',
+            models: ['custom-model']
+          }
+        ]
+      },
+      agents: {
+        kun: {
+          ...defaultKunRuntimeSettings(),
+          providerId: 'custom-provider-2',
+          model: 'custom-model'
+        }
+      }
+    } as unknown as AppSettingsV1)
+
+    expect(migrated.provider.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'custom-provider-2',
+          name: 'Custom Provider',
+          apiKey: 'sk-custom',
+          baseUrl: 'https://custom.example/v1',
+          models: ['custom-model']
+        })
+      ])
+    )
+    expect(migrated.agents.kun.providerId).toBe('custom-provider-2')
+    expect(resolveKunRuntimeSettings(migrated)).toEqual(
+      expect.objectContaining({
+        apiKey: 'sk-custom',
+        baseUrl: 'https://custom.example/v1'
+      })
+    )
   })
 })
 


### PR DESCRIPTION
## Summary

- Fixes #152 #151 #153 
- 修复了“添加模型供应商无反应”的问题

## Why

- 添加模型供应商时，组件连续触发两次设置更新：第一次写入新增的 `provider.providers`，第二次切换 `agents.kun.providerId`。
- 父级设置合并逻辑基于同一个旧 `form` 快照执行，第二次更新会覆盖第一次新增的供应商列表，导致点击按钮后 UI 看起来没有变化。
- 删除当前选中的自定义供应商时也存在同类覆盖风险。

## Changes

- 将模型供应商列表更新和当前供应商切换合并为一次 settings patch。
- 新增 `modelProvidersSettingsPatch` 纯函数，统一构造 provider 与 Kun runtime 的组合 patch。
- 修复新增供应商后立即选中新供应商的状态更新。
- 修复删除当前自定义供应商时切回默认 DeepSeek 的状态更新。
- 补充新增和删除供应商的回归测试。

## Tests

- Logic changes: updated `src/renderer/src/components/settings-section-agents.test.ts`
- Added coverage for adding and selecting a model provider in one patch.
- Added coverage for removing the active model provider and falling back to DeepSeek.

## Validation

- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Logic change: unit tests added or updated

## Notes

- 目标测试通过: `npx vitest run src/renderer/src/components/settings-section-agents.test.ts --reporter=dot`
> [!IMPORTANT]
> 只修复了该按钮无反应的问题，实际切换模型供应商的功能还有许多问题，待后续跟进。