### PR TITLE
feat(write): add document character count in write toolbar

### DIFF
--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -50,6 +50,7 @@ type Props = {
   onBuildPlan?: () => void
   /** Opens/focuses the Plan panel (Open button on the inline card). */
   onOpenPlan?: () => void
+  compactCards?: boolean
 }
 
 const TURN_PAGE_SIZE = 18
@@ -118,7 +119,8 @@ export function MessageTimeline({
   devPreviewCard,
   planActionsBusy,
   onBuildPlan,
-  onOpenPlan
+  onOpenPlan,
+  compactCards = false
 }: Props): ReactElement {
   const { t } = useTranslation('common')
   const {
@@ -322,6 +324,7 @@ export function MessageTimeline({
                 onBuildPlan={onBuildPlan}
                 onOpenPlan={onOpenPlan}
                 viewportRef={containerRef}
+                compactCards={compactCards}
               />
             </div>
           )
@@ -355,6 +358,7 @@ export function MessageTimeline({
             live={live}
             devPreviewCard={devPreviewCard}
             viewportRef={containerRef}
+            compactCards={compactCards}
             durationMs={
               currentTurnUserId && typeof turnStartedAtByUserId[currentTurnUserId] === 'number'
                 ? Math.max(0, tickNow - turnStartedAtByUserId[currentTurnUserId])
@@ -386,7 +390,8 @@ function MessageTurn({
   planActionsBusy,
   onBuildPlan,
   onOpenPlan,
-  viewportRef
+  viewportRef,
+  compactCards = false
 }: {
   turn: Turn
   isProcessing: boolean
@@ -399,6 +404,7 @@ function MessageTurn({
   onBuildPlan?: () => void
   onOpenPlan?: () => void
   viewportRef: RefObject<HTMLDivElement | null>
+  compactCards?: boolean
 }): ReactElement {
   const workspaceRoot = useChatStore((s) => s.workspaceRoot)
   const activeThreadGoal = useChatStore((s) => s.activeThreadGoal)
@@ -513,7 +519,7 @@ function MessageTurn({
       ) : null}
 
       {!isProcessing && turnFileChanges.length > 0 ? (
-        <TurnChangeSummary changes={turnFileChanges} viewportRef={viewportRef} />
+        <TurnChangeSummary changes={turnFileChanges} viewportRef={viewportRef} compact={compactCards} />
       ) : null}
     </div>
   )
@@ -560,5 +566,6 @@ const MemoMessageTurn = memo(MessageTurn, (prev, next) => (
   prev.planActionsBusy === next.planActionsBusy &&
   prev.onBuildPlan === next.onBuildPlan &&
   prev.onOpenPlan === next.onOpenPlan &&
+  prev.compactCards === next.compactCards &&
   prev.viewportRef === next.viewportRef
 ))

--- a/src/renderer/src/components/chat/message-timeline-cards.tsx
+++ b/src/renderer/src/components/chat/message-timeline-cards.tsx
@@ -175,10 +175,12 @@ export function ReviewSummaryCard({ review }: { review: ReviewBlock }): ReactEle
 
 export function TurnChangeSummary({
   changes,
-  viewportRef
+  viewportRef,
+  compact = false
 }: {
   changes: ToolBlock[]
   viewportRef: RefObject<HTMLDivElement | null>
+  compact?: boolean
 }): ReactElement {
   const { t } = useTranslation('common')
   const [expanded, setExpanded] = useState(false)
@@ -211,22 +213,36 @@ export function TurnChangeSummary({
   })
 
   return (
-    <section className="ds-card-strong overflow-hidden rounded-[24px] border border-ds-border shadow-[0_16px_40px_rgba(86,103,136,0.08)]">
+    <section
+      className={`ds-card-strong overflow-hidden border border-ds-border shadow-[0_16px_40px_rgba(86,103,136,0.08)] ${
+        compact ? 'rounded-[20px]' : 'rounded-[24px]'
+      }`}
+    >
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-4 px-5 py-4 text-left transition hover:bg-ds-hover/40"
+        className={`flex w-full items-center text-left transition hover:bg-ds-hover/40 ${
+          compact ? 'gap-3 px-4 py-3' : 'gap-4 px-5 py-4'
+        }`}
       >
-        <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-[16px] bg-ds-card-muted text-ds-muted">
-          <FileEdit className="h-5 w-5" strokeWidth={1.85} />
+        <span
+          className={`flex shrink-0 items-center justify-center bg-ds-card-muted text-ds-muted ${
+            compact ? 'h-10 w-10 rounded-[14px]' : 'h-12 w-12 rounded-[16px]'
+          }`}
+        >
+          <FileEdit className={compact ? 'h-4.5 w-4.5' : 'h-5 w-5'} strokeWidth={1.85} />
         </span>
         <span className="min-w-0 flex-1">
-          <span className="block text-[18px] font-semibold tracking-[-0.02em] text-ds-ink">
+          <span
+            className={`block font-semibold tracking-[-0.02em] text-ds-ink ${
+              compact ? 'text-[15px]' : 'text-[18px]'
+            }`}
+          >
             {title}
           </span>
           {totals ? (
-            <span className="mt-1 block font-mono text-[12px]">
+            <span className={`block font-mono ${compact ? 'mt-0.5 text-[11px]' : 'mt-1 text-[12px]'}`}>
               <span className="text-ds-diff-added">+{totals.added}</span>
               <span className="mx-1.5 text-ds-faint">·</span>
               <span className="text-ds-diff-removed">-{totals.removed}</span>
@@ -244,7 +260,7 @@ export function TurnChangeSummary({
         <div
           ref={deferredBodyRef}
           className="border-t border-ds-border-muted/70"
-          style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 280px' }}
+          style={{ contentVisibility: 'auto', containIntrinsicSize: compact ? 'auto 180px' : 'auto 280px' }}
         >
           {shouldRenderBody
             ? changes.map((change) => {
@@ -258,17 +274,20 @@ export function TurnChangeSummary({
                   type="button"
                   onClick={() => setActiveId(open ? null : change.id)}
                   aria-expanded={open}
-                  className={`flex w-full items-start gap-3 px-5 py-3 text-left transition ${
+                  className={`flex w-full items-start text-left transition ${
                     open ? 'bg-ds-hover/45' : 'hover:bg-ds-hover/35'
-                  }`}
+                  } ${compact ? 'gap-2.5 px-4 py-2.5' : 'gap-3 px-5 py-3'}`}
                 >
                   <span className="min-w-0 flex-1">
-                    <span className="block break-all text-[14px] font-medium text-ds-ink">
+                    <span
+                      className={`block truncate font-medium text-ds-ink ${compact ? 'text-[12px]' : 'text-[13px]'}`}
+                      title={primary}
+                    >
                       {primary}
                     </span>
                   </span>
                   {stats ? (
-                    <span className="shrink-0 font-mono text-[12px] tabular-nums">
+                    <span className={`shrink-0 font-mono tabular-nums ${compact ? 'text-[11px]' : 'text-[12px]'}`}>
                       <span className="text-ds-diff-added">+{stats.added}</span>
                       <span className="ml-1.5 text-ds-diff-removed">-{stats.removed}</span>
                     </span>
@@ -281,11 +300,11 @@ export function TurnChangeSummary({
                 </button>
 
                 {open && change.detail ? (
-                  <div className="bg-ds-card-muted/45 px-4 pb-4 pt-1">
+                  <div className={`bg-ds-card-muted/45 ${compact ? 'px-3 pb-2.5 pt-1' : 'px-4 pb-3 pt-1'}`}>
                     <DiffView
                       patch={change.detail}
                       filePath={change.filePath}
-                      maxHeight={440}
+                      maxHeight={compact ? 148 : 260}
                       className="border border-ds-border-muted/70"
                     />
                   </div>

--- a/src/renderer/src/components/write/WriteAssistantPanel.tsx
+++ b/src/renderer/src/components/write/WriteAssistantPanel.tsx
@@ -196,6 +196,7 @@ export function WriteAssistantPanel({
             onRetryConnection={onRetryConnection}
             onOpenSettings={onOpenSettings}
             onSelectSuggestion={(text) => setInput(text)}
+            compactCards
           />
         ) : (
           <div className="flex min-h-full flex-col justify-end px-5 py-5">

--- a/src/renderer/src/components/write/WriteWorkspaceToolbar.tsx
+++ b/src/renderer/src/components/write/WriteWorkspaceToolbar.tsx
@@ -31,6 +31,7 @@ type Props = {
   activeFileLabel: string
   activeFileName: string
   activeFilePath: string
+  documentStatsLabel: string | null
   assistantOpen: boolean
   exportInFlight: boolean
   exportMenuOpen: boolean
@@ -61,6 +62,7 @@ export function WriteWorkspaceToolbar({
   activeFileLabel,
   activeFileName,
   activeFilePath,
+  documentStatsLabel,
   assistantOpen,
   exportInFlight,
   exportMenuOpen,
@@ -161,8 +163,13 @@ export function WriteWorkspaceToolbar({
               <div className="truncate text-[15px] font-semibold tracking-[-0.01em] text-ds-ink">
                 {activeFileName}
               </div>
-              <div className="mt-1.5 truncate text-[12px] text-ds-faint">
-                {activeFileLabel}
+              <div className="mt-1.5 flex min-w-0 items-center gap-2 text-[12px] text-ds-faint">
+                <span className="truncate">{activeFileLabel}</span>
+                {documentStatsLabel ? (
+                  <span className="shrink-0 rounded-full bg-ds-hover px-2 py-0.5 text-[11px] font-medium text-ds-muted">
+                    {documentStatsLabel}
+                  </span>
+                ) : null}
               </div>
             </div>
           </div>

--- a/src/renderer/src/components/write/WriteWorkspaceView.tsx
+++ b/src/renderer/src/components/write/WriteWorkspaceView.tsx
@@ -54,6 +54,7 @@ import {
   formatSaveLabel,
   inlineAgentPosition,
   isMarkdownFile,
+  computeWriteDocumentStats,
   useDebouncedValue,
   type WriteNotice
 } from './write-workspace-view-utils'
@@ -196,6 +197,8 @@ export function WriteWorkspaceView({
     ? writeRelativeToWorkspace(workspaceRoot, activeFilePath)
     : t('writeNoFileOpen')
   const activeFileName = activeFilePath ? writeBasenameFromPath(activeFilePath) : t('writeStudio')
+  const documentStats = activeFileIsText ? computeWriteDocumentStats(fileContent, isMarkdown) : null
+  const documentStatsLabel = documentStats ? t('writeCharacterCount', { count: documentStats.characterCount }) : null
   const workspacePathLabel = rootDirectory || workspaceRoot
   const workspaceName = workspacePathLabel ? writeBasenameFromPath(workspacePathLabel) : t('writeWorkspace')
   const exportInFlight = exportingFormat !== null
@@ -877,6 +880,7 @@ export function WriteWorkspaceView({
         activeFileLabel={activeFileLabel}
         activeFileName={activeFileName}
         activeFilePath={activeFilePath ?? ''}
+        documentStatsLabel={documentStatsLabel}
         assistantOpen={assistantOpen}
         exportInFlight={exportInFlight}
         exportMenuOpen={exportMenuOpen}

--- a/src/renderer/src/components/write/write-workspace-view-utils.test.ts
+++ b/src/renderer/src/components/write/write-workspace-view-utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { computeWriteDocumentStats } from './write-workspace-view-utils'
+
+describe('computeWriteDocumentStats', () => {
+  it('counts visible markdown text instead of syntax markers', () => {
+    const stats = computeWriteDocumentStats('# 标题\n\n- 第一项\n- 第二项 **加粗**\n', true)
+
+    expect(stats).toEqual({ characterCount: 10 })
+  })
+
+  it('counts non-whitespace characters for plain text files', () => {
+    const stats = computeWriteDocumentStats('Hello world\n  2026  ', false)
+
+    expect(stats).toEqual({ characterCount: 14 })
+  })
+})

--- a/src/renderer/src/components/write/write-workspace-view-utils.ts
+++ b/src/renderer/src/components/write/write-workspace-view-utils.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactElement } from 'react'
 import type { WriteExportFormat } from '@shared/write-export'
 import type { WritePreviewMode, WriteSaveStatus } from '../../write/write-workspace-store'
+import { parseWriteMarkdown } from '../../write/tiptap/markdown-manager'
 
 export const WRITE_AUTOSAVE_MS = 900
 export const WRITE_PREVIEW_DEBOUNCE_MS = 60
@@ -29,6 +30,10 @@ export type WriteNotice = {
   message: string
 }
 
+export type WriteDocumentStats = {
+  characterCount: number
+}
+
 export type WriteModeMenuItem = {
   mode: WritePreviewMode
   label: string
@@ -55,6 +60,33 @@ export function formatSaveLabel(status: WriteSaveStatus, t: (key: string) => str
   if (status === 'dirty') return t('writeUnsaved')
   if (status === 'error') return t('writeSaveError')
   return t('writeSaved')
+}
+
+function collectVisibleText(node: { type?: string; text?: string; content?: unknown[] } | undefined, acc: string[]): string[] {
+  if (!node) return acc
+  if (node.type === 'text' && typeof node.text === 'string') acc.push(node.text)
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) {
+      if (child && typeof child === 'object') {
+        collectVisibleText(child as { type?: string; text?: string; content?: unknown[] }, acc)
+      }
+    }
+  }
+  return acc
+}
+
+function visibleTextFromMarkdown(markdown: string): string {
+  try {
+    return collectVisibleText(parseWriteMarkdown(markdown), []).join('')
+  } catch {
+    return markdown
+  }
+}
+
+export function computeWriteDocumentStats(content: string, isMarkdown: boolean): WriteDocumentStats {
+  const visibleText = isMarkdown ? visibleTextFromMarkdown(content) : content
+  const characterCount = Array.from(visibleText.replace(/\s+/g, '')).length
+  return { characterCount }
 }
 
 export function clamp(value: number, min: number, max: number): number {

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1155,6 +1155,7 @@
   "writeModeEdit": "Editor only",
   "writeModeSplit": "Split preview",
   "writeModePreview": "Preview only",
+  "writeCharacterCount": "{{count}} chars",
   "writePreviewErrorFallback": "Markdown preview failed, showing source text instead.",
   "writeUnsupportedFileType": "Write currently opens only Markdown, TXT, PDF, and common image files.",
   "writeImagePreview": "Image preview",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1155,6 +1155,7 @@
   "writeModeEdit": "仅编辑",
   "writeModeSplit": "分栏预览",
   "writeModePreview": "仅预览",
+  "writeCharacterCount": "字数 {{count}}",
   "writePreviewErrorFallback": "Markdown 预览渲染失败，已临时显示源码文本。",
   "writeUnsupportedFileType": "Write 模式目前只打开 Markdown、TXT、PDF 和常见图片文件。",
   "writeImagePreview": "图片预览",


### PR DESCRIPTION
## Summary
- reapply the write-toolbar document character count from #226 onto current develop
- count visible Markdown text instead of Markdown syntax markers
- keep the compact changed-files card behavior from the original PR

## Verification
- npm test -- src/renderer/src/components/write/write-workspace-view-utils.test.ts
- npm run typecheck
- npm run build

Reapplies #226
Fixes #224
