### PR TITLE
feat(write): add selection quote action

### DIFF
--- a/src/renderer/src/components/write/WriteInlineAgent.tsx
+++ b/src/renderer/src/components/write/WriteInlineAgent.tsx
@@ -58,6 +58,8 @@ type Props = {
   /** Configurable AI quick actions (edit ones rewrite in place, chat ones go to the sidebar). */
   quickActions?: ResolvedWriteQuickAction[]
   onQuickAction?: (action: ResolvedWriteQuickAction) => void
+  /** Adds the current selection to the writing assistant quote tray without sending a message. */
+  onQuoteSelection?: () => void
   /** Shown only when the image generation provider is configured. Generation
    * is async: the click inserts an animated placeholder and returns. */
   infographicEnabled?: boolean
@@ -163,6 +165,7 @@ export function WriteInlineAgent({
   onSetBlockType,
   quickActions = [],
   onQuickAction,
+  onQuoteSelection,
   infographicEnabled = false,
   onGenerateInfographic,
   designDraftEnabled = false,
@@ -178,6 +181,7 @@ export function WriteInlineAgent({
 
   const showBlockSelector = !imageMode && formattingEnabled && Boolean(onSetBlockType)
   const showFormatting = !imageMode && formattingEnabled && Boolean(onApplyFormat)
+  const showQuoteSelection = !imageMode && Boolean(onQuoteSelection)
   const showQuickActions = !imageMode && quickActions.length > 0 && Boolean(onQuickAction)
   const showInfographic = !imageMode && infographicEnabled && Boolean(onGenerateInfographic)
   const showDesignDraft = designDraftEnabled && Boolean(onGenerateDesignDraft)
@@ -210,6 +214,7 @@ export function WriteInlineAgent({
     inFlight,
     showFormatting,
     showBlockSelector,
+    showQuoteSelection,
     showInfographic,
     showDesignDraft,
     showPrototype,
@@ -319,9 +324,20 @@ export function WriteInlineAgent({
           </div>
         ) : null}
 
-        {showQuickActions || showInfographic || showDesignDraft || showPrototype ? (
+        {showQuoteSelection || showQuickActions || showInfographic || showDesignDraft || showPrototype ? (
           <div className="write-inline-agent-actions">
             <div className="write-inline-agent-section-label">{t('writeSelectionSkills')}</div>
+            {showQuoteSelection ? (
+              <ToolbarButton
+                className="write-inline-agent-action-row"
+                label={t('writeSelectionQuote')}
+                onActivate={() => onQuoteSelection?.()}
+              >
+                <MessageSquareQuote className="h-4 w-4 shrink-0 text-accent" strokeWidth={1.85} />
+                <span className="min-w-0 flex-1 truncate text-left">{t('writeSelectionQuote')}</span>
+                <MessageSquareQuote className="write-inline-agent-action-hint h-3.5 w-3.5" strokeWidth={1.8} />
+              </ToolbarButton>
+            ) : null}
             {showQuickActions
               ? quickActions.map((quickAction) => {
                   const Icon = quickActionIcon(quickAction.id)

--- a/src/renderer/src/components/write/WriteWorkspaceView.tsx
+++ b/src/renderer/src/components/write/WriteWorkspaceView.tsx
@@ -246,6 +246,12 @@ export function WriteWorkspaceView({
     setInput(input.trim() ? `${input.trim()}\n\n${trimmed}` : trimmed)
   }
 
+  const quoteSelectionToAssistant = (): void => {
+    if (!workspaceReady || !activeFilePath) return
+    quoteCurrentSelection(workspaceRoot)
+    setInlineAgentValue('')
+  }
+
   // Edit-mode quick actions rewrite the selection in place through the
   // inline-edit pipeline; chat-mode actions (润色/解释) quote the selection and
   // hand the prompt to the sidebar assistant (auto-expanding it).
@@ -970,6 +976,7 @@ export function WriteWorkspaceView({
           onSetBlockType={applyBlockType}
           quickActions={inlineQuickActions}
           onQuickAction={runQuickAction}
+          onQuoteSelection={quoteSelectionToAssistant}
           infographicEnabled={activeFileIsText && imageGenReady && isMarkdown && !renderSafety.readOnly}
           onGenerateInfographic={generateInfographic}
         />

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1294,6 +1294,7 @@
   "writeQuickActionReformat": "Reformat",
   "writeQuickActionReformatPrompt": "Tidy up the layout and structure of this text: sensible paragraphing, consistent punctuation and spacing, and clean list and heading levels, without changing the meaning.",
   "writeSelectionSkills": "Skills",
+  "writeSelectionQuote": "Add quote",
   "writeBlockTypeLabel": "Block style",
   "writeBlockTypeParagraph": "Normal text",
   "writeBlockTypeHeading1": "Heading 1",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1294,6 +1294,7 @@
   "writeQuickActionReformat": "重新格式化",
   "writeQuickActionReformatPrompt": "整理这段文字的排版与结构：合理分段、统一标点与空格、规范列表和标题层级，不改变原意。",
   "writeSelectionSkills": "技能",
+  "writeSelectionQuote": "添加引用",
   "writeBlockTypeLabel": "段落样式",
   "writeBlockTypeParagraph": "普通文本",
   "writeBlockTypeHeading1": "标题 1",


### PR DESCRIPTION
## Summary

- Add an explicit `添加引用` / `Add quote` action to the write selection skills menu.
- Reuse the existing writing assistant quote tray so selected text can be staged as a quote without sending a message.
- Keep the existing send-to-assistant button behavior unchanged for prompt-driven sends.

## Validation

- `npm run typecheck`
- `npm run lint` (passes with existing hook dependency warnings)
- `npm run build`
- Built local macOS arm64 zip: `dist/Kun-0.1.0-mac-arm64.zip`
