### PR TITLE
fix: keep active goals running through repeated status replies

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -205,6 +205,18 @@ function goalContinuationInstruction(goal: ThreadGoal | undefined): string | nul
 
 const GOAL_NO_TOOL_REPEAT_SIMILARITY = 0.85
 const GOAL_NO_TOOL_REPEAT_MIN_LENGTH = 12
+const GOAL_NO_TOOL_REPEAT_MAX_RECOVERY_STEPS = 3
+
+function goalNoToolRecoveryInstruction(recoveryStep: number): string {
+  return [
+    'Goal continuation recovery:',
+    `- The active goal continuation has produced near-identical no-tool replies ${recoveryStep} time(s).`,
+    '- Do not repeat the same status update, promise, or summary again.',
+    `- If the objective is actually achieved, call ${UPDATE_GOAL_TOOL_NAME} with status "complete" after verifying the current state.`,
+    `- If the strict blocked audit is satisfied, call ${UPDATE_GOAL_TOOL_NAME} with status "blocked".`,
+    '- Otherwise, continue with new substantive work or call an available tool to make concrete progress.'
+  ].join('\n')
+}
 
 /**
  * Goal continuation re-prompts the model whenever it stops without tool
@@ -388,6 +400,7 @@ export class AgentLoop {
   private readonly toolStormBreakers = new Map<string, ToolStormBreaker>()
   private readonly toolCatalogSnapshots = new Map<string, ToolCatalogSnapshot>()
   private readonly lastNoToolTextByTurn = new Map<string, string>()
+  private readonly goalNoToolRecoveryStepsByTurn = new Map<string, number>()
 
   constructor(opts: AgentLoopOptions) {
     this.opts = opts
@@ -449,6 +462,7 @@ export class AgentLoop {
       this.autoModelRoutes.delete(autoModelRouteKey(threadId, turnId))
       this.toolStormBreakers.delete(turnId)
       this.lastNoToolTextByTurn.delete(turnId)
+      this.goalNoToolRecoveryStepsByTurn.delete(turnId)
     }
   }
 
@@ -624,6 +638,9 @@ export class AgentLoop {
     const activeGoalInstruction = planTurnActive
       ? null
       : goalContinuationInstruction(thread?.goal)
+    const goalRecoveryInstruction = activeGoalInstruction
+      ? goalNoToolRecoveryInstruction(this.goalNoToolRecoveryStepsByTurn.get(turnId) ?? 0)
+      : null
     const activeTodoInstruction = planTurnActive
       ? null
       : todoContinuationInstruction(thread?.todos)
@@ -719,6 +736,9 @@ export class AgentLoop {
     })
     const contextInstructions = [
       ...(activeGoalInstruction ? [activeGoalInstruction] : []),
+      ...(goalRecoveryInstruction && (this.goalNoToolRecoveryStepsByTurn.get(turnId) ?? 0) > 0
+        ? [goalRecoveryInstruction]
+        : []),
       ...(activeTodoInstruction ? [activeTodoInstruction] : []),
       ...memoryInstructions(memories),
       ...skillResolution.instructions,
@@ -1024,8 +1044,14 @@ export class AgentLoop {
       if (stopReason === 'stop' && activeGoalInstruction) {
         const previousText = this.lastNoToolTextByTurn.get(turnId)
         if (isRepeatedNoToolAssistantText(previousText, textAccumulator.value)) {
+          const recoverySteps = (this.goalNoToolRecoveryStepsByTurn.get(turnId) ?? 0) + 1
+          if (recoverySteps <= GOAL_NO_TOOL_REPEAT_MAX_RECOVERY_STEPS) {
+            this.goalNoToolRecoveryStepsByTurn.set(turnId, recoverySteps)
+            this.lastNoToolTextByTurn.set(turnId, textAccumulator.value)
+            return 'continue'
+          }
           const message =
-            'Goal continuation stopped: the model repeated a near-identical reply twice in a row without calling any tool.'
+            'Goal continuation stopped: the model kept repeating near-identical replies without calling tools or updating the goal.'
           await this.opts.turns.applyItem(
             threadId,
             makeErrorItem({
@@ -1046,8 +1072,10 @@ export class AgentLoop {
             severity: 'warning'
           })
           this.lastNoToolTextByTurn.delete(turnId)
+          this.goalNoToolRecoveryStepsByTurn.delete(turnId)
           return 'stop'
         }
+        this.goalNoToolRecoveryStepsByTurn.delete(turnId)
         this.lastNoToolTextByTurn.set(turnId, textAccumulator.value)
         return 'continue'
       }
@@ -1056,6 +1084,7 @@ export class AgentLoop {
     // Tool calls mean the turn is making progress again; reset the no-tool
     // repetition window so unrelated later status texts are not compared.
     this.lastNoToolTextByTurn.delete(turnId)
+    this.goalNoToolRecoveryStepsByTurn.delete(turnId)
     const dispatched = await this.dispatchToolCalls({
       calls: completedToolCalls,
       threadId,

--- a/kun/tests/goal-repetition-guard.test.ts
+++ b/kun/tests/goal-repetition-guard.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { LocalToolHost, buildDefaultLocalTools } from '../src/adapters/tool/local-tool-host.js'
 import { GET_GOAL_TOOL_NAME, UPDATE_GOAL_TOOL_NAME } from '../src/adapters/tool/goal-tools.js'
-import type { ModelStreamChunk } from '../src/ports/model-client.js'
+import type { ModelRequest, ModelStreamChunk } from '../src/ports/model-client.js'
 import { bootstrapThread, makeHarness, type Harness } from './loop-test-harness.js'
 
 function makeGoalTools(getHarness: () => Harness) {
@@ -50,14 +50,16 @@ async function loadRepetitionStops(h: Harness) {
 }
 
 describe('goal continuation repetition guard', () => {
-  it('stops after two no-tool replies that differ only in punctuation and casing', async () => {
+  it('tries recovery prompts before stopping repeated no-tool replies', async () => {
     let h: Harness
     let calls = 0
+    const requests: ModelRequest[] = []
     h = makeHarness(
       {
         provider: 'goal-repeat',
         model: 'goal-repeat',
-        async *stream(): AsyncIterable<ModelStreamChunk> {
+        async *stream(request): AsyncIterable<ModelStreamChunk> {
+          requests.push(request)
           calls += 1
           yield {
             kind: 'assistant_text_delta',
@@ -74,14 +76,17 @@ describe('goal continuation repetition guard', () => {
     const status = await h.loop.runTurn(h.threadId, h.turnId)
 
     expect(status).toBe('completed')
-    expect(calls).toBe(2)
+    expect(calls).toBe(5)
     expect((await h.threads.getGoal(h.threadId))?.status).toBe('active')
+    expect(requests.some((request) =>
+      request.contextInstructions?.some((line) => line.includes('Goal continuation recovery:'))
+    )).toBe(true)
     const stops = await loadRepetitionStops(h)
     expect(stops).toHaveLength(1)
     expect(stops[0]?.kind === 'error' ? stops[0].severity : undefined).toBe('warning')
   })
 
-  it('stops when consecutive no-tool replies are reordered but near-identical', async () => {
+  it('stops only after near-identical reordered replies exhaust recovery', async () => {
     let h: Harness
     let calls = 0
     h = makeHarness(
@@ -107,8 +112,52 @@ describe('goal continuation repetition guard', () => {
     const status = await h.loop.runTurn(h.threadId, h.turnId)
 
     expect(status).toBe('completed')
-    expect(calls).toBe(2)
+    expect(calls).toBe(5)
     expect(await loadRepetitionStops(h)).toHaveLength(1)
+  })
+
+  it('lets a repeated no-tool reply recover by calling update_goal', async () => {
+    let h: Harness
+    let calls = 0
+    const requests: ModelRequest[] = []
+    h = makeHarness(
+      {
+        provider: 'goal-recover',
+        model: 'goal-recover',
+        async *stream(request): AsyncIterable<ModelStreamChunk> {
+          requests.push(request)
+          calls += 1
+          if (calls <= 2) {
+            yield { kind: 'assistant_text_delta', text: 'I will run the build command now.' }
+            yield { kind: 'completed', stopReason: 'stop' }
+            return
+          }
+          if (calls === 3) {
+            yield {
+              kind: 'tool_call_complete',
+              callId: 'call_complete_goal',
+              toolName: UPDATE_GOAL_TOOL_NAME,
+              arguments: { status: 'complete' }
+            }
+            yield { kind: 'completed', stopReason: 'tool_calls' }
+            return
+          }
+          yield { kind: 'assistant_text_delta', text: 'Goal complete.' }
+          yield { kind: 'completed', stopReason: 'stop' }
+        }
+      },
+      { tools: [...buildDefaultLocalTools(), ...makeGoalTools(() => h)] }
+    )
+    await bootstrapThread(h, { request: { prompt: 'run the build' } })
+    await h.threads.setGoal(h.threadId, { objective: 'run the build', status: 'active' })
+
+    const status = await h.loop.runTurn(h.threadId, h.turnId)
+
+    expect(status).toBe('completed')
+    expect(calls).toBe(4)
+    expect((await h.threads.getGoal(h.threadId))?.status).toBe('complete')
+    expect(requests[2]?.contextInstructions?.join('\n')).toContain('Goal continuation recovery:')
+    expect(await loadRepetitionStops(h)).toHaveLength(0)
   })
 
   it('keeps continuing while no-tool replies make distinct progress', async () => {
@@ -188,9 +237,10 @@ describe('goal continuation repetition guard', () => {
     const status = await h.loop.runTurn(h.threadId, h.turnId)
 
     // Step 1 stores the text, step 2's tool call resets the window, step 3
-    // stores it again, step 4 repeats it and trips the guard.
+    // stores it again, and the guard gives three recovery prompts before
+    // stopping the repeated no-tool replies.
     expect(status).toBe('completed')
-    expect(calls).toBe(4)
+    expect(calls).toBe(7)
     expect(await loadRepetitionStops(h)).toHaveLength(1)
   })
 })


### PR DESCRIPTION
﻿## Summary
- keep active goals running when the model repeats no-tool status replies instead of stopping immediately
- add a recovery instruction that asks the model to verify completion/blocking or continue with concrete work
- preserve the repetition guard by stopping only after the recovery window is exhausted

Fixes #203.

## Test Plan
- `npm.cmd test -- tests/goal-repetition-guard.test.ts tests/goal-tools.test.ts` in `kun/`
- `npm.cmd test -- tests/loop.test.ts -t "continues an active goal"` in `kun/`
- `npm.cmd test -- tests/loop.test.ts -t "injects active goal"` in `kun/`
- `npm.cmd run typecheck` in `kun/`
- `npm.cmd run typecheck`
- `git diff --check`

## Notes
- Checked open PRs before submission.
- PR #190 also touches `kun/src/loop/agent-loop.ts`, but its current `develop` diff is in the compaction prompt area; this PR changes the active goal no-tool repetition guard.
- Full `kun/tests/loop.test.ts` was attempted once and exceeded the local 3-minute command timeout, so the goal-specific loop tests above were run instead.
