### PR TITLE
fix: improve chat workbench recovery and navigation

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -22,7 +22,7 @@ import { getProvider } from '../agent/registry'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 import { useChatStore } from '../store/chat-store'
 import { isClawThread } from '../store/chat-store-helpers'
-import { hasPendingRuntimeWork } from '../store/chat-store-runtime-helpers'
+import { threadHasPendingRuntimeWork } from '../store/chat-store-runtime-helpers'
 import {
   extractLatestTurnAutoOpenDevPreviewUrls,
   extractLatestTurnDevPreviewUrls
@@ -356,6 +356,7 @@ export function Workbench(): ReactElement {
   const [attachmentUploadError, setAttachmentUploadError] = useState<string | null>(null)
   const [connectPhoneSidebarOpen, setConnectPhoneSidebarOpen] = useState(false)
   const [runtimeLogPath, setRuntimeLogPath] = useState('')
+  const [planPanelOverlayPreferred, setPlanPanelOverlayPreferred] = useState(false)
   const writeAssistantOpen = useWriteWorkspaceStore((s) => s.assistantOpen)
   const setWriteAssistantOpen = useWriteWorkspaceStore((s) => s.setAssistantOpen)
   const writeAssistantModel = useWriteWorkspaceStore((s) => s.assistantModel)
@@ -488,6 +489,33 @@ export function Workbench(): ReactElement {
       await useChatStore.getState().refreshThreads()
     }
   })
