### PR TITLE
fix(chat): improve agent code block contrast

### DIFF
--- a/src/renderer/src/components/chat/StreamdownCode.test.ts
+++ b/src/renderer/src/components/chat/StreamdownCode.test.ts
@@ -14,6 +14,7 @@ describe('StreamdownCode plain text fences', () => {
     )
 
     expect(html).toContain('ds-plain-text-block')
+    expect(html).toContain('ds-plain-code-block')
     expect(html).toContain('refactor(chat): simplify composer')
     expect(html).toContain('- Keep only Stop')
     expect(html).not.toContain('ds-code-block-header')

--- a/src/renderer/src/components/chat/StreamdownCode.tsx
+++ b/src/renderer/src/components/chat/StreamdownCode.tsx
@@ -100,7 +100,7 @@ function PlainTextBlock({ code }: { code: string }): ReactNode {
   if (!trimmedCode.trim()) return null
 
   return (
-    <div className="ds-plain-text-block" data-streamdown="plain-text-block">
+    <div className="ds-plain-text-block ds-plain-code-block" data-streamdown="plain-text-block">
       {trimmedCode}
     </div>
   )

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -84,6 +84,7 @@
   --ds-inline-code-bg: rgba(240, 245, 251, 0.92);
   --ds-inline-code-hover-bg: rgba(228, 238, 250, 0.98);
   --ds-pre-bg: rgba(245, 248, 253, 0.96);
+  --ds-code-block-bg: #edf3fb;
   --ds-table-head-bg: rgba(242, 246, 252, 0.96);
   --ds-scrollbar-thumb: rgba(84, 103, 140, 0.24);
   --ds-scrollbar-thumb-hover: rgba(84, 103, 140, 0.34);
@@ -192,6 +193,7 @@
   --ds-inline-code-bg: rgba(151, 192, 235, 0.09);
   --ds-inline-code-hover-bg: rgba(111, 176, 232, 0.2);
   --ds-pre-bg: #151c2e;
+  --ds-code-block-bg: #101827;
   --ds-table-head-bg: rgba(27, 35, 56, 0.94);
   --ds-scrollbar-thumb: rgba(151, 178, 215, 0.28);
   --ds-scrollbar-thumb-hover: rgba(171, 198, 233, 0.38);
@@ -282,6 +284,7 @@
   --ds-inline-code-bg: rgba(249, 242, 226, 0.92);
   --ds-inline-code-hover-bg: rgba(247, 233, 203, 0.98);
   --ds-pre-bg: rgba(252, 247, 235, 0.96);
+  --ds-code-block-bg: #f6ecd7;
   --ds-table-head-bg: rgba(250, 244, 229, 0.96);
   --ds-scrollbar-thumb: rgba(117, 96, 63, 0.24);
   --ds-scrollbar-thumb-hover: rgba(117, 96, 63, 0.34);
@@ -372,6 +375,7 @@
   --ds-inline-code-bg: rgba(238, 198, 128, 0.09);
   --ds-inline-code-hover-bg: rgba(242, 177, 61, 0.2);
   --ds-pre-bg: #1e1812;
+  --ds-code-block-bg: #15110d;
   --ds-table-head-bg: rgba(39, 31, 23, 0.94);
   --ds-scrollbar-thumb: rgba(214, 188, 142, 0.28);
   --ds-scrollbar-thumb-hover: rgba(233, 208, 162, 0.38);
@@ -681,6 +685,7 @@ html {
   --ds-inline-code-bg: rgba(151, 192, 235, 0.075);
   --ds-inline-code-hover-bg: rgba(111, 176, 232, 0.18);
   --ds-pre-bg: #151c2e;
+  --ds-code-block-bg: #101827;
   --ds-table-head-bg: rgba(27, 35, 56, 0.94);
   --ds-scrollbar-thumb: rgba(170, 170, 170, 0.26);
   --ds-scrollbar-thumb-hover: rgba(200, 200, 200, 0.36);

--- a/src/renderer/src/styles/markdown-code.css
+++ b/src/renderer/src/styles/markdown-code.css
@@ -143,11 +143,12 @@
   max-width: 100%;
   width: 100%;
   min-width: 0;
-  border: 1px solid var(--ds-border);
+  border: 1px solid color-mix(in srgb, var(--ds-border-strong) 72%, var(--ds-border));
   border-radius: 14px;
-  background: var(--ds-pre-bg);
+  background: var(--ds-code-block-bg, var(--ds-pre-bg));
   padding: 0.6rem 0.72rem;
   box-sizing: border-box;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--ds-bg-canvas) 62%, transparent);
 }
 
 .ds-markdown pre code {
@@ -221,9 +222,10 @@
   width: 100%;
   min-width: 0;
   overflow: hidden;
-  border: 1px solid var(--ds-border);
+  border: 1px solid color-mix(in srgb, var(--ds-border-strong) 72%, var(--ds-border));
   border-radius: 14px;
-  background: var(--ds-pre-bg);
+  background: var(--ds-code-block-bg, var(--ds-pre-bg));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--ds-bg-canvas) 62%, transparent);
   box-sizing: border-box;
 }
 
