### PR TITLE
fix(issue-template): separate logs from screenshots

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
-name: Bug report
-description: Report a reproducible bug or regression in Kun
+name: Bug report / 缺陷反馈
+description: Report a reproducible bug or regression in Kun / 反馈 Kun 中可复现的问题或回归
 title: "[Bug] "
 labels:
   - bug
@@ -9,65 +9,85 @@ body:
       value: |
         Thanks for helping us improve Kun.
         Please include enough detail for someone else to reproduce the issue.
+
+        感谢你帮助我们改进 Kun。
+        请提供足够的信息，方便其他人复现这个问题。
   - type: textarea
     id: summary
     attributes:
-      label: Summary
-      description: What happened?
-      placeholder: A concise description of the bug.
+      label: Summary / 问题概述
+      description: What happened? / 发生了什么？
+      placeholder: |
+        A concise description of the bug.
+
+        请简要描述这个问题。
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
-      label: Steps to reproduce
-      description: Share the exact steps we should follow.
+      label: Steps to reproduce / 复现步骤
+      description: Share the exact steps we should follow. / 请提供可复现问题的具体步骤。
       placeholder: |
         1. Open ...
         2. Click ...
         3. See error ...
+
+        1. 打开 ...
+        2. 点击 ...
+        3. 看到错误 ...
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
-      label: Expected behavior
-      placeholder: What did you expect to happen?
+      label: Expected behavior / 期望行为
+      description: What did you expect to happen? / 你期望发生什么？
+      placeholder: |
+        What did you expect to happen?
+
+        请描述你期望看到的正确行为。
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
-      label: Actual behavior
-      placeholder: What actually happened?
+      label: Actual behavior / 实际行为
+      description: What actually happened? Paste screenshots here if they help explain the issue. / 实际发生了什么？如果截图有助于说明问题，请粘贴在这里。
+      placeholder: |
+        What actually happened?
+        Paste screenshots here if they help explain the issue.
+
+        请描述实际发生的情况。
+        如果截图有助于说明问题，请粘贴在这里。
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: Kun version
-      placeholder: e.g. v0.1.0
+      label: Kun version / Kun 版本
+      placeholder: e.g. v0.1.0 / 例如 v0.1.0
     validations:
       required: true
   - type: input
     id: os
     attributes:
-      label: Operating system
-      placeholder: e.g. macOS 15.5, Windows 11, Ubuntu 24.04
+      label: Operating system / 操作系统
+      placeholder: e.g. macOS 15.5, Windows 11, Ubuntu 24.04 / 例如 macOS 15.5、Windows 11、Ubuntu 24.04
     validations:
       required: true
   - type: textarea
     id: logs
     attributes:
-      label: Logs or screenshots
-      description: Paste relevant logs, stack traces, or screenshots if available.
+      label: Logs / 日志
+      description: Paste relevant logs or stack traces here. Do not paste screenshots in this field; screenshots should go in Actual behavior so they render as images. / 请在这里粘贴相关日志或堆栈信息。不要在这里粘贴截图；截图请放到“实际行为”中，这样才能正常渲染为图片。
       render: shell
   - type: checkboxes
     id: terms
     attributes:
-      label: Checklist
+      label: Checklist / 检查清单
       options:
-        - label: I searched existing issues before opening this report.
+        - label: I searched existing issues before opening this report. / 我已经搜索过现有 issue。
           required: true
-        - label: I removed sensitive information from logs and screenshots.
+        - label: I removed sensitive information from logs and screenshots. / 我已经从日志和截图中移除敏感信息。
           required: true


### PR DESCRIPTION
## Summary

- add Chinese and English text to the bug report issue form
- keep screenshots in the Actual behavior field so pasted images render normally
- make the Logs field log-only and keep `render: shell` for stack traces and terminal output

## Why

The previous combined Logs or screenshots textarea used `render: shell`. Screenshots pasted there were rendered inside a code block instead of as images.

## Tests

- `ruby -e "require 'yaml'; YAML.load_file('.github/ISSUE_TEMPLATE/bug_report.yml'); puts 'yaml ok'"`\n- `git diff --check`\n- `git diff --cached --check`