### PR TITLE
feat: add LiteLLM provider preset with model auto-discovery

### DIFF
--- a/src/renderer/src/components/settings-section-agents.test.ts
+++ b/src/renderer/src/components/settings-section-agents.test.ts
@@ -18,6 +18,8 @@ const labels: Record<string, string> = {
   kunProvider: 'Provider',
   kunProviderDesc: 'Provider description',
   modelProviderEndpointFormat: 'Endpoint format',
+  modelProviderFetchModels: 'Fetch models',
+  modelProviderFetchEmpty: 'No models found',
   modelEndpointChatCompletions: '/v1/chat/completions',
   modelEndpointResponses: '/v1/responses',
   modelEndpointMessages: '/v1/messages',
@@ -474,5 +476,10 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
     expect(html).not.toContain('DeepSeek auth')
     expect(html).not.toContain('Base URL are stored in this file')
     expect(html).not.toContain('config.toml')
+  })
+
+  it('renders LiteLLM preset button when preset not yet added', () => {
+    const html = renderToStaticMarkup(createElement(AgentsSettingsSection, { ctx: baseCtx() }))
+    expect(html).toContain('LiteLLM')
   })
 })

--- a/src/renderer/src/components/settings-section-agents.tsx
+++ b/src/renderer/src/components/settings-section-agents.tsx
@@ -19,7 +19,8 @@ import {
   WRITE_INLINE_COMPLETION_MODEL_IDS,
   defaultModelProviderSettings,
   isKunRuntimeInsecure,
-  normalizeModelProviderId
+  normalizeModelProviderId,
+  PROVIDER_PRESETS
 } from '@shared/app-settings'
 import type { GuiUpdateChannel } from '@shared/gui-update'
 import type { SkillRootId } from '../lib/skill-root-preference'
@@ -303,6 +304,44 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
       ...(kun.tokenEconomy?.historyHygiene ?? {})
     }
   }
+  const [fetchingModels, setFetchingModels] = useState(false)
+  const [fetchModelsError, setFetchModelsError] = useState('')
+
+  const fetchProviderModels = async (provider: ModelProviderProfileV1): Promise<void> => {
+    if (!provider.baseUrl.trim()) return
+    setFetchingModels(true)
+    setFetchModelsError('')
+    try {
+      const base = provider.baseUrl.replace(/\/+$/, '')
+      const segment = base.split('/').pop()?.toLowerCase() ?? ''
+      const versioned = /^v\d+$/i.test(segment) ? base : `${base}/v1`
+      const url = `${versioned}/models`
+      const headers: Record<string, string> = { Accept: 'application/json' }
+      if (provider.apiKey.trim()) {
+        headers.Authorization = `Bearer ${provider.apiKey.trim()}`
+      }
+      const res = await fetch(url, { headers, signal: AbortSignal.timeout(8000) })
+      if (!res.ok) {
+        setFetchModelsError(`HTTP ${res.status}`)
+        return
+      }
+      const json = await res.json() as { data?: Array<{ id?: string }> }
+      const ids = (json.data ?? [])
+        .map((m) => typeof m.id === 'string' ? m.id.trim() : '')
+        .filter(Boolean)
+        .sort()
+      if (ids.length === 0) {
+        setFetchModelsError(t('modelProviderFetchEmpty'))
+        return
+      }
+      updateModelProvider(provider.id, { models: ids })
+    } catch (e) {
+      setFetchModelsError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setFetchingModels(false)
+    }
+  }
+
   const [tokenEconomySavingsState, setTokenEconomySavingsState] =
     useState<TokenEconomySavingsState>(EMPTY_TOKEN_ECONOMY_SAVINGS_STATE)
   useEffect(() => {
@@ -446,6 +485,18 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
       activeProviderId === id ? { providerId: nextId } : undefined
     )
   }
