### PR TITLE
fix: inject local image file paths into attachment fallback

### DIFF
--- a/kun/src/adapters/model/deepseek-compat-model-client.ts
+++ b/kun/src/adapters/model/deepseek-compat-model-client.ts
@@ -1869,6 +1869,7 @@ function formatAttachmentTextFallback(
   return [
     '[Attached image as base64 text]',
     `Name: ${attachment.name}`,
+    `FilePath: ${attachment.localFilePath ?? 'unknown'}`,
     `MIME: ${attachment.mimeType}`,
     `Dimensions: ${formatAttachmentDimensions(attachment)}`,
     `Bytes: ${attachment.byteSize}`,

--- a/kun/src/attachments/attachment-store.ts
+++ b/kun/src/attachments/attachment-store.ts
@@ -14,6 +14,7 @@ export interface AttachmentStore {
     name: string
     data: Buffer
     mimeType?: string
+    localFilePath?: string
     textFallback?: AttachmentTextFallback
     threadId?: string
     workspace?: string
@@ -40,6 +41,7 @@ export class FileAttachmentStore implements AttachmentStore {
     name: string
     data: Buffer
     mimeType?: string
+    localFilePath?: string
     textFallback?: AttachmentTextFallback
     threadId?: string
     workspace?: string
@@ -64,6 +66,7 @@ export class FileAttachmentStore implements AttachmentStore {
     if (existing) {
       const next = mergeScope({
         ...existing,
+        ...(input.localFilePath ? { localFilePath: input.localFilePath } : {}),
         ...(input.textFallback ? { textFallback: input.textFallback } : {}),
         updatedAt: now
       }, input)
@@ -79,6 +82,7 @@ export class FileAttachmentStore implements AttachmentStore {
       hash,
       ...(image.width ? { width: image.width } : {}),
       ...(image.height ? { height: image.height } : {}),
+      ...(input.localFilePath ? { localFilePath: input.localFilePath } : {}),
       ...(input.textFallback ? { textFallback: input.textFallback } : {}),
       threadIds: [],
       workspaces: [],

--- a/kun/src/contracts/attachments.ts
+++ b/kun/src/contracts/attachments.ts
@@ -18,6 +18,7 @@ export const AttachmentMetadata = z.object({
   hash: z.string().min(1),
   width: z.number().int().positive().optional(),
   height: z.number().int().positive().optional(),
+  localFilePath: z.string().min(1).optional(),
   textFallback: AttachmentTextFallback.optional(),
   threadIds: z.array(z.string().min(1)).default([]),
   workspaces: z.array(z.string().min(1)).default([]),
@@ -30,6 +31,7 @@ export const AttachmentUploadRequest = z.object({
   name: z.string().min(1),
   mimeType: z.string().min(1).optional(),
   dataBase64: z.string().min(1),
+  localFilePath: z.string().min(1).optional(),
   textFallback: AttachmentTextFallback.optional(),
   threadId: z.string().min(1).optional(),
   workspace: z.string().min(1).optional()

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -1819,6 +1819,7 @@ function buildTextAttachmentFallback(
       byteSize: fallback.byteSize,
       ...(fallback.width ? { width: fallback.width } : {}),
       ...(fallback.height ? { height: fallback.height } : {}),
+      ...(attachment.localFilePath ? { localFilePath: attachment.localFilePath } : {}),
       ...(fallback.wasCompressed !== undefined ? { wasCompressed: fallback.wasCompressed } : {})
     }
   }
@@ -1837,6 +1838,7 @@ function buildTextAttachmentFallback(
     byteSize: attachment.byteSize,
     ...(attachment.width ? { width: attachment.width } : {}),
     ...(attachment.height ? { height: attachment.height } : {}),
+    ...(attachment.localFilePath ? { localFilePath: attachment.localFilePath } : {}),
     wasCompressed: false
   }
 }

--- a/kun/src/ports/model-client.ts
+++ b/kun/src/ports/model-client.ts
@@ -81,6 +81,7 @@ export type ModelTextAttachmentFallback = {
   byteSize: number
   width?: number
   height?: number
+  localFilePath?: string
   wasCompressed?: boolean
 }
 

--- a/kun/src/server/routes/attachments.ts
+++ b/kun/src/server/routes/attachments.ts
@@ -18,6 +18,7 @@ export async function uploadAttachment(
       name: parsed.data.name,
       mimeType: parsed.data.mimeType,
       data: Buffer.from(parsed.data.dataBase64, 'base64'),
+      localFilePath: parsed.data.localFilePath,
       textFallback: parsed.data.textFallback,
       threadId: parsed.data.threadId,
       workspace: parsed.data.workspace

--- a/kun/tests/attachment-store.test.ts
+++ b/kun/tests/attachment-store.test.ts
@@ -33,6 +33,7 @@ describe('Attachment store and multimodal input', () => {
       name: 'shot.png',
       data,
       mimeType: 'image/png',
+      localFilePath: '/tmp/picked/shot.png',
       threadId: 'thr_1',
       workspace: '/tmp/ws'
     })
@@ -43,7 +44,13 @@ describe('Attachment store and multimodal input', () => {
     })
 
     expect(second.id).toBe(first.id)
-    expect(first).toMatchObject({ mimeType: 'image/png', width: 2, height: 3, byteSize: data.byteLength })
+    expect(first).toMatchObject({
+      mimeType: 'image/png',
+      width: 2,
+      height: 3,
+      byteSize: data.byteLength,
+      localFilePath: '/tmp/picked/shot.png'
+    })
     await expect(store.resolveContent(first.id, { threadId: 'thr_2' })).rejects.toThrow(/not authorized/)
     await expect(store.resolveContent(first.id, { workspace: '/tmp/ws' })).resolves.toMatchObject({ id: first.id })
   })
@@ -113,6 +120,7 @@ describe('Attachment store and multimodal input', () => {
           name: 'shot.png',
           mimeType: 'image/png',
           dataBase64: png(1, 1).toString('base64'),
+          localFilePath: '/tmp/picked/shot.png',
           threadId: 'thr_1',
           textFallback: {
             dataBase64: 'abcd',
@@ -137,6 +145,7 @@ describe('Attachment store and multimodal input', () => {
     expect(metadata.status).toBe(200)
     expect(await readJson(metadata)).toMatchObject({
       attachment: {
+        localFilePath: '/tmp/picked/shot.png',
         textFallback: {
           dataBase64: 'abcd',
           mimeType: 'image/png'
@@ -167,6 +176,7 @@ describe('Attachment store and multimodal input', () => {
     const attachment = await store.create({
       name: 'shot.png',
       data: png(1, 1),
+      localFilePath: '/tmp/picked/shot.png',
       threadId: 'thr_1',
       workspace: '/tmp/ws'
     })
@@ -210,6 +220,7 @@ describe('Attachment store and multimodal input', () => {
       id: attachment.id,
       mimeType: 'image/png',
       dataBase64: expect.any(String),
+      localFilePath: '/tmp/picked/shot.png',
       wasCompressed: false
     })
   })
@@ -219,6 +230,7 @@ describe('Attachment store and multimodal input', () => {
     const attachment = await store.create({
       name: 'shot.png',
       data: png(1, 1),
+      localFilePath: '/tmp/picked/shot.png',
       threadId: 'thr_1',
       workspace: '/tmp/ws'
     })
@@ -252,6 +264,7 @@ describe('Attachment store and multimodal input', () => {
       id: attachment.id,
       mimeType: 'image/png',
       dataBase64: expect.any(String),
+      localFilePath: '/tmp/picked/shot.png',
       wasCompressed: false
     })
     const preSend = (await h.sessionStore.loadEventsSince(h.threadId, 0))
@@ -392,6 +405,7 @@ describe('Attachment store and multimodal input', () => {
         byteSize: 3,
         width: 1280,
         height: 720,
+        localFilePath: '/tmp/picked/shot.png',
         wasCompressed: true
       }],
       tools: [],
@@ -402,6 +416,7 @@ describe('Attachment store and multimodal input', () => {
 
     expect(body?.messages?.[0]?.content).toContain('describe')
     expect(body?.messages?.[0]?.content).toContain('[Attached image as base64 text]')
+    expect(body?.messages?.[0]?.content).toContain('FilePath: /tmp/picked/shot.png')
     expect(body?.messages?.[0]?.content).toContain('MIME: image/webp')
     expect(body?.messages?.[0]?.content).toContain('Dimensions: 1280x720')
     expect(body?.messages?.[0]?.content).toContain('```base64\nYWJj\n```')

--- a/src/main/services/workspace-files.ts
+++ b/src/main/services/workspace-files.ts
@@ -11,6 +11,7 @@ import {
   writeFile
 } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import type {
   WorkspaceClipboardImageSavePayload,
@@ -50,7 +51,7 @@ import {
 const MAX_FILE_PREVIEW_BYTES = 1_500_000
 const MAX_IMAGE_PREVIEW_BYTES = 12 * 1024 * 1024
 const WORKSPACE_IMAGE_DIR = 'img'
-const CLIPBOARD_TEMP_DIR = '/tmp/kun'
+const CLIPBOARD_TEMP_DIR = join(tmpdir(), 'kun')
 
 const WORKSPACE_IMAGE_MIME_BY_EXT = new Map([
   ['.png', 'image/png'],

--- a/src/main/services/workspace-files.ts
+++ b/src/main/services/workspace-files.ts
@@ -50,6 +50,7 @@ import {
 const MAX_FILE_PREVIEW_BYTES = 1_500_000
 const MAX_IMAGE_PREVIEW_BYTES = 12 * 1024 * 1024
 const WORKSPACE_IMAGE_DIR = 'img'
+const CLIPBOARD_TEMP_DIR = '/tmp/kun'
 
 const WORKSPACE_IMAGE_MIME_BY_EXT = new Map([
   ['.png', 'image/png'],
@@ -230,6 +231,10 @@ function buildWorkspaceImageName(now = new Date()): string {
   return `pasted-image-${iso}-${randomUUID().slice(0, 8)}.png`
 }
 
+function buildClipboardTempImagePath(now = new Date()): string {
+  return join(CLIPBOARD_TEMP_DIR, `${now.getTime()}.png`)
+}
+
 export async function readClipboardImage(): Promise<ClipboardImageReadResult> {
   try {
     const image = clipboard.readImage()
@@ -242,10 +247,15 @@ export async function readClipboardImage(): Promise<ClipboardImageReadResult> {
       return { ok: false, message: 'Clipboard image could not be encoded as PNG.' }
     }
 
+    const localFilePath = buildClipboardTempImagePath()
+    await mkdir(CLIPBOARD_TEMP_DIR, { recursive: true })
+    await writeFile(localFilePath, buffer)
+
     const size = image.getSize()
     return {
       ok: true,
       name: buildWorkspaceImageName(),
+      localFilePath,
       mimeType: 'image/png',
       dataBase64: buffer.toString('base64'),
       byteSize: buffer.length,

--- a/src/main/services/workspace-service.test.ts
+++ b/src/main/services/workspace-service.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdir, mkdtemp, readFile, realpath, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 vi.mock('electron', () => ({
   app: {
@@ -191,7 +191,8 @@ describe('workspace-service boundary checks', () => {
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.name).toMatch(/^pasted-image-.+\.png$/)
-    expect(result.localFilePath).toMatch(/^\/tmp\/kun\/\d+\.png$/)
+    expect(dirname(result.localFilePath)).toBe(join(tmpdir(), 'kun'))
+    expect(basename(result.localFilePath)).toMatch(/^\d+\.png$/)
     expect(result.mimeType).toBe('image/png')
     expect(result.dataBase64).toBe(Buffer.from('clipboard-png-bytes').toString('base64'))
     expect(result.byteSize).toBe(Buffer.byteLength('clipboard-png-bytes'))

--- a/src/main/services/workspace-service.test.ts
+++ b/src/main/services/workspace-service.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdir, mkdtemp, readFile, realpath, readdir, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, realpath, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -45,6 +45,7 @@ describe('workspace-service boundary checks', () => {
     await mkdir(workspaceRoot, { recursive: true })
     await writeFile(join(workspaceRoot, 'inside.txt'), 'inside', 'utf8')
     await writeFile(outsideFile, 'outside', 'utf8')
+    await rm('/tmp/kun', { recursive: true, force: true })
   })
 
   it('allows files inside the selected workspace', async () => {
@@ -178,7 +179,7 @@ describe('workspace-service boundary checks', () => {
     await expect(readFile(result.path)).resolves.toEqual(Buffer.from('fake-png-bytes'))
   })
 
-  it('reads clipboard images as PNG base64 without writing workspace files', async () => {
+  it('reads clipboard images as PNG base64 and saves a temp file', async () => {
     vi.mocked(clipboard.readImage).mockReturnValue({
       isEmpty: () => false,
       toPNG: () => Buffer.from('clipboard-png-bytes'),
@@ -190,11 +191,13 @@ describe('workspace-service boundary checks', () => {
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.name).toMatch(/^pasted-image-.+\.png$/)
+    expect(result.localFilePath).toMatch(/^\/tmp\/kun\/\d+\.png$/)
     expect(result.mimeType).toBe('image/png')
     expect(result.dataBase64).toBe(Buffer.from('clipboard-png-bytes').toString('base64'))
     expect(result.byteSize).toBe(Buffer.byteLength('clipboard-png-bytes'))
     expect(result.width).toBe(12)
     expect(result.height).toBe(8)
+    await expect(readFile(result.localFilePath)).resolves.toEqual(Buffer.from('clipboard-png-bytes'))
   })
 
   it('saves SDD pasted clipboard images into .kunsdd/img with draft-relative markdown', async () => {

--- a/src/renderer/src/agent/kun-contract.ts
+++ b/src/renderer/src/agent/kun-contract.ts
@@ -46,6 +46,7 @@ export type CoreAttachmentMetadataJson = {
   hash: string
   width?: number
   height?: number
+  localFilePath?: string
   textFallback?: CoreAttachmentTextFallbackJson
   threadIds?: string[]
   workspaces?: string[]

--- a/src/renderer/src/agent/kun-runtime.test.ts
+++ b/src/renderer/src/agent/kun-runtime.test.ts
@@ -419,6 +419,7 @@ describe('KunRuntimeProvider', () => {
               mimeType: 'image/png',
               byteSize: 3,
               hash: 'hash',
+              localFilePath: '/tmp/picked/shot.png',
               createdAt: 't0',
               updatedAt: 't0'
             }
@@ -436,6 +437,7 @@ describe('KunRuntimeProvider', () => {
               mimeType: 'image/png',
               byteSize: 3,
               hash: 'hash',
+              localFilePath: '/tmp/picked/shot.png',
               createdAt: 't0',
               updatedAt: 't0'
             },
@@ -465,6 +467,7 @@ describe('KunRuntimeProvider', () => {
       name: 'shot.png',
       mimeType: 'image/png',
       dataBase64: 'abc',
+      localFilePath: '/tmp/picked/shot.png',
       textFallback: {
         dataBase64: 'xyz',
         mimeType: 'image/webp',
@@ -474,7 +477,7 @@ describe('KunRuntimeProvider', () => {
         wasCompressed: true
       },
       threadId: 'thr_1'
-    })).resolves.toMatchObject({ id: 'att_1', name: 'shot.png' })
+    })).resolves.toMatchObject({ id: 'att_1', name: 'shot.png', localFilePath: '/tmp/picked/shot.png' })
     await expect(provider.getAttachmentContent('att_1', { threadId: 'thr_1' })).resolves.toMatchObject({
       attachment: { id: 'att_1', mimeType: 'image/png' },
       dataBase64: 'abc'
@@ -486,6 +489,7 @@ describe('KunRuntimeProvider', () => {
         name: 'shot.png',
         mimeType: 'image/png',
         dataBase64: 'abc',
+        localFilePath: '/tmp/picked/shot.png',
         textFallback: {
           dataBase64: 'xyz',
           mimeType: 'image/webp',

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -567,6 +567,7 @@ export class KunRuntimeProvider implements AgentProvider {
     name: string
     mimeType?: string
     dataBase64: string
+    localFilePath?: string
     textFallback?: CoreAttachmentTextFallbackJson
     threadId?: string
     workspace?: string

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -436,6 +436,7 @@ export interface AgentProvider {
     name: string
     mimeType?: string
     dataBase64: string
+    localFilePath?: string
     textFallback?: CoreAttachmentTextFallbackJson
     threadId?: string
     workspace?: string

--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -767,7 +767,10 @@ export function Workbench(): ReactElement {
     if (route !== 'chat') setComposerFileReferences([])
   }, [route])
 
-  const handlePickAttachments = async (files: File[]): Promise<void> => {
+  const handlePickAttachments = async (
+    files: File[],
+    options: { localFilePaths?: string[] } = {}
+  ): Promise<void> => {
     if (!files.length || !attachmentUploadEnabled) return
     const provider = getProvider()
     if (typeof provider.uploadAttachment !== 'function') {
@@ -784,13 +787,17 @@ export function Workbench(): ReactElement {
         return
       }
       const uploaded: AttachmentReference[] = []
-      for (const file of files) {
+      for (const [index, file] of files.entries()) {
         if (!file.type.startsWith('image/')) continue
         const prepared = await prepareImageAttachmentUpload(file, attachmentCapabilities)
+        const localFilePath =
+          options.localFilePaths?.[index] ||
+          (typeof window.dsGui?.getPathForFile === 'function' ? window.dsGui.getPathForFile(file) : '')
         const attachment = await provider.uploadAttachment({
           name: file.name || 'image',
           mimeType: prepared.mimeType,
           dataBase64: prepared.dataBase64,
+          ...(localFilePath ? { localFilePath } : {}),
           textFallback: prepared.textFallback,
           ...(activeThreadId ? { threadId: activeThreadId } : {}),
           ...(workspace ? { workspace } : {})
@@ -836,7 +843,7 @@ export function Workbench(): ReactElement {
       setAttachmentUploadError(image.message)
       return
     }
-    await handlePickAttachments([clipboardImageToFile(image)])
+    await handlePickAttachments([clipboardImageToFile(image)], { localFilePaths: [image.localFilePath] })
   }
 
   const sendWritePrompt = (value: string): void => {

--- a/src/renderer/src/components/chat/FloatingComposer.test.ts
+++ b/src/renderer/src/components/chat/FloatingComposer.test.ts
@@ -271,7 +271,7 @@ describe('FloatingComposer image transfer helpers', () => {
     expect(imageTransferHasImages(source)).toBe(true)
   })
 
-  it('handles pasted image files through the attachment picker', () => {
+  it('routes pasted image files through the clipboard bridge when available', () => {
     const screenshot = new File([new Uint8Array([1])], 'shot.png', { type: 'image/png' })
     const preventDefault = vi.fn()
     const onPickAttachments = vi.fn()
@@ -292,8 +292,30 @@ describe('FloatingComposer image transfer helpers', () => {
 
     expect(handled).toBe(true)
     expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(onPickAttachments).not.toHaveBeenCalled()
+    expect(onPasteClipboardImage).toHaveBeenCalledWith({ silentNoImage: false })
+  })
+
+  it('still uses the attachment picker for pasted image files when the clipboard bridge is unavailable', () => {
+    const screenshot = new File([new Uint8Array([1])], 'shot.png', { type: 'image/png' })
+    const preventDefault = vi.fn()
+    const onPickAttachments = vi.fn()
+    const handled = handleComposerImagePaste({
+      canPickAttachment: true,
+      clipboardData: {
+        getData: () => '',
+        items: {
+          length: 1,
+          0: { kind: 'file', type: 'image/png', getAsFile: () => screenshot }
+        }
+      },
+      preventDefault,
+      onPickAttachments
+    })
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalledTimes(1)
     expect(onPickAttachments).toHaveBeenCalledWith([screenshot])
-    expect(onPasteClipboardImage).not.toHaveBeenCalled()
   })
 
   it('does not intercept ordinary text paste', () => {

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -439,6 +439,10 @@ export function handleComposerImagePaste({
   const hasImageTransfer = imageTransferHasImages(clipboardData)
   if (files.length > 0) {
     preventDefault()
+    if (onPasteClipboardImage) {
+      void onPasteClipboardImage({ silentNoImage: false })
+      return true
+    }
     onPickAttachments?.(files)
     return true
   }

--- a/src/shared/workspace-file.ts
+++ b/src/shared/workspace-file.ts
@@ -60,6 +60,7 @@ export type ClipboardImageReadResult =
   | {
       ok: true
       name: string
+      localFilePath: string
       mimeType: string
       dataBase64: string
       byteSize: number


### PR DESCRIPTION
## Summary
- inject local file paths into attachment metadata and text fallbacks
- persist clipboard images to /tmp/kun/<timestamp>.png before uploading
- route pasted image files through the clipboard bridge so FilePath is never lost

## Testing
- npx vitest run src/renderer/src/components/chat/FloatingComposer.test.ts src/main/services/workspace-service.test.ts
- npx vitest run kun/tests/attachment-store.test.ts src/renderer/src/agent/kun-runtime.test.ts
- npm run typecheck

Refs KunAgent/Kun#220