### PR TITLE
fix(git): detect non-repo dirs regardless of git locale

### DIFF
--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -34,7 +34,12 @@ async function runGit(
   const { stdout, stderr } = await execFileAsync('git', args, {
     cwd,
     timeout,
-    maxBuffer: 1024 * 1024
+    maxBuffer: 1024 * 1024,
+    // Force a C locale so git emits English diagnostics. gitFailure() matches
+    // messages like "not a git repository"; without this, a localized git
+    // (e.g. zh_CN: "不是 Git 仓库") falls through to a generic `error` reason
+    // and the UI shows the wrong state instead of "not a Git repository".
+    env: { ...process.env, LC_ALL: 'C', LANG: 'C' }
   })
   return { stdout: String(stdout), stderr: String(stderr) }
 }


### PR DESCRIPTION
## Summary
- Regression found while auditing the refactor: `getGitBranches` decides between the `not_git_repo` and generic `error` states by matching the English phrase `not a git repository` in git's stderr (`gitFailure`).
- On a localized git install the message is translated (e.g. zh_CN: `不是 Git 仓库（或者任何父目录）`), so the regex misses and a non-repo workspace is reported as a generic `error` instead of `not_git_repo` — the GUI then shows the wrong state. This hits every Chinese-locale user, and the existing comment about issue #98 ("未检测到 Git") points at the same class of locale fragility.
- Fix: run all git invocations with `LC_ALL=C`/`LANG=C` so diagnostics are always English and the existing parsing is deterministic across locales.

## Test plan
- [x] `npx vitest run src/main/services/git-service.test.ts` — previously the "returns not_git_repo when the path is outside any repository" case failed on this (zh_CN) host; now all 7 pass.