### PR TITLE
fix: enforce plan-mode tool isolation and auto-scroll on new user message

### DIFF
--- a/kun/src/loop/agent-loop.test.ts
+++ b/kun/src/loop/agent-loop.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePlanModeToolSpecs } from './agent-loop.js'
+import type { ModelToolSpec } from '../ports/model-client.js'
+
+function spec(name: string): ModelToolSpec {
+  return {
+    name,
+    description: `Tool: ${name}`,
+    toolKind: name === 'create_plan' || name === 'write' || name === 'edit'
+      ? 'file_change'
+      : 'discovery',
+    inputSchema: { type: 'object', properties: {} }
+  }
+}
+
+const ALL_TOOLS: ModelToolSpec[] = [
+  spec('read'),
+  spec('write'),
+  spec('edit'),
+  spec('ls'),
+  spec('find'),
+  spec('grep'),
+  spec('bash'),
+  spec('web_search'),
+  spec('web_fetch'),
+  spec('create_plan')
+]
+
+const READ_ONLY_TOOLS = new Set([
+  'read', 'ls', 'find', 'grep', 'web_search', 'web_fetch'
+])
+
+describe('resolvePlanModeToolSpecs', () => {
+  it('step 0: read-only tools + create_plan only', () => {
+    const result = resolvePlanModeToolSpecs(ALL_TOOLS, {
+      planTurnActive: true,
+      createPlanSatisfied: false,
+      stepIndex: 0,
+      readOnlyToolNames: READ_ONLY_TOOLS
+    })
+    const names = result.map((t) => t.name)
+    expect(names).toContain('read')
+    expect(names).toContain('ls')
+    expect(names).toContain('find')
+    expect(names).toContain('grep')
+    expect(names).toContain('web_search')
+    expect(names).toContain('web_fetch')
+    expect(names).toContain('create_plan')
+    expect(names).not.toContain('write')
+    expect(names).not.toContain('edit')
+    expect(names).not.toContain('bash')
+  })
+
+  it('step > 0: only create_plan', () => {
+    const result = resolvePlanModeToolSpecs(ALL_TOOLS, {
+      planTurnActive: true,
+      createPlanSatisfied: false,
+      stepIndex: 1,
+      readOnlyToolNames: READ_ONLY_TOOLS
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('create_plan')
+  })
+
+  it('plan satisfied: returns all tools unchanged (pass-through)', () => {
+    const result = resolvePlanModeToolSpecs(ALL_TOOLS, {
+      planTurnActive: true,
+      createPlanSatisfied: true,
+      stepIndex: 0,
+      readOnlyToolNames: READ_ONLY_TOOLS
+    })
+    expect(result).toBe(ALL_TOOLS)
+  })
+
+  it('not plan-active: returns all tools unchanged (pass-through)', () => {
+    const result = resolvePlanModeToolSpecs(ALL_TOOLS, {
+      planTurnActive: false,
+      createPlanSatisfied: false,
+      stepIndex: 0,
+      readOnlyToolNames: READ_ONLY_TOOLS
+    })
+    expect(result).toBe(ALL_TOOLS)
+  })
+
+  it('uses PLAN_READ_ONLY_TOOL_NAMES default when readOnlyToolNames omitted', () => {
+    const result = resolvePlanModeToolSpecs(ALL_TOOLS, {
+      planTurnActive: true,
+      createPlanSatisfied: false,
+      stepIndex: 0
+    })
+    const names = result.map((t) => t.name)
+    // Default set excludes bash
+    expect(names).not.toContain('bash')
+    expect(names).toContain('create_plan')
+    expect(names).toContain('read')
+  })
+
+  it('uses CREATE_PLAN_TOOL_NAME default when planToolName omitted', () => {
+    const result = resolvePlanModeToolSpecs(ALL_TOOLS, {
+      planTurnActive: true,
+      createPlanSatisfied: false,
+      stepIndex: 1
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('create_plan')
+  })
+
+  it('custom readOnlyToolNames and planToolName', () => {
+    const customTools: ModelToolSpec[] = [
+      spec('custom-read'),
+      spec('custom-plan'),
+      spec('write'),
+      spec('bash')
+    ]
+    const result = resolvePlanModeToolSpecs(customTools, {
+      planTurnActive: true,
+      createPlanSatisfied: false,
+      stepIndex: 0,
+      readOnlyToolNames: new Set(['custom-read']),
+      planToolName: 'custom-plan'
+    })
+    const names = result.map((t) => t.name)
+    expect(names).toContain('custom-read')
+    expect(names).toContain('custom-plan')
+    expect(names).not.toContain('write')
+    expect(names).not.toContain('bash')
+  })
+})

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -124,21 +124,46 @@ export const PLAN_MODE_INSTRUCTION = [
   'After saving, give the user a short summary of the plan and what to review.'
 ].join('\n')
 
-/** Tools allowed during the investigation phase of a Plan-mode turn
- * (step 0, before `create_plan` has been called). These are all read-only
- * or safe-read-only tools that match the PLAN_MODE_INSTRUCTION guidance.
- * `bash` is included so the model can inspect the workspace via safe
- * read-only shell commands; the tool host still requires approval for
- * mutations. */
+/** Read-only tools allowed during the investigation phase of a Plan-mode
+ * turn (step 0, before `create_plan` has been called). Matches the
+ * PLAN_MODE_INSTRUCTION guidance. `bash` is intentionally excluded —
+ * it can execute arbitrary commands and its policy is `on-request` which
+ * auto-approves under `approvalPolicy: auto`. */
 const PLAN_READ_ONLY_TOOL_NAMES = new Set([
   'read',
   'ls',
   'find',
   'grep',
   'web_search',
-  'web_fetch',
-  'bash'
+  'web_fetch'
 ])
+
+/**
+ * Resolve the tool list for a Plan-mode turn step. Extracted as a pure
+ * function so the behaviour can be unit-tested without spinning up the
+ * full agent loop.
+ *
+ * - Not plan-active or plan already satisfied → pass through unchanged.
+ * - Step 0 (investigation): read-only tools + create_plan.
+ * - Step > 0 (must produce plan): only create_plan.
+ */
+export function resolvePlanModeToolSpecs(
+  toolSpecs: ModelToolSpec[],
+  options: {
+    planTurnActive: boolean
+    createPlanSatisfied: boolean
+    stepIndex: number
+    readOnlyToolNames?: ReadonlySet<string>
+    planToolName?: string
+  }
+): ModelToolSpec[] {
+  if (!options.planTurnActive || options.createPlanSatisfied) return toolSpecs
+  const readOnly = options.readOnlyToolNames ?? PLAN_READ_ONLY_TOOL_NAMES
+  const planTool = options.planToolName ?? CREATE_PLAN_TOOL_NAME
+  return options.stepIndex === 0
+    ? toolSpecs.filter((tool) => tool.name === planTool || readOnly.has(tool.name))
+    : toolSpecs.filter((tool) => tool.name === planTool)
+}
 
 function goalContinuationInstruction(goal: ThreadGoal | undefined): string | null {
   if (!goal || goal.status !== 'active') return null
@@ -611,17 +636,11 @@ export class AgentLoop {
       toolSpecs.some((tool) => tool.name === CREATE_PLAN_TOOL_NAME)
         ? CREATE_PLAN_TOOL_NAME
         : undefined
-    // Plan-mode tool filtering: progressively narrow the tool set so the
-    // model investigates first, then must create_plan before the turn can
-    // continue. DeepSeek-compatible providers ignore forced tool_choice,
-    // so we enforce this by removing non-plan tools from the request.
-    const effectiveToolSpecs = planTurnActive && !createPlanSatisfied
-      ? toolSpecs.filter((tool) =>
-          stepIndex === 0
-            ? tool.name === CREATE_PLAN_TOOL_NAME || PLAN_READ_ONLY_TOOL_NAMES.has(tool.name)
-            : tool.name === CREATE_PLAN_TOOL_NAME
-        )
-      : toolSpecs
+    const effectiveToolSpecs = resolvePlanModeToolSpecs(toolSpecs, {
+      planTurnActive,
+      createPlanSatisfied,
+      stepIndex
+    })
     const history = await this.compactIfNeeded(items, model, signal, { threadId, turnId })
     if (signal.aborted) return 'aborted'
     await this.recordPipelineStage(threadId, turnId, 'input_compressed', {

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -124,6 +124,22 @@ export const PLAN_MODE_INSTRUCTION = [
   'After saving, give the user a short summary of the plan and what to review.'
 ].join('\n')
 
+/** Tools allowed during the investigation phase of a Plan-mode turn
+ * (step 0, before `create_plan` has been called). These are all read-only
+ * or safe-read-only tools that match the PLAN_MODE_INSTRUCTION guidance.
+ * `bash` is included so the model can inspect the workspace via safe
+ * read-only shell commands; the tool host still requires approval for
+ * mutations. */
+const PLAN_READ_ONLY_TOOL_NAMES = new Set([
+  'read',
+  'ls',
+  'find',
+  'grep',
+  'web_search',
+  'web_fetch',
+  'bash'
+])
+
 function goalContinuationInstruction(goal: ThreadGoal | undefined): string | null {
   if (!goal || goal.status !== 'active') return null
   const tokenBudget = goal.tokenBudget == null ? 'none' : String(goal.tokenBudget)
@@ -595,10 +611,17 @@ export class AgentLoop {
       toolSpecs.some((tool) => tool.name === CREATE_PLAN_TOOL_NAME)
         ? CREATE_PLAN_TOOL_NAME
         : undefined
-    // Final step of a plan turn that still owes a plan. Offer ONLY create_plan
-    // (this DeepSeek-compatible provider ignores a forced tool_choice, so we
-    // remove the investigation tools instead) so the model can only save the
-    // plan or answer with plan text that the create_plan fallback materializes.
+    // Plan-mode tool filtering: progressively narrow the tool set so the
+    // model investigates first, then must create_plan before the turn can
+    // continue. DeepSeek-compatible providers ignore forced tool_choice,
+    // so we enforce this by removing non-plan tools from the request.
+    const effectiveToolSpecs = planTurnActive && !createPlanSatisfied
+      ? toolSpecs.filter((tool) =>
+          stepIndex === 0
+            ? tool.name === CREATE_PLAN_TOOL_NAME || PLAN_READ_ONLY_TOOL_NAMES.has(tool.name)
+            : tool.name === CREATE_PLAN_TOOL_NAME
+        )
+      : toolSpecs
     const history = await this.compactIfNeeded(items, model, signal, { threadId, turnId })
     if (signal.aborted) return 'aborted'
     await this.recordPipelineStage(threadId, turnId, 'input_compressed', {
@@ -609,7 +632,7 @@ export class AgentLoop {
       ...(activeTodoInstruction ? [activeTodoInstruction] : []),
       ...memoryInstructions(memories),
       ...skillResolution.instructions,
-      ...(toolSpecs.some((tool) => tool.name === 'bash') ? [shellRuntimeInstruction()] : []),
+      ...(effectiveToolSpecs.some((tool) => tool.name === 'bash') ? [shellRuntimeInstruction()] : []),
       ...(toolCatalogDriftMessage ? [toolCatalogDriftMessage] : [])
     ]
     await this.recordPipelineStage(threadId, turnId, 'input_remembered', {
@@ -628,7 +651,7 @@ export class AgentLoop {
       history,
       ...(attachments.imageAttachments.length ? { attachments: attachments.imageAttachments } : {}),
       ...(attachments.textFallbacks.length ? { attachmentTextFallbacks: attachments.textFallbacks } : {}),
-      tools: toolSpecs,
+      tools: effectiveToolSpecs,
       ...(requiredToolName ? { requiredToolName } : {}),
       ...(modelRoute.reasoningEffort ? { reasoningEffort: modelRoute.reasoningEffort } : {}),
       abortSignal: signal

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -127,7 +127,8 @@ export function MessageTimeline({
     busy,
     scrollDeps: {
       contentKey: scrollContentKey,
-      streaming: Boolean(live.trim() || liveReasoning.trim())
+      streaming: Boolean(live.trim() || liveReasoning.trim()),
+      userTurnKey: currentTurnUserId ?? ''
     }
   })
   const visibleTurns = useMemo(

--- a/src/renderer/src/components/chat/use-timeline-scroll.ts
+++ b/src/renderer/src/components/chat/use-timeline-scroll.ts
@@ -16,7 +16,7 @@ type UseTimelineScrollOptions = {
   totalTurns: number
   busy: boolean
   /** Triggers stick-to-bottom snap scroll. */
-  scrollDeps: { contentKey: string; streaming: boolean }
+  scrollDeps: { contentKey: string; streaming: boolean; userTurnKey: string }
 }
 
 export type UseTimelineScrollResult = {
@@ -63,7 +63,7 @@ export function useTimelineScroll({
   busy,
   scrollDeps
 }: UseTimelineScrollOptions): UseTimelineScrollResult {
-  const { contentKey, streaming } = scrollDeps
+  const { contentKey, streaming, userTurnKey } = scrollDeps
   const shouldCollapseHistory = totalTurns > autoCollapseThreshold
   const [visibleTurnCount, setVisibleTurnCount] = useState(() =>
     deriveTimelineVisibleTurnCount({
@@ -77,10 +77,19 @@ export function useTimelineScroll({
   const hiddenTurnCount = Math.max(0, totalTurns - visibleTurnCount)
 
   const stickToBottomRef = useRef(true)
+  const lastUserTurnKeyRef = useRef(userTurnKey)
   const historyExpansionRequestedRef = useRef(false)
   const pendingPrependRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null)
   const prependInFlightRef = useRef(false)
   const scrollFrameRef = useRef<number | null>(null)
+
+  // When the user sends a new message (userTurnKey changes to a new value),
+  // force stick-to-bottom so the timeline auto-scrolls to the new turn even
+  // if the user had previously scrolled up to read history.
+  if (userTurnKey && lastUserTurnKeyRef.current !== userTurnKey) {
+    lastUserTurnKeyRef.current = userTurnKey
+    stickToBottomRef.current = true
+  }
 
   const loadEarlierTurns = useCallback(
     (options?: { userInitiated?: boolean }): void => {

--- a/src/renderer/src/components/workbench-plan-controller.ts
+++ b/src/renderer/src/components/workbench-plan-controller.ts
@@ -215,9 +215,12 @@ export function useWorkbenchPlanController({
       return false
     }
     planTurnInFlightRef.current = true
-    const planOverrides = planTurnOverrides(targetWorkspaceRoot, currentChatState.activeThreadId)
     const { workspaceRoot: _workspaceRoot, ...messageOverrides } = overrides ?? {}
-    const guiPlan = messageOverrides.guiPlan ?? planOverrides?.guiPlan ?? buildDraftGuiPlanTurnOverrides({
+    // Default to draft: an explicit guiPlan override (e.g. from SDD upgrade)
+    // takes priority; otherwise we always start a fresh plan. Previously the
+    // active plan was auto-detected as operation: 'refine', which caused new
+    // composer requests to be treated as refinements of an old plan.
+    const guiPlan = messageOverrides.guiPlan ?? buildDraftGuiPlanTurnOverrides({
       request: text,
       workspaceRoot: targetWorkspaceRoot,
       activeThreadId: currentChatState.activeThreadId,


### PR DESCRIPTION
Fixes #93

Three related Plan-mode fixes:

1. agent-loop: filter toolSpecs in plan mode (read-only + create_plan during investigation, only create_plan when plan owed). Previously the comment described this behavior but it wasn't implemented.

2. workbench-plan-controller: default new plan turns to draft instead of auto-refine from the active plan, so each composer send starts a fresh plan.

3. use-timeline-scroll: force stick-to-bottom when currentTurnUserId changes, so new user messages auto-scroll even when user had scrolled up.