### PR TITLE
[codex] fix: support /new for current project sessions

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -1881,6 +1881,7 @@ export function Workbench(): ReactElement {
                 onRemoveQueuedMessage={removeQueuedMessage}
                 onInterrupt={(options) => void interrupt(options)}
                 onPlanCommand={() => void handleGuiPlanCommand()}
+                onNewCommand={() => void createThread({ workspaceRoot: activeSkillWorkspace, forceNew: true })}
                 onReviewCommand={(target) => void reviewActiveThread(target)}
                 onExecutionSettingsChange={updateComposerExecutionSettings}
                 onOpenChanges={() => setRightPanelMode('changes')}

--- a/src/renderer/src/components/chat/FloatingComposer.test.ts
+++ b/src/renderer/src/components/chat/FloatingComposer.test.ts
@@ -9,6 +9,7 @@ import {
   imageTransferHasImages,
   parseCompactCommand,
   parseGoalCommand,
+  parseNewCommand,
   parseReviewCommand
 } from './FloatingComposer'
 import {
@@ -59,6 +60,14 @@ describe('FloatingComposer slash commands', () => {
       objective: 'ship the feature'
     })
     expect(parseGoalCommand('/goalkeeper')).toBe(false)
+  })
+
+  it('parses new session command aliases', () => {
+    expect(parseNewCommand('/new')).toBe(true)
+    expect(parseNewCommand('/new-thread')).toBe(true)
+    expect(parseNewCommand('/新建会话')).toBe(true)
+    expect(parseNewCommand('/new current task')).toBe(false)
+    expect(parseNewCommand('/new-topic')).toBe(false)
   })
 
   it('parses review command targets', () => {
@@ -365,6 +374,42 @@ describe('FloatingComposer capability controls', () => {
     const goalButton = html.match(/<button[^>]*>[\s\S]*?\/goal[\s\S]*?<\/button>/)?.[0] ?? ''
     expect(goalButton).toContain('/goal')
     expect(goalButton).not.toContain('disabled=""')
+  })
+
+  it('enables new session before a thread exists when a workspace is available', () => {
+    useChatStore.setState({
+      activeThreadId: null,
+      activeThreadGoal: null,
+      route: 'chat',
+      workspaceRoot: ''
+    })
+
+    const html = renderToStaticMarkup(
+      createElement(FloatingComposer, {
+        input: '/new',
+        setInput: () => undefined,
+        mode: 'agent',
+        setMode: () => undefined,
+        busy: false,
+        runtimeReady: true,
+        hasActiveThread: false,
+        workspaceRootOverride: '/workspace/deepseek-gui',
+        composerModel: '',
+        composerPickList: [],
+        onComposerModelChange: () => undefined,
+        queuedMessages: [],
+        onRemoveQueuedMessage: () => undefined,
+        onSend: () => undefined,
+        onInterrupt: () => undefined,
+        onNewCommand: () => undefined,
+        attachmentUploadEnabled: false,
+        webAccessAvailable: false
+      })
+    )
+
+    const newButton = html.match(/<button[^>]*>[\s\S]*?\/new[\s\S]*?<\/button>/)?.[0] ?? ''
+    expect(newButton).toContain('/new')
+    expect(newButton).not.toContain('disabled=""')
   })
 
   it('enables plan mode before a thread exists when a workspace is available', () => {

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -54,15 +54,17 @@ import {
   COMPACT_COMMAND_ALIASES,
   getGoalPanelDraftObjective,
   getSlashQuery,
+  NEW_COMMAND_ALIASES,
   parseBtwCommand,
   parseCompactCommand,
   parseGoalCommand,
+  parseNewCommand,
   parseReviewCommand,
   REVIEW_COMMAND_ALIASES,
   type SlashCommand,
   type SlashCommandId
 } from './floating-composer-commands'
-export { parseBtwCommand, parseCompactCommand, parseGoalCommand, parseReviewCommand } from './floating-composer-commands'
+export { parseBtwCommand, parseCompactCommand, parseGoalCommand, parseNewCommand, parseReviewCommand } from './floating-composer-commands'
 import {
   formatCompactNumber,
   formatCost,
@@ -139,6 +141,7 @@ type Props = {
   onSend: () => void
   onInterrupt: (options?: { discard?: boolean }) => void
   onPlanCommand?: () => void
+  onNewCommand?: () => void
   onReviewCommand?: (target: ReviewTarget) => void
   onExecutionSettingsChange?: (patch: Partial<ComposerExecutionSettings>) => void
   onOpenChanges?: () => void
@@ -506,6 +509,7 @@ export function FloatingComposer({
   onSend,
   onInterrupt,
   onPlanCommand,
+  onNewCommand,
   onReviewCommand,
   onExecutionSettingsChange,
   onOpenChanges,
@@ -578,9 +582,11 @@ export function FloatingComposer({
   const showIntentToolbar = !compact && route === 'chat'
   const showComposerMenuButton = showIntentToolbar
   const canTogglePlanMode = canCompose && Boolean(onPlanCommand)
+  const canCreateNewThread = runtimeReady && route !== 'claw' && Boolean(effectiveWorkspaceRoot) && Boolean(onNewCommand)
   const canOpenGoalPanel = canCompose && route !== 'claw'
   const canRunReview = canCompose && route !== 'claw' && Boolean(onReviewCommand)
-  const canOpenComposerMenu = showComposerMenuButton && (canTogglePlanMode || canOpenGoalPanel || canRunReview)
+  const canOpenComposerMenu = showComposerMenuButton
+    && (canTogglePlanMode || canCreateNewThread || canOpenGoalPanel || canRunReview)
   const showToolbarStartControls = showComposerMenuButton
   const showChangeSummary = !compact && route === 'chat' && changedFiles.length > 0
   const effectiveChangedFileStats = changedFileStats ?? changedFiles.reduce(
@@ -640,6 +646,16 @@ export function FloatingComposer({
     const threadActionDisabled = !runtimeReady || busy || !activeThreadId
     const goalActionDisabled = !canOpenGoalPanel
     const commands: SlashCommand[] = []
+    if (route !== 'claw') {
+      commands.push({
+        id: 'new',
+        title: t('slashCommandNewTitle'),
+        description: t('slashCommandNewDescription'),
+        keywords: ['create', 'new', 'thread', 'chat', '会话', '新建', ...NEW_COMMAND_ALIASES],
+        icon: <Plus className="h-4 w-4" strokeWidth={1.9} />,
+        disabled: !canCreateNewThread
+      })
+    }
     if (onPlanCommand) {
       commands.push({
         id: 'plan',
@@ -768,6 +784,7 @@ export function FloatingComposer({
     effectiveWorkspaceRoot,
     hideBtwCommand,
     onBtwCommand,
+    canCreateNewThread,
     onPlanCommand,
     onReviewCommand,
     route,
@@ -947,6 +964,12 @@ export function FloatingComposer({
       draft.focusComposer()
       return
     }
+    if (commandId === 'new' && onNewCommand) {
+      setInput('')
+      onNewCommand()
+      draft.focusComposer()
+      return
+    }
     if (commandId === 'compact') {
       setInput('')
       void compactActiveThread()
@@ -1108,6 +1131,14 @@ export function FloatingComposer({
       return
     }
     if (runGoalCommand(parsedGoalCommand)) {
+      return
+    }
+    if (onNewCommand && parseNewCommand(input)) {
+      const command = slashCommands.find((item) => item.id === 'new')
+      if (command?.disabled) return
+      setInput('')
+      onNewCommand()
+      draft.focusComposer()
       return
     }
     const compactCommand = parseCompactCommand(input)

--- a/src/renderer/src/components/chat/floating-composer-commands.ts
+++ b/src/renderer/src/components/chat/floating-composer-commands.ts
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import type { ReviewTarget } from '../../agent/types'
 
-export type BuiltinSlashCommandId = 'plan' | 'goal' | 'review' | 'compact' | 'fork' | 'archive' | 'restore' | 'btw'
+export type BuiltinSlashCommandId = 'new' | 'plan' | 'goal' | 'review' | 'compact' | 'fork' | 'archive' | 'restore' | 'btw'
 export type SkillSlashCommandId = `skill:${string}`
 export type SlashCommandId = BuiltinSlashCommandId | SkillSlashCommandId
 
@@ -38,6 +38,14 @@ export const COMPACT_COMMAND_ALIASES = [
   '总结'
 ]
 
+export const NEW_COMMAND_ALIASES = [
+  'new',
+  'new-chat',
+  'new-thread',
+  '新会话',
+  '新建会话'
+]
+
 export const REVIEW_COMMAND_ALIASES = [
   'review',
   'code-review',
@@ -71,6 +79,14 @@ export function parseCompactCommand(input: string): CompactCommand | null {
     return reason ? { reason } : {}
   }
   return null
+}
+
+export function parseNewCommand(input: string): boolean {
+  const trimmed = input.trim()
+  if (!trimmed.startsWith('/')) return false
+  const body = trimmed.slice(1).trimStart()
+  const lowerBody = body.toLowerCase()
+  return NEW_COMMAND_ALIASES.some((alias) => lowerBody === alias.toLowerCase())
 }
 
 export function parseGoalCommand(input: string): GoalCommand | false {

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -706,6 +706,8 @@
   "slashCommandApply": "Apply command",
   "slashCommandCurrent": "Current",
   "slashCommandEmpty": "No matching command. Keep typing to send the raw text instead.",
+  "slashCommandNewTitle": "New session",
+  "slashCommandNewDescription": "Create a new session for the current project immediately.",
   "slashCommandPlanTitle": "Plan",
   "slashCommandPlanDescription": "Add a Plan marker to the composer before sending.",
   "slashCommandPlanActiveDescription": "Plan mode is already active.",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -706,6 +706,8 @@
   "slashCommandApply": "应用命令",
   "slashCommandCurrent": "当前",
   "slashCommandEmpty": "没有匹配的命令，继续输入可直接发送原文。",
+  "slashCommandNewTitle": "新建会话",
+  "slashCommandNewDescription": "立即为当前项目创建一个新的会话。",
   "slashCommandPlanTitle": "计划",
   "slashCommandPlanDescription": "在输入框里添加 Plan 标识，发送后先生成计划。",
   "slashCommandPlanActiveDescription": "计划模式已经开启。",


### PR DESCRIPTION
## Summary
- add a `/new` slash command in the desktop composer for chat sessions
- wire the command to create a brand-new session for the current project instead of reusing the current thread
- add slash-command parsing and renderer coverage tests for the new behavior

## Root Cause
The desktop composer exposed several slash commands, but it did not provide a local `/new` entry even though users needed a fast way to start a fresh project session from the current workspace.

## Validation
- `npm ci`
- `npm test -- --run src/renderer/src/components/chat/FloatingComposer.test.ts`
- `npm run typecheck`
- `npm run dist:mac:arm64`

Fixes XingYu-Zhong/DeepSeek-GUI#175
