### PR TITLE
fix: remove duplicate usage stats from chat topbar

### DIFF
--- a/src/renderer/src/components/SessionHeader.tsx
+++ b/src/renderer/src/components/SessionHeader.tsx
@@ -27,9 +27,11 @@ export function SessionHeader({ compact = false, className = '' }: Props): React
     : workspaceLabel
   const [editing, setEditing] = useState(false)
   const [draftTitle, setDraftTitle] = useState('')
+  // Usage stats are no longer shown in compact mode (the composer footer
+  // already shows them in the chat route), so skip fetching there.
   const threadUsage = useThreadUsage(
     activeThreadId,
-    runtimeConnection === 'ready',
+    runtimeConnection === 'ready' && !compact,
     `${active?.updatedAt ?? ''}:${busy ? 'busy' : 'idle'}`
   )
   const forkedFromTitle = active?.forkedFromTitle?.trim() ?? ''
@@ -97,21 +99,6 @@ export function SessionHeader({ compact = false, className = '' }: Props): React
                         ? t('sessionForkedFromCompact', { title: forkedFromTitle })
                         : t('sessionForked')}
                     </span>
-                  </span>
-                </>
-              ) : null}
-              {threadUsage ? (
-                <>
-                  <span className="session-meta-usage-separator opacity-70">·</span>
-                  <span
-                    className="session-meta-usage shrink-0 tabular-nums"
-                    title={t('sessionUsageTitle', { turns: threadUsage.turns })}
-                  >
-                    {t('sessionUsageCompact', {
-                      tokens: formatCompactNumber(threadUsage.totalTokens),
-                      cost: formatCost(threadUsage.costUsd, i18n.language, threadUsage.costCny),
-                      cache: formatPercent(threadUsage.cacheHitRate)
-                    })}
                   </span>
                 </>
               ) : null}

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -830,7 +830,6 @@
   "noSessionSelected": "No thread selected",
   "sessionHeaderHint": "Start a thread from the left, or reconnect the runtime to continue working.",
   "sessionUsageTitle": "{{turns}} turns in this thread",
-  "sessionUsageCompact": "{{tokens}} tok / {{cost}} / cache {{cache}}",
   "sessionUsageTokens": "{{tokens}} tokens",
   "sessionUsageCost": "{{cost}}",
   "sessionUsageContextSavings": "saved {{cost}}",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -830,7 +830,6 @@
   "noSessionSelected": "未选择会话",
   "sessionHeaderHint": "从左侧进入一个会话，或先恢复运行时连接再继续工作。",
   "sessionUsageTitle": "当前会话 {{turns}} 个回合",
-  "sessionUsageCompact": "{{tokens}} tok / {{cost}} / cache {{cache}}",
   "sessionUsageTokens": "{{tokens}} tokens",
   "sessionUsageCost": "{{cost}}",
   "sessionUsageContextSavings": "省 {{cost}}",


### PR DESCRIPTION
## Summary

- 移除 chat 顶部栏(compact SessionHeader)里重复的 usage 统计(tokens / cost / cache),只保留 composer footer 一处展示
- compact 模式下跳过 usage 数据拉取,消除重复轮询

## Why

chat 路由下选中会话时,同一份 usage 数据会同时显示在两个地方:

- 顶部 topbar:`1.8M tok / $0.0452 / cache 96%`
- 底部 composer footer:`1.8M tokens · $0.0452 · cache 96% · 41 turns`

底部是顶部的超集(多 turns 和 context savings),且两处各自独立调用 `/v1/usage?group_by=thread` 和 thread turns 接口轮询——视觉和请求都是双份的。

## Changes

- `SessionHeader.tsx`:删除 compact 分支 meta 行中的 usage 段;`useThreadUsage` 的 enabled 条件加上 `!compact`,compact 模式不再发起 usage 请求。非 compact 分支(usage 药丸)不受影响
- `locales/en|zh/common.json`:移除删除后无引用的 `sessionUsageCompact` key

## Media

| Before(顶部与底部重复) | After(仅保留底部) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/leesta24/DeepSeek-GUI/assets/topbar-usage-dedup/before.png) | ![after](https://raw.githubusercontent.com/leesta24/DeepSeek-GUI/assets/topbar-usage-dedup/after.png) |

顶部栏放大对比:

Before:
![before-topbar](https://raw.githubusercontent.com/leesta24/DeepSeek-GUI/assets/topbar-usage-dedup/before-topbar.png)

After:
![after-topbar](https://raw.githubusercontent.com/leesta24/DeepSeek-GUI/assets/topbar-usage-dedup/after-topbar.png)

## Tests

- 纯 UI 删减 + 数据拉取条件收紧,无新增逻辑;`SessionHeader` 无既有测试文件

## Validation

- [x] `npm run test`(688 中 686 通过;2 个失败为 `src/main/index.test.ts` 与 `src/main/kun-process.test.ts`,在干净 develop 上同样失败,与本 PR 无关)
- [x] `npm run typecheck`
- [x] `npm run dev`(UI 行为验证,见上方截图)
- [x] UI change: 截图已附

## Notes

- 截图来自 `npm run dev` 实跑,同一会话前后对比

🤖 Generated with [Claude Code](https://claude.com/claude-code)