+  const addModelProviderFromPreset = (preset: typeof PROVIDER_PRESETS[number]): void => {
+    if (modelProviders.some((item) => item.id === preset.id)) return
+    const nextProvider: ModelProviderProfileV1 = {
+      id: preset.id,
+      name: preset.name,
+      apiKey: '',
+      baseUrl: preset.baseUrl,
+      endpointFormat: preset.endpointFormat,
+      models: []
+    }
+    updateModelProviders([...modelProviders, nextProvider], { providerId: preset.id })
+  }
   const addModelProvider = (): void => {
     const baseId = 'custom-provider'
     let index = modelProviders.length + 1
@@ -542,6 +593,17 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                             <Plus className="h-3.5 w-3.5" strokeWidth={1.9} />
                             {t('modelProviderAdd')}
                           </button>
+                          {PROVIDER_PRESETS.filter((preset) => !modelProviders.some((p) => p.id === preset.id)).map((preset) => (
+                            <button
+                              key={preset.id}
+                              type="button"
+                              onClick={() => addModelProviderFromPreset(preset)}
+                              className="inline-flex h-9 items-center gap-2 rounded-full border border-ds-border bg-ds-card px-3 text-[12.5px] font-medium text-ds-muted shadow-sm transition hover:bg-ds-hover hover:text-ds-ink"
+                            >
+                              <Plus className="h-3.5 w-3.5" strokeWidth={1.9} />
+                              {preset.name}
+                            </button>
+                          ))}
                         </div>
                         {activeProvider ? (
                           <div className="grid gap-3 rounded-xl border border-ds-border-muted bg-ds-main/35 p-3">
@@ -618,6 +680,24 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                                 })}
                               />
                             </label>
+                            <div className="flex items-center gap-2">
+                              <button
+                                type="button"
+                                onClick={() => void fetchProviderModels(activeProvider)}
+                                disabled={fetchingModels}
+                                className="inline-flex h-8 items-center gap-1.5 rounded-full border border-ds-border bg-ds-card px-3 text-[12px] font-medium text-ds-muted shadow-sm transition hover:bg-ds-hover hover:text-ds-ink disabled:cursor-not-allowed disabled:opacity-55"
+                              >
+                                {fetchingModels ? (
+                                  <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
+                                ) : (
+                                  <RefreshCw className="h-3 w-3" strokeWidth={1.9} />
+                                )}
+                                {t('modelProviderFetchModels')}
+                              </button>
+                              {fetchModelsError ? (
+                                <span className="text-[12px] text-red-600 dark:text-red-300">{fetchModelsError}</span>
+                              ) : null}
+                            </div>
                             {activeProvider.id !== DEFAULT_MODEL_PROVIDER_ID ? (
                               <button
                                 type="button"

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -165,6 +165,8 @@
   "modelEndpointResponses": "/v1/responses",
   "modelEndpointMessages": "/v1/messages",
   "modelProviderModels": "Models, one model ID per line",
+  "modelProviderFetchModels": "Fetch models",
+  "modelProviderFetchEmpty": "No models found",
   "kunApiKey": "Assistant-only API key",
   "kunApiKeyDesc": "Optional. Leave empty to use the Basics API key. Fill this only when chat/code assistance needs a different key.",
   "kunApiKeyPlaceholder": "Leave empty to use Basics",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -165,6 +165,8 @@
   "modelEndpointResponses": "/v1/responses",
   "modelEndpointMessages": "/v1/messages",
   "modelProviderModels": "模型列表（每行一个模型 ID）",
+  "modelProviderFetchModels": "Fetch models",
+  "modelProviderFetchEmpty": "No models found",
   "kunApiKey": "助手专用 API Key",
   "kunApiKeyDesc": "可选。留空则沿用通用 API Key；只有聊天/代码助手需要使用不同 Key 时才填写。",
   "kunApiKeyPlaceholder": "留空则沿用通用设置",

--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -7,6 +7,7 @@ import {
   defaultScheduleSettings,
   defaultWriteSettings,
   resolveKunRuntimeSettings,
+  PROVIDER_PRESETS,
   type AppSettingsV1
 } from './app-settings'
 
@@ -57,5 +58,14 @@ describe('model provider settings', () => {
     expect(runtime.apiKey).toBe('sk-custom')
     expect(runtime.baseUrl).toBe('https://custom.example/v1')
     expect(runtime.endpointFormat).toBe('messages')
+  })
+})
+
+describe('provider presets', () => {
+  it('includes a LiteLLM preset', () => {
+    const litellm = PROVIDER_PRESETS.find((p) => p.id === 'litellm')
+    expect(litellm).toBeTruthy()
+    expect(litellm?.baseUrl).toBe('http://localhost:4000')
+    expect(litellm?.endpointFormat).toBe('chat_completions')
   })
 })

