### PR TITLE
feat: add gui_thread_create MCP tool

### DIFF
--- a/src/main/claw-schedule-mcp-server-thread-create.test.ts
+++ b/src/main/claw-schedule-mcp-server-thread-create.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mcpMock = vi.hoisted(() => {
+  const tools: Array<{
+    name: string
+    config: Record<string, unknown>
+    handler: (args: Record<string, unknown>) => Promise<unknown>
+  }> = []
+  return {
+    tools,
+    connect: vi.fn(async (_transport: unknown) => undefined)
+  }
+})
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: class {
+    registerTool(
+      name: string,
+      config: Record<string, unknown>,
+      handler: (args: Record<string, unknown>) => Promise<unknown>
+    ) {
+      mcpMock.tools.push({ name, config, handler })
+    }
+
+    async connect(transport: unknown) {
+      await mcpMock.connect(transport)
+    }
+  }
+}))
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: class {}
+}))
+
+describe('claw schedule MCP server gui_thread_create', () => {
+  beforeEach(() => {
+    mcpMock.tools.length = 0
+    mcpMock.connect.mockClear()
+  })
+
+  it('registers gui_thread_create and forwards arguments to the thread internal endpoint', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        ok: true,
+        threadId: 'thr_created',
+        turnId: 'turn_created',
+        title: 'Continue work',
+        message: 'Started'
+      })
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { runClawScheduleMcpServerFromArgv } = await import('./claw-schedule-mcp-server')
+
+    await expect(runClawScheduleMcpServerFromArgv([
+      'node',
+      'entry',
+      '--gui-schedule-mcp-server',
+      '--base-url',
+      'http://127.0.0.1:8788',
+      '--secret',
+      'test-secret'
+    ])).resolves.toBe(true)
+
+    const tool = mcpMock.tools.find((entry) => entry.name === 'gui_thread_create')
+    expect(tool).toBeTruthy()
+    const result = await tool!.handler({
+      title: 'Continue work',
+      prompt: 'Pick up from the handoff.',
+      workspace_root: '/tmp/project',
+      model: 'deepseek-v4-pro',
+      mode: 'agent',
+      reasoning_effort: 'medium'
+    }) as { content?: Array<{ text?: string }>; structuredContent?: Record<string, unknown> }
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:8788/schedule/internal/thread/create',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-secret',
+          'Content-Type': 'application/json'
+        })
+      })
+    )
+    const init = fetchMock.mock.calls[0]?.[1]
+    const body = JSON.parse(String(init?.body))
+    expect(body).toEqual({
+      input: {
+        title: 'Continue work',
+        prompt: 'Pick up from the handoff.',
+        workspaceRoot: '/tmp/project',
+        model: 'deepseek-v4-pro',
+        reasoningEffort: 'medium',
+        mode: 'agent'
+      }
+    })
+    expect(result.content?.[0]?.text).toBe('Thread created: Continue work')
+    expect(result.structuredContent).toMatchObject({
+      thread_id: 'thr_created',
+      turn_id: 'turn_created',
+      title: 'Continue work',
+      message: 'Started'
+    })
+  })
+})

--- a/src/main/claw-schedule-mcp-server.ts
+++ b/src/main/claw-schedule-mcp-server.ts
@@ -148,6 +148,42 @@ export async function runClawScheduleMcpServerFromArgv(argv: string[]): Promise<
   registerCreateTool('claw_schedule_create')
   registerCreateTool('gui_schedule_create')
 