@@ -236,13 +238,24 @@
   font: inherit;
 }
 
+.ds-markdown .ds-plain-code-block {
+  border: 1px solid color-mix(in srgb, var(--ds-border-strong) 72%, var(--ds-border));
+  border-radius: 14px;
+  background: var(--ds-code-block-bg, var(--ds-pre-bg));
+  padding: 0.64rem 0.72rem;
+  font-family: 'SF Mono', 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--ds-bg-canvas) 62%, transparent);
+}
+
 .ds-markdown .ds-code-block-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
   border-bottom: 1px solid var(--ds-border-muted);
-  background: color-mix(in srgb, var(--ds-code-bg) 88%, var(--ds-card-muted));
+  background: color-mix(in srgb, var(--ds-code-block-bg, var(--ds-code-bg)) 88%, var(--ds-card-muted));
   padding: 0.42rem 0.6rem;
 }
 
@@ -291,7 +304,7 @@
 
 .ds-markdown .ds-code-block-body {
   position: relative;
-  background: var(--ds-pre-bg);
+  background: var(--ds-code-block-bg, var(--ds-pre-bg));
 }
 
 .ds-markdown .ds-code-block-body.is-collapsed {


### PR DESCRIPTION
## 中文

### 改动
- 为 Agent Markdown 的纯文本 fenced code block 增加独立的 `ds-plain-code-block` 样式类，避免目录树、纯文本片段看起来像普通正文。
- 为普通 `pre`、高亮代码块和纯文本代码块统一增强背景、边框和内阴影。
- 增加跨主题的 `--ds-code-block-bg`，让明暗主题和 ikun 主题下代码块都有明确底色。
- 补充 `StreamdownCode` 单测断言，确保纯文本 fenced block 保留代码块视觉类。

### 原因
Agent 输出无语言代码块或纯文本代码块时，之前会按普通文本块渲染，在深色聊天背景下缺少明确代码块边界。

### 验证
- `npm run test -- src/renderer/src/components/chat/StreamdownCode.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run dist:mac:arm64`
- 解压 `dist/Kun-0.1.0-mac-arm64.zip` 并从 `dist/Kun-0.1.0-mac-arm64-unzipped/Kun.app` 启动 packaged app
- `curl http://127.0.0.1:8899/health` 返回 `{"status":"ok","service":"kun","mode":"serve"}`
- packaged `app.asar` 中确认包含 `ds-plain-code-block` 和 `--ds-code-block-bg`

## English

### Changes
- Adds a dedicated `ds-plain-code-block` class for plain-text fenced blocks rendered by Agent Markdown, so directory trees and plain text snippets no longer blend into prose.
- Strengthens the background, border, and inset highlight for native `pre`, highlighted code blocks, and plain-text code blocks.
- Adds theme-level `--ds-code-block-bg` values so code blocks have a distinct surface across light, dark, and ikun themes.
- Extends the `StreamdownCode` test coverage for plain-text fenced blocks.

### Why
Plain-text fenced blocks previously rendered like normal text, which made Agent code blocks hard to identify on dark chat backgrounds.

### Validation
- `npm run test -- src/renderer/src/components/chat/StreamdownCode.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run dist:mac:arm64`
- Unzipped `dist/Kun-0.1.0-mac-arm64.zip` and launched packaged app from `dist/Kun-0.1.0-mac-arm64-unzipped/Kun.app`
- `curl http://127.0.0.1:8899/health` returned `{"status":"ok","service":"kun","mode":"serve"}`
- Confirmed packaged `app.asar` contains `ds-plain-code-block` and `--ds-code-block-bg`
