### PR TITLE
[codex] Align settings actions to the right / 调整设置项操作控件右对齐

### DIFF
--- a/src/renderer/src/components/settings-controls.tsx
+++ b/src/renderer/src/components/settings-controls.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactElement, type ReactNode } from 'react'
+import { isValidElement, useRef, useState, type ReactElement, type ReactNode } from 'react'
 import { ChevronDown, Eye, EyeOff } from 'lucide-react'
 
 export type InlineNotice = {
@@ -127,6 +127,11 @@ export function SettingRow({
   control: ReactNode
   wideControl?: boolean
 }): ReactElement {
+  const compactControl =
+    !wideControl
+    && isValidElement(control)
+    && (control.type === Toggle || control.type === 'button')
+
   return (
     <div
       className={`flex gap-3 px-3 py-4 ${
@@ -141,7 +146,15 @@ export function SettingRow({
           <p className="mt-0.5 text-[13px] leading-relaxed text-ds-muted">{description}</p>
         ) : null}
       </div>
-      <div className={`w-full min-w-0 ${wideControl ? '' : 'sm:max-w-[420px]'}`}>
+      <div
+        className={`w-full min-w-0 ${
+          wideControl
+            ? ''
+            : compactControl
+              ? 'flex justify-end sm:w-fit sm:max-w-none sm:shrink-0'
+              : 'flex justify-end sm:max-w-[420px]'
+        }`}
+      >
         {control}
       </div>
     </div>

--- a/src/renderer/src/components/settings-section-general.tsx
+++ b/src/renderer/src/components/settings-section-general.tsx
@@ -255,7 +255,7 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                     <button
                       type="button"
                       onClick={openOnboardingPreview}
-                      className="w-full rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[14px] font-medium text-ds-ink shadow-sm transition hover:bg-ds-hover"
+                      className="inline-flex w-fit items-center rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[14px] font-medium text-ds-ink shadow-sm transition hover:bg-ds-hover"
                     >
                       {t('onboardingPreviewOpen')}
                     </button>


### PR DESCRIPTION
## 中文

### 变更内容
- 将普通设置行的控制区改为右对齐，让开关和单独操作按钮靠近右侧操作列展示。
- 对开关和单独按钮使用紧凑控制区，不再为它们预留完整表单控件宽度，让左侧文字描述可以向右扩张。
- 将“首次设置向导”按钮从整列宽度改为自然宽度，避免按钮横跨整条操作列。

### 背景原因
设置页里多个开关和按钮原本显示在内容中间，且右侧操作区会预留较宽空间，导致左侧描述文字过早换行，不利于快速扫描和操作。

### 影响
- 设置项说明仍在左侧，操作控件统一靠右展示。
- 开关、单独按钮会按自身宽度占位，让描述文字获得更多空间。
- 下拉框、输入框和 `wideControl` 行保持原有布局宽度。

### 验证
- 已执行 `npm run typecheck`。

## English

### Changes
- Align regular settings row controls to the right so switches and standalone action buttons sit in the right-side action column.
- Use compact control width for switches and standalone buttons so they no longer reserve the full form-control column, allowing descriptions to expand further to the right.
- Change the “first setup guide” action button from full width to natural width so it no longer spans the whole control column.

### Why
Several settings switches and buttons were rendered around the middle of the settings card, and the reserved control column made descriptions wrap too early. This made the page harder to scan and operate.

### Impact
- Setting descriptions remain on the left, while actions are consistently aligned to the right.
- Switches and standalone buttons take only their natural width, giving descriptions more room.
- Selects, inputs, and `wideControl` rows keep their existing layout width.

### Validation
- Ran `npm run typecheck`.
