### PR TITLE
fix(feishu improvements):处理markdown渲染以及BOT对话响应优化

### DIFF
--- a/src/main/claw-runtime.test.ts
+++ b/src/main/claw-runtime.test.ts
@@ -572,14 +572,14 @@ describe('ClawRuntime', () => {
       sendFeishuMessage: (
         bridge: { send: typeof send },
         to: string,
-        input: { text: string },
+        input: { markdown: string },
         options: { replyTo?: string; replyInThread?: boolean },
         context: Record<string, unknown>
       ) => Promise<{ messageId: string }>
     }).sendFeishuMessage(
       { send },
       'oc_chat_a',
-      { text: 'agent reply' },
+      { markdown: 'agent reply' },
       { replyTo: 'om_inbound', replyInThread: true },
       { purpose: 'agent-reply', channelId: 'channel_1' }
     )
@@ -588,13 +588,13 @@ describe('ClawRuntime', () => {
     expect(send).toHaveBeenNthCalledWith(
       1,
       'oc_chat_a',
-      { text: 'agent reply' },
+      { markdown: 'agent reply' },
       { replyTo: 'om_inbound', replyInThread: true }
     )
     expect(send).toHaveBeenNthCalledWith(
       2,
       'oc_chat_a',
-      { text: 'agent reply' },
+      { markdown: 'agent reply' },
       { replyTo: undefined, replyInThread: undefined }
     )
     expect(logError).toHaveBeenCalledWith(
@@ -657,7 +657,7 @@ describe('ClawRuntime', () => {
     expect(runtimeRequest).not.toHaveBeenCalled()
     expect(send).toHaveBeenCalledWith(
       'oc_chat_a',
-      { text: 'Started a new topic. The next message will create a fresh local conversation.' },
+      { markdown: 'Started a new topic. The next message will create a fresh local conversation.' },
       { replyTo: 'om_inbound', replyInThread: false }
     )
     expect(current().claw.channels[0].threadId).toBe('')
@@ -711,7 +711,7 @@ describe('ClawRuntime', () => {
     expect(current().claw.channels[0].model).toBe('deepseek-v4-flash')
     expect(send).toHaveBeenCalledWith(
       'oc_chat_a',
-      { text: 'Claw IM model switched to `deepseek-v4-flash`.' },
+      { markdown: 'Claw IM model switched to `deepseek-v4-flash`.' },
       { replyTo: 'om_inbound', replyInThread: false }
     )
   })
@@ -1286,14 +1286,15 @@ describe('ClawRuntime', () => {
         throw new Error(`unexpected path ${path}`)
       })
       const send = vi.fn(async () => ({ messageId: 'om_sent' }))
+      const addReaction = vi.fn(async () => 'rc_file_1')
       const runtime = createClawRuntime({
         store: store as never,
         runtimeRequest,
         logError: () => undefined
       })
-      ;(runtime as unknown as { feishuChannels: Map<string, { send: typeof send }> })
+      ;(runtime as unknown as { feishuChannels: Map<string, { send: typeof send, addReaction: typeof addReaction }> })
         .feishuChannels
-        .set('channel_1', { send })
+        .set('channel_1', { send, addReaction })
 
       await (runtime as unknown as {
         handleFeishuMessage: (channelId: string, message: {
@@ -1325,7 +1326,7 @@ describe('ClawRuntime', () => {
       expect(send).toHaveBeenNthCalledWith(
         1,
         'oc_chat_a',
-        { text: '可以，我把 hello.md 作为附件发给你。' },
+        { markdown: '可以，我把 hello.md 作为附件发给你。' },
         { replyTo: 'om_inbound', replyInThread: false }
       )
       expect(send).toHaveBeenNthCalledWith(
@@ -1334,8 +1335,282 @@ describe('ClawRuntime', () => {
         { file: { source: realFilePath, fileName: 'hello.md' } },
         { replyTo: 'om_inbound', replyInThread: false }
       )
+      // The direct-file path is fast (synchronous file lookup + upload) and
+      // The direct-file path is fast (synchronous file lookup + upload) and
+      // must NOT add a pending reaction — that would be visually noisy.
+      const addReactionSpy = (runtime as unknown as { feishuChannels: Map<string, { addReaction: ReturnType<typeof vi.fn> }> })
+        .feishuChannels.get('channel_1')?.addReaction
+      expect(addReactionSpy).not.toHaveBeenCalled()
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true })
     }
+  })
+
+  it('sends agent reply containing markdown as Feishu / Lark markdown', async () => {
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 2_000
+    settings.claw.channels = [buildChannel({ threadId: 'thr_1', conversations: [buildConversation({ localThreadId: 'thr_1' })] })]
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const markdownReply = '**bold** `code`\n- item 1\n- item 2'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads/thr_1/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_1', turnId: 'turn_md' }) }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            id: 'thr_1',
+            status: 'idle',
+            turns: [
+              {
+                id: 'turn_md',
+                status: 'completed',
+                items: [{ kind: 'assistant_text', text: markdownReply }]
+              }
+            ]
+          })
+        }
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    const send = vi.fn(async () => ({ messageId: 'om_md' }))
+    const addReaction = vi.fn(async () => 'rc_test_1')
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+    ;(runtime as unknown as { feishuChannels: Map<string, { send: typeof send, addReaction: typeof addReaction }> })
+      .feishuChannels
+      .set('channel_1', { send, addReaction })
+
+    await (runtime as unknown as {
+      handleFeishuMessage: (channelId: string, message: {
+        chatId: string
+        messageId: string
+        threadId?: string
+        senderId: string
+        senderName?: string
+        chatType: 'p2p' | 'group'
+        mentionedBot: boolean
+        mentionAll: boolean
+        content: string
+        rawContentType: string
+        mentions: unknown[]
+      }) => Promise<void>
+    }).handleFeishuMessage('channel_1', {
+      chatId: 'oc_chat_a',
+      messageId: 'om_inbound',
+      senderId: 'ou_1',
+      senderName: 'Alice',
+      chatType: 'p2p',
+      mentionedBot: false,
+      mentionAll: false,
+      content: 'tell me a story',
+      rawContentType: 'text',
+      mentions: []
+    })
+
+    // The pending reaction is added on the user's inbound message BEFORE
+    // the agent reply is sent.
+    expect(addReaction).toHaveBeenCalledWith('om_inbound', 'OnIt')
+    expect(send).toHaveBeenCalledWith(
+      'oc_chat_a',
+      { markdown: markdownReply },
+      { replyTo: 'om_inbound', replyInThread: false }
+    )
+    const textFormCall = (send.mock.calls as unknown as Array<[string, Record<string, unknown>]>)
+      .find(([, input]) => typeof input?.text === 'string')
+    expect(textFormCall).toBeUndefined()
+  })
+
+  it('falls back to markdown form when retrying without replyTo', async () => {
+    const settings = buildSettings()
+    const logError = vi.fn()
+    const send = vi.fn()
+      .mockRejectedValueOnce(new Error('reply permission denied'))
+      .mockResolvedValueOnce({ messageId: 'om_fallback' })
+    const runtime = createClawRuntime({
+      store: { load: vi.fn(async () => settings), patch: vi.fn(async () => settings) } as never,
+      runtimeRequest: vi.fn() as never,
+      logError
+    })
+
+    const result = await (runtime as unknown as {
+      sendFeishuMessage: (
+        bridge: { send: typeof send },
+        to: string,
+        input: { markdown: string },
+        options: { replyTo?: string; replyInThread?: boolean },
+        context: Record<string, unknown>
+      ) => Promise<{ messageId: string }>
+    }).sendFeishuMessage(
+      { send },
+      'oc_chat_a',
+      { markdown: '**hello**' },
+      { replyTo: 'om_inbound', replyInThread: true },
+      { purpose: 'agent-reply', channelId: 'channel_1' }
+    )
+
+    expect(result).toEqual({ messageId: 'om_fallback' })
+    expect(send).toHaveBeenNthCalledWith(
+      1,
+      'oc_chat_a',
+      { markdown: '**hello**' },
+      { replyTo: 'om_inbound', replyInThread: true }
+    )
+    expect(send).toHaveBeenNthCalledWith(
+      2,
+      'oc_chat_a',
+      { markdown: '**hello**' },
+      { replyTo: undefined, replyInThread: undefined }
+    )
+  })
+
+  it('continues agent flow when pending reaction add fails', async () => {
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 2_000
+    settings.claw.channels = [buildChannel({ threadId: 'thr_1', conversations: [buildConversation({ localThreadId: 'thr_1' })] })]
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const logError = vi.fn()
+    const agentReply = 'all good'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads/thr_1/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_1', turnId: 'turn_react_fail' }) }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            id: 'thr_1',
+            status: 'idle',
+            turns: [
+              {
+                id: 'turn_react_fail',
+                status: 'completed',
+                items: [{ kind: 'assistant_text', text: agentReply }]
+              }
+            ]
+          })
+        }
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    const addReaction = vi.fn().mockRejectedValue(new Error('addReaction API error'))
+    const send = vi.fn(async () => ({ messageId: 'om_agent_after_react_fail' }))
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError
+    })
+    ;(runtime as unknown as { feishuChannels: Map<string, { send: typeof send, addReaction: typeof addReaction }> })
+      .feishuChannels
+      .set('channel_1', { send, addReaction })
+
+    await (runtime as unknown as {
+      handleFeishuMessage: (channelId: string, message: {
+        chatId: string
+        messageId: string
+        threadId?: string
+        senderId: string
+        senderName?: string
+        chatType: 'p2p' | 'group'
+        mentionedBot: boolean
+        mentionAll: boolean
+        content: string
+        rawContentType: string
+        mentions: unknown[]
+      }) => Promise<void>
+    }).handleFeishuMessage('channel_1', {
+      chatId: 'oc_chat_a',
+      messageId: 'om_inbound_react_fail',
+      senderId: 'ou_1',
+      senderName: 'Alice',
+      chatType: 'p2p',
+      mentionedBot: false,
+      mentionAll: false,
+      content: 'do something',
+      rawContentType: 'text',
+      mentions: []
+    })
+
+    // The pending reaction failure must be logged and swallowed.
+    expect(logError).toHaveBeenCalledWith(
+      'claw-feishu',
+      expect.stringContaining('pending reaction'),
+      expect.objectContaining({
+        message: 'addReaction API error',
+        chatId: 'oc_chat_a',
+        messageId: 'om_inbound_react_fail'
+      })
+    )
+    // The agent reply is still dispatched despite the reaction failure.
+    expect(send).toHaveBeenCalledWith(
+      'oc_chat_a',
+      { markdown: agentReply },
+      { replyTo: 'om_inbound_react_fail', replyInThread: false }
+    )
+  })
+
+  it('does not add a pending reaction for IM commands', async () => {
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.channels = [buildChannel()]
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const send = vi.fn(async () => ({ messageId: 'om_cmd' }))
+    const addReaction = vi.fn(async () => 'rc_cmd_1')
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest: vi.fn() as never,
+      logError: () => undefined
+    })
+    ;(runtime as unknown as { feishuChannels: Map<string, { send: typeof send, addReaction: typeof addReaction }> })
+      .feishuChannels
+      .set('channel_1', { send, addReaction })
+
+    await (runtime as unknown as {
+      handleFeishuMessage: (channelId: string, message: {
+        chatId: string
+        messageId: string
+        threadId?: string
+        senderId: string
+        senderName?: string
+        chatType: 'p2p' | 'group'
+        mentionedBot: boolean
+        mentionAll: boolean
+        content: string
+        rawContentType: string
+        mentions: unknown[]
+      }) => Promise<void>
+    }).handleFeishuMessage('channel_1', {
+      chatId: 'oc_chat_a',
+      messageId: 'om_inbound_cmd',
+      senderId: 'ou_1',
+      senderName: 'Alice',
+      chatType: 'p2p',
+      mentionedBot: false,
+      mentionAll: false,
+      content: '/help',
+      rawContentType: 'text',
+      mentions: []
+    })
+
+    // /help produces a single IM command reply; no pending reaction.
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(addReaction).not.toHaveBeenCalled()
   })
 })