--- a/src/shared/app-settings-provider.ts
+++ b/src/shared/app-settings-provider.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_MODEL_PROVIDER_ID,
   type AppSettingsV1,
   type KunRuntimeSettingsV1,
+  type ModelEndpointFormat,
   type ModelProviderProfilePatchV1,
   type ModelProviderProfileV1,
   type ModelProviderSettingsPatchV1,
@@ -15,6 +16,20 @@ import { normalizeDeepseekBaseUrl } from './app-settings-normalizers'
 import { DEFAULT_COMPOSER_MODEL_IDS } from './default-composer-models'
 
 const DEFAULT_MODEL_PROVIDER_NAME = 'DeepSeek'
+
+export const PROVIDER_PRESETS: ReadonlyArray<{
+  id: string
+  name: string
+  baseUrl: string
+  endpointFormat: ModelEndpointFormat
+}> = [
+  {
+    id: 'litellm',
+    name: 'LiteLLM',
+    baseUrl: 'http://localhost:4000',
+    endpointFormat: 'chat_completions' as ModelEndpointFormat
+  }
+]
 
 export function defaultModelProviderSettings(): ModelProviderSettingsV1 {
   const defaultProvider = defaultModelProviderProfile('', DEFAULT_DEEPSEEK_BASE_URL)


### PR DESCRIPTION


## Summary

- Add LiteLLM as a pre-configured provider preset with one-click setup
- Add a "Fetch Models" button that auto-discovers models from any provider's `/v1/models` endpoint

## Why

- [LiteLLM](https://github.com/BerriAI/litellm) is an AI gateway that unifies 100+ LLM providers (OpenAI, Anthropic, Azure, Vertex AI, Bedrock, OpenRouter, Groq, etc.) behind a single OpenAI-compatible API.
- Users can already add custom providers manually, but a LiteLLM preset removes the friction: one click instead of typing proxy URL, selecting endpoint format, and looking up model names.
- The "Fetch Models" button benefits ALL custom providers, not just LiteLLM. It auto-populates the model list from `/v1/models`.

## Changes

- `src/shared/app-settings-provider.ts` - Add `PROVIDER_PRESETS` array with LiteLLM preset (`http://localhost:4000`, `chat_completions` format)
- `src/renderer/src/components/settings-section-agents.tsx` - Add preset button alongside "Add provider", add `fetchProviderModels()` function and "Fetch Models" button in provider card
- `src/renderer/src/locales/en/settings.json` - Add i18n keys for "Fetch models" and "No models found"
- `src/renderer/src/locales/zh/settings.json` - Add matching keys (English fallback for maintainer to translate)
- `src/shared/app-settings-provider.test.ts` - Test LiteLLM preset exists with correct config
- `src/renderer/src/components/settings-section-agents.test.ts` - Test LiteLLM button renders

## Media

- UI changes: will attach if needed. The changes are a "LiteLLM" button next to "Add provider" in the advanced provider section, and a "Fetch models" button below the models textarea in the provider card.

## Tests

- `app-settings-provider.test.ts`: verifies LiteLLM preset has `baseUrl: 'http://localhost:4000'` and `endpointFormat: 'chat_completions'`
- `settings-section-agents.test.ts`: verifies LiteLLM preset button renders in the settings UI

E2E against a live LiteLLM proxy (Azure AI Foundry Anthropic backend):

```
=== Model discovery (GET /v1/models) ===
Discovered 1 model(s): ['claude-sonnet-4-6']
PASS

=== Non-streaming chat completion ===
Model: claude-sonnet-4-6
Response: OK
Tokens: prompt=11 completion=4
PASS

=== Streaming chat completion ===
SSE frames: 3
[DONE] received: True
PASS
```

## Validation

- [x] `npm run test`
- [x] `npm run typecheck`
- [ ] `npm run build`
- [x] `npm run dev` (if runtime or UI behavior changed)
- [ ] UI change: video or GIF attached
- [x] Logic change: unit tests added or updated

## Notes

- Purely additive. No existing providers or code paths are modified.
- The "Fetch Models" button works for any custom provider with an OpenAI-compatible `/v1/models` endpoint, not just LiteLLM.
- Chinese locale strings use English fallback. Maintainer can translate in a follow-up.
