### PR TITLE
fix(ui): align chat toolbar with session header

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -1750,7 +1750,7 @@ export function Workbench(): ReactElement {
           ) : (
             <section className="ds-chat-stage ds-drag flex min-h-0 min-w-0 flex-1 flex-col">
             <header className="chat-topbar ds-topbar-surface relative z-10 mt-3 flex min-h-[46px] w-full shrink-0 items-stretch overflow-visible rounded-[24px]">
-              <div className="chat-topbar-grid grid w-full min-w-0 items-center gap-2.5 px-3 py-2 sm:px-4 md:pl-5 md:pr-2">
+              <div className="chat-topbar-grid grid w-full min-w-0 items-start gap-2.5 px-3 py-2 sm:px-4 md:pl-5 md:pr-2">
                 <div
                   className={`chat-topbar-session flex min-w-0 items-center gap-2.5 ${
                     leftSidebarCollapsed ? 'ds-window-controls-safe-inset' : ''
@@ -1765,7 +1765,7 @@ export function Workbench(): ReactElement {
                   ) : null}
                   <SessionHeader compact className="min-w-0 flex-1" />
                 </div>
-                <div className="chat-topbar-actions flex min-w-0 flex-wrap items-center justify-end gap-2">
+                <div className="chat-topbar-actions flex min-w-0 flex-wrap items-center justify-end gap-2 self-start">
                   {busy ? (
                     <span className="inline-flex shrink-0 rounded-full bg-amber-500/16 px-2.5 py-1 text-[11.5px] font-semibold text-amber-950 dark:text-amber-100">
                       {t('running')}

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -2199,20 +2199,23 @@ textarea {
 }
 
 .chat-topbar-grid {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
   gap: 0.5rem;
   padding-block: 0.35rem;
 }
 
 .chat-topbar-session {
   min-width: 0;
+  align-self: start;
 }
 
 .chat-topbar-actions {
-  width: 100%;
+  width: auto;
   flex-wrap: nowrap;
-  overflow-x: auto;
+  overflow-x: visible;
   overflow-y: visible;
+  align-self: start;
   justify-self: end;
   scrollbar-width: none;
 }
@@ -2229,15 +2232,14 @@ textarea {
   overflow: hidden;
 }
 
-@container (min-width: 900px) {
+@container (max-width: 640px) {
   .chat-topbar-grid {
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .chat-topbar-actions {
-    width: auto;
-    overflow-x: visible;
-    justify-content: flex-end;
+    width: 100%;
+    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- Keep the chat header session title and action toolbar in the same top row on desktop-width layouts.
- Top-align the toolbar with the compact session header instead of centering or wrapping below it.
- Preserve the stacked toolbar layout only for narrow containers.

## Root Cause
The chat topbar defaulted to a single-column layout and only switched to two columns at a wider container breakpoint. On desktop windows where the chat stage was below that breakpoint, the toolbar wrapped to a second row and appeared lower than the session title.

## Validation
- npm run typecheck
