### PR TITLE
fix(plugins): remove filesystem recommendation

### DIFF
--- a/src/renderer/src/components/PluginMarketplaceView.test.ts
+++ b/src/renderer/src/components/PluginMarketplaceView.test.ts
@@ -5,10 +5,15 @@ import {
   mcpConfigHasServer,
   mcpMarketplaceItemsFromConfigAndDiagnostics,
   mergeMcpJsonConfig,
+  recommendedMarketplaceItemIds,
   skillMarketplaceItemsFromDiscoveredSkills
 } from './PluginMarketplaceView'
 
 describe('PluginMarketplaceView MCP config helpers', () => {
+  it('does not recommend the filesystem MCP server because Kun has built-in file tools', () => {
+    expect(recommendedMarketplaceItemIds()).not.toContain('filesystem')
+  })
+
   it('merges recommended MCP servers into JSON config without dropping existing fields', () => {
     const existing = JSON.stringify({
       timeouts: { read_timeout: 120 },

--- a/src/renderer/src/components/PluginMarketplaceView.tsx
+++ b/src/renderer/src/components/PluginMarketplaceView.tsx
@@ -367,23 +367,6 @@ const RECOMMENDED_ITEMS: MarketplaceItem[] = [
     systemManaged: true
   },
   {
-    id: 'filesystem',
-    kind: 'mcp',
-    titleKey: 'pluginMcpFilesystemTitle',
-    descriptionKey: 'pluginMcpFilesystemDesc',
-    group: 'recommended',
-    mcpConfig: (workspaceRoot) =>
-      buildMcpConfig(
-        'filesystem',
-        'npx',
-        ['-y', '@modelcontextprotocol/server-filesystem', workspaceRoot || '/path/to/project'],
-        {
-          trustScope: 'workspace',
-          trustedWorkspaceRoots: [workspaceRoot || '/path/to/project']
-        }
-      )
-  },
-  {
     id: 'playwright',
     kind: 'mcp',
     titleKey: 'pluginMcpPlaywrightTitle',
@@ -459,6 +442,10 @@ const RECOMMENDED_ITEMS: MarketplaceItem[] = [
       'Use this skill when preparing release notes. Group user-facing changes by outcome, call out migrations or risks, and keep wording concise and scannable.'
   }
 ]
+
+export function recommendedMarketplaceItemIds(): string[] {
+  return RECOMMENDED_ITEMS.map((item) => item.id)
+}
 
 export function PluginMarketplaceView(): ReactElement {
   const { t } = useTranslation('common')

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -518,8 +518,6 @@
   "pluginCustomSkillBody": "Skill instructions for the agent",
   "pluginCustomSkillFallbackBody": "Describe this Skill's workflow, constraints, and expected output here.",
   "pluginAddCustom": "Add custom",
-  "pluginMcpFilesystemTitle": "Filesystem",
-  "pluginMcpFilesystemDesc": "Let the agent read and write files in the selected workspace.",
   "pluginMcpGuiScheduleTitle": "Kun Schedule",
   "pluginMcpGuiScheduleDesc": "Built-in MCP tools for listing, creating, updating, and deleting scheduled tasks.",
   "pluginMcpPlaywrightTitle": "Playwright",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -518,8 +518,6 @@
   "pluginCustomSkillBody": "写给智能体的 Skill 指令",
   "pluginCustomSkillFallbackBody": "在这里补充这个 Skill 的具体工作方式、限制和输出要求。",
   "pluginAddCustom": "添加自定义",
-  "pluginMcpFilesystemTitle": "Filesystem",
-  "pluginMcpFilesystemDesc": "允许智能体读取和写入指定工作区文件。",
   "pluginMcpGuiScheduleTitle": "Kun 定时任务",
   "pluginMcpGuiScheduleDesc": "内置 MCP 工具，用于查看、创建、更新和删除定时任务。",
   "pluginMcpPlaywrightTitle": "Playwright",


### PR DESCRIPTION
## 中文

### 变更
- 从插件市场推荐列表移除 Filesystem MCP server。
- 删除对应的中英文 locale 残留文案。
- 增加回归测试，确保 Filesystem 不再作为推荐项出现。

### 原因
Kun 已经内置 read/write/edit/bash 等本地工具，推荐额外的 filesystem MCP server 会造成重复能力，缺少实际收益。

### 验证
- npm test -- src/renderer/src/components/PluginMarketplaceView.test.ts
- npm run typecheck

## English

### Changes
- Removed the Filesystem MCP server from the plugin marketplace recommendations.
- Removed the unused English and Chinese locale strings.
- Added a regression test to keep Filesystem out of the recommended list.

### Why
Kun already ships built-in read/write/edit/bash local tools, so recommending the filesystem MCP server duplicates existing capability without clear benefit.

### Validation
- npm test -- src/renderer/src/components/PluginMarketplaceView.test.ts
- npm run typecheck