### PR TITLE
feat: support custom model endpoints

### DIFF
--- a/kun/src/adapters/model/deepseek-compat-model-client.ts
+++ b/kun/src/adapters/model/deepseek-compat-model-client.ts
@@ -9,8 +9,11 @@ import { repairToolArguments } from './tool-argument-repair.js'
 import { isDeepSeekHost, probeDeepSeekReachable } from './model-error-probe.js'
 import {
   DEFAULT_MODEL_ENDPOINT_FORMAT,
+  isCustomModelEndpointFormat,
   modelEndpointPath,
   normalizeModelEndpointFormat,
+  resolveModelEndpointFormat,
+  usesChatCompletionsShape,
   type ModelEndpointFormat
 } from '../../contracts/model-endpoint-format.js'
 
@@ -167,11 +170,19 @@ export class DeepseekCompatModelClient implements ModelClient {
       yield { kind: 'error', message: 'request was aborted before start' }
       return
     }
-    const endpointFormat = this.endpointFormat()
-    const url = buildModelEndpointUrl(this.config.baseUrl, endpointFormat)
+    const configuredEndpointFormat = this.endpointFormat()
+    const endpointFormat = resolveModelEndpointFormat(configuredEndpointFormat, this.config.baseUrl)
+    if (!endpointFormat) {
+      yield {
+        kind: 'error',
+        message: 'custom full endpoint URL must end with /chat/completions, /completions, /responses, or /messages'
+      }
+      return
+    }
+    const url = buildModelEndpointUrl(this.config.baseUrl, configuredEndpointFormat)
     const stream = request.stream ?? !this.config.nonStreaming
     const requestModel = request.model?.trim() || this.config.model
