### PR TITLE
fix(ui): disable system text selection

### DIFF
--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -496,6 +496,8 @@ body {
     'SF Pro Text', 'PingFang SC', 'Noto Sans SC', 'Helvetica Neue', Arial, sans-serif;
   background-color: var(--ds-bg-main);
   color: var(--ds-text);
+  user-select: none;
+  -webkit-user-select: none;
   zoom: var(--ds-ui-scale);
 }
 
@@ -524,6 +526,20 @@ input,
 select,
 textarea {
   font: inherit;
+}
+
+input,
+textarea,
+[contenteditable='true'],
+.ds-markdown,
+.ds-user-message-bubble,
+.ds-code-block-html,
+.ds-file-preview-code-html,
+.write-codemirror-host,
+.write-markdown-preview,
+pre {
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 * {


### PR DESCRIPTION
## Summary
- Disable default text selection for application chrome and system UI labels.
- Restore text selection for editable fields, chat/markdown content, code blocks, file previews, and the write editor.

## Root Cause
System UI text inherited the browser default selectable behavior, so dragging across sidebar and header chrome highlighted labels that should behave like application controls.

## Validation
- npm run build
