### PR TITLE
fix: hide DeepSeek alias models from picker

### DIFF
--- a/src/main/upstream-models.test.ts
+++ b/src/main/upstream-models.test.ts
@@ -115,6 +115,7 @@ describe('upstream model picker list', () => {
     if (result.ok) {
       expect(result.modelIds).toContain('local-only-model')
       expect(result.modelIds).toContain('custom-provider-model')
+      expect(result.modelIds).toContain('deepseek-chat')
       expect(result.modelIds).not.toContain('auto')
       expect(result.defaultModelId).toBe('local-only-model')
       expect(result.modelGroups).toEqual(expect.arrayContaining([
@@ -126,9 +127,12 @@ describe('upstream model picker list', () => {
         expect.objectContaining({
           providerId: 'deepseek',
           label: 'DeepSeek',
-          modelIds: expect.arrayContaining(['deepseek-chat', 'deepseek-reasoner'])
+          modelIds: expect.arrayContaining(['deepseek-v4-flash'])
         })
       ]))
+      const deepseekGroup = result.modelGroups?.find((group) => group.providerId === 'deepseek')
+      expect(deepseekGroup?.modelIds).not.toContain('deepseek-chat')
+      expect(deepseekGroup?.modelIds).not.toContain('deepseek-reasoner')
     }
   })
 

--- a/src/main/upstream-models.ts
+++ b/src/main/upstream-models.ts
@@ -10,7 +10,6 @@ import {
   listNonTextModelIds,
   modelProfileSupportsTextChat,
   modelProviderModelProfile,
-  modelProviderModelProfilesForSettings,
   resolveKunRuntimeSettings,
   type AppSettingsV1
 } from '../shared/app-settings'
@@ -182,10 +181,7 @@ async function readConfiguredModelGroups(settings: AppSettingsV1): Promise<Model
       modelProfiles: provider.modelProfiles
     })
   }
-  return mergeModelGroups([
-    ...groups,
-    ...(await readConfiguredProfileAliasGroups(settings, groups))
-  ])
+  return mergeModelGroups(groups)
 }
 
 function mergeModelGroups(groups: readonly ModelProviderModelGroup[]): ModelProviderModelGroup[] {
@@ -229,62 +225,6 @@ function modelIdsFromProfiles(
     }
   }
   return ids
-}
-
-async function readConfiguredProfileAliasGroups(
-  settings: AppSettingsV1,
-  providerGroups: readonly ModelProviderModelGroup[]
-): Promise<ModelProviderModelGroup[]> {
-  const runtime = resolveKunRuntimeSettings(settings)
-  const configPath = join(expandHome(runtime.dataDir), 'config.json')
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(await readFile(configPath, 'utf8')) as unknown
-  } catch {
-    return []
-  }
-  const root = objectValue(parsed)
-  const models = objectValue(root.models)
-  const contextCompaction = objectValue(root.contextCompaction)
-  const aliasesByModel = new Map<string, string[]>()
-  collectModelProfileAliases(aliasesByModel, objectValue(contextCompaction.modelProfiles))
-  collectModelProfileAliases(aliasesByModel, objectValue(models.profiles))
-  const providerModelProfiles = modelProviderModelProfilesForSettings(settings)
-
-  const aliasGroups: ModelProviderModelGroup[] = []
-  for (const group of providerGroups) {
-    const aliases: string[] = []
-    for (const modelId of group.modelIds) {
-      aliases.push(...(aliasesByModel.get(modelId.trim()) ?? []))
-    }
-    if (aliases.length === 0) continue
-    aliasGroups.push({
-      providerId: group.providerId,
-      label: group.label,
-      modelIds: aliases,
-      modelProfiles: providerModelProfiles
-    })
-  }
-  return aliasGroups
-}
-
-function collectModelProfileAliases(
-  target: Map<string, string[]>,
-  profiles: Record<string, unknown>
-): void {
-  for (const [modelId, rawProfile] of Object.entries(profiles)) {
-    const trimmed = modelId.trim()
-    if (!trimmed) continue
-    const aliases = objectValue(rawProfile).aliases
-    if (!Array.isArray(aliases)) continue
-    const ids = target.get(trimmed) ?? []
-    for (const alias of aliases) {
-      if (typeof alias !== 'string') continue
-      const trimmedAlias = alias.trim()
-      if (trimmedAlias) ids.push(trimmedAlias)
-    }
-    target.set(trimmed, ids)
-  }
 }
 
 function mergeModelIds(ids: readonly string[]): string[] {


### PR DESCRIPTION
## Summary
- stop adding Kun model profile aliases into provider model groups for the composer picker
- keep aliases in the flat compatibility model list so legacy settings and old sessions can still resolve them
- update upstream model picker tests to verify DeepSeek aliases do not appear under the DeepSeek provider menu

## Root cause
Kun config model profile aliases such as `deepseek-chat` and `deepseek-reasoner` were being merged back into the DeepSeek provider group. That made the chat model picker show aliases that were not configured as provider models.

## Verification
- `npm test -- --run src/main/upstream-models.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts`
- `npm run build`
- `npx --yes electron-builder@26.8.1 --config electron-builder.config.cjs --publish never --mac zip --arm64`
- launched `dist/mac-arm64/Kun.app` with remote debugging and confirmed the model menu no longer contained `deepseek-chat` or `deepseek-reasoner`