+  const planPanelInOverlay =
+    route === 'chat' &&
+    !activeSddDraft &&
+    rightPanelMode === 'plan' &&
+    planPanelOverlayPreferred
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const media = window.matchMedia('(max-width: 900px), (orientation: portrait)')
+    const sync = (): void => setPlanPanelOverlayPreferred(media.matches)
+    sync()
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', sync)
+      return () => media.removeEventListener('change', sync)
+    }
+    media.addListener(sync)
+    return () => media.removeListener(sync)
+  }, [])
+
+  useEffect(() => {
+    if (!planPanelInOverlay) return
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') setRightPanelMode(null)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [planPanelInOverlay, setRightPanelMode])
 
   useEffect(() => {
     const runDesktopShortcut = (command: DesktopCommand): void => {
@@ -1118,7 +1146,7 @@ export function Workbench(): ReactElement {
       return
     }
     const chatSnapshot = useChatStore.getState()
-    if (chatSnapshot.busy || chatSnapshot.blocks.some(hasPendingRuntimeWork)) {
+    if (chatSnapshot.busy || threadHasPendingRuntimeWork(chatSnapshot.blocks)) {
       setError(t('composerQueuePlaceholder'))
       return
     }
@@ -1539,9 +1567,24 @@ export function Workbench(): ReactElement {
   const writeRuntimeBannerMessage = runtimeConnection !== 'ready'
     ? (error?.trim() || t('writeRuntimeUnavailable'))
     : null
+  const rightPanelDockedVisible = rightPanelVisible && !planPanelInOverlay
+
+  const renderPlanPanel = (className: string): ReactElement => (
+    <PlanPanel
+      workspaceRoot={workspaceRoot}
+      activeThreadId={activeThreadId}
+      runtimeReady={runtimeConnection === 'ready'}
+      busy={busy}
+      className={className}
+      onCollapse={closeRightPanel}
+      onBuildPlan={() => void buildGuiPlan()}
+      onVerifyPlan={() => void verifyGuiPlan()}
+      onReplanChanged={(ids) => void replanChangedRequirements(ids)}
+    />
+  )
 
   const renderRightPanel = (): ReactElement | null => {
-    if (!rightPanelVisible) return null
+    if (!rightPanelDockedVisible) return null
     return (
       <>
         <div
@@ -1632,17 +1675,7 @@ export function Workbench(): ReactElement {
                 onCollapse={closeRightPanel}
               />
             ) : rightPanelMode === 'plan' ? (
-              <PlanPanel
-                workspaceRoot={workspaceRoot}
-                activeThreadId={activeThreadId}
-                runtimeReady={runtimeConnection === 'ready'}
-                busy={busy}
-                className="h-full max-h-full w-full"
-                onCollapse={closeRightPanel}
-                onBuildPlan={() => void buildGuiPlan()}
-                onVerifyPlan={() => void verifyGuiPlan()}
-                onReplanChanged={(ids) => void replanChangedRequirements(ids)}
-              />
+              renderPlanPanel('h-full max-h-full w-full')
             ) : (
               <WorkspaceFilePreviewPanel
                 target={filePreviewTarget}
@@ -1654,6 +1687,30 @@ export function Workbench(): ReactElement {
           </Suspense>
         </div>
       </>
+    )
+  }
+
+  const renderPlanPanelOverlay = (): ReactElement | null => {
+    if (!planPanelInOverlay) return null
+    return (
+      <div
+        className="ds-plan-panel-overlay ds-no-drag"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('planPanelTitle')}
+      >
+        <button
+          type="button"
+          className="ds-plan-panel-overlay-backdrop"
+          aria-label={t('cancel')}
+          onClick={closeRightPanel}
+        />
+        <div className="ds-plan-panel-overlay-card">
+          <Suspense fallback={<div className="h-full w-full bg-ds-sidebar" />}>
+            {renderPlanPanel('h-full max-h-full w-full')}
+          </Suspense>
+        </div>
+      </div>
     )
   }
 
@@ -1900,7 +1957,7 @@ export function Workbench(): ReactElement {
           </div>
 
           {route === 'chat' && !activeSddDraft ? (
-            <SideConversationPanel rightOffset={rightPanelVisible ? rightSidebarWidth + 24 : 24} />
+            <SideConversationPanel rightOffset={rightPanelDockedVisible ? rightSidebarWidth + 24 : 24} />
           ) : null}
 
           {renderRightPanel()}
@@ -1908,6 +1965,7 @@ export function Workbench(): ReactElement {
 
           </>
         )}
+        {renderPlanPanelOverlay()}
       </main>
     </div>
   )

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -1,8 +1,9 @@
 import type { ReactElement, RefObject } from 'react'
-import { Fragment, memo, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ChatBlock, RuntimeConnectionStatus } from '../../agent/types'
 import { useChatStore } from '../../store/chat-store'
+import { threadHasPendingRuntimeWork } from '../../store/chat-store-runtime-helpers'
 import { useTimelineStores } from './use-timeline-stores'
 import { useTimelineScroll } from './use-timeline-scroll'
 import { deriveTurnSections } from './derive-turn-sections'
@@ -16,7 +17,6 @@ import {
   sameTurnContent,
   splitThink,
   stableTurnKey,
-  turnHasPendingRuntimeWork,
   type Turn
 } from './message-timeline-turns'
 import { extractPlanMetadataFromBlock } from '../../plan/plan-tool'
@@ -67,6 +67,13 @@ function blockScrollStamp(block: ChatBlock | undefined): string {
   }
 }
 
+function turnPreview(turn: Turn, fallback: string): string {
+  const text = turn.user?.text.trim() ?? ''
+  if (!text) return fallback
+  const oneLine = text.replace(/\s+/g, ' ')
+  return oneLine.length > 48 ? `${oneLine.slice(0, 47).trimEnd()}...` : oneLine
+}
+
 export function MessageTimeline({
   blocks,
   liveReasoning,
@@ -101,6 +108,7 @@ export function MessageTimeline({
   const hasContent = blocks.length > 0 || live || liveReasoning
   const endRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const turnRefMap = useRef(new Map<string, HTMLDivElement>())
 
   const turns = useMemo(() => groupTurns(blocks), [blocks])
   const latestBlock = blocks[blocks.length - 1]
@@ -135,6 +143,29 @@ export function MessageTimeline({
     () => (hiddenTurnCount > 0 ? turns.slice(hiddenTurnCount) : turns),
     [hiddenTurnCount, turns]
   )
+  const visibleTurnAnchors = useMemo(
+    () => {
+      const anchors: { key: string; label: string; title: string }[] = []
+      let questionIndex = turns
+        .slice(0, hiddenTurnCount)
+        .filter((turn) => turn.user)
+        .length
+
+      visibleTurns.forEach((turn, index) => {
+        if (!turn.user) return
+        questionIndex += 1
+        const absoluteTurnIndex = hiddenTurnCount + index
+        const key = stableTurnKey(turn, absoluteTurnIndex)
+        anchors.push({
+          key,
+          label: String(questionIndex),
+          title: turnPreview(turn, t('timelineJumpTurn', { index: questionIndex }))
+        })
+      })
+      return anchors
+    },
+    [hiddenTurnCount, t, turns, visibleTurns]
+  )
   const forkedFromTitle = activeThread?.forkedFromTitle?.trim() ?? ''
   const forkBoundaryTurnCount =
     typeof activeThread?.forkedFromTurnCount === 'number'
@@ -150,8 +181,33 @@ export function MessageTimeline({
     return () => window.clearInterval(id)
   }, [busy, currentTurnUserId])
 
+  const jumpToTurn = (key: string): void => {
+    const target = turnRefMap.current.get(key)
+    if (!target) return
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
   return (
-    <div ref={containerRef} className="ds-no-drag flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden">
+    <div ref={containerRef} className="ds-no-drag relative flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden">
+      {visibleTurnAnchors.length > 2 ? (
+        <nav
+          aria-label={t('timelineJumpRailLabel')}
+          className="timeline-jump-rail"
+        >
+          {visibleTurnAnchors.map((anchor) => (
+            <button
+              key={anchor.key}
+              type="button"
+              className="timeline-jump-rail-button"
+              title={anchor.title}
+              aria-label={anchor.title}
+              onClick={() => jumpToTurn(anchor.key)}
+            >
+              {anchor.label}
+            </button>
+          ))}
+        </nav>
+      ) : null}
       <div className="ds-message-timeline-content ds-chat-column-inset mx-auto flex w-full min-w-0 max-w-4xl flex-col gap-8 pb-10 pt-8">
         {!hasContent || !activeThreadId ? (
           <MessageTimelineEmptyHero
@@ -200,13 +256,24 @@ export function MessageTimeline({
             typeof reasoningFirst === 'number' && typeof reasoningLast === 'number'
               ? Math.max(0, reasoningLast - reasoningFirst)
               : undefined
-          const turnPending = turnHasPendingRuntimeWork(turn)
+          const turnPending = threadHasPendingRuntimeWork(turn.blocks)
           const isLatestTurn = index === visibleTurns.length - 1
           const hasLiveStream = isLatestTurn && !!(liveReasoning.trim() || live.trim())
           const showForkPoint =
             forkBoundaryTurnCount !== undefined && absoluteTurnIndex === forkBoundaryTurnCount
+          const turnKey = stableTurnKey(turn, absoluteTurnIndex)
           return (
-            <Fragment key={stableTurnKey(turn, absoluteTurnIndex)}>
+            <div
+              key={turnKey}
+              ref={(node) => {
+                if (node) {
+                  turnRefMap.current.set(turnKey, node)
+                } else {
+                  turnRefMap.current.delete(turnKey)
+                }
+              }}
+              className="scroll-mt-6"
+            >
               {showForkPoint ? <ThreadForkPoint parentTitle={forkedFromTitle} /> : null}
               <MemoMessageTurn
                 turn={turn}
@@ -221,7 +288,7 @@ export function MessageTimeline({
                 onOpenPlan={onOpenPlan}
                 viewportRef={containerRef}
               />
-            </Fragment>
+            </div>
           )
         })}
 

--- a/src/renderer/src/components/chat/message-timeline-turns.ts
+++ b/src/renderer/src/components/chat/message-timeline-turns.ts
@@ -65,10 +65,6 @@ export function isProcessBlock(block: ChatBlock): boolean {
   )
 }
 
-export function turnHasPendingRuntimeWork(turn: Turn): boolean {
-  return turn.blocks.some(blockHasPendingRuntimeWork)
-}
-
 export function findTrailingAssistantContentStart(blocks: ChatBlock[]): number {
   let start = blocks.length
 

--- a/src/renderer/src/components/workbench-plan-controller.ts
+++ b/src/renderer/src/components/workbench-plan-controller.ts
@@ -387,7 +387,9 @@ export function useWorkbenchPlanController({
     if (latestPlanBlock && lastLoadedPlanBlockIdRef.current === latestPlanBlock.blockId) return
     if (!latestPlanBlock) return
     lastLoadedPlanBlockIdRef.current = latestPlanBlock.blockId
-    const shouldOpen = planTurnInFlightRef.current || mode === 'plan'
+    // Keep generated plans inline until the user explicitly opens the preview.
+    // This avoids squeezing the chat on portrait/narrow screens after a plan turn.
+    const shouldOpen = false
     planTurnInFlightRef.current = false
     void loadPlanFromMeta(latestPlanBlock.meta, shouldOpen).catch((error) => {
       useGuiPlanStore.getState().setOperationStatus(
@@ -395,7 +397,7 @@ export function useWorkbenchPlanController({
         error instanceof Error ? error.message : String(error)
       )
     })
-  }, [latestPlanBlock, loadPlanFromMeta, mode])
+  }, [latestPlanBlock, loadPlanFromMeta])
 
   useEffect(() => {
     if (!busy) planTurnInFlightRef.current = false

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1223,6 +1223,8 @@
   "thoughtSteps": "Thought ({{count}} steps)",
   "timelineShowEarlierTurns": "Show {{count}} earlier turns",
   "timelineCollapseEarlierTurns": "Show recent turns only",
+  "timelineJumpRailLabel": "Jump to a question",
+  "timelineJumpTurn": "Jump to question {{index}}",
   "groupEditedFiles": "Edited {{count}} files",
   "groupEditedFile": "Edited 1 file",
   "turnChangeFilesOne": "Edited 1 file",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1223,6 +1223,8 @@
   "thoughtSteps": "思考（{{count}} 步）",
   "timelineShowEarlierTurns": "显示更早的 {{count}} 轮对话",
   "timelineCollapseEarlierTurns": "仅显示最近对话",
+  "timelineJumpRailLabel": "跳转到某次提问",
+  "timelineJumpTurn": "跳转到第 {{index}} 次提问",
   "groupEditedFiles": "修改了 {{count}} 个文件",
   "groupEditedFile": "修改了 1 个文件",
   "turnChangeFilesOne": "已编辑 1 个文件",

--- a/src/renderer/src/store/chat-store-maintenance-actions.ts
+++ b/src/renderer/src/store/chat-store-maintenance-actions.ts
@@ -40,7 +40,6 @@ import {
   collectAssistantTextForTurn,
   findLatestUserBlockId,
   findReusableEmptyThreadId,
-  hasPendingRuntimeWork,
   reconcileOptimisticUserBlock,
   settlePendingRuntimeWorkAfterInterrupt,
   threadSnapshotLooksRunning,

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -40,7 +40,6 @@ import {
   collectAssistantTextForTurn,
   findLatestUserBlockId,
   findReusableEmptyThreadId,
-  hasPendingRuntimeWork,
   reconcileOptimisticUserBlock,
   threadSnapshotLooksRunning,
   threadBelongsToWorkspace

--- a/src/renderer/src/store/chat-store-runtime-helpers.test.ts
+++ b/src/renderer/src/store/chat-store-runtime-helpers.test.ts
@@ -3,6 +3,7 @@ import type { ChatBlock } from '../agent/types'
 import {
   hasPendingRuntimeWork,
   settlePendingRuntimeWorkAfterInterrupt,
+  threadHasPendingRuntimeWork,
   threadSnapshotLooksRunning
 } from './chat-store-runtime-helpers'
 
@@ -40,6 +41,58 @@ describe('chat-store-runtime-helpers compaction state', () => {
     expect(threadSnapshotLooksRunning([staleTool], 'aborted')).toBe(false)
     expect(threadSnapshotLooksRunning([staleTool], 'running')).toBe(true)
     expect(threadSnapshotLooksRunning([staleTool])).toBe(true)
+  })
+
+  it('ignores stale pending work once the same turn has visible assistant content', () => {
+    const blocks: ChatBlock[] = [
+      { kind: 'user', id: 'user-1', text: 'Run the task' },
+      {
+        kind: 'tool',
+        id: 'tool-stale',
+        summary: 'Old tool',
+        status: 'running',
+        toolKind: 'tool_call'
+      },
+      { kind: 'assistant', id: 'answer-1', text: 'The task is complete.' }
+    ]
+
+    expect(threadHasPendingRuntimeWork(blocks)).toBe(false)
+    expect(threadSnapshotLooksRunning(blocks)).toBe(false)
+  })
+
+  it('keeps the thread busy when pending work has no later assistant answer', () => {
+    const blocks: ChatBlock[] = [
+      { kind: 'user', id: 'user-1', text: 'Run the task' },
+      { kind: 'assistant', id: 'partial-1', text: 'I will check that.' },
+      {
+        kind: 'tool',
+        id: 'tool-running',
+        summary: 'Still running',
+        status: 'running',
+        toolKind: 'tool_call'
+      }
+    ]
+
+    expect(threadHasPendingRuntimeWork(blocks)).toBe(true)
+    expect(threadSnapshotLooksRunning(blocks)).toBe(true)
+  })
+
+  it('does not let stale pending work from an older turn block new input', () => {
+    const blocks: ChatBlock[] = [
+      { kind: 'user', id: 'user-1', text: 'First task' },
+      {
+        kind: 'tool',
+        id: 'tool-stale',
+        summary: 'Old tool',
+        status: 'running',
+        toolKind: 'tool_call'
+      },
+      { kind: 'user', id: 'user-2', text: 'Second task' },
+      { kind: 'assistant', id: 'answer-2', text: 'Second answer.' }
+    ]
+
+    expect(threadHasPendingRuntimeWork(blocks)).toBe(false)
+    expect(threadSnapshotLooksRunning(blocks)).toBe(false)
   })
 
   it('settles local pending work after a successful interrupt', () => {

--- a/src/renderer/src/store/chat-store-runtime-helpers.ts
+++ b/src/renderer/src/store/chat-store-runtime-helpers.ts
@@ -29,6 +29,31 @@ export function hasPendingRuntimeWork(block: ChatBlock): boolean {
   return false
 }
 
+function assistantBlockHasVisibleContent(block: Extract<ChatBlock, { kind: 'assistant' }>): boolean {
+  const withoutThink = block.text.replace(/<think>[\s\S]*?(?:<\/think>|$)/g, '').trim()
+  return withoutThink.length > 0
+}
+
+export function threadHasPendingRuntimeWork(blocks: ChatBlock[]): boolean {
+  let pendingInCurrentTurn = false
+
+  for (const block of blocks) {
+    if (block.kind === 'user') {
+      pendingInCurrentTurn = false
+      continue
+    }
+    if (hasPendingRuntimeWork(block)) {
+      pendingInCurrentTurn = true
+      continue
+    }
+    if (pendingInCurrentTurn && block.kind === 'assistant' && assistantBlockHasVisibleContent(block)) {
+      pendingInCurrentTurn = false
+    }
+  }
+
+  return pendingInCurrentTurn
+}
+
 export function settlePendingRuntimeWorkAfterInterrupt(blocks: ChatBlock[]): ChatBlock[] {
   let changed = false
   const next = blocks.map((block): ChatBlock => {
@@ -61,7 +86,7 @@ export function threadSnapshotLooksRunning(blocks: ChatBlock[], threadStatus?: s
   if (threadStatus != null && threadStatus.trim()) {
     return runtimeStatusLooksRunning(threadStatus)
   }
-  return blocks.some(hasPendingRuntimeWork)
+  return threadHasPendingRuntimeWork(blocks)
 }
 
 export function findLatestUserBlockId(blocks: ChatBlock[]): string | null {

--- a/src/renderer/src/store/chat-store-thread-actions.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.ts
@@ -40,8 +40,8 @@ import {
   collectAssistantTextForTurn,
   findLatestUserBlockId,
   findReusableEmptyThreadId,
-  hasPendingRuntimeWork,
   reconcileOptimisticUserBlock,
+  threadHasPendingRuntimeWork,
   threadSnapshotLooksRunning,
   threadBelongsToWorkspace
 } from './chat-store-runtime-helpers'
@@ -363,7 +363,7 @@ export function createThreadActions(
       const writeThreadId = await get().ensureWriteThreadForWorkspace()
       if (!writeThreadId) return false
     }
-    const hasPendingActiveTurn = get().blocks.some(hasPendingRuntimeWork)
+    const hasPendingActiveTurn = threadHasPendingRuntimeWork(get().blocks)
     if (get().busy || hasPendingActiveTurn) {
       if (overrides?.guiPlan) {
         set({ error: i18n.t('common:composerQueuePlaceholder') })
@@ -713,7 +713,7 @@ export function createThreadActions(
       set({ error: i18n.t('common:reviewUnavailable') })
       return false
     }
-    if (get().busy || get().blocks.some(hasPendingRuntimeWork)) {
+    if (get().busy || threadHasPendingRuntimeWork(get().blocks)) {
       set({ error: i18n.t('common:composerQueuePlaceholder') })
       return false
     }

--- a/src/renderer/src/store/chat-store.ts
+++ b/src/renderer/src/store/chat-store.ts
@@ -56,7 +56,6 @@ import {
   collectAssistantTextForTurn,
   findLatestUserBlockId,
   findReusableEmptyThreadId,
-  hasPendingRuntimeWork,
   threadBelongsToWorkspace
 } from './chat-store-runtime-helpers'
 import {

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -2235,6 +2235,107 @@ pre {
   container-type: inline-size;
 }
 
+.timeline-jump-rail {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 30;
+  display: flex;
+  max-height: min(48vh, 22rem);
+  flex-direction: column;
+  gap: 0.25rem;
+  align-self: flex-end;
+  overflow-y: auto;
+  margin: 0.65rem 0.65rem -0.65rem 0;
+  border: 1px solid var(--ds-border-muted);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ds-surface-card) 88%, transparent);
+  padding: 0.3rem;
+  box-shadow: 0 12px 34px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(18px);
+  scrollbar-width: none;
+}
+
+.timeline-jump-rail::-webkit-scrollbar {
+  display: none;
+}
+
+.timeline-jump-rail-button {
+  display: inline-flex;
+  min-width: 1.55rem;
+  height: 1.55rem;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ds-text-faint);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  transition:
+    background 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.timeline-jump-rail-button:hover,
+.timeline-jump-rail-button:focus-visible {
+  background: var(--ds-accent-soft);
+  color: var(--ds-accent);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.ds-plan-panel-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: grid;
+  place-items: center;
+  padding: clamp(0.75rem, 3vw, 2rem);
+}
+
+.ds-plan-panel-overlay-backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background:
+    radial-gradient(circle at 50% 8%, color-mix(in srgb, var(--ds-accent) 12%, transparent), transparent 32%),
+    color-mix(in srgb, var(--ds-bg-main) 74%, rgba(0, 0, 0, 0.18));
+  backdrop-filter: blur(12px);
+}
+
+.ds-plan-panel-overlay-card {
+  position: relative;
+  width: min(92vw, 720px);
+  height: min(88vh, 900px);
+  min-height: min(36rem, 88vh);
+  overflow: hidden;
+  border: 1px solid var(--ds-border);
+  border-radius: 28px;
+  background: var(--ds-bg-sidebar);
+  box-shadow:
+    0 28px 80px rgba(15, 23, 42, 0.22),
+    0 0 0 1px color-mix(in srgb, var(--ds-border-muted) 60%, transparent);
+}
+
+@media (max-width: 720px) {
+  .timeline-jump-rail {
+    display: none;
+  }
+
+  .ds-plan-panel-overlay {
+    padding: 0.5rem;
+  }
+
+  .ds-plan-panel-overlay-card {
+    width: calc(100vw - 1rem);
+    height: calc(100vh - 1rem);
+    min-height: 0;
+    border-radius: 22px;
+  }
+}
+
 .chat-topbar {
   margin-top: 0.35rem;
   min-height: 40px;


### PR DESCRIPTION
## Summary
- prevent completed turns with stale pending runtime blocks from keeping the chat busy or blocking queued input
- keep generated plans inline by default, and show the Plan panel as an overlay on narrow/portrait layouts when opened manually
- add a compact question jump rail for long conversations

Fixes KunAgent/DeepSeek-GUI#177
Fixes KunAgent/DeepSeek-GUI#178
Fixes KunAgent/DeepSeek-GUI#179
Fixes KunAgent/DeepSeek-GUI#182

Note: KunAgent/DeepSeek-GUI#183 is intentionally not included because KunAgent/DeepSeek-GUI#200 already covers the chat title drag-region fix.

## Conflict check
- rebased on latest upstream/develop (e7e8252)
- checked open PRs before publishing; #199 touches different Workbench hunks, #200 covers #183 so this branch avoids SessionHeader changes

## Test Plan
- npm.cmd test -- src/renderer/src/store/chat-store-runtime-helpers.test.ts src/renderer/src/components/chat/message-timeline-turns.test.ts src/renderer/src/components/chat/derive-turn-sections.test.ts
- npm.cmd run typecheck
- npm.cmd run lint (passes with existing hook dependency warnings)
- npm.cmd run build