### PR TITLE
Improve MCP npx PATH diagnostics / 改进 MCP npx 路径诊断

### DIFF
--- a/kun/src/adapters/tool/mcp-tool-provider.ts
+++ b/kun/src/adapters/tool/mcp-tool-provider.ts
@@ -1,5 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { createHash } from 'node:crypto'
+import { posix, win32 } from 'node:path'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
@@ -86,6 +87,11 @@ export type McpToolProviderOptions = {
 }
 
 const DEFAULT_MCP_STARTUP_CONNECT_TIMEOUT_MS = 10_000
+
+export type McpStdioEnvironmentOptions = {
+  platform?: NodeJS.Platform
+  baseEnv?: NodeJS.ProcessEnv
+}
 
 type McpConnectionState = {
   serverId: string
@@ -184,7 +190,12 @@ export async function buildMcpToolProviders(
     }
     if (outcome.status === 'error') {
       diagnostics.push(
-        serverDiagnostic({ serverId: outcome.serverId, server: outcome.server }, 'error', 0, errorMessage(outcome.error))
+        serverDiagnostic(
+          { serverId: outcome.serverId, server: outcome.server },
+          'error',
+          0,
+          formatMcpConnectionError(outcome.error, outcome.server)
+        )
       )
       continue
     }
@@ -290,7 +301,7 @@ function createTransport(server: McpServerConfig): Transport {
       return new StdioClientTransport({
         command: server.command ?? '',
         args: server.args,
-        env: server.env,
+        env: buildMcpStdioEnvironment(server.env),
         stderr: 'pipe'
       })
     case 'streamable-http':
@@ -511,4 +522,128 @@ function normalizePathForTrust(value: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+export function buildMcpStdioEnvironment(
+  serverEnv: Record<string, string> = {},
+  options: McpStdioEnvironmentOptions = {}
+): Record<string, string> {
+  const platform = options.platform ?? process.platform
+  const baseEnv = options.baseEnv ?? process.env
+  const pathKey = findPathKey(serverEnv) ?? findPathKey(baseEnv) ?? 'PATH'
+  const configuredPath = readEnvPath(serverEnv)
+  const inheritedPath = readEnvPath(baseEnv)
+  const pathValue = mergePathEntries(
+    [configuredPath ?? inheritedPath ?? '', ...commonMcpCommandPathEntries(platform, baseEnv)],
+    pathDelimiter(platform)
+  )
+  return {
+    ...serverEnv,
+    ...(pathValue ? { [pathKey]: pathValue } : {})
+  }
+}
+
+export function formatMcpConnectionError(error: unknown, server: McpServerConfig): string {
+  const message = errorMessage(error)
+  if (server.transport !== 'stdio' || !isMissingExecutableError(error, message)) return message
+  const command = missingExecutableCommand(error) ?? server.command ?? 'configured command'
+  const hint = isBareCommand(command)
+    ? missingBareCommandHint(command)
+    : `Could not find MCP command "${command}". Check that the configured executable path exists.`
+  return `${message}. ${hint}`
+}
+
+function commonMcpCommandPathEntries(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv
+): string[] {
+  if (platform === 'darwin') {
+    return [
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/opt/local/bin',
+      homePath(env, '.volta/bin'),
+      homePath(env, '.local/bin'),
+      homePath(env, '.bun/bin')
+    ].filter((entry): entry is string => Boolean(entry))
+  }
+  if (platform === 'linux') {
+    return [
+      '/home/linuxbrew/.linuxbrew/bin',
+      '/usr/local/bin',
+      '/usr/bin',
+      homePath(env, '.volta/bin'),
+      homePath(env, '.local/bin'),
+      homePath(env, '.bun/bin')
+    ].filter((entry): entry is string => Boolean(entry))
+  }
+  if (platform === 'win32') {
+    return [
+      env.APPDATA ? win32.join(env.APPDATA, 'npm') : '',
+      env.ProgramFiles ? win32.join(env.ProgramFiles, 'nodejs') : '',
+      env['ProgramFiles(x86)'] ? win32.join(env['ProgramFiles(x86)'], 'nodejs') : ''
+    ].filter((entry): entry is string => Boolean(entry))
+  }
+  return []
+}
+
+function findPathKey(env: Record<string, string | undefined>): string | undefined {
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path')
+}
+
+function readEnvPath(env: Record<string, string | undefined>): string | undefined {
+  const key = findPathKey(env)
+  const value = key ? env[key] : undefined
+  return value && value.trim() ? value : undefined
+}
+
+function mergePathEntries(values: string[], delimiter: string): string {
+  const seen = new Set<string>()
+  const entries: string[] = []
+  for (const value of values) {
+    for (const entry of value.split(delimiter)) {
+      const trimmed = entry.trim()
+      if (!trimmed) continue
+      const key = trimmed.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      entries.push(trimmed)
+    }
+  }
+  return entries.join(delimiter)
+}
+
+function pathDelimiter(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? ';' : ':'
+}
+
+function homePath(env: NodeJS.ProcessEnv, relativePath: string): string {
+  return env.HOME ? posix.join(env.HOME, relativePath) : ''
+}
+
+function isMissingExecutableError(error: unknown, message: string): boolean {
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code ?? '')
+    : ''
+  return code === 'ENOENT' || /\bspawn\s+\S+\s+ENOENT\b/i.test(message)
+}
+
+function missingExecutableCommand(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const path = (error as { path?: unknown }).path
+  return typeof path === 'string' && path.trim() ? path.trim() : undefined
+}
+
+function isBareCommand(command: string): boolean {
+  return Boolean(command.trim()) && !command.includes('/') && !command.includes('\\')
+}
+
+function missingBareCommandHint(command: string): string {
+  if (process.platform === 'win32') {
+    return `Could not find "${command}" on PATH while starting the MCP server. Make sure Node/npm is installed and available to DeepSeek GUI, or set the MCP command to an absolute path.`
+  }
+  if (process.platform === 'darwin') {
+    return `Could not find "${command}" on PATH while starting the MCP server. If DeepSeek GUI was launched from Finder or the desktop, make sure Node/npm is installed and available to GUI apps, or set the MCP command to an absolute path such as /opt/homebrew/bin/${command}.`
+  }
+  return `Could not find "${command}" on PATH while starting the MCP server. Make sure Node/npm is installed and available to DeepSeek GUI, or set the MCP command to an absolute path such as /usr/local/bin/${command}.`
 }

--- a/kun/tests/builtin-tools.test.ts
+++ b/kun/tests/builtin-tools.test.ts
@@ -230,7 +230,7 @@ describe('Kun built-in tools', () => {
       }
     })
 
-    let seenInput: { questions: Array<{ options: Array<{ label: string; description: string }> }> } | null = null
+    const seenInputs: Array<{ questions: Array<{ options: Array<{ label: string; description: string }> }> }> = []
     const result = await host.execute(
       {
         callId: 'call_input',
@@ -244,7 +244,7 @@ describe('Kun built-in tools', () => {
       {
         ...buildContext(workspace),
         awaitUserInput: async (input) => {
-          seenInput = input
+          seenInputs.push(input)
           return {
             status: 'submitted',
             answers: [{ id: input.questions[0]?.id ?? 'choice', label: 'South', value: 'South' }]
@@ -253,8 +253,7 @@ describe('Kun built-in tools', () => {
       }
     )
 
-    const capturedInput = seenInput as { questions: Array<{ options: unknown }> } | null
-    expect(capturedInput?.questions[0]?.options).toEqual([
+    expect(seenInputs[0]?.questions[0]?.options).toEqual([
       { label: 'South', description: '' },
       { label: 'North', description: 'Cooler weather' }
     ])

--- a/kun/tests/mcp-tool-provider.test.ts
+++ b/kun/tests/mcp-tool-provider.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import { CapabilityRegistry } from '../src/adapters/tool/capability-registry.js'
 import { LocalToolHost } from '../src/adapters/tool/local-tool-host.js'
 import {
+  buildMcpStdioEnvironment,
   buildMcpToolProviders,
+  formatMcpConnectionError,
   isMcpServerTrusted,
   normalizeMcpToolName,
   type McpClientLike
@@ -56,6 +58,65 @@ function fakeClient(): McpClientLike {
 describe('MCP tool provider', () => {
   it('normalizes stable MCP tool names', () => {
     expect(normalizeMcpToolName('GitHub Server', 'Search Issues')).toBe('mcp_github_server_search_issues')
+  })
+
+  it('adds common GUI app command paths to stdio MCP environments', () => {
+    const env = buildMcpStdioEnvironment({ NODE_ENV: 'test' }, {
+      platform: 'darwin',
+      baseEnv: {
+        PATH: '/usr/bin:/opt/homebrew/bin',
+        HOME: '/Users/alice'
+      }
+    })
+
+    expect(env.NODE_ENV).toBe('test')
+    expect(env.PATH?.split(':')).toEqual([
+      '/usr/bin',
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/opt/local/bin',
+      '/Users/alice/.volta/bin',
+      '/Users/alice/.local/bin',
+      '/Users/alice/.bun/bin'
+    ])
+  })
+
+  it('keeps explicitly configured stdio MCP PATH values ahead of common paths', () => {
+    const env = buildMcpStdioEnvironment({ Path: 'C:\\Tools' }, {
+      platform: 'win32',
+      baseEnv: {
+        APPDATA: 'C:\\Users\\alice\\AppData\\Roaming',
+        ProgramFiles: 'C:\\Program Files',
+        PATH: 'C:\\Windows\\System32'
+      }
+    })
+
+    expect(env.Path?.split(';')).toEqual([
+      'C:\\Tools',
+      'C:\\Users\\alice\\AppData\\Roaming\\npm',
+      'C:\\Program Files\\nodejs'
+    ])
+  })
+
+  it('formats missing stdio MCP commands with an actionable PATH hint', () => {
+    const server = KunCapabilitiesConfig.parse({
+      mcp: {
+        enabled: true,
+        servers: {
+          filesystem: {
+            transport: 'stdio',
+            command: 'npx',
+            trustScope: 'user'
+          }
+        }
+      }
+    }).mcp.servers.filesystem
+    const error = Object.assign(new Error('spawn npx ENOENT'), {
+      code: 'ENOENT',
+      path: 'npx'
+    })
+
+    expect(formatMcpConnectionError(error, server)).toContain('Could not find "npx" on PATH')
   })
 
   it('evaluates workspace trust scopes', () => {
@@ -287,6 +348,36 @@ describe('MCP tool provider', () => {
       status: 'error',
       lastError: 'connect failed'
     })
+  })
+
+  it('records actionable diagnostics when stdio MCP commands are missing', async () => {
+    const config = KunCapabilitiesConfig.parse({
+      mcp: {
+        enabled: true,
+        servers: {
+          filesystem: {
+            transport: 'stdio',
+            command: 'npx',
+            trustScope: 'user'
+          }
+        }
+      }
+    })
+    const built = await buildMcpToolProviders(config.mcp, {
+      clientFactory: async () => {
+        throw Object.assign(new Error('spawn npx ENOENT'), {
+          code: 'ENOENT',
+          path: 'npx'
+        })
+      }
+    })
+
+    expect(built.providers).toEqual([])
+    expect(built.diagnostics[0]).toMatchObject({
+      id: 'filesystem',
+      status: 'error'
+    })
+    expect(built.diagnostics[0]?.lastError).toContain('Could not find "npx" on PATH')
   })
 
   it('passes MCP timeouts and abort signals to discovery and execution', async () => {


### PR DESCRIPTION
﻿## Summary / 概要

English:
- Add common Node/Homebrew command paths to stdio MCP server environments so `npx` can be found when the packaged macOS app is launched outside a login shell.
- Preserve MCP server-provided env values, including an explicit PATH/Path, before appending common command paths.
- Convert missing stdio executable failures like `spawn npx ENOENT` into actionable MCP diagnostics.
- Fix a Kun test-only type narrowing issue so Kun typecheck passes on current TypeScript.

中文：
- 给 stdio MCP server 的启动环境补充常见 Node/Homebrew 路径，降低 macOS 打包 App 从 Finder/桌面启动时找不到 `npx` 的概率。
- 保留 MCP server 配置里显式提供的 env，包括 PATH/Path，并把常见命令路径追加在后面。
- 将 `spawn npx ENOENT` 这类 stdio 可执行文件缺失错误转换成更明确的 MCP 诊断提示。
- 顺手修了一个 Kun 测试里的类型收窄问题，让当前 TypeScript 下 Kun typecheck 可以通过。

Fixes #168

## Scope / 范围

English:
This PR only touches Kun MCP stdio startup and diagnostics. It does not change the plugin marketplace UI or MCP config storage format.

中文：
这个 PR 只改 Kun MCP stdio 启动环境和诊断文案，不改插件市场 UI，也不改 MCP 配置文件结构。

## Verification / 验证

- `npm.cmd test -- tests/mcp-tool-provider.test.ts -t "MCP tool provider"` in `kun`
- `npm.cmd test -- tests/builtin-tools.test.ts -t "advertises structured GUI input choices"` in `kun`
- `npm.cmd run typecheck` in `kun`
- `npm.cmd run typecheck`
- `git diff --check`

Note: running the full `kun/tests/builtin-tools.test.ts` file on Windows still exposes unrelated existing cross-platform test assumptions around `/bin/echo`, Unix shell syntax, and path separators; the touched user-input test case passes when run directly.
