### PR TITLE
fix(plugins): keep catalog description after an MCP plugin is installed

### DIFF
--- a/src/renderer/src/components/PluginMarketplaceView.test.ts
+++ b/src/renderer/src/components/PluginMarketplaceView.test.ts
@@ -162,7 +162,8 @@ describe('PluginMarketplaceView MCP config helpers', () => {
         id: 'github',
         sourceLabel: 'Connected',
         statusTone: 'success',
-        description: expect.stringContaining('github-mcp')
+        descriptionKey: 'pluginMcpGithubDesc',
+        detail: expect.stringContaining('github-mcp')
       })
     ])
   })

--- a/src/renderer/src/components/PluginMarketplaceView.tsx
+++ b/src/renderer/src/components/PluginMarketplaceView.tsx
@@ -49,6 +49,7 @@ type MarketplaceItem = {
   description?: string
   group: 'recommended' | 'personal'
   sourceLabel?: string
+  detail?: string
   statusTone?: 'default' | 'success' | 'warning' | 'error'
   systemManaged?: boolean
   mcpConfig?: (workspaceRoot: string) => JsonRecord
@@ -327,11 +328,20 @@ export function mcpMarketplaceItemsFromConfigAndDiagnostics(
       status === 'error' || status === 'unavailable' ? labels.error :
       status === 'disabled' ? labels.disabled :
       labels.configured
+    const detail = mcpServerDescription(details, labels.configured)
+    const catalogItem = RECOMMENDED_ITEMS.find((entry) => entry.kind === 'mcp' && entry.id === id)
     return {
       id,
       kind: 'mcp' as const,
       title: id,
-      description: mcpServerDescription(details, labels.configured),
+      // Keep the catalog description for known servers so installing an item
+      // does not replace its human-readable intro with the raw status string (#211).
+      ...(catalogItem?.descriptionKey
+        ? { descriptionKey: catalogItem.descriptionKey }
+        : catalogItem?.description
+          ? { description: catalogItem.description }
+          : { description: detail }),
+      detail,
       group: 'personal' as const,
       sourceLabel,
       statusTone: mcpStatusTone(status)
@@ -1175,6 +1185,11 @@ function PluginSection({
                   <p className="mt-1 line-clamp-2 text-[14px] leading-5 text-ds-muted">
                     {itemDescription(item, t)}
                   </p>
+                  {item.detail && item.detail !== itemDescription(item, t) ? (
+                    <p className="mt-0.5 truncate font-mono text-[12px] text-ds-faint" title={item.detail}>
+                      {item.detail}
+                    </p>
+                  ) : null}
                 </div>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- Fixes #211: after installing/configuring a recommended MCP plugin, its description was replaced by the raw runtime status string (e.g. `status: connected · stdio · github-mcp · 12 tools`), so the human-readable intro disappeared.
- `mcpMarketplaceItemsFromConfigAndDiagnostics` now keeps the catalog `descriptionKey`/`description` for known servers and exposes the runtime status/command as a secondary `detail` line instead of overwriting the description.
- The marketplace card renders the `detail` line under the description only when it differs, so unknown/custom servers are unchanged.

## Test plan
- [x] `npx vitest run src/renderer/src/components/PluginMarketplaceView.test.ts` (7 passed)
- [x] `npx tsc --noEmit -p tsconfig.web.json`
- [ ] Manual: add the GitHub MCP plugin from the marketplace and confirm its description stays after install, with the status shown as a smaller detail line.