### PR TITLE
fix(kun): keep token economy from rewriting history

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -977,7 +977,9 @@ export class AgentLoop {
     const economyRequest = applyTokenEconomyToRequest(baseRequest, tokenEconomy)
     const request: ModelRequest = {
       ...economyRequest,
-      history: applyRequestHistoryHygiene(economyRequest.history, tokenEconomy.historyHygiene)
+      history: applyRequestHistoryHygiene(economyRequest.history, tokenEconomy.historyHygiene, {
+        currentTurnId: turnId
+      })
     }
     if (tokenEconomy.enabled) {
       await this.recordTokenEconomySavings({

--- a/kun/src/loop/request-history-hygiene.ts
+++ b/kun/src/loop/request-history-hygiene.ts
@@ -24,6 +24,10 @@ export type RequestHistoryHygieneOptions = {
   keepRecentToolResults?: number
 }
 
+export type RequestHistoryHygieneScope = {
+  currentTurnId?: string
+}
+
 const DEFAULT_MAX_TOOL_RESULT_LINES = 320
 const DEFAULT_MAX_TOOL_RESULT_BYTES = 32 * 1024
 const DEFAULT_MAX_TOOL_RESULT_TOKENS = 8_000
@@ -59,16 +63,21 @@ type CompactResult<T> = {
  */
 export function applyRequestHistoryHygiene(
   items: TurnItem[],
-  options: RequestHistoryHygieneOptions = {}
+  options: RequestHistoryHygieneOptions = {},
+  scope: RequestHistoryHygieneScope = {}
 ): TurnItem[] {
   const limits = normalizeOptions(options)
   const pairedToolCallIds = new Set(
     items
-      .filter((item) => item.kind === 'tool_result')
-      .map((item) => item.callId)
+      .flatMap((item) =>
+        shouldCleanItem(item, scope) && item.kind === 'tool_result'
+          ? [item.callId]
+          : []
+      )
   )
   let changed = false
   const next = items.map((item) => {
+    if (!shouldCleanItem(item, scope)) return item
     if (item.kind === 'tool_result') {
       const output = compactToolResultOutput(item.output, limits)
       if (!output.changed) return item
@@ -88,9 +97,13 @@ export function applyRequestHistoryHygiene(
     }
     return item
   })
-  const budgeted = applyCumulativeToolResultBudget(next, limits)
+  const budgeted = applyCumulativeToolResultBudget(next, limits, scope)
   if (budgeted !== next) changed = true
   return changed ? budgeted : items
+}
+
+function shouldCleanItem(item: TurnItem, scope: RequestHistoryHygieneScope): boolean {
+  return !scope.currentTurnId || item.turnId === scope.currentTurnId
 }
 
 /**
@@ -103,14 +116,17 @@ export function applyRequestHistoryHygiene(
  */
 function applyCumulativeToolResultBudget(
   items: TurnItem[],
-  limits: Required<RequestHistoryHygieneOptions>
+  limits: Required<RequestHistoryHygieneOptions>,
+  scope: RequestHistoryHygieneScope
 ): TurnItem[] {
   const budget = limits.maxCumulativeToolResultTokens
   if (budget <= 0) return items
 
   const toolResultIndexes: number[] = []
   for (let index = 0; index < items.length; index += 1) {
-    if (items[index].kind === 'tool_result') toolResultIndexes.push(index)
+    const item = items[index]
+    if (!item) continue
+    if (shouldCleanItem(item, scope) && item.kind === 'tool_result') toolResultIndexes.push(index)
   }
   if (toolResultIndexes.length === 0) return items
 

--- a/kun/src/loop/token-economy.ts
+++ b/kun/src/loop/token-economy.ts
@@ -96,7 +96,7 @@ export function applyTokenEconomyToRequest(
       ? request.tools.map(compactToolSpec)
       : request.tools,
     history: economy.compressToolResults
-      ? request.history.map(compactHistoryItem)
+      ? request.history.map((item) => item.turnId === request.turnId ? compactHistoryItem(item) : item)
       : request.history
   }
 }

--- a/kun/tests/request-history-hygiene.test.ts
+++ b/kun/tests/request-history-hygiene.test.ts
@@ -154,4 +154,39 @@ describe('request history hygiene', () => {
       mime: 'image/png'
     })
   })
+
+  it('leaves previous-turn history untouched when scoped to the current turn', () => {
+    const previousResult = makeToolResultItem({
+      id: 'previous_image_result',
+      threadId: 'thr_1',
+      turnId: 'turn_previous',
+      callId: 'call_previous_read',
+      toolName: 'read',
+      output: { data_base64: 'a'.repeat(2_000), mime: 'image/png' }
+    })
+    const currentResult = makeToolResultItem({
+      id: 'current_image_result',
+      threadId: 'thr_1',
+      turnId: 'turn_current',
+      callId: 'call_current_read',
+      toolName: 'read',
+      output: { data_base64: 'b'.repeat(2_000), mime: 'image/png' }
+    })
+
+    const compacted = applyRequestHistoryHygiene([previousResult, currentResult], {}, {
+      currentTurnId: 'turn_current'
+    })
+    const compactedPrevious = compacted[0]
+    const compactedCurrent = compacted[1]
+
+    expect(compactedPrevious).toBe(previousResult)
+    expect(compactedPrevious?.kind === 'tool_result' ? compactedPrevious.output : {}).toMatchObject({
+      data_base64: 'a'.repeat(2_000),
+      mime: 'image/png'
+    })
+    expect(compactedCurrent?.kind === 'tool_result' ? compactedCurrent.output : {}).toMatchObject({
+      data_base64: expect.stringContaining('omitted base64 data'),
+      mime: 'image/png'
+    })
+  })
 })

--- a/kun/tests/token-economy.test.ts
+++ b/kun/tests/token-economy.test.ts
@@ -33,12 +33,24 @@ describe('token economy', () => {
     expect(output).toContain('./src/App.tsx')
   })
 
-  it('compresses tool descriptions and long tool results only in the model request', () => {
+  it('compresses tool descriptions and current-turn tool results only in the model request', () => {
     const longOutput = Array.from({ length: 500 }, (_, index) =>
       index === 240 ? 'ERROR failed to compile auth middleware' : `noise line ${index}`
     ).join('\n')
-    const originalToolResult = makeToolResultItem({
-      id: 'item_result',
+    const previousToolResult = makeToolResultItem({
+      id: 'item_previous_result',
+      threadId: 'thr_1',
+      turnId: 'turn_previous',
+      callId: 'call_previous_bash',
+      toolName: 'bash',
+      output: {
+        command: 'npm test',
+        output: longOutput,
+        full_output_path: '/tmp/previous-full.log'
+      }
+    })
+    const currentToolResult = makeToolResultItem({
+      id: 'item_current_result',
       threadId: 'thr_1',
       turnId: 'turn_1',
       callId: 'call_bash',
@@ -67,28 +79,43 @@ describe('token economy', () => {
     ]
     original.history = [
       makeToolCallItem({
-        id: 'item_call',
+        id: 'item_previous_call',
+        threadId: 'thr_1',
+        turnId: 'turn_previous',
+        callId: 'call_previous_bash',
+        toolName: 'bash',
+        arguments: { command: 'npm test' }
+      }),
+      previousToolResult,
+      makeToolCallItem({
+        id: 'item_current_call',
         threadId: 'thr_1',
         turnId: 'turn_1',
         callId: 'call_bash',
         toolName: 'bash',
         arguments: { command: 'npm test' }
       }),
-      originalToolResult
+      currentToolResult
     ]
 
     const compacted = applyTokenEconomyToRequest(original, { enabled: true })
-    const result = compacted.history.find((item) => item.kind === 'tool_result')
-    const originalOutput = originalToolResult.kind === 'tool_result'
-      ? originalToolResult.output
+    const previousResult = compacted.history.find((item) =>
+      item.kind === 'tool_result' && item.callId === 'call_previous_bash')
+    const currentResult = compacted.history.find((item) =>
+      item.kind === 'tool_result' && item.callId === 'call_bash')
+    const currentOutput = currentToolResult.kind === 'tool_result'
+      ? currentToolResult.output
       : {}
 
     expect(compacted.contextInstructions).toContain(TOKEN_ECONOMY_INSTRUCTION)
     expect(compacted.tools[0]?.description).not.toContain('Please')
     expect(JSON.stringify(compacted.tools[0]?.inputSchema)).not.toContain('The path')
-    expect(result?.kind === 'tool_result' ? JSON.stringify(result.output).length : 0)
-      .toBeLessThan(JSON.stringify(originalOutput).length)
-    expect(JSON.stringify(originalOutput)).toContain('noise line 499')
+    expect(previousResult).toBe(previousToolResult)
+    expect(previousResult?.kind === 'tool_result' ? JSON.stringify(previousResult.output) : '')
+      .toContain('noise line 499')
+    expect(currentResult?.kind === 'tool_result' ? JSON.stringify(currentResult.output).length : 0)
+      .toBeLessThan(JSON.stringify(currentOutput).length)
+    expect(JSON.stringify(currentOutput)).toContain('noise line 499')
   })
 
   it('returns the original request when disabled', () => {


### PR DESCRIPTION
## 中文

### 变更
- 将 token economy 的 tool result 压缩限制到当前 turn，避免改写旧历史。
- 为 request history hygiene 增加 currentTurnId scope，并在 agent loop 中传入当前 turn。
- 补充测试覆盖旧 turn 历史保持原样、当前 turn 仍可被压缩。

### 原因
历史记录压缩如果每轮改写旧 tool result，会让已进入请求历史的前缀不再稳定，破坏 provider prompt cache 命中。这个 PR 只修复历史压缩作用域，不包含 Read 工具多模态注入修复。

### 验证
- npm --prefix kun test -- token-economy.test.ts request-history-hygiene.test.ts
- npm --prefix kun test -- loop.test.ts -t "uses compact tool history for model requests without mutating persisted results|bounds tool history for model requests even when token economy is disabled"
- npm --prefix kun run build

## English

### Changes
- Limit token economy tool-result compression to the current turn.
- Add a currentTurnId scope to request history hygiene and pass it from the agent loop.
- Add tests that keep previous-turn history unchanged while still allowing current-turn compression.

### Why
Rewriting historical tool results changes the stable request prefix between turns and can invalidate provider prompt-cache hits. This PR only fixes the history-compression scope and intentionally excludes the multimodal Read tool fix.

### Validation
- npm --prefix kun test -- token-economy.test.ts request-history-hygiene.test.ts
- npm --prefix kun test -- loop.test.ts -t "uses compact tool history for model requests without mutating persisted results|bounds tool history for model requests even when token economy is disabled"
- npm --prefix kun run build