### PR TITLE
[codex] fix: restore draggable chat title region

### DIFF
--- a/src/renderer/src/components/SessionHeader.test.ts
+++ b/src/renderer/src/components/SessionHeader.test.ts
@@ -1,0 +1,39 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import i18n from '../i18n'
+import { useChatStore } from '../store/chat-store'
+import { SessionHeader } from './SessionHeader'
+
+const initialChatState = useChatStore.getState()
+
+describe('SessionHeader', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+    useChatStore.setState({
+      ...initialChatState,
+      workspaceLabel: 'Working directory',
+      activeThreadId: 'thread-1',
+      threads: [{
+        id: 'thread-1',
+        title: 'Fix drag region',
+        updatedAt: '2026-06-10T10:00:00.000Z',
+        model: 'deepseek-chat',
+        mode: 'chat',
+        workspace: '/workspace/deepseek-gui'
+      }]
+    })
+  })
+
+  afterEach(() => {
+    useChatStore.setState(initialChatState)
+  })
+
+  it('keeps the compact session title area draggable in desktop shells', () => {
+    const html = renderToStaticMarkup(createElement(SessionHeader, { compact: true }))
+
+    expect(html).toContain('session-header-compact flex')
+    expect(html).not.toContain('session-header-compact ds-no-drag')
+    expect(html).toContain('Working directory')
+  })
+})

--- a/src/renderer/src/components/SessionHeader.tsx
+++ b/src/renderer/src/components/SessionHeader.tsx
@@ -66,7 +66,7 @@ export function SessionHeader({ compact = false, className = '' }: Props): React
   if (compact) {
     return (
       <div
-        className={`session-header-compact ds-no-drag flex min-h-0 min-w-0 flex-1 items-center gap-2 text-left ${className}`}
+        className={`session-header-compact flex min-h-0 min-w-0 flex-1 items-center gap-2 text-left ${className}`}
       >
         {active ? (
           <div className="min-w-0 flex-1">
@@ -127,7 +127,7 @@ export function SessionHeader({ compact = false, className = '' }: Props): React
   }
 
   return (
-    <div className={`ds-no-drag flex min-h-[74px] min-w-0 flex-1 items-center gap-4 px-5 py-4 sm:px-6 ${className}`}>
+    <div className={`flex min-h-[74px] min-w-0 flex-1 items-center gap-4 px-5 py-4 sm:px-6 ${className}`}>
       {active ? (
         <>
           <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- restore the chat title area drag behavior by removing the broad `ds-no-drag` wrapper from `SessionHeader`
- keep interactive controls draggable-safe by relying on existing button/input no-drag behavior
- add a regression test to lock the compact header drag-shell contract

## Root Cause
The chat header wrapper was marked `ds-no-drag`, which caused the title area in the main conversation pane to stop participating in Electron window dragging.

## Issue
Fixes #183

## Validation
- `npm test -- src/renderer/src/components/SessionHeader.test.ts`
- `npm test -- src/renderer/src/components/WindowsTitleBar.test.ts`
