### PR TITLE
fix: avoid goal overlay blocking chat content

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposer.test.ts
+++ b/src/renderer/src/components/chat/FloatingComposer.test.ts
@@ -9,7 +9,8 @@ import {
   imageTransferHasImages,
   parseCompactCommand,
   parseGoalCommand,
-  parseReviewCommand
+  parseReviewCommand,
+  shouldShowGoalFloater
 } from './FloatingComposer'
 import {
   FloatingComposerModelPicker,
@@ -88,6 +89,48 @@ describe('FloatingComposer goal helpers', () => {
     expect(formatGoalElapsedSeconds(60)).toBe('1m')
     expect(formatGoalElapsedSeconds(125)).toBe('2m 5s')
     expect(formatGoalElapsedSeconds(3720)).toBe('1h 2m')
+  })
+
+  it('shows the goal banner only when no other composer overlay is active', () => {
+    expect(shouldShowGoalFloater({
+      compact: false,
+      hasActiveGoal: true,
+      slashQuery: null,
+      goalPanelOpen: false,
+      composerMenuOpen: false
+    })).toBe(true)
+
+    expect(shouldShowGoalFloater({
+      compact: true,
+      hasActiveGoal: true,
+      slashQuery: null,
+      goalPanelOpen: false,
+      composerMenuOpen: false
+    })).toBe(false)
+
+    expect(shouldShowGoalFloater({
+      compact: false,
+      hasActiveGoal: true,
+      slashQuery: 'goal',
+      goalPanelOpen: false,
+      composerMenuOpen: false
+    })).toBe(false)
+
+    expect(shouldShowGoalFloater({
+      compact: false,
+      hasActiveGoal: true,
+      slashQuery: null,
+      goalPanelOpen: true,
+      composerMenuOpen: false
+    })).toBe(false)
+
+    expect(shouldShowGoalFloater({
+      compact: false,
+      hasActiveGoal: false,
+      slashQuery: null,
+      goalPanelOpen: false,
+      composerMenuOpen: false
+    })).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -467,6 +467,22 @@ export function formatGoalElapsedSeconds(seconds: number): string {
     : `${hours}h ${remainingMinutes}m`
 }
 
+export function shouldShowGoalFloater({
+  compact,
+  hasActiveGoal,
+  slashQuery,
+  goalPanelOpen,
+  composerMenuOpen
+}: {
+  compact: boolean
+  hasActiveGoal: boolean
+  slashQuery: string | null
+  goalPanelOpen: boolean
+  composerMenuOpen: boolean
+}): boolean {
+  return !compact && hasActiveGoal && slashQuery == null && !goalPanelOpen && !composerMenuOpen
+}
+
 export function FloatingComposer({
   variant = 'default',
   workspaceRootOverride,
@@ -840,6 +856,13 @@ export function FloatingComposer({
       : t(`goalStatusShort.${activeThreadGoal.status}`)
     : ''
   const goalMenuChecked = activeThreadGoal?.status === 'active'
+  const showGoalFloater = shouldShowGoalFloater({
+    compact,
+    hasActiveGoal: Boolean(activeThreadGoal),
+    slashQuery,
+    goalPanelOpen,
+    composerMenuOpen
+  })
 
   useEffect(() => {
     setSelectedCommandIndex(0)
@@ -1323,7 +1346,7 @@ export function FloatingComposer({
       />
 
       <div className="relative">
-        {!compact && activeThreadGoal && slashQuery == null && !goalPanelOpen && !composerMenuOpen ? (
+        {showGoalFloater && activeThreadGoal ? (
           <div className="pointer-events-none absolute inset-x-3 bottom-full z-20 mb-2 flex justify-center">
             <div className="pointer-events-auto flex min-h-11 w-full max-w-[46rem] items-center gap-2 rounded-full border border-ds-border bg-ds-card/95 px-3 py-1.5 text-ds-muted shadow-[0_12px_34px_rgba(15,23,42,0.10)] backdrop-blur-xl dark:bg-ds-card/90">
               <Target className="h-3.5 w-3.5 shrink-0 text-ds-faint" strokeWidth={1.9} />

--- a/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
+++ b/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
@@ -3,7 +3,7 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ChatBlock, NormalizedThread, ToolBlock } from '../../agent/types'
 import { useChatStore } from '../../store/chat-store'
-import { MessageTimeline, summarizeToolBlock } from './MessageTimeline'
+import { MessageTimeline, goalTimelinePaddingClass, liveTurnProgressClass, summarizeToolBlock } from './MessageTimeline'
 import { MessageBubble } from './message-timeline-bubbles'
 import { ProcessSectionRow } from './message-timeline-process'
 
@@ -453,5 +453,16 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
     expect(html).toContain('Read')
     expect(html).toContain('/tmp/project/src/app.ts')
     expect(html).not.toContain('running timeline detail should stay collapsed')
+  })
+
+  it('adds extra bottom padding only for chat timelines with an active goal banner', () => {
+    expect(goalTimelinePaddingClass('chat', true)).toBe('pb-32 md:pb-40')
+    expect(goalTimelinePaddingClass('chat', false)).toBe('pb-10')
+    expect(goalTimelinePaddingClass('claw', true)).toBe('pb-10')
+  })
+
+  it('pushes the live progress row above the goal banner when a goal is active', () => {
+    expect(liveTurnProgressClass(true)).toContain('mb-16 md:mb-20')
+    expect(liveTurnProgressClass(false)).not.toContain('mb-16 md:mb-20')
   })
 })

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -46,6 +46,16 @@ type Props = {
 const TURN_PAGE_SIZE = 18
 const AUTO_COLLAPSE_THRESHOLD = 24
 
+export function goalTimelinePaddingClass(route: 'chat' | 'claw', hasActiveGoal: boolean): string {
+  return route === 'chat' && hasActiveGoal ? 'pb-32 md:pb-40' : 'pb-10'
+}
+
+export function liveTurnProgressClass(hasActiveGoal: boolean): string {
+  return hasActiveGoal
+    ? 'flex w-fit max-w-full items-center gap-2 py-0.5 text-[14px] font-medium text-ds-muted mb-16 md:mb-20'
+    : 'flex w-fit max-w-full items-center gap-2 py-0.5 text-[14px] font-medium text-ds-muted'
+}
+
 function blockScrollStamp(block: ChatBlock | undefined): string {
   if (!block) return ''
   switch (block.kind) {
@@ -94,6 +104,7 @@ export function MessageTimeline({
     turnDurationByUserId,
     turnReasoningFirstAtByUserId,
     turnReasoningLastAtByUserId,
+    activeThreadGoal,
     activeThread
   } = useTimelineStores(activeThreadId)
 
@@ -152,7 +163,9 @@ export function MessageTimeline({
 
   return (
     <div ref={containerRef} className="ds-no-drag flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden">
-      <div className="ds-message-timeline-content ds-chat-column-inset mx-auto flex w-full min-w-0 max-w-4xl flex-col gap-8 pb-10 pt-8">
+      <div className={`ds-message-timeline-content ds-chat-column-inset mx-auto flex w-full min-w-0 max-w-4xl flex-col gap-8 pt-8 ${
+        goalTimelinePaddingClass(heroRoute, Boolean(activeThreadGoal))
+      }`}>
         {!hasContent || !activeThreadId ? (
           <MessageTimelineEmptyHero
             route={heroRoute}
@@ -299,6 +312,7 @@ function MessageTurn({
   viewportRef: RefObject<HTMLDivElement | null>
 }): ReactElement {
   const workspaceRoot = useChatStore((s) => s.workspaceRoot)
+  const activeThreadGoal = useChatStore((s) => s.activeThreadGoal)
   // Inline Review Plan card: surfaced under a turn that produced a
   // successful `create_plan` result so the user can open/build the plan
   // without leaving the conversation.
@@ -391,7 +405,7 @@ function MessageTurn({
         <ReviewSummaryCard key={review.id} review={review} />
       ))}
 
-      {isProcessing ? <LiveTurnProgressRow /> : null}
+      {isProcessing ? <LiveTurnProgressRow hasActiveGoal={Boolean(activeThreadGoal)} /> : null}
 
       {!isProcessing && devPreviewCard ? devPreviewCard : null}
 
@@ -412,11 +426,11 @@ function MessageTurn({
   )
 }
 
-function LiveTurnProgressRow(): ReactElement {
+function LiveTurnProgressRow({ hasActiveGoal }: { hasActiveGoal: boolean }): ReactElement {
   const { t } = useTranslation('common')
 
   return (
-    <div className="flex w-fit max-w-full items-center gap-2 py-0.5 text-[14px] font-medium text-ds-muted">
+    <div className={liveTurnProgressClass(hasActiveGoal)}>
       <span className="ds-work-logo-slot ds-work-logo-slot-sm mr-0.5">
         <AnimatedWorkLogo active phase="trail" size="sm" />
       </span>

--- a/src/renderer/src/components/chat/use-timeline-stores.ts
+++ b/src/renderer/src/components/chat/use-timeline-stores.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useChatStore } from '../../store/chat-store'
 import type { ClawImChannelV1 } from '@shared/app-settings'
-import type { NormalizedThread } from '../../agent/types'
+import type { NormalizedThread, ThreadGoal } from '../../agent/types'
 import type { AppRoute } from '../../store/chat-store-types'
 
 /**
@@ -21,6 +21,7 @@ export type TimelineStores = {
   turnDurationByUserId: Record<string, number>
   turnReasoningFirstAtByUserId: Record<string, number>
   turnReasoningLastAtByUserId: Record<string, number>
+  activeThreadGoal: ThreadGoal | null
   activeThread: NormalizedThread | null
 }
 
@@ -36,6 +37,7 @@ export function useTimelineStores(activeThreadId: string | null): TimelineStores
   const turnDurationByUserId = useChatStore((s) => s.turnDurationByUserId)
   const turnReasoningFirstAtByUserId = useChatStore((s) => s.turnReasoningFirstAtByUserId)
   const turnReasoningLastAtByUserId = useChatStore((s) => s.turnReasoningLastAtByUserId)
+  const activeThreadGoal = useChatStore((s) => s.activeThreadGoal)
   const activeThread = useChatStore((s) =>
     activeThreadId ? s.threads.find((thread) => thread.id === activeThreadId) ?? null : null
   )
@@ -56,6 +58,7 @@ export function useTimelineStores(activeThreadId: string | null): TimelineStores
     turnDurationByUserId,
     turnReasoningFirstAtByUserId,
     turnReasoningLastAtByUserId,
+    activeThreadGoal,
     activeThread
   }
 }


### PR DESCRIPTION
## Summary
- keep the goal floater in its original composer position
- add bottom spacing so timeline content is not covered by the goal banner
- push the live progress row above the goal floater when a goal is active

Fixes #194