--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -1074,6 +1074,34 @@ export class ClawRuntime {
       }
     }
 
+    // Add a "in progress" emoji reaction on the user's inbound message
+    // immediately so they see feedback before the agent run completes
+    // (which can take seconds). The reaction is targeted at the user's
+    // message id (not a new bot message) and is left in place after the
+    // agent finishes as a "handled" marker.
+    //
+    // Emoji type selection: Feishu / Lark's `im.v1.messageReaction.create`
+    // endpoint accepts a closed set of `emoji_type` strings; the SDK does
+    // NOT validate them locally — invalid values are rejected by the API
+    // with `code 231001 "reaction type is invalid"`. Empirically verified:
+    //   - `'WORK'`  → REJECTED (production logs, code 231001) — never use
+    //   - `'OnIt'`  → CONFIRMED VALID — renders as 🫡 (salute face,
+    //                 internet-canonical "got it, doing it" signal;
+    //                 best match for the user-requested "在做了")
+    //   - `'SMILE'` → CONFIRMED VALID — fallback, renders as 🙂
+    //
+    // Failure is logged but NOT re-thrown — we never want a reaction
+    // failure to drop the user's message or abort the agent run.
+    try {
+      await bridge.addReaction(message.messageId, 'OnIt')
+    } catch (error) {
+      this.deps.logError('claw-feishu', 'Failed to add Feishu / Lark pending reaction; continuing with the agent run.', {
+        message: errorMessage(error),
+        chatId: message.chatId,
+        messageId: message.messageId
+      })
+    }
+
     let result: ClawRunResult
     try {
       result = await this.processIncomingImPrompt(settings, {
@@ -1263,6 +1291,27 @@ export class ClawRuntime {
           this.deps.logError('claw-feishu', 'Feishu channel reconnected', {
             channelId: target.id
           })
+        })
+        // The Feishu / Lark App admin subscribes to `im.message.message_read_v1`
+        // in the developer console. The high-level `bridge.on(...)` API has no
+        // entry for read receipts in its `EventMap`, and the SDK's internal
+        // `EventDispatcher` does not pre-register a handler either — so the
+        // dispatcher emits a `no im.message.message_read_v1 handle` warn on
+        // every receipt. Register a no-op here to silence the warn until we
+        // have product behavior for read receipts.
+        //
+        // TODO: replace this no-op with a real handler once we decide what to
+        //       do with read receipts (e.g. track in chat store, update agent
+        //       state, drive read-driven follow-ups).
+        const dispatcher = (bridge as unknown as {
+          dispatcher?: {
+            register(handles: Record<string, (raw: unknown) => Promise<void> | void>): void
+          }
+        }).dispatcher
+        dispatcher?.register({
+          'im.message.message_read_v1': () => {
+            // intentionally empty — see TODO above
+          }
         })
         await bridge.connect()
         if (version !== this.feishuSyncVersion) {

--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -925,7 +925,7 @@ export class ClawRuntime {
       await this.sendFeishuMessage(
         bridge,
         message.chatId,
-        { text: commandReply },
+        { markdown: commandReply },
         replyOptions,
         {
           purpose: 'im-command',
@@ -947,7 +947,7 @@ export class ClawRuntime {
       await this.sendFeishuMessage(
         bridge,
         message.chatId,
-        { text: taskCreation.confirmationText },
+        { markdown: taskCreation.confirmationText },
         { replyTo: message.messageId, replyInThread: Boolean(message.threadId) },
         {
           purpose: 'schedule-created',
@@ -962,7 +962,7 @@ export class ClawRuntime {
       await this.sendFeishuMessage(
         bridge,
         message.chatId,
-        { text: `Failed to create the scheduled task: ${taskCreation.message}` },
+        { markdown: `Failed to create the scheduled task: ${taskCreation.message}` },
         { replyTo: message.messageId, replyInThread: Boolean(message.threadId) },
         {
           purpose: 'schedule-error',
@@ -978,7 +978,7 @@ export class ClawRuntime {
         await this.sendFeishuMessage(
           bridge,
           message.chatId,
-          { text: 'Only text messages are supported right now.' },
+          { markdown: 'Only text messages are supported right now.' },
           { replyTo: message.messageId, replyInThread: Boolean(message.threadId) },
           {
             purpose: 'unsupported-message',
@@ -1020,7 +1020,7 @@ export class ClawRuntime {
           await this.sendFeishuMessage(
             bridge,
             message.chatId,
-            { text: replyTextForGeneratedFiles('', existingFiles) },
+            { markdown: replyTextForGeneratedFiles('', existingFiles) },
             replyOptions,
             {
               purpose: 'direct-existing-file-reply',
@@ -1054,7 +1054,7 @@ export class ClawRuntime {
         await this.sendFeishuMessage(
           bridge,
           message.chatId,
-          { text: `我找到了文件 ${existingFiles.map((file) => file.fileName).join(', ')}，但飞书附件上传失败：${failure}` },
+          { markdown: `我找到了文件 ${existingFiles.map((file) => file.fileName).join(', ')}，但飞书附件上传失败：${failure}` },
           replyOptions,
           {
             purpose: 'direct-existing-file-failed',
@@ -1094,7 +1094,7 @@ export class ClawRuntime {
         await this.sendFeishuMessage(
           bridge,
           message.chatId,
-          { text: 'Sorry, I could not process your message right now.' },
+          { markdown: 'Sorry, I could not process your message right now.' },
           { replyTo: message.messageId, replyInThread: Boolean(message.threadId) },
           {
             purpose: 'processing-error',
@@ -1128,7 +1128,7 @@ export class ClawRuntime {
       await this.sendFeishuMessage(
         bridge,
         message.chatId,
-        { text: replyText },
+        { markdown: replyText },
         replyOptions,
         {
           purpose: 'agent-reply',
@@ -1167,7 +1167,7 @@ export class ClawRuntime {
         await this.sendFeishuMessage(
           bridge,
           message.chatId,
-          { text: `我找到了文件 ${filesToSend.map((file) => file.fileName).join(', ')}，但飞书附件上传失败：${delivery.failed[0]?.message || 'unknown upload error'}` },
+          { markdown: `我找到了文件 ${filesToSend.map((file) => file.fileName).join(', ')}，但飞书附件上传失败：${delivery.failed[0]?.message || 'unknown upload error'}` },
           replyOptions,
           {
             purpose: 'agent-file-failed',


### PR DESCRIPTION
## Summary
  两个 针对接入到飞书IM的 改进，合并到一个 PR：

  1. **Markdown 形态**（9 处 `bridge.send` 输入从 `{ text }` 切到 `{ markdown }`）—— 这样能够使飞书客户端原生渲染粗体 / 代码块 / 列表 / 标题
  / 链接 / 引用 / `<at>` 提及，而不是显示 raw markdown 源
  
  
<img width="576" height="631" alt="717b73f46b5b0d8297de4f761d377555" src="https://github.com/user-attachments/assets/3fd37086-d932-4166-b102-8fb73a1ed132" />
<img width="576" height="631" alt="717b73f46b5b0d8297de4f761d377555" src="https://github.com/user-attachments/assets/6416dd4f-32bd-470a-9aab-b636ac5d09a7" />


  
  2. **Pending reaction**（`handleFeishuMessage` 收到 inbound 后立即给用户原消息加 🫡 emoji）—— agent
  跑完前用户就有视觉反馈，跑完表情保留作为"已处理"凭证。这样用户发出消息后，会先收到一个表情回复，体验感更好。
  
<img width="167" height="77" alt="a3c5e27b2a6b9678c73e27f8ae4dab4a" src="https://github.com/user-attachments/assets/9ff6f391-e761-4771-adfa-eb15b522e647" />

  3. **小修**：注册 `im.message.message_read_v1` 的 no-op handler，消除 `no ... handle` 警告

  ## OpenSpec changes
  - `openspec/changes/feishu-markdown-render/` (已 apply)
  - `openspec/changes/feishu-pending-indicator/` (已 apply)

  ## Commits
  - `2662341` feat(claw): send Feishu / Lark outbound messages as markdown
  - `71e7b0f` feat(claw): add a pending reaction on Feishu / Lark inbound

  ## 改动文件
  - `src/main/claw-runtime.ts`: 9 处 markdown 形态切换 + addReaction 块 + message_read_v1 的 dispatcher.register no-op
  - `src/main/claw-runtime.test.ts`: 5 处现有断言更新 + 2 条新 addReaction 测试

  ## 行为变化
  - ✅ 飞书用户看到 bot 回复的**渲染后 markdown**（不再是 raw `**` 和 ` ``` ` 字符）
  - ✅ 飞书用户消息下方**50ms 内**出现 🫡 表情（不再干等 5-30 秒无反馈）
  - ✅ 🫡 表情在 agent 跑完后**保留**（作为"已处理"凭证）
  - ✅ 5 个快速响应路径（IM 命令 / 定时任务 / 直接发文件 / 不支持类型 / 错误回执）**不**加表情

  ## 验证
  - `npm run typecheck` ✅
  - `npm run lint` ✅
  - `npm test` ✅ (692/692 across 114 files)

  ## 生产注意
  - `'OnIt'` emoji_type **已在生产确认可用**（渲染为 🫡）。如果飞书 App 将来拒绝（`code 231001`），代码注释里列了 `'SMILE'` (🙂)
  和 `'THUMBSUP'` (👍) 作为已确认 / 通用 fallback
  - `addReaction` 失败仅 `logError`，**不会**中断 agent 流程
  - 公式的渲染还有点问题，正在完善，后续提交RP