### PR TITLE
fix(kun): preserve partial response on interrupt

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -995,6 +995,38 @@ export class AgentLoop {
     const completedToolCalls: ToolCallLike[] = []
     let stopReason: 'stop' | 'tool_calls' | 'length' | 'error' = 'stop'
     const modelClientDiagnostics = this.modelClientDiagnostics()
+    let persistedReasoning = false
+    let persistedText = false
+    const persistAccumulatedResponse = async (): Promise<void> => {
+      if (!persistedReasoning && reasoningAccumulator.value) {
+        persistedReasoning = true
+        const itemId = reasoningItemId || this.opts.ids.next('item_reasoning')
+        await this.opts.turns.applyItem(
+          threadId,
+          makeAssistantReasoningItem({
+            id: itemId,
+            turnId,
+            threadId,
+            text: reasoningAccumulator.value,
+            status: 'completed'
+          })
+        )
+      }
+      if (!persistedText && textAccumulator.value) {
+        persistedText = true
+        const itemId = textItemId || this.opts.ids.next('item_text')
+        await this.opts.turns.applyItem(
+          threadId,
+          makeAssistantTextItem({
+            id: itemId,
+            turnId,
+            threadId,
+            text: textAccumulator.value,
+            status: 'completed'
+          })
+        )
+      }
+    }
     await this.recordPipelineStage(threadId, turnId, 'pre_send', {
       model: request.model,
       ...modelClientDiagnostics,
@@ -1013,7 +1045,10 @@ export class AgentLoop {
       ...modelClientDiagnostics
     })
     for await (const chunk of this.opts.model.stream(request)) {
-      if (signal.aborted) return 'aborted'
+      if (signal.aborted) {
+        await persistAccumulatedResponse()
+        return 'aborted'
+      }
       switch (chunk.kind) {
         case 'assistant_text_delta':
           textItemId ||= this.opts.ids.next('item_text')
@@ -1128,36 +1163,15 @@ export class AgentLoop {
           break
       }
     }
+    if (signal.aborted) {
+      await persistAccumulatedResponse()
+      return 'aborted'
+    }
     await this.recordPipelineStage(threadId, turnId, 'response_received', {
       stopReason,
       toolCallCount: completedToolCalls.length
     })
-    if (reasoningAccumulator.value) {
-      const itemId = reasoningItemId || this.opts.ids.next('item_reasoning')
-      await this.opts.turns.applyItem(
-        threadId,
-        makeAssistantReasoningItem({
-          id: itemId,
-          turnId,
-          threadId,
-          text: reasoningAccumulator.value,
-          status: 'completed'
-        })
-      )
-    }
-    if (textAccumulator.value) {
-      const itemId = textItemId || this.opts.ids.next('item_text')
-      await this.opts.turns.applyItem(
-        threadId,
-        makeAssistantTextItem({
-          id: itemId,
-          turnId,
-          threadId,
-          text: textAccumulator.value,
-          status: 'completed'
-        })
-      )
-    }
+    await persistAccumulatedResponse()
     if (stopReason === 'error') return 'failed'
     if (completedToolCalls.length === 0) {
       if (request.requiredToolName) {

--- a/kun/tests/loop.test.ts
+++ b/kun/tests/loop.test.ts
@@ -261,6 +261,58 @@ describe('AgentLoop', () => {
     expect(turnItems.map((item) => item.kind)).toEqual(['user_message'])
   })
 
+  it('keeps partial assistant text when interrupting a foreground turn', async () => {
+    let resolveDelta: (() => void) | undefined
+    const sawDelta = new Promise<void>((resolve) => {
+      resolveDelta = resolve
+    })
+    const h = makeHarness({
+      provider: 'partial-abort',
+      model: 'partial-abort',
+      async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+        yield { kind: 'assistant_text_delta', text: 'partial answer' }
+        resolveDelta?.()
+        await new Promise<void>((resolve) => {
+          if (request.abortSignal.aborted) {
+            resolve()
+            return
+          }
+          request.abortSignal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    })
+    await bootstrapThread(h)
+
+    const run = h.loop.runTurn(h.threadId, h.turnId)
+    await sawDelta
+    await h.turns.interruptTurn({ threadId: h.threadId, turnId: h.turnId })
+    const status = await run
+    const sessionItems = await h.sessionStore.loadItems(h.threadId)
+    const thread = await h.threadStore.get(h.threadId)
+    const turnItems = thread?.turns.find((turn) => turn.id === h.turnId)?.items ?? []
+
+    expect(status).toBe('aborted')
+    expect(sessionItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'assistant_text',
+          text: 'partial answer',
+          status: 'completed'
+        })
+      ])
+    )
+    expect(turnItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'assistant_text',
+          text: 'partial answer',
+          status: 'completed'
+        })
+      ])
+    )
+  })
+
   it('runs a tool call and surfaces its result item', async () => {
     let calls = 0
     const h = makeHarness({


### PR DESCRIPTION
## Summary
- persist streamed assistant reasoning/text before an interrupted foreground turn is marked aborted
- keep the current stop button behavior as an interrupt so generated content remains visible after runtime recovery
- add a regression test for preserving partial assistant text after interrupt

## Root cause
Assistant text deltas were emitted over SSE during streaming, but the accumulated assistant item was only persisted after a normal model completion. If the turn was aborted first, recovery from the runtime snapshot had no assistant item to render, so the UI appeared to roll back to the last user prompt.

## Validation
- npm --prefix kun test -- loop.test.ts -t "keeps partial assistant text when interrupting a foreground turn"
- npm --prefix kun run typecheck

## Notes
- Full `npm --prefix kun test -- loop.test.ts` still has 3 existing compaction assertion failures unrelated to this change.