-    const body = this.buildRequestBody(request, stream)
+    const body = this.buildRequestBody(request, stream, { endpointFormat })
     const headers = this.buildHeaders(stream, endpointFormat)
     const result = await this.postChatCompletion(url, headers, body, request.abortSignal)
     if (result.kind === 'error') {
@@ -181,8 +192,8 @@ export class DeepseekCompatModelClient implements ModelClient {
     let response = result.response
     if (!response.ok) {
       const text = await response.text()
-      if (endpointFormat === 'chat_completions' && shouldRetryWithoutStreamUsage(response.status, text, body)) {
-        const retryBody = this.buildRequestBody(request, stream, { includeStreamUsage: false })
+      if (usesChatCompletionsShape(endpointFormat) && shouldRetryWithoutStreamUsage(response.status, text, body)) {
+        const retryBody = this.buildRequestBody(request, stream, { endpointFormat, includeStreamUsage: false })
         const retry = await this.postChatCompletion(url, headers, retryBody, request.abortSignal)
         if (retry.kind === 'error') {
           yield { kind: 'error', message: retry.message }
@@ -203,6 +214,14 @@ export class DeepseekCompatModelClient implements ModelClient {
           return
         }
         const retryText = await response.text()
+        this.logHttpFailure({
+          url,
+          status: response.status,
+          body: retryText,
+          endpointFormat,
+          configuredEndpointFormat,
+          model: requestModel
+        })
         const retryClassified = await this.classifyHttpError(response.status, retryText)
         yield {
           kind: 'error',
@@ -211,6 +230,14 @@ export class DeepseekCompatModelClient implements ModelClient {
         }
         return
       }
+      this.logHttpFailure({
+        url,
+        status: response.status,
+        body: text,
+        endpointFormat,
+        configuredEndpointFormat,
+        model: requestModel
+      })
       const classified = await this.classifyHttpError(response.status, text)
       yield {
         kind: 'error',
@@ -281,6 +308,13 @@ export class DeepseekCompatModelClient implements ModelClient {
 
   private async classifyHttpError(status: number, text: string): Promise<{ message: string; code: string }> {
     const body = text
+    if (status === 404) {
+      const prefix = body ? `${body} ` : ''
+      return {
+        message: `model request failed with status 404: ${prefix}Check your model provider configuration, especially Base URL and Endpoint format.`,
+        code: 'http_404'
+      }
+    }
     if (status === 429) {
       return {
         message: `model request was rate limited (HTTP 429): ${body}`,
@@ -303,15 +337,36 @@ export class DeepseekCompatModelClient implements ModelClient {
     }
   }
 
+  private logHttpFailure(input: {
+    url: string
+    status: number
+    body: string
+    endpointFormat: ModelEndpointFormat
+    configuredEndpointFormat: ModelEndpointFormat
+    model: string
+  }): void {
+    console.warn('[kun:model] model HTTP request failed', {
+      provider: this.provider,
+      status: input.status,
+      model: input.model,
+      configuredModel: this.config.model,
+      baseUrl: redactUrlForLog(this.config.baseUrl),
+      requestUrl: redactUrlForLog(input.url),
+      endpointFormat: input.endpointFormat,
+      configuredEndpointFormat: input.configuredEndpointFormat,
+      responseBody: summarizeForLog(input.body)
+    })
+  }
+
   private buildRequestBody(
     request: ModelRequest,
     stream: boolean,
-    options: { includeStreamUsage?: boolean } = {}
+    options: { endpointFormat?: ModelEndpointFormat; includeStreamUsage?: boolean } = {}
   ): Record<string, unknown> {
     const requestModel = request.model?.trim()
     const model = requestModel || this.config.model
     const messages = this.collectMessages(request, model)
-    const endpointFormat = this.endpointFormat()
+    const endpointFormat = options.endpointFormat ?? this.endpointFormat()
     if (endpointFormat === 'responses') {
       return this.buildResponsesRequestBody(request, model, messages, stream)
     }
@@ -1555,29 +1610,46 @@ function responsesReasoningForEffort(
 }
 
 function buildModelEndpointUrl(baseUrl: string, endpointFormat: ModelEndpointFormat): string {
+  if (isCustomModelEndpointFormat(endpointFormat)) return exactModelEndpointUrl(baseUrl)
   const path = modelEndpointPath(endpointFormat)
   const normalized = baseUrl.trim().replace(/\/+$/, '')
   if (!normalized) return `/v1/${path}`
-  if (normalized.toLowerCase().endsWith(`/${path}`)) return normalized
-  const withoutEndpoint = stripKnownEndpointPath(normalized)
-  const lastSegment = withoutEndpoint.split('/').pop()?.toLowerCase() ?? ''
+  const lastSegment = normalized.split('/').pop()?.toLowerCase() ?? ''
   if (lastSegment === 'beta') {
-    return `${withoutEndpoint.slice(0, -'/beta'.length)}/v1/${path}`
+    return `${normalized.slice(0, -'/beta'.length)}/v1/${path}`
   }
   if (/^v\d+$/.test(lastSegment)) {
-    return `${withoutEndpoint}/${path}`
+    return `${normalized}/${path}`
   }
-  return `${withoutEndpoint}/v1/${path}`
+  return `${normalized}/v1/${path}`
 }
 
-function stripKnownEndpointPath(baseUrl: string): string {
-  const lower = baseUrl.toLowerCase()
-  for (const path of ['chat/completions', 'responses', 'messages']) {
-    if (lower.endsWith(`/${path}`)) {
-      return baseUrl.slice(0, -path.length).replace(/\/+$/, '')
+function exactModelEndpointUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim()
+  const query = trimmed.search(/[?#]/)
+  if (query < 0) return trimmed.replace(/\/+$/, '')
+  return `${trimmed.slice(0, query).replace(/\/+$/, '')}${trimmed.slice(query)}`
+}
+
+function redactUrlForLog(url: string): string {
+  const trimmed = url.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (/(key|token|secret|signature|auth|password)/i.test(key)) {
+        parsed.searchParams.set(key, '[redacted]')
+      }
     }
+    return parsed.toString()
+  } catch {
+    return trimmed.replace(/([?&][^=&]*(?:key|token|secret|signature|auth|password)[^=]*=)[^&#]*/gi, '$1[redacted]')
   }
-  return baseUrl
+}
+
+function summarizeForLog(text: string): string {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+  return normalized.length > 1_000 ? `${normalized.slice(0, 1_000)}...` : normalized
 }
 
 function buildChatCompletionsUrl(baseUrl: string): string {

--- a/kun/src/contracts/model-endpoint-format.ts
+++ b/kun/src/contracts/model-endpoint-format.ts
@@ -1,4 +1,4 @@
-export const MODEL_ENDPOINT_FORMATS = ['chat_completions', 'responses', 'messages'] as const
+export const MODEL_ENDPOINT_FORMATS = ['chat_completions', 'responses', 'messages', 'custom_endpoint'] as const
 export type ModelEndpointFormat = (typeof MODEL_ENDPOINT_FORMATS)[number]
 export const DEFAULT_MODEL_ENDPOINT_FORMAT: ModelEndpointFormat = 'chat_completions'
 
@@ -13,6 +13,16 @@ export function normalizeModelEndpointFormat(value: unknown): ModelEndpointForma
     case 'chat/completions':
     case '/v1/chat/completions':
       return 'chat_completions'
+    case 'custom':
+    case 'custom-endpoint':
+    case 'custom_endpoint':
+    case 'custom-full-path':
+    case 'custom_full_path':
+    case 'full-path':
+    case 'full_path':
+    case 'full-url':
+    case 'full_url':
+      return 'custom_endpoint'
     case 'response':
     case 'responses':
     case 'v1/responses':
@@ -34,8 +44,35 @@ export function modelEndpointPath(format: ModelEndpointFormat): string {
       return 'responses'
     case 'messages':
       return 'messages'
+    case 'custom_endpoint':
     case 'chat_completions':
     default:
       return 'chat/completions'
   }
+}
+
+export function isCustomModelEndpointFormat(format: ModelEndpointFormat): boolean {
+  return format === 'custom_endpoint'
+}
+
+export function usesChatCompletionsShape(format: ModelEndpointFormat): boolean {
+  return format === 'chat_completions'
+}
+
+export function inferModelEndpointFormatFromUrl(url: string): ModelEndpointFormat | null {
+  const query = url.search(/[?#]/)
+  const path = (query < 0 ? url : url.slice(0, query)).trim().replace(/\/+$/, '').toLowerCase()
+  if (path.endsWith('/chat/completions') || path.endsWith('/completions')) return 'chat_completions'
+  if (path.endsWith('/responses')) return 'responses'
+  if (path.endsWith('/messages')) return 'messages'
+  return null
+}
+
+export function resolveModelEndpointFormat(
+  endpointFormat: ModelEndpointFormat,
+  baseUrl: string
+): ModelEndpointFormat | null {
+  return isCustomModelEndpointFormat(endpointFormat)
+    ? inferModelEndpointFormatFromUrl(baseUrl)
+    : endpointFormat
 }

--- a/kun/tests/model-client.test.ts
+++ b/kun/tests/model-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { DeepseekCompatModelClient } from '../src/adapters/model/deepseek-compat-model-client.js'
 import {
   makeAssistantReasoningItem,
@@ -99,7 +99,6 @@ describe('DeepseekCompatModelClient', () => {
       ['https://zenmux.ai/api/v1', 'https://zenmux.ai/api/v1/chat/completions'],
       ['https://zenmux.ai/api/v1/', 'https://zenmux.ai/api/v1/chat/completions'],
       ['https://zenmux.ai/api/v2', 'https://zenmux.ai/api/v2/chat/completions'],
-      ['https://zenmux.ai/api/v1/chat/completions', 'https://zenmux.ai/api/v1/chat/completions'],
       ['https://api.deepseek.com/beta', 'https://api.deepseek.com/v1/chat/completions'],
       ['https://api.deepseek.com', 'https://api.deepseek.com/v1/chat/completions']
     ]
@@ -150,7 +149,7 @@ describe('DeepseekCompatModelClient', () => {
       })
     }
     const client = new DeepseekCompatModelClient({
-      baseUrl: 'https://example.com/api/v1/chat/completions',
+      baseUrl: 'https://example.com/api/v1',
       apiKey: 'k',
       model: 'gpt-5-mini',
       endpointFormat: 'responses',
@@ -1723,6 +1722,7 @@ describe('DeepseekCompatModelClient', () => {
   })
 
   it('reports an error when the HTTP response is not OK', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const providerMessage = `Not supported model ${'mimo-v2.5-pro-ultraspeed'.repeat(40)}`
     const body = JSON.stringify({ error: { code: '400', message: providerMessage } })
     const fetchImpl: typeof fetch = async () =>
@@ -1737,6 +1737,7 @@ describe('DeepseekCompatModelClient', () => {
     for await (const chunk of client.stream(buildRequest(new AbortController().signal))) {
       chunks.push(chunk)
     }
+    warn.mockRestore()
     expect(chunks[0].kind).toBe('error')
     expect(chunks[0]).toMatchObject({
       kind: 'error',
@@ -1744,6 +1745,40 @@ describe('DeepseekCompatModelClient', () => {
       code: 'http_400'
     })
     expect(JSON.stringify(chunks[0])).toContain(providerMessage)
+  })
+
+  it('adds a provider configuration hint and logs request context for HTTP 404', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const fetchImpl: typeof fetch = async () => new Response('', { status: 404 })
+    const client = new DeepseekCompatModelClient({
+      baseUrl: 'https://api.example.com/chat/completions?api_key=secret',
+      apiKey: 'k',
+      model: 'deepseek-chat',
+      endpointFormat: 'custom_endpoint',
+      fetchImpl
+    })
+    const chunks: ModelStreamChunk[] = []
+    for await (const chunk of client.stream(buildRequest(new AbortController().signal))) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks[0]).toMatchObject({
+      kind: 'error',
+      message: 'model request failed with status 404: Check your model provider configuration, especially Base URL and Endpoint format.',
+      code: 'http_404'
+    })
+    expect(warn).toHaveBeenCalledWith('[kun:model] model HTTP request failed', expect.objectContaining({
+      provider: 'deepseek-compat',
+      status: 404,
+      model: 'deepseek-chat',
+      configuredModel: 'deepseek-chat',
+      baseUrl: 'https://api.example.com/chat/completions?api_key=%5Bredacted%5D',
+      requestUrl: 'https://api.example.com/chat/completions?api_key=%5Bredacted%5D',
+      endpointFormat: 'chat_completions',
+      configuredEndpointFormat: 'custom_endpoint',
+      responseBody: ''
+    }))
+    warn.mockRestore()
   })
 
   it('reports provider JSON error payloads returned with HTTP 200', async () => {

--- a/src/main/claw-scheduled-task-detector.test.ts
+++ b/src/main/claw-scheduled-task-detector.test.ts
@@ -109,4 +109,37 @@ describe('detectClawScheduledTaskRequest endpoint formats', () => {
       'anthropic-version': '2023-06-01'
     })
   })
+
+  it('uses the configured full endpoint URL in custom endpoint mode', async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = []
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      calls.push({ url: String(url), body: JSON.parse(String(init.body ?? '{}')) })
+      return new Response(JSON.stringify({
+        output_text: '{"shouldCreateTask":false}'
+      }), { status: 200 })
+    })
+    const appSettings = settings('custom_endpoint')
+    appSettings.provider.baseUrl = 'https://gateway.example/custom-path/responses'
+    appSettings.provider.providers[0] = {
+      ...appSettings.provider.providers[0],
+      baseUrl: 'https://gateway.example/custom-path/responses',
+      endpointFormat: 'custom_endpoint'
+    }
+
+    await detectClawScheduledTaskRequest(
+      appSettings,
+      'remind me tomorrow to stretch',
+      'custom-model',
+      new Date('2026-06-09T12:00:00+08:00')
+    )
+
+    expect(calls[0]).toMatchObject({
+      url: 'https://gateway.example/custom-path/responses',
+      body: {
+        model: 'custom-model',
+        input: 'remind me tomorrow to stretch',
+        max_output_tokens: 300
+      }
+    })
+  })
 })

--- a/src/main/claw-scheduled-task-detector.ts
+++ b/src/main/claw-scheduled-task-detector.ts
@@ -8,8 +8,10 @@ import type {
 import {
   DEFAULT_SCHEDULE_MODEL,
   DEFAULT_SCHEDULE_REASONING_EFFORT,
+  isCustomModelEndpointFormat,
   modelEndpointPath,
-  resolveKunRuntimeSettings
+  resolveKunRuntimeSettings,
+  resolveModelEndpointFormat
 } from '../shared/app-settings'
 
 const SCHEDULED_TASK_CANDIDATE_RE =
@@ -29,6 +31,7 @@ type DetectionRequestPayload = {
   url: string
   headers: Record<string, string>
   body: Record<string, unknown>
+  endpointFormat: ModelEndpointFormat
 }
 
 export type ParsedClawScheduledTaskRequest = {
@@ -147,26 +150,22 @@ function normalizeDetectedRequest(
 }
 
 function buildModelEndpointUrl(baseUrl: string, endpointFormat: ModelEndpointFormat): string {
+  if (isCustomModelEndpointFormat(endpointFormat)) return exactModelEndpointUrl(baseUrl)
   const path = modelEndpointPath(endpointFormat)
   const normalized = baseUrl.replace(/\/+$/, '')
   if (!normalized) return `/v1/${path}`
-  if (normalized.endsWith(`/${path}`)) return normalized
-  const base = stripKnownEndpointPath(normalized)
-  if (base.endsWith('/v1')) return `${base}/${path}`
-  if (base.endsWith('/beta')) {
-    return `${base.slice(0, -5)}/v1/${path}`
+  if (normalized.endsWith('/v1')) return `${normalized}/${path}`
+  if (normalized.endsWith('/beta')) {
+    return `${normalized.slice(0, -5)}/v1/${path}`
   }
-  return `${base}/v1/${path}`
+  return `${normalized}/v1/${path}`
 }
 
-function stripKnownEndpointPath(baseUrl: string): string {
-  const lower = baseUrl.toLowerCase()
-  for (const path of ['chat/completions', 'responses', 'messages']) {
-    if (lower.endsWith(`/${path}`)) {
-      return baseUrl.slice(0, -path.length).replace(/\/+$/, '')
-    }
-  }
-  return baseUrl
+function exactModelEndpointUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim()
+  const query = trimmed.search(/[?#]/)
+  if (query < 0) return trimmed.replace(/\/+$/, '')
+  return `${trimmed.slice(0, query).replace(/\/+$/, '')}${trimmed.slice(query)}`
 }
 
 function buildDetectionPrompt(now: Date): string {
@@ -197,19 +196,22 @@ function buildDetectionRequest(input: {
   model: string
   systemPrompt: string
   sourceText: string
-}): DetectionRequestPayload {
+}): DetectionRequestPayload | null {
+  const endpointFormat = resolveModelEndpointFormat(input.endpointFormat, input.baseUrl)
+  if (!endpointFormat) return null
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${input.apiKey}`
   }
-  if (input.endpointFormat === 'messages') {
+  if (endpointFormat === 'messages') {
     headers['x-api-key'] = input.apiKey
     headers['anthropic-version'] = '2023-06-01'
   }
-  if (input.endpointFormat === 'responses') {
+  if (endpointFormat === 'responses') {
     return {
       url: buildModelEndpointUrl(input.baseUrl, input.endpointFormat),
       headers,
+      endpointFormat,
       body: {
         model: input.model,
         instructions: input.systemPrompt,
@@ -219,10 +221,11 @@ function buildDetectionRequest(input: {
       }
     }
   }
-  if (input.endpointFormat === 'messages') {
+  if (endpointFormat === 'messages') {
     return {
       url: buildModelEndpointUrl(input.baseUrl, input.endpointFormat),
       headers,
+      endpointFormat,
       body: {
         model: input.model,
         system: input.systemPrompt,
@@ -234,6 +237,7 @@ function buildDetectionRequest(input: {
   return {
     url: buildModelEndpointUrl(input.baseUrl, input.endpointFormat),
     headers,
+    endpointFormat,
     body: {
       model: input.model,
       messages: [
@@ -302,6 +306,7 @@ export async function detectClawScheduledTaskRequest(
     systemPrompt: buildDetectionPrompt(now),
     sourceText
   })
+  if (!detectionRequest) return null
   const response = await fetch(detectionRequest.url, {
     method: 'POST',
     headers: detectionRequest.headers,
@@ -312,7 +317,7 @@ export async function detectClawScheduledTaskRequest(
   if (!response.ok) return null
   let content = ''
   try {
-    content = extractDetectionContent(text, runtime.endpointFormat)
+    content = extractDetectionContent(text, detectionRequest.endpointFormat)
   } catch {
     return null
   }

--- a/src/main/provider-connection.test.ts
+++ b/src/main/provider-connection.test.ts
@@ -100,4 +100,19 @@ describe('probeModelProvider', () => {
 
     expect(result).toEqual({ ok: false, message: 'socket hang up' })
   })
+
+  it('does not probe /models for custom full endpoint providers', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await probeModelProvider({
+      baseUrl: 'https://api.example.com/custom-path',
+      apiKey: 'sk-x',
+      endpointFormat: 'custom_endpoint'
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.message).toContain('does not support /models probing')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/provider-connection.ts
+++ b/src/main/provider-connection.ts
@@ -1,4 +1,8 @@
-import { normalizeModelEndpointFormat, type ModelEndpointFormat } from '../shared/app-settings'
+import {
+  isCustomModelEndpointFormat,
+  normalizeModelEndpointFormat,
+  type ModelEndpointFormat
+} from '../shared/app-settings'
 import type { ModelProviderProbeRequest, ModelProviderProbeResult } from '../shared/kun-gui-api'
 import { upstreamOpenAiModelsUrl } from '../shared/openai-compat-url'
 
@@ -31,8 +35,14 @@ export async function probeModelProvider(
   if (!/^https?:\/\//i.test(baseUrl)) {
     return { ok: false, message: 'Base URL must start with http:// or https://.' }
   }
-  const url = upstreamOpenAiModelsUrl(baseUrl)
   const endpointFormat = normalizeModelEndpointFormat(request.endpointFormat)
+  if (isCustomModelEndpointFormat(endpointFormat)) {
+    return {
+      ok: false,
+      message: 'Custom full endpoint mode does not support /models probing. Add model IDs manually.'
+    }
+  }
+  const url = upstreamOpenAiModelsUrl(baseUrl)
   const startedAt = Date.now()
   let res: Response
   let text: string

--- a/src/main/services/write-inline-completion-service.test.ts
+++ b/src/main/services/write-inline-completion-service.test.ts
@@ -259,6 +259,65 @@ describe('requestWriteInlineCompletion', () => {
     })
   })
 
+  it('uses /completions as a Chat Completions-shaped custom endpoint', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ choices: [{ message: { content: ' custom text' } }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const settings = createSettings()
+    settings.provider.apiKey = 'sk-custom'
+    settings.provider.baseUrl = 'https://gateway.example/custom-path/completions'
+    settings.provider.providers[0] = {
+      ...settings.provider.providers[0],
+      apiKey: 'sk-custom',
+      baseUrl: 'https://gateway.example/custom-path/completions',
+      endpointFormat: 'custom_endpoint'
+    }
+
+    const result = await requestWriteInlineCompletion(settings, {
+      ...createRequest(),
+      model: 'custom-model'
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      model: 'custom-model'
+    })
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://gateway.example/custom-path/completions')
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      model: 'custom-model',
+      messages: expect.any(Array)
+    })
+  })
+
+  it('rejects custom full endpoint URLs that do not end with a known endpoint path', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const settings = createSettings()
+    settings.provider.apiKey = 'sk-custom'
+    settings.provider.baseUrl = 'https://gateway.example/custom-path'
+    settings.provider.providers[0] = {
+      ...settings.provider.providers[0],
+      apiKey: 'sk-custom',
+      baseUrl: 'https://gateway.example/custom-path',
+      endpointFormat: 'custom_endpoint'
+    }
+
+    const result = await requestWriteInlineCompletion(settings, createRequest())
+
+    expect(result).toMatchObject({
+      ok: false,
+      message: 'Custom full endpoint URL must end with /chat/completions, /completions, /responses, or /messages.'
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('uses an explicit flash override when write disables model inheritance', async () => {
     const fetchMock = vi.fn(async () =>
       new Response(JSON.stringify({ choices: [{ text: ' explicit flash' }] }), {

--- a/src/main/services/write-inline-completion-service.ts
+++ b/src/main/services/write-inline-completion-service.ts
@@ -1,16 +1,19 @@
 import { randomUUID } from 'node:crypto'
 import {
   DEFAULT_WRITE_INLINE_COMPLETION_MAX_TOKENS,
+  isCustomModelEndpointFormat,
   modelEndpointPath,
   resolveWriteInlineCompletionEndpointFormat,
   resolveWriteInlineCompletionApiKey,
   resolveWriteInlineCompletionBaseUrl,
   resolveWriteInlineCompletionModel,
+  resolveModelEndpointFormat,
   type ModelEndpointFormat,
   type AppSettingsV1
 } from '../../shared/app-settings'
 import {
   upstreamDeepSeekFimCompletionsUrl,
+  upstreamOpenAiCustomEndpointUrl,
   upstreamOpenAiChatCompletionsUrl
 } from '../../shared/openai-compat-url'
 import type {
@@ -402,30 +405,19 @@ function debugPromptFromMessages(messages: ChatCompletionMessage[]): string {
 }
 
 function compatibleModelEndpointUrl(baseUrl: string, endpointFormat: ModelEndpointFormat): string {
+  if (isCustomModelEndpointFormat(endpointFormat)) return upstreamOpenAiCustomEndpointUrl(baseUrl)
   if (endpointFormat === 'chat_completions') return upstreamOpenAiChatCompletionsUrl(baseUrl)
   const path = modelEndpointPath(endpointFormat)
   const normalized = baseUrl.trim().replace(/\/+$/, '')
   if (!normalized) return `/v1/${path}`
-  if (normalized.toLowerCase().endsWith(`/${path}`)) return normalized
-  const withoutEndpoint = stripKnownModelEndpointPath(normalized)
-  const lastSegment = withoutEndpoint.split('/').pop()?.toLowerCase() ?? ''
+  const lastSegment = normalized.split('/').pop()?.toLowerCase() ?? ''
   if (lastSegment === 'beta') {
-    return `${withoutEndpoint.slice(0, -'/beta'.length)}/v1/${path}`
+    return `${normalized.slice(0, -'/beta'.length)}/v1/${path}`
   }
   if (/^v\d+$/.test(lastSegment)) {
-    return `${withoutEndpoint}/${path}`
+    return `${normalized}/${path}`
   }
-  return `${withoutEndpoint}/v1/${path}`
-}
-
-function stripKnownModelEndpointPath(baseUrl: string): string {
-  const lower = baseUrl.toLowerCase()
-  for (const path of ['chat/completions', 'responses', 'messages']) {
-    if (lower.endsWith(`/${path}`)) {
-      return baseUrl.slice(0, -path.length).replace(/\/+$/, '')
-    }
-  }
-  return baseUrl
+  return `${normalized}/v1/${path}`
 }
 
 function isDeepSeekInlineCompletionBaseUrl(baseUrl: string): boolean {
@@ -725,17 +717,24 @@ export async function requestWriteInlineCompletion(
   const actionMayEdit = Boolean(request.editCandidate && request.recentEdits?.length)
   const useChatCompletions = mode === 'edit' || actionMayEdit
   const baseUrl = resolveWriteInlineCompletionBaseUrl(settings)
-  const endpointFormat = resolveWriteInlineCompletionEndpointFormat(settings)
+  const configuredEndpointFormat = resolveWriteInlineCompletionEndpointFormat(settings)
+  const endpointFormat = resolveModelEndpointFormat(configuredEndpointFormat, baseUrl)
+  if (!endpointFormat) {
+    return {
+      ok: false,
+      message: 'Custom full endpoint URL must end with /chat/completions, /completions, /responses, or /messages.'
+    }
+  }
   const useFimCompletions =
     !useChatCompletions &&
-    endpointFormat === 'chat_completions' &&
+    configuredEndpointFormat === 'chat_completions' &&
     isDeepSeekInlineCompletionBaseUrl(baseUrl)
   const responseFormat: WriteInlineProviderResponseFormat = useFimCompletions
     ? 'fim_completions'
     : endpointFormat
   const url = useFimCompletions
     ? upstreamDeepSeekFimCompletionsUrl(baseUrl)
-    : compatibleModelEndpointUrl(baseUrl, endpointFormat)
+    : compatibleModelEndpointUrl(baseUrl, configuredEndpointFormat)
   const maxTokens = mode === 'long' || mode === 'edit' || actionMayEdit
     ? settings.write.inlineCompletion.longMaxTokens || settings.write.inlineCompletion.maxTokens || DEFAULT_WRITE_INLINE_COMPLETION_MAX_TOKENS
     : settings.write.inlineCompletion.maxTokens || DEFAULT_WRITE_INLINE_COMPLETION_MAX_TOKENS

--- a/src/main/upstream-models.test.ts
+++ b/src/main/upstream-models.test.ts
@@ -170,6 +170,32 @@ describe('upstream model picker list', () => {
     }
   })
 
+  it('uses configured model ids without fetching models for custom full endpoint providers', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'deepseek-gui-models-'))
+    await mkdir(dataDir, { recursive: true })
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const customSettings = settings(dataDir, 'custom-provider-model')
+    customSettings.provider.providers = customSettings.provider.providers.map((provider) =>
+      provider.id === 'custom-provider'
+        ? { ...provider, baseUrl: 'https://gateway.example/custom-path', endpointFormat: 'custom_endpoint' }
+        : provider
+    )
+
+    try {
+      const result = await fetchUpstreamModelIds(customSettings, 'sk-custom')
+
+      expect(result).toMatchObject({ ok: true })
+      if (result.ok) {
+        expect(result.modelIds).toContain('custom-provider-model')
+        expect(result.defaultModelId).toBe('custom-provider-model')
+      }
+      expect(fetchMock).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('filters image-generation and other non-text models out of the composer picker', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'deepseek-gui-models-'))
     await mkdir(dataDir, { recursive: true })

--- a/src/main/upstream-models.ts
+++ b/src/main/upstream-models.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import {
   getModelProviderProfile,
   getModelProviderSettings,
+  isCustomModelEndpointFormat,
   isComposerChatModelId,
   listModelProviderModelIds,
   listNonTextModelIds,
@@ -37,6 +38,14 @@ export async function fetchUpstreamModelIds(
   const runtime = resolveKunRuntimeSettings(settings)
   const runtimeModel = runtime.model.trim()
   const defaultModelId = isComposerChatModelId(runtimeModel, nonTextModelIds) ? runtimeModel : ''
+  if (isCustomModelEndpointFormat(runtime.endpointFormat)) {
+    return modelListOrError(
+      configuredModelIds,
+      configuredGroups,
+      defaultModelId,
+      'Custom full endpoint mode does not support querying upstream /models.'
+    )
+  }
   const key = apiKey.trim()
   if (!key) {
     return modelListOrError(

--- a/src/renderer/src/components/chat/FloatingComposer.test.ts
+++ b/src/renderer/src/components/chat/FloatingComposer.test.ts
@@ -18,6 +18,7 @@ import {
   buildComposerModelMenuGroups,
   calculateFloatingMenuPlacement,
   calculateFloatingSubmenuPlacement,
+  composerModelMenuItemSelected,
   composerMenuSupportsModel,
   composerReasoningEffortRequestValue,
   normalizeComposerReasoningEffort
@@ -322,6 +323,53 @@ describe('FloatingComposer model controls', () => {
       label: 'Other models',
       modelIds: ['loose-model']
     })
+  })
+
+  it('deduplicates models within a provider but keeps the same model id across providers', () => {
+    const groups = buildComposerModelMenuGroups({
+      composerModelGroups: [
+        {
+          providerId: 'deepseek',
+          label: 'DeepSeek',
+          modelIds: ['deepseek-v4-pro', 'deepseek-v4-pro'],
+          modelProfiles: {}
+        },
+        {
+          providerId: 'custom-provider-3',
+          label: 'test',
+          modelIds: ['deepseek-v4-pro'],
+          modelProfiles: {}
+        }
+      ],
+      modelOptions: ['deepseek-v4-pro'],
+      ungroupedLabel: 'Other models'
+    })
+
+    expect(groups).toEqual([
+      expect.objectContaining({
+        providerId: 'deepseek',
+        modelIds: ['deepseek-v4-pro']
+      }),
+      expect.objectContaining({
+        providerId: 'custom-provider-3',
+        modelIds: ['deepseek-v4-pro']
+      })
+    ])
+  })
+
+  it('selects duplicate model ids by provider and model id together', () => {
+    expect(composerModelMenuItemSelected({
+      groupProviderId: 'deepseek',
+      selectedProviderId: 'deepseek',
+      currentModel: 'deepseek-v4-pro',
+      modelId: 'deepseek-v4-pro'
+    })).toBe(true)
+    expect(composerModelMenuItemSelected({
+      groupProviderId: 'custom-provider-3',
+      selectedProviderId: 'deepseek',
+      currentModel: 'deepseek-v4-pro',
+      modelId: 'deepseek-v4-pro'
+    })).toBe(false)
   })
 
   it('keeps the reasoning strength visible in the model control', () => {

--- a/src/renderer/src/components/chat/FloatingComposerModelPicker.tsx
+++ b/src/renderer/src/components/chat/FloatingComposerModelPicker.tsx
@@ -356,7 +356,12 @@ export function FloatingComposerModelPicker({
               </div>
             ) : (
               providerMenuGroups.map((group) => {
-                const selectedModel = group.modelIds.some((id) => modelIdsMatch(id, currentModel))
+                const selectedModel = composerModelMenuItemSelected({
+                  groupProviderId: group.providerId,
+                  selectedProviderId,
+                  currentModel,
+                  modelId: currentModel
+                })
                   ? currentModel
                   : ''
                 return (
@@ -392,7 +397,12 @@ export function FloatingComposerModelPicker({
             {activeProviderGroup.modelIds.map((id) => (
               <PickerRow
                 key={`${activeProviderGroup.providerId}:${id}`}
-                selected={modelIdsMatch(currentModel, id)}
+                selected={composerModelMenuItemSelected({
+                  groupProviderId: activeProviderGroup.providerId,
+                  selectedProviderId,
+                  currentModel,
+                  modelId: id
+                })}
                 title={id}
                 rightSlot={
                   modelSupportsImageInput(modelProfileForModel(activeProviderGroup, id))
@@ -517,16 +527,18 @@ export function buildComposerModelMenuGroups({
   modelOptions: readonly string[]
   ungroupedLabel: string
 }): ComposerModelMenuGroup[] {
-  const seen = new Set<string>()
+  const configuredModelKeys = new Set<string>()
   const groups = composerModelGroups
     .map((group) => {
+      const seenInProvider = new Set<string>()
       const ids = group.modelIds
         .map((id) => id.trim())
         .filter((id) => {
           const key = normalizeModelCapabilityKey(id)
-          if (!key || seen.has(key)) return false
+          if (!key || seenInProvider.has(key)) return false
           if (!composerMenuSupportsModel(group, id)) return false
-          markModelSeen(seen, group, id)
+          markModelSeen(seenInProvider, group, id)
+          markModelSeen(configuredModelKeys, group, id)
           return true
         })
       return {
@@ -539,11 +551,12 @@ export function buildComposerModelMenuGroups({
     .filter((group) => group.modelIds.length > 0)
 
   const ungrouped: string[] = []
+  const seenUngrouped = new Set<string>()
   for (const rawId of modelOptions) {
     const id = rawId.trim()
     const key = normalizeModelCapabilityKey(id)
-    if (!key || seen.has(key) || !isComposerChatModelId(id)) continue
-    seen.add(key)
+    if (!key || configuredModelKeys.has(key) || seenUngrouped.has(key) || !isComposerChatModelId(id)) continue
+    seenUngrouped.add(key)
     ungrouped.push(id)
   }
 
@@ -740,6 +753,19 @@ function normalizeModelCapabilityKey(modelId: string): string {
 function modelIdsMatch(a: string, b: string): boolean {
   const left = normalizeModelCapabilityKey(a)
   return Boolean(left) && left === normalizeModelCapabilityKey(b)
+}
+
+export function composerModelMenuItemSelected(input: {
+  groupProviderId: string
+  selectedProviderId: string | null
+  currentModel: string
+  modelId: string
+}): boolean {
+  return (
+    Boolean(input.selectedProviderId) &&
+    input.groupProviderId === input.selectedProviderId &&
+    modelIdsMatch(input.currentModel, input.modelId)
+  )
 }
 
 function markModelSeen(

--- a/src/renderer/src/components/settings-section-agents.test.ts
+++ b/src/renderer/src/components/settings-section-agents.test.ts
@@ -49,6 +49,7 @@ const labels: Record<string, string> = {
   modelEndpointChatCompletions: '/v1/chat/completions',
   modelEndpointResponses: '/v1/responses',
   modelEndpointMessages: '/v1/messages',
+  modelEndpointCustomEndpoint: 'Custom full endpoint',
   modelProviderModels: 'Provider models',
   modelProviderImageCapability: 'Image capability',
   modelProviderImageCapabilityDesc: 'Image capability description',
@@ -493,6 +494,7 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
     expect(providerIdInput).not.toContain('readonly')
     expect(html).toContain('Endpoint format')
     expect(html).toContain('<option value="messages" selected="">/v1/messages</option>')
+    expect(html).toContain('<option value="custom_endpoint">Custom full endpoint</option>')
     expect(html).toContain('Add provider')
     expect(html).toContain('Test connection')
     expect(html).toContain('Fetch from API')

--- a/src/renderer/src/components/settings-section-providers.tsx
+++ b/src/renderer/src/components/settings-section-providers.tsx
@@ -69,7 +69,8 @@ import { ProviderModelsManager } from './settings-section-provider-models'
 const MODEL_ENDPOINT_FORMAT_LABEL_KEYS: Record<ModelEndpointFormat, string> = {
   chat_completions: 'modelEndpointChatCompletions',
   responses: 'modelEndpointResponses',
-  messages: 'modelEndpointMessages'
+  messages: 'modelEndpointMessages',
+  custom_endpoint: 'modelEndpointCustomEndpoint'
 }
 
 const IMAGE_GENERATION_PROTOCOL_LABEL_KEYS: Record<ImageGenerationProtocol, string> = {
@@ -1165,6 +1166,11 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
                       ))}
                     </select>
                   </label>
+                  {activeProvider.endpointFormat === 'custom_endpoint' ? (
+                    <p className="text-[12px] leading-5 text-ds-muted">
+                      {t('modelEndpointCustomEndpointDesc')}
+                    </p>
+                  ) : null}
                 </DetailSection>
                 <DetailSection
                   title={`${t('modelProviderModels')} · ${providerModelCount(activeProvider)}`}

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -175,6 +175,8 @@
   "modelEndpointChatCompletions": "/v1/chat/completions",
   "modelEndpointResponses": "/v1/responses",
   "modelEndpointMessages": "/v1/messages",
+  "modelEndpointCustomEndpoint": "Custom full endpoint",
+  "modelEndpointCustomEndpointDesc": "Uses this URL as the final endpoint. Only paths ending in /chat/completions, /completions, /responses, or /messages can be recognized; other endings are not supported.",
   "modelProviderModels": "Models",
   "modelProviderModelsPlaceholder": "Type a model ID and press Enter",
   "modelProviderModelRemove": "Remove {{model}}",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -175,6 +175,8 @@
   "modelEndpointChatCompletions": "/v1/chat/completions",
   "modelEndpointResponses": "/v1/responses",
   "modelEndpointMessages": "/v1/messages",
+  "modelEndpointCustomEndpoint": "自定义完整路径",
+  "modelEndpointCustomEndpointDesc": "自定义完整路径会把当前 URL 当作最终请求端点。只识别以 /chat/completions、/completions、/responses 或 /messages 结尾的路径；其他结尾暂不支持。",
   "modelProviderModels": "模型列表",
   "modelProviderModelsPlaceholder": "输入模型 ID，回车添加",
   "modelProviderModelRemove": "移除 {{model}}",

--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -4,9 +4,13 @@ import type { ApprovalPolicy, SandboxMode } from '../../kun/src/contracts/policy
 import type { ModelEndpointFormat } from '../../kun/src/contracts/model-endpoint-format.js'
 export {
   DEFAULT_MODEL_ENDPOINT_FORMAT,
+  inferModelEndpointFormatFromUrl,
+  isCustomModelEndpointFormat,
   MODEL_ENDPOINT_FORMATS,
   modelEndpointPath,
-  normalizeModelEndpointFormat
+  normalizeModelEndpointFormat,
+  resolveModelEndpointFormat,
+  usesChatCompletionsShape
 } from '../../kun/src/contracts/model-endpoint-format.js'
 export { DEFAULT_GUI_UPDATE_CHANNEL, normalizeGuiUpdateChannel, type GuiUpdateChannel } from './gui-update'
 export {

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -27,6 +27,7 @@ import {
   migrateLegacyAppSettings,
   normalizeAppSettings,
   parseClawUserPromptForDisplay,
+  inferModelEndpointFormatFromUrl,
   normalizeScheduleSettings,
   resolveKunRuntimeSettings,
   resolveWriteInlineCompletionApiKey,
@@ -59,6 +60,15 @@ function settings(): AppSettingsV1 {
     codePromptPrefix: ''
   }
 }
+
+describe('model endpoint format inference', () => {
+  it('treats /completions custom endpoints as Chat Completions-shaped', () => {
+    expect(inferModelEndpointFormatFromUrl('https://api.example.com/custom/completions')).toBe('chat_completions')
+    expect(inferModelEndpointFormatFromUrl('https://api.example.com/custom/completions?api-version=2026-01-01')).toBe(
+      'chat_completions'
+    )
+  })
+})
 
 function clawChannel(provider: ClawImProvider, label: string, name = label): ClawImChannelV1 {
   const now = '2026-06-01T00:00:00.000Z'

--- a/src/shared/openai-compat-url.test.ts
+++ b/src/shared/openai-compat-url.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  upstreamDeepSeekFimCompletionsUrl,
+  upstreamOpenAiCustomEndpointUrl,
+  upstreamOpenAiChatCompletionsUrl,
+  upstreamOpenAiModelsUrl
+} from './openai-compat-url'
+
+describe('openai compatible url builders', () => {
+  it('keeps root base URLs on the OpenAI v1 path', () => {
+    expect(upstreamOpenAiChatCompletionsUrl('https://api.example.com')).toBe(
+      'https://api.example.com/v1/chat/completions'
+    )
+    expect(upstreamOpenAiModelsUrl('https://api.example.com')).toBe('https://api.example.com/v1/models')
+  })
+
+  it('appends chat completions suffix even when the base URL already looks like an endpoint', () => {
+    expect(upstreamOpenAiChatCompletionsUrl('https://api.example.com/custom/chat/completions')).toBe(
+      'https://api.example.com/custom/chat/completions/v1/chat/completions'
+    )
+    expect(upstreamOpenAiChatCompletionsUrl('https://api.example.com/custom/chat/completions/')).toBe(
+      'https://api.example.com/custom/chat/completions/v1/chat/completions'
+    )
+  })
+
+  it('appends chat completions suffix before query strings outside custom endpoint mode', () => {
+    const endpoint = 'https://api.example.com/openai/deployments/m/chat/completions?api-version=2026-01-01'
+
+    expect(
+      upstreamOpenAiChatCompletionsUrl(endpoint)
+    ).toBe(
+      'https://api.example.com/openai/deployments/m/chat/completions/v1/chat/completions?api-version=2026-01-01'
+    )
+  })
+
+  it('keeps custom full endpoint URLs unchanged without known suffix matching', () => {
+    expect(upstreamOpenAiCustomEndpointUrl('https://api.example.com/custom/chat/completions')).toBe(
+      'https://api.example.com/custom/chat/completions'
+    )
+    expect(
+      upstreamOpenAiCustomEndpointUrl('https://api.example.com/openai/deployments/m/chat/completions?api-version=2026-01-01')
+    ).toBe('https://api.example.com/openai/deployments/m/chat/completions?api-version=2026-01-01')
+    expect(upstreamOpenAiCustomEndpointUrl('https://api.example.com/custom-path')).toBe(
+      'https://api.example.com/custom-path'
+    )
+    expect(upstreamOpenAiCustomEndpointUrl('https://api.example.com/custom-path/?api-version=2026-01-01')).toBe(
+      'https://api.example.com/custom-path?api-version=2026-01-01'
+    )
+  })
+
+  it('appends models suffix without stripping endpoint-looking paths', () => {
+    expect(upstreamOpenAiModelsUrl('https://api.example.com/api/v3/chat/completions')).toBe(
+      'https://api.example.com/api/v3/chat/completions/v1/models'
+    )
+  })
+
+  it('keeps DeepSeek beta FIM completions behavior', () => {
+    expect(upstreamDeepSeekFimCompletionsUrl('https://api.deepseek.com')).toBe(
+      'https://api.deepseek.com/beta/completions'
+    )
+    expect(upstreamDeepSeekFimCompletionsUrl('https://api.deepseek.com/v1')).toBe(
+      'https://api.deepseek.com/beta/completions'
+    )
+  })
+})

--- a/src/shared/openai-compat-url.ts
+++ b/src/shared/openai-compat-url.ts
@@ -2,6 +2,27 @@
  * Build `.../models` URL for OpenAI-compatible providers, matching
  * DeepSeek-TUI `client::api_url(base, "models")` so `/beta` bases still hit `/v1/models`.
  */
+function splitUrlSuffix(url: string): { path: string; suffix: string } {
+  const query = url.search(/[?#]/)
+  if (query < 0) return { path: url, suffix: '' }
+  return { path: url.slice(0, query), suffix: url.slice(query) }
+}
+
+function appendUrlPath(baseUrl: string, path: string): string {
+  const split = splitUrlSuffix(baseUrl)
+  return `${split.path.replace(/\/+$/, '')}/${path}${split.suffix}`
+}
+
+function trimUrlPathEnd(baseUrl: string): string {
+  const split = splitUrlSuffix(baseUrl.trim())
+  return `${split.path.replace(/\/+$/, '')}${split.suffix}`
+}
+
+function lastPathSegment(baseUrl: string): string {
+  const split = splitUrlSuffix(baseUrl.trim())
+  return split.path.replace(/\/+$/, '').split('/').pop() ?? ''
+}
+
 function isVersionSegment(segment: string): boolean {
   const s = segment.toLowerCase()
   if (s === 'beta') return true
@@ -9,48 +30,55 @@ function isVersionSegment(segment: string): boolean {
 }
 
 function unversionedBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.replace(/\/+$/, '')
+  const split = splitUrlSuffix(baseUrl)
+  const trimmed = split.path.replace(/\/+$/, '')
   const slash = trimmed.lastIndexOf('/')
-  if (slash < 0) return trimmed
+  if (slash < 0) return `${trimmed}${split.suffix}`
   const seg = trimmed.slice(slash + 1)
-  if (isVersionSegment(seg)) return trimmed.slice(0, slash)
-  return trimmed
+  if (isVersionSegment(seg)) return `${trimmed.slice(0, slash)}${split.suffix}`
+  return `${trimmed}${split.suffix}`
 }
 
 function versionedBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.replace(/\/+$/, '')
-  const seg = trimmed.split('/').pop() ?? ''
+  const trimmed = trimUrlPathEnd(baseUrl)
+  const seg = lastPathSegment(trimmed)
   if (isVersionSegment(seg)) return trimmed
-  return `${trimmed}/v1`
+  return appendUrlPath(trimmed, 'v1')
 }
 
 export function upstreamOpenAiModelsUrl(baseUrl: string): string {
   const path = 'models'
-  let versioned = versionedBaseUrl(baseUrl.trim())
-  if (versioned.toLowerCase().endsWith('/beta')) {
-    versioned = `${unversionedBaseUrl(baseUrl.trim())}/v1`
+  const endpointBase = baseUrl.trim()
+  let versioned = versionedBaseUrl(endpointBase)
+  if (lastPathSegment(versioned).toLowerCase() === 'beta') {
+    versioned = appendUrlPath(unversionedBaseUrl(endpointBase), 'v1')
   }
-  return `${versioned.replace(/\/+$/, '')}/${path}`
+  return appendUrlPath(versioned, path)
 }
 
 export function upstreamOpenAiChatCompletionsUrl(baseUrl: string): string {
   const path = 'chat/completions'
-  let versioned = versionedBaseUrl(baseUrl.trim())
-  if (versioned.toLowerCase().endsWith('/beta')) {
-    versioned = `${unversionedBaseUrl(baseUrl.trim())}/v1`
+  const trimmed = baseUrl.trim()
+  let versioned = versionedBaseUrl(trimmed)
+  if (lastPathSegment(versioned).toLowerCase() === 'beta') {
+    versioned = appendUrlPath(unversionedBaseUrl(trimmed), 'v1')
   }
-  return `${versioned.replace(/\/+$/, '')}/${path}`
+  return appendUrlPath(versioned, path)
+}
+
+export function upstreamOpenAiCustomEndpointUrl(baseUrl: string): string {
+  return trimUrlPathEnd(baseUrl)
 }
 
 export function upstreamDeepSeekFimCompletionsUrl(baseUrl: string): string {
   const path = 'completions'
-  const trimmed = baseUrl.trim().replace(/\/+$/, '')
+  const trimmed = trimUrlPathEnd(baseUrl)
   const base = trimmed || 'https://api.deepseek.com/beta'
-  const segment = base.split('/').pop()?.toLowerCase() ?? ''
+  const segment = lastPathSegment(base).toLowerCase()
   const betaBase = segment === 'beta'
     ? base
     : isVersionSegment(segment)
-      ? `${unversionedBaseUrl(base)}/beta`
-      : `${base}/beta`
-  return `${betaBase.replace(/\/+$/, '')}/${path}`
+      ? appendUrlPath(unversionedBaseUrl(base), 'beta')
+      : appendUrlPath(base, 'beta')
+  return appendUrlPath(betaBase, path)
 }


### PR DESCRIPTION
## Summary

This PR contains three user-facing changes:

1. Adds a new provider endpoint option: Custom full path.
   - The existing three options still behave as fixed endpoint-format selections and keep appending their own suffixes.
   - The new custom option treats the user input as the final request path instead of forcing `/v1/chat/completions`.
   - When Custom full path is selected, the settings UI shows a small helper note explaining which endpoint endings can be recognized.

2. Fixes model picker handling for providers with duplicate model ids.
   - Models are de-duplicated only within the same provider.
   - Different providers can now expose the same model id without one provider hiding the other.
   - Selected state now checks provider id and model id together, so duplicate model ids across providers do not all appear selected.

3. Improves model HTTP 404 diagnostics.
   - 404 errors now tell the user to check the model provider configuration, especially Base URL and Endpoint format.
   - Kun logs now include a redacted model HTTP failure record with provider, status, model, baseUrl, final requestUrl, endpoint formats, and response body summary.

## Custom Endpoint Logic

When the provider uses one of the original endpoint options, the app does not infer the protocol from the URL. It keeps using the selected endpoint format and builds the request URL by appending the matching suffix:

- Chat Completions -> `chat/completions`
- Responses -> `responses`
- Messages -> `messages`

When the provider uses Custom full path, the app treats the configured URL as the final endpoint and only then infers the protocol/body shape from the path ending:

- URLs ending with `/chat/completions` or `/completions` use the Chat Completions request/response shape.
- URLs ending with `/responses` use the Responses request/response shape.
- URLs ending with `/messages` use the Messages request/response shape.
- Any other custom full path is rejected because the app cannot safely determine which request and response contract to use.

This keeps the old fixed-option behavior unchanged while allowing non-`/v1` compatible endpoints to work through the custom full path option.

## Validation

- `npm run test -- src/shared/app-settings.test.ts src/shared/openai-compat-url.test.ts src/main/services/write-inline-completion-service.test.ts src/main/claw-scheduled-task-detector.test.ts src/main/provider-connection.test.ts src/main/upstream-models.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts src/renderer/src/components/settings-section-agents.test.ts`
- `npm run test -- src/renderer/src/components/settings-section-agents.test.ts src/shared/app-settings.test.ts`
- `npm run test -- src/renderer/src/components/chat/FloatingComposer.test.ts`
- `npm --prefix kun test -- tests/model-client.test.ts`
- `npm run typecheck`
- `npm --prefix kun run build`
- `git diff --check`
- `npm run dist`
- Extracted `dist/Kun-0.1.0-mac-arm64.zip` to `dist/Kun-0.1.0-mac-arm64-unzipped/Kun.app`
