### PR TITLE
fix(chat): keep composer footer hint on one line

### DIFF
--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -2937,6 +2937,9 @@ pre {
 .ds-composer-footer-hint {
   flex: 0 1 auto;
   min-width: min(160px, 100%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @container (max-width: 640px) {


### PR DESCRIPTION
## Summary

- Keep the composer footer hint on a single line to avoid wrapping `输入 / 打开命令` in narrow layouts.
- Use ellipsis when the hint does not have enough horizontal space.

## 中文说明

- 让 composer 底部提示保持单行，避免 `输入 / 打开命令` 在窄布局下被挤到换行。
- 空间不足时使用省略号截断，避免撑高底栏。

## Validation

- `npm test -- FloatingComposer.test.ts`
- `npm run typecheck`
- `npm run build`