+  server.registerTool('gui_thread_create', {
+    description: 'Create a new DeepSeek GUI thread and immediately start its first agent turn.',
+    inputSchema: {
+      title: z.string().min(1).describe('Short thread title shown in the GUI'),
+      prompt: z.string().min(1).describe('The first prompt/instruction the agent should run in the new thread'),
+      mode: z.enum(['agent', 'plan']).optional().describe('Execution mode; defaults to the GUI schedule default mode'),
+      model: z.string().optional().describe('Optional model id, e.g. auto / deepseek-v4-pro / deepseek-v4-flash'),
+      workspace_root: z.string().optional().describe('Optional workspace directory override'),
+      reasoning_effort: z.enum(['off', 'low', 'medium', 'high', 'max']).optional().describe('Optional reasoning strength')
+    }
+  }, async (args) => {
+    try {
+      const result = await postJson(options, '/schedule/internal/thread/create', {
+        input: {
+          title: args.title,
+          prompt: args.prompt,
+          workspaceRoot: args.workspace_root,
+          model: args.model,
+          reasoningEffort: args.reasoning_effort,
+          mode: args.mode
+        }
+      })
+      return textResult(
+        `Thread created: ${typeof result.title === 'string' ? result.title : args.title}`,
+        {
+          thread_id: result.threadId,
+          turn_id: result.turnId,
+          title: typeof result.title === 'string' ? result.title : args.title,
+          message: result.message
+        }
+      )
+    } catch (error) {
+      return errorResult(`Failed to create thread: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  })
+
   const registerUpdateTool = (name: string): void => {
     server.registerTool(name, {
       description: name.startsWith('claw_')

--- a/src/main/schedule-runtime-helpers.ts
+++ b/src/main/schedule-runtime-helpers.ts
@@ -65,6 +65,7 @@ export type RunPromptOptions = {
   mode: ScheduleRunMode
   waitForResult: boolean
   responseTimeoutMs: number
+  promptKind?: 'schedule' | 'direct'
 }
 
 export const SCHEDULER_INTERVAL_MS = 30_000

--- a/src/main/schedule-runtime-thread-create.test.ts
+++ b/src/main/schedule-runtime-thread-create.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  defaultClawSettings,
+  defaultKeyboardShortcuts,
+  defaultKunRuntimeSettings,
+  defaultModelProviderSettings,
+  defaultScheduleSettings,
+  defaultWriteSettings,
+  mergeScheduleSettings,
+  type AppSettingsPatch,
+  type AppSettingsV1
+} from '../shared/app-settings'
+import { ScheduleRuntime } from './schedule-runtime'
+
+function settingsWith(schedulePatch: AppSettingsPatch['schedule'] = {}): AppSettingsV1 {
+  return {
+    version: 1,
+    locale: 'en',
+    theme: 'system',
+    uiFontScale: 'small',
+    provider: defaultModelProviderSettings(),
+    agents: {
+      kun: {
+        ...defaultKunRuntimeSettings(),
+        apiKey: 'test-key'
+      }
+    },
+    workspaceRoot: '/tmp/workspace',
+    log: { enabled: true, retentionDays: 7 },
+    notifications: { turnComplete: true },
+    appBehavior: { openAtLogin: false, startMinimized: false, closeToTray: false },
+    keyboardShortcuts: defaultKeyboardShortcuts(),
+    write: defaultWriteSettings(),
+    claw: defaultClawSettings(),
+    schedule: mergeScheduleSettings(defaultScheduleSettings(), {
+      enabled: true,
+      promptPrefix: 'Schedule-only prefix',
+      ...schedulePatch
+    }),
+    guiUpdate: { channel: 'stable' },
+    codePromptPrefix: ''
+  }
+}
+
+function createStore(initial: AppSettingsV1) {
+  let current = initial
+  return {
+    load: vi.fn(async () => current),
+    patch: vi.fn(async (partial: AppSettingsPatch) => {
+      current = {
+        ...current,
+        schedule: mergeScheduleSettings(current.schedule, partial.schedule),
+        claw: current.claw
+      }
+      return current
+    }),
+    read: () => current
+  }
+}
+
+describe('ScheduleRuntime gui thread creation', () => {
+  it('starts a direct Kun thread without wrapping the prompt as a scheduled task', async () => {
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads' && init?.method === 'POST') {
+        return { ok: true, status: 201, body: JSON.stringify({ id: 'thr_direct' }) }
+      }
+      if (path === '/v1/threads/thr_direct/turns' && init?.method === 'POST') {
+        return { ok: true, status: 202, body: JSON.stringify({ turnId: 'turn_direct' }) }
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    const store = createStore(settingsWith())
+    const runtime = new ScheduleRuntime({
+      store: store as never,
+      runtimeRequest: runtimeRequest as never,
+      logError: vi.fn()
+    })
+
+    const result = await runtime.createThreadFromInput({
+      title: 'Continue long task',
+      prompt: 'Continue from the handoff summary.',
+      workspaceRoot: '/tmp/project',
+      model: 'deepseek-v4-flash',
+      reasoningEffort: 'high',
+      mode: 'plan'
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      threadId: 'thr_direct',
+      turnId: 'turn_direct',
+      message: 'Started'
+    })
+    const createBody = JSON.parse(String(runtimeRequest.mock.calls[0]?.[2]?.body))
+    const turnBody = JSON.parse(String(runtimeRequest.mock.calls[1]?.[2]?.body))
+    expect(createBody).toMatchObject({
+      title: 'Continue long task',
+      workspace: '/tmp/project',
+      model: 'deepseek-v4-flash',
+      mode: 'plan'
+    })
+    expect(turnBody).toMatchObject({
+      prompt: 'Continue from the handoff summary.',
+      mode: 'plan',
+      model: 'deepseek-v4-flash',
+      reasoningEffort: 'high'
+    })
+    expect(turnBody.prompt).not.toContain('Current scheduled task')
+    expect(turnBody.prompt).not.toContain('Schedule-only prefix')
+    expect(store.patch).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/schedule-runtime.ts
+++ b/src/main/schedule-runtime.ts
@@ -194,6 +194,30 @@ export class ScheduleRuntime {
     return saved
   }
 
+  async createThreadFromInput(input: {
+    title: string
+    prompt: string
+    workspaceRoot?: string
+    model?: string
+    reasoningEffort?: ScheduleReasoningEffort
+    mode?: ScheduleRunMode
+  }): Promise<ScheduleRunResult> {
+    const settings = await this.deps.store.load()
+    const prompt = input.prompt.trim()
+    if (!prompt) return { ok: false, message: 'Prompt is empty.' }
+    return this.runPrompt(settings, {
+      prompt,
+      title: input.title.trim() || 'New thread',
+      workspaceRoot: input.workspaceRoot?.trim() || this.resolveDefaultWorkspaceRoot(settings),
+      model: input.model?.trim() || settings.schedule.model || DEFAULT_SCHEDULE_MODEL,
+      reasoningEffort: normalizeScheduleReasoningEffort(input.reasoningEffort),
+      mode: input.mode ?? settings.schedule.mode,
+      waitForResult: false,
+      responseTimeoutMs: TASK_RESPONSE_TIMEOUT_MS,
+      promptKind: 'direct'
+    })
+  }
+
   async updateTaskById(taskId: string, patch: Partial<ScheduledTaskV1>): Promise<ScheduledTaskV1 | null> {
     const settings = await this.deps.store.load()
     const task = settings.schedule.tasks.find((item) => item.id === taskId)
@@ -439,12 +463,12 @@ export class ScheduleRuntime {
     if (!create.ok) return { ok: false, message: runtimeErrorMessage(create, 'Failed to create thread.') }
     const thread = JSON.parse(create.body) as ThreadRecordJson
 
+    const isDirectPrompt = options.promptKind === 'direct'
     const turnBody: Record<string, unknown> = {
-      prompt: buildScheduleRuntimePrompt(settings, options.prompt),
+      prompt: isDirectPrompt ? options.prompt : buildScheduleRuntimePrompt(settings, options.prompt),
       mode: options.mode,
-      // Scheduled turns are headless — nobody can answer a user_input
-      // prompt, and a turn that asks one hangs until the response timeout.
-      disableUserInput: true
+      // Scheduled turns are headless; nobody can answer a user_input prompt.
+      ...(!isDirectPrompt ? { disableUserInput: true } : {})
     }
     if (model) turnBody.model = model
     if (options.reasoningEffort) {
@@ -624,6 +648,39 @@ export class ScheduleRuntime {
           return
         }
         writeJson(res, 200, { ok: true, task: updated })
+        return
+      }
+
+      if (url.pathname === '/schedule/internal/thread/create') {
+        const input = nestedRecord(payload.input)
+        if (!input || Object.keys(input).length === 0) {
+          writeJson(res, 400, { ok: false, message: 'Missing thread input.' })
+          return
+        }
+        const prompt = asString(input.prompt)
+        if (!prompt) {
+          writeJson(res, 400, { ok: false, message: 'Missing prompt.' })
+          return
+        }
+        const result = await this.createThreadFromInput({
+          title: asString(input.title),
+          prompt,
+          workspaceRoot: asString(input.workspaceRoot) || undefined,
+          model: asString(input.model) || undefined,
+          reasoningEffort: (asString(input.reasoningEffort) as ScheduleReasoningEffort) || undefined,
+          mode: (asString(input.mode) as ScheduleRunMode) || undefined
+        })
+        if (!result.ok) {
+          writeJson(res, 500, { ok: false, message: result.message })
+          return
+        }
+        writeJson(res, 200, {
+          ok: true,
+          threadId: result.threadId,
+          turnId: result.turnId,
+          title: asString(input.title) || 'New thread',
+          message: result.message ?? 'Started'
+        })
         return
       }
 


### PR DESCRIPTION
## Summary
- add a `gui_thread_create` MCP tool to create a fresh DeepSeek GUI thread and start the first turn immediately
- add a schedule internal bridge endpoint for direct thread creation without saving a scheduled task
- keep direct thread prompts unwrapped by schedule-only prompt prefixes
- cover the MCP tool registration/argument forwarding and runtime thread creation path with tests

Fixes #198

## Conflict check
- Based on latest upstream/develop (e7e8252) before commit
- Checked current open PRs before submission; no open PR currently covers `gui_thread_create`
- Noted related open PRs #201/#202/#205 cover chat UX issues and are intentionally not duplicated here

## Tests
- npm.cmd test -- src/main/claw-schedule-mcp-server-thread-create.test.ts src/main/schedule-runtime-thread-create.test.ts src/main/schedule-runtime.test.ts src/main/claw-schedule-mcp-server.test.ts
- npm.cmd run typecheck
- git diff --check