### PR TITLE
fix(plugins): keep catalog description after an MCP plugin is installed

### DIFF
--- a/src/renderer/src/components/PluginMarketplaceView.test.ts
+++ b/src/renderer/src/components/PluginMarketplaceView.test.ts
@@ -162,7 +162,8 @@ describe('PluginMarketplaceView MCP config helpers', () => {
         id: 'github',
         sourceLabel: 'Connected',
         statusTone: 'success',
-        description: expect.stringContaining('github-mcp')
+        descriptionKey: 'pluginMcpGithubDesc',
+        detail: expect.stringContaining('github-mcp')
       })
     ])
   })

--- a/src/renderer/src/components/PluginMarketplaceView.tsx
+++ b/src/renderer/src/components/PluginMarketplaceView.tsx
@@ -49,6 +49,7 @@ type MarketplaceItem = {
   description?: string
   group: 'recommended' | 'personal'
   sourceLabel?: string
+  detail?: string
   statusTone?: 'default' | 'success' | 'warning' | 'error'
   systemManaged?: boolean
   mcpConfig?: (workspaceRoot: string) => JsonRecord
@@ -327,11 +328,20 @@ export function mcpMarketplaceItemsFromConfigAndDiagnostics(
       status === 'error' || status === 'unavailable' ? labels.error :
       status === 'disabled' ? labels.disabled :
       labels.configured
+    const detail = mcpServerDescription(details, labels.configured)
+    const catalogItem = RECOMMENDED_ITEMS.find((entry) => entry.kind === 'mcp' && entry.id === id)
     return {
       id,
       kind: 'mcp' as const,
       title: id,
-      description: mcpServerDescription(details, labels.configured),
+      // Keep the catalog description for known servers so installing an item
+      // does not replace its human-readable intro with the raw status string.
+      ...(catalogItem?.descriptionKey
+        ? { descriptionKey: catalogItem.descriptionKey }
+        : catalogItem?.description
+          ? { description: catalogItem.description }
+          : { description: detail }),
+      detail,
       group: 'personal' as const,
       sourceLabel,
       statusTone: mcpStatusTone(status)
@@ -1175,6 +1185,11 @@ function PluginSection({
                   <p className="mt-1 line-clamp-2 text-[14px] leading-5 text-ds-muted">
                     {itemDescription(item, t)}
                   </p>
+                  {item.detail && item.detail !== itemDescription(item, t) ? (
+                    <p className="mt-0.5 truncate font-mono text-[12px] text-ds-faint" title={item.detail}>
+                      {item.detail}
+                    </p>
+                  ) : null}
                 </div>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- Fixes #211: after adding a recommended MCP plugin, its human-readable intro was replaced by the raw status string (`status: connected · stdio · npx …`) because installed items are rebuilt from config/diagnostics
- Installed items that match a catalog entry now keep the original catalog description; runtime details (status, transport, command, tool count) are shown on a secondary mono line instead, so users can still see which servers expose how many tools
- Custom/non-catalog servers keep the current behavior (status string as description)

## Test plan
- [x] Updated `PluginMarketplaceView.test.ts` — catalog item (`github`) keeps `descriptionKey` and exposes runtime info via `detail`; non-catalog items unchanged (7/7 pass)
- [x] `tsc --noEmit` and eslint pass
- [ ] Manual: add "Context7" from marketplace → entry under personal section still shows its intro, with status/tool count on the line below