### PR TITLE
feat(lsp): add lsp AI tool for code navigation (TS/JS)

### DIFF
--- a/kun/src/adapters/tool/builtin-lsp-tool.ts
+++ b/kun/src/adapters/tool/builtin-lsp-tool.ts
@@ -1,0 +1,281 @@
+/**
+ * `lsp` tool — exposes Language Server Protocol queries to the AI agent.
+ *
+ * Currently supports TypeScript / JavaScript via typescript-language-server.
+ * The server binary must be installed (locally or on PATH); if missing the
+ * tool returns a helpful error instead of crashing.
+ *
+ * Operations: goToDefinition, findReferences, hover, documentSymbol,
+ * workspaceSymbol, goToImplementation. All queries are read-only.
+ *
+ * Positions use 1-based line/character (as editors display them); the tool
+ * converts to 0-based before sending to the LSP server.
+ */
+
+import { readFile } from 'node:fs/promises'
+import { LocalToolHost, type LocalTool } from './local-tool-host.js'
+import { resolveWorkspacePath, withToolBoundary } from './builtin-tool-utils.js'
+import {
+  acquireLspSession,
+  lspCloseDocument,
+  lspDefinition,
+  lspDocumentSymbol,
+  lspHover,
+  lspImplementation,
+  lspOpenDocument,
+  lspReferences,
+  releaseLspSession,
+  lspWorkspaceSymbol,
+  type LspSession
+} from './lsp-client.js'
+
+type LspOperation =
+  | 'goToDefinition'
+  | 'findReferences'
+  | 'hover'
+  | 'documentSymbol'
+  | 'workspaceSymbol'
+  | 'goToImplementation'
+
+const OPERATIONS: LspOperation[] = [
+  'goToDefinition',
+  'findReferences',
+  'hover',
+  'documentSymbol',
+  'workspaceSymbol',
+  'goToImplementation'
+]
+
+const POSITION_REQUIRED: LspOperation[] = [
+  'goToDefinition',
+  'findReferences',
+  'hover',
+  'goToImplementation'
+]
+
+export function createLspLocalTool(): LocalTool {
+  return LocalToolHost.defineTool({
+    name: 'lsp',
+    description:
+      'Query a language server (TypeScript/JavaScript via typescript-language-server). ' +
+      'Supports: goToDefinition, findReferences, hover, documentSymbol, workspaceSymbol, goToImplementation. ' +
+      'Positions are 1-based (line/character as shown in editors). ' +
+      'Requires typescript-language-server to be installed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operation: {
+          type: 'string',
+          enum: OPERATIONS,
+          description: 'The LSP operation to perform'
+        },
+        filePath: {
+          type: 'string',
+          description: 'Absolute or workspace-relative path to the source file'
+        },
+        line: {
+          type: 'number',
+          description: 'Line number (1-based). Required for position-based operations.'
+        },
+        character: {
+          type: 'number',
+          description: 'Character offset (1-based). Required for position-based operations.'
+        },
+        query: {
+          type: 'string',
+          description: 'Search query (used by workspaceSymbol)'
+        }
+      },
+      required: ['operation', 'filePath'],
+      additionalProperties: false
+    },
+    policy: 'auto',
+    toolKind: 'tool_call',
+    execute: async (args, context) =>
+      withToolBoundary(async () => {
+        const operation = String(args.operation ?? '') as LspOperation
+        const rawPath = typeof args.filePath === 'string' ? args.filePath : ''
+        if (!rawPath.trim()) {
+          return { output: { error: 'filePath is required' }, isError: true }
+        }
+        if (!OPERATIONS.includes(operation)) {
+          return { output: { error: `Unknown operation: ${operation}` }, isError: true }
+        }
+
+        const { absolutePath, workspaceRoot } = resolveWorkspacePath(rawPath, context)
+
+        const line = typeof args.line === 'number' ? args.line : 0
+        const character = typeof args.character === 'number' ? args.character : 0
+        if (POSITION_REQUIRED.includes(operation) && (line < 1 || character < 1)) {
+          return {
+            output: { error: `${operation} requires both line and character (1-based)` },
+            isError: true
+          }
+        }
+
+        // LSP uses 0-based positions.
+        const lspLine = Math.max(0, line - 1)
+        const lspChar = Math.max(0, character - 1)
+
+        let session: LspSession
+        try {
+          session = await acquireLspSession(workspaceRoot)
+        } catch (err) {
+          return {
+            output: {
+              error: err instanceof Error ? err.message : String(err),
+              hint: 'Install with: npm install -g typescript-language-server typescript'
+            },
+            isError: true
+          }
+        }
+
+        // For file-level operations, open the document first so the server has it in memory.
+        const needsDocument = operation !== 'workspaceSymbol'
+        if (needsDocument) {
+          try {
+            const content = await readFile(absolutePath, 'utf-8')
+            await lspOpenDocument(session, absolutePath, content)
+          } catch {
+            return {
+              output: { error: `Could not read file: ${absolutePath}` },
+              isError: true
+            }
+          }
+        }
+
+        try {
+          let result: unknown
+          switch (operation) {
+            case 'goToDefinition':
+              result = await lspDefinition(session, absolutePath, lspLine, lspChar)
+              break
+            case 'findReferences':
+              result = await lspReferences(session, absolutePath, lspLine, lspChar)
+              break
+            case 'hover':
+              result = await lspHover(session, absolutePath, lspLine, lspChar)
+              break
+            case 'documentSymbol':
+              result = await lspDocumentSymbol(session, absolutePath)
+              break
+            case 'workspaceSymbol':
+              result = await lspWorkspaceSymbol(session, String(args.query ?? ''))
+              break
+            case 'goToImplementation':
+              result = await lspImplementation(session, absolutePath, lspLine, lspChar)
+              break
+            default:
+              return { output: { error: `Unsupported operation: ${operation}` }, isError: true }
+          }
+          return { output: { operation, result: simplifyResult(result) } }
+        } catch (err) {
+          return {
+            output: { error: err instanceof Error ? err.message : String(err) },
+            isError: true
+          }
+        } finally {
+          if (needsDocument) {
+            try { await lspCloseDocument(session, absolutePath) } catch { /* ignore */ }
+          }
+          releaseLspSession(workspaceRoot)
+        }
+      })
+  })
+}
+
+/**
+ * Strip file:// URIs to plain paths and slim down verbose LSP types so the
+ * output is compact enough to fit in the agent's context window.
+ */
+function simplifyResult(result: unknown): unknown {
+  if (result === null || result === undefined) return null
+  if (Array.isArray(result)) return result.map(simplifyLocation)
+  return simplifyLocation(result)
+}
+
+function simplifyLocation(item: unknown): unknown {
+  if (item === null || typeof item !== 'object') return item
+  const obj = item as Record<string, unknown>
+  // Location: { uri, range }
+  if (typeof obj.uri === 'string') {
+    return {
+      path: uriToPath(obj.uri),
+      range: simplifyRange(obj.range),
+      ...(obj.name ? { name: obj.name } : {}),
+      ...(obj.kind ? { kind: obj.kind } : {}),
+      ...(obj.containerName ? { containerName: obj.containerName } : {})
+    }
+  }
+  // Hover: { contents }
+  if (obj.contents) {
+    return { contents: simplifyHoverContents(obj.contents), range: simplifyRange(obj.range) }
+  }
+  // DocumentSymbol / SymbolInformation
+  if (obj.name && (obj.kind !== undefined || obj.location !== undefined)) {
+    return {
+      name: obj.name,
+      kind: symbolKindName(obj.kind),
+      ...(obj.detail ? { detail: obj.detail } : {}),
+      ...(obj.range ? { range: simplifyRange(obj.range) } : {}),
+      ...(obj.selectionRange ? { selectionRange: simplifyRange(obj.selectionRange) } : {}),
+      ...(obj.containerName ? { containerName: obj.containerName } : {}),
+      ...(obj.location ? { path: uriToPath((obj.location as Record<string, unknown>).uri as string) } : {})
+    }
+  }
+  return obj
+}
+
+function simplifyRange(range: unknown): unknown {
+  if (!range || typeof range !== 'object') return range
+  const r = range as Record<string, unknown>
+  return {
+    start: pos(r.start),
+    end: pos(r.end)
+  }
+}
+
+function pos(p: unknown): unknown {
+  if (!p || typeof p !== 'object') return p
+  const point = p as Record<string, unknown>
+  // Convert back to 1-based for display.
+  return {
+    line: (typeof point.line === 'number' ? point.line : 0) + 1,
+    character: (typeof point.character === 'number' ? point.character : 0) + 1
+  }
+}
+
+function simplifyHoverContents(contents: unknown): string {
+  if (typeof contents === 'string') return contents
+  if (Array.isArray(contents)) {
+    return contents.map(simplifyHoverContents).join('\n\n')
+  }
+  if (contents && typeof contents === 'object') {
+    const c = contents as Record<string, unknown>
+    if (typeof c.value === 'string') return c.value
+  }
+  return String(contents)
+}
+
+function uriToPath(uri: unknown): string {
+  if (typeof uri !== 'string') return ''
+  try {
+    return new URL(uri).pathname
+  } catch {
+    return uri
+  }
+}
+
+const SYMBOL_KINDS: Record<number, string> = {
+  1: 'File', 2: 'Module', 3: 'Namespace', 4: 'Package', 5: 'Class',
+  6: 'Method', 7: 'Property', 8: 'Field', 9: 'Constructor', 10: 'Enum',
+  11: 'Interface', 12: 'Function', 13: 'Variable', 14: 'Constant', 15: 'String',
+  16: 'Number', 17: 'Boolean', 18: 'Array', 19: 'Object', 20: 'Key',
+  21: 'Null', 22: 'EnumMember', 23: 'Struct', 24: 'Event', 25: 'Operator',
+  26: 'TypeParameter'
+}
+
+function symbolKindName(kind: unknown): string {
+  const k = typeof kind === 'number' ? kind : Number(kind)
+  return SYMBOL_KINDS[k] ?? String(kind)
+}

--- a/kun/src/adapters/tool/builtin-tools.ts
+++ b/kun/src/adapters/tool/builtin-tools.ts
@@ -7,6 +7,7 @@ import type {
 } from './builtin-tool-types.js'
 import { createBashLocalTool } from './builtin-bash-tool.js'
 import { createEditLocalTool, createWriteLocalTool } from './builtin-file-tools.js'
+import { createLspLocalTool } from './builtin-lsp-tool.js'
 import { createReadLocalTool } from './builtin-read-tool.js'
 import { createFindLocalTool, createGrepLocalTool, createLsLocalTool } from './builtin-search-tools.js'
 
@@ -55,7 +56,8 @@ export function buildBuiltinLocalTools(options: BuiltinLocalToolsOptions = {}): 
     createWriteLocalTool(options.write),
     createGrepLocalTool(options.grep),
     createFindLocalTool(options.find),
-    createLsLocalTool(options.ls)
+    createLsLocalTool(options.ls),
+    createLspLocalTool()
   ]
 }
 

--- a/kun/src/adapters/tool/lsp-client.ts
+++ b/kun/src/adapters/tool/lsp-client.ts
@@ -35,8 +35,15 @@ interface LspSession {
   initPromise: Promise<void> | null
 }
 
-/** Map<workspaceRoot, LspSession> */
-const sessions = new Map<string, LspSession>()
+/**
+ * Map<workspaceRoot, Promise<LspSession>>.
+ * Storing the Promise (not the resolved session) prevents a race where two
+ * concurrent acquireLspSession calls both see sessions.get() === undefined
+ * and each spawns their own server. The first caller writes its Promise
+ * into the map before awaiting anything; the second caller awaits the same
+ * Promise.
+ */
+const sessions = new Map<string, Promise<LspSession>>()
 
 /**
  * Check whether a language server binary is available on PATH.
@@ -199,10 +206,14 @@ function sendNotification(session: LspSession, method: string, params: Record<st
  * Acquire (or reuse) an LSP session for the given workspace.
  * The returned session is initialized and ready for requests.
  * Caller MUST call releaseLspSession when done.
+ *
+ * Race-safe: the in-flight Promise is written to the sessions map before
+ * any await, so concurrent callers get the same session.
  */
 export async function acquireLspSession(workspaceRoot: string): Promise<LspSession> {
-  let session = sessions.get(workspaceRoot)
-  if (session) {
+  const existing = sessions.get(workspaceRoot)
+  if (existing) {
+    const session = await existing
     if (session.cleanupTimer) {
       clearTimeout(session.cleanupTimer)
       session.cleanupTimer = null
@@ -212,6 +223,21 @@ export async function acquireLspSession(workspaceRoot: string): Promise<LspSessi
     return session
   }
 
+  // Write the Promise immediately to prevent concurrent spawns.
+  const sessionPromise = createSession(workspaceRoot)
+  sessions.set(workspaceRoot, sessionPromise)
+
+  try {
+    const session = await sessionPromise
+    return session
+  } catch (err) {
+    // If spawn/init fails, remove the placeholder so the next call can retry.
+    sessions.delete(workspaceRoot)
+    throw err
+  }
+}
+
+async function createSession(workspaceRoot: string): Promise<LspSession> {
   const cmd = await resolveTsLsCommand(workspaceRoot)
   if (!cmd) {
     throw new Error(
@@ -226,7 +252,7 @@ export async function acquireLspSession(workspaceRoot: string): Promise<LspSessi
     windowsHide: true
   })
 
-  session = {
+  const session: LspSession = {
     process: proc,
     workspaceRoot,
     refCount: 1,
@@ -239,39 +265,62 @@ export async function acquireLspSession(workspaceRoot: string): Promise<LspSessi
   }
 
   proc.stdout?.on('data', (chunk: Buffer) => {
-    session!.stdoutBuffer += chunk.toString('utf-8')
-    processBuffer(session!)
+    session.stdoutBuffer += chunk.toString('utf-8')
+    processBuffer(session)
   })
 
   proc.on('error', (err) => {
+    // Kill + reject pending rather than throwing (throw in an event handler
+    // becomes an uncaught exception).
+    killSession(session)
     sessions.delete(workspaceRoot)
-    throw new Error(`Failed to start language server: ${err.message}`)
+    void err
   })
 
   proc.on('exit', () => {
-    const s = sessions.get(workspaceRoot)
-    if (s === session) sessions.delete(workspaceRoot)
+    // Reject all pending requests so callers don't hang for 30s.
+    killSession(session)
+    sessions.delete(workspaceRoot)
   })
 
-  sessions.set(workspaceRoot, session)
   await initialize(session)
   return session
 }
 
-export function releaseLspSession(workspaceRoot: string): void {
-  const session = sessions.get(workspaceRoot)
-  if (!session) return
-  session.refCount -= 1
-  if (session.refCount <= 0) {
-    session.cleanupTimer = setTimeout(() => {
-      const s = sessions.get(workspaceRoot)
-      if (s && s.refCount <= 0) {
-        killSession(s)
-        sessions.delete(workspaceRoot)
-      }
-    }, CLEANUP_DELAY)
+/**
+ * Kill all active LSP sessions. Should be called on app quit / process exit
+ * to prevent orphaned language-server processes.
+ */
+export function shutdownAllLspSessions(): void {
+  for (const [workspaceRoot, sessionPromise] of sessions) {
+    sessions.delete(workspaceRoot)
+    sessionPromise
+      .then((session) => killSession(session))
+      .catch(() => { /* session failed to init — nothing to kill */ })
   }
 }
+
+export function releaseLspSession(workspaceRoot: string): void {
+  const sessionPromise = sessions.get(workspaceRoot)
+  if (!sessionPromise) return
+  sessionPromise
+    .then((session) => {
+      session.refCount -= 1
+      if (session.refCount <= 0) {
+        session.cleanupTimer = setTimeout(() => {
+          const sp = sessions.get(workspaceRoot)
+          if (!sp) return
+          sp.then((s) => {
+            if (s.refCount <= 0) {
+              killSession(s)
+              sessions.delete(workspaceRoot)
+            }
+          }).catch(() => { /* ignore */ })
+        }, CLEANUP_DELAY)
+      }
+    })
+    .catch(() => { /* session failed to init — nothing to release */ })
+  }
 
 // --- LSP operations ---
 
@@ -362,5 +411,24 @@ export async function lspDocumentSymbol(session: LspSession, filePath: string): 
 export async function lspWorkspaceSymbol(session: LspSession, query: string): Promise<unknown> {
   return sendRequest(session, 'workspace/symbol', { query })
 }
+
+/**
+ * Synchronous last-resort cleanup on process exit. The exit handler can only
+ * run synchronous code, so we SIGKILL immediately (no grace period). This
+ * prevents orphaned typescript-language-server / tsserver processes when the
+ * host process (Electron / kun serve) terminates.
+ */
+function syncKillAll(): void {
+  for (const [, sessionPromise] of sessions) {
+    sessionPromise
+      .then((session) => {
+        try { session.process.kill('SIGKILL') } catch { /* already dead */ }
+      })
+      .catch(() => { /* init failed — no process to kill */ })
+  }
+  sessions.clear()
+}
+
+process.on('exit', syncKillAll)
 
 export type { LspSession }

--- a/kun/src/adapters/tool/lsp-client.ts
+++ b/kun/src/adapters/tool/lsp-client.ts
@@ -1,0 +1,366 @@
+/**
+ * Minimal LSP client for the `lsp` AI tool.
+ *
+ * Speaks JSON-RPC 2.0 over stdio to a language server process (currently
+ * typescript-language-server). Implements only what the tool needs:
+ * initialize, textDocument/didOpen, and a handful of textDocument/ and
+ * workspace/ requests. No subscriptions, no diagnostics, no completion —
+ * this is a query-only client, not a full editor integration.
+ *
+ * Sessions are keyed by workspace root and reference-counted; when the last
+ * caller releases, the server is kept alive briefly (CLEANUP_DELAY) before
+ * being killed, so back-to-back tool calls don't respawn the server.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { pathToFileURL } from 'node:url'
+
+const CLEANUP_DELAY = 30_000
+const REQUEST_TIMEOUT = 30_000
+const SERVER_PROBE_TIMEOUT = 3_000
+
+interface LspSession {
+  process: ChildProcess
+  workspaceRoot: string
+  refCount: number
+  cleanupTimer: NodeJS.Timeout | null
+  /** Sequential buffer for stdout framing. */
+  stdoutBuffer: string
+  /** Pending JSON-RPC requests awaiting a response, keyed by id. */
+  pending: Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout }>
+  /** Monotonic request id counter. */
+  nextId: number
+  initialized: boolean
+  initPromise: Promise<void> | null
+}
+
+/** Map<workspaceRoot, LspSession> */
+const sessions = new Map<string, LspSession>()
+
+/**
+ * Check whether a language server binary is available on PATH.
+ * Returns the binary name if found, null otherwise.
+ */
+async function probeServerBinary(binary: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn('which', [binary], { stdio: ['ignore', 'pipe', 'ignore'], timeout: SERVER_PROBE_TIMEOUT })
+    let stdout = ''
+    child.stdout?.on('data', (chunk) => { stdout += chunk })
+    child.on('error', () => resolve(null))
+    child.on('close', (code) => {
+      resolve(code === 0 && stdout.trim() ? stdout.trim() : null)
+    })
+  })
+}
+
+/**
+ * Resolve the typescript-language-server binary.
+ * Returns the spawn command + args, or null if not available.
+ */
+export async function resolveTsLsCommand(workspaceRoot: string): Promise<{ command: string; args: string[] } | null> {
+  // Prefer a project-local install.
+  const localPath = `${workspaceRoot}/node_modules/.bin/typescript-language-server`
+  try {
+    const { access } = await import('node:fs/promises')
+    await access(localPath)
+    return { command: localPath, args: ['--stdio'] }
+  } catch {
+    // fall through to PATH lookup
+  }
+  const found = await probeServerBinary('typescript-language-server')
+  if (found) return { command: 'typescript-language-server', args: ['--stdio'] }
+  return null
+}
+
+function killSession(session: LspSession): void {
+  if (session.cleanupTimer) {
+    clearTimeout(session.cleanupTimer)
+    session.cleanupTimer = null
+  }
+  for (const [id, entry] of session.pending) {
+    clearTimeout(entry.timer)
+    entry.reject(new Error('LSP session closed'))
+    session.pending.delete(id)
+  }
+  try {
+    session.process.kill('SIGTERM')
+  } catch {
+    // already dead
+  }
+  // Force-kill after grace period.
+  setTimeout(() => {
+    try { session.process.kill('SIGKILL') } catch { /* ignore */ }
+  }, 2_000)
+}
+
+function sendMessage(session: LspSession, message: Record<string, unknown>): void {
+  const body = JSON.stringify(message)
+  const chunk = `Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`
+  session.process.stdin?.write(chunk)
+}
+
+function handleResponse(session: LspSession, msg: Record<string, unknown>): void {
+  const id = String(msg.id ?? '')
+  const entry = session.pending.get(id)
+  if (!entry) return
+  clearTimeout(entry.timer)
+  session.pending.delete(id)
+  if (msg.error) {
+    entry.reject(new Error(typeof msg.error === 'object' && msg.error !== null && 'message' in msg.error
+      ? String((msg.error as { message: unknown }).message)
+      : 'LSP request failed'))
+  } else {
+    entry.resolve(msg.result)
+  }
+}
+
+function processBuffer(session: LspSession): void {
+  while (true) {
+    const headerEnd = session.stdoutBuffer.indexOf('\r\n\r\n')
+    if (headerEnd === -1) return
+    const header = session.stdoutBuffer.slice(0, headerEnd)
+    const lengthMatch = header.match(/Content-Length:\s*(\d+)/i)
+    if (!lengthMatch) {
+      // Malformed; drop the header to resync.
+      session.stdoutBuffer = session.stdoutBuffer.slice(headerEnd + 4)
+      continue
+    }
+    const contentLength = Number(lengthMatch[1])
+    const bodyStart = headerEnd + 4
+    if (session.stdoutBuffer.length < bodyStart + contentLength) return // incomplete
+    const body = session.stdoutBuffer.slice(bodyStart, bodyStart + contentLength)
+    session.stdoutBuffer = session.stdoutBuffer.slice(bodyStart + contentLength)
+    try {
+      const msg = JSON.parse(body) as Record<string, unknown>
+      if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+        handleResponse(session, msg)
+      }
+      // Notifications (no id) are ignored — this client doesn't subscribe to anything.
+    } catch {
+      // Malformed JSON; skip.
+    }
+  }
+}
+
+async function initialize(session: LspSession): Promise<void> {
+  if (session.initialized) return
+  if (session.initPromise) return session.initPromise
+
+  session.initPromise = (async () => {
+    const initResult = await sendRequest(session, 'initialize', {
+      processId: process.pid,
+      rootUri: pathToFileURL(session.workspaceRoot).href,
+      capabilities: {
+        textDocument: {
+          synchronization: { didOpen: true, didChange: false, willSave: false },
+          hover: { contentFormat: ['markdown', 'plaintext'] },
+          definition: { linkSupport: false },
+          references: {},
+          documentSymbol: { hierarchicalDocumentSymbolSupport: false },
+          implementation: {},
+          callHierarchy: { dynamicRegistration: false }
+        },
+        workspace: {
+          symbol: {}
+        }
+      },
+      workspaceFolders: null
+    }).catch((err) => {
+      throw new Error(`LSP initialize failed: ${err instanceof Error ? err.message : String(err)}`)
+    })
+
+    // ts_ls / typescript-language-server: pull out tsserver path from init result if present.
+    void initResult
+    sendNotification(session, 'initialized', {})
+    session.initialized = true
+  })()
+
+  return session.initPromise
+}
+
+function sendRequest(session: LspSession, method: string, params: Record<string, unknown> | null): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const id = String(session.nextId++)
+    const timer = setTimeout(() => {
+      session.pending.delete(id)
+      reject(new Error(`LSP request "${method}" timed out after ${REQUEST_TIMEOUT}ms`))
+    }, REQUEST_TIMEOUT)
+    session.pending.set(id, { resolve, reject, timer })
+    sendMessage(session, { jsonrpc: '2.0', id, method, params: params ?? {} })
+  })
+}
+
+function sendNotification(session: LspSession, method: string, params: Record<string, unknown>): void {
+  sendMessage(session, { jsonrpc: '2.0', method, params })
+}
+
+/**
+ * Acquire (or reuse) an LSP session for the given workspace.
+ * The returned session is initialized and ready for requests.
+ * Caller MUST call releaseLspSession when done.
+ */
+export async function acquireLspSession(workspaceRoot: string): Promise<LspSession> {
+  let session = sessions.get(workspaceRoot)
+  if (session) {
+    if (session.cleanupTimer) {
+      clearTimeout(session.cleanupTimer)
+      session.cleanupTimer = null
+    }
+    session.refCount += 1
+    await initialize(session)
+    return session
+  }
+
+  const cmd = await resolveTsLsCommand(workspaceRoot)
+  if (!cmd) {
+    throw new Error(
+      'typescript-language-server is not installed. Install it with `npm install -g typescript-language-server typescript` and try again.'
+    )
+  }
+
+  const proc = spawn(cmd.command, cmd.args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    cwd: workspaceRoot,
+    env: process.env,
+    windowsHide: true
+  })
+
+  session = {
+    process: proc,
+    workspaceRoot,
+    refCount: 1,
+    cleanupTimer: null,
+    stdoutBuffer: '',
+    pending: new Map(),
+    nextId: 1,
+    initialized: false,
+    initPromise: null
+  }
+
+  proc.stdout?.on('data', (chunk: Buffer) => {
+    session!.stdoutBuffer += chunk.toString('utf-8')
+    processBuffer(session!)
+  })
+
+  proc.on('error', (err) => {
+    sessions.delete(workspaceRoot)
+    throw new Error(`Failed to start language server: ${err.message}`)
+  })
+
+  proc.on('exit', () => {
+    const s = sessions.get(workspaceRoot)
+    if (s === session) sessions.delete(workspaceRoot)
+  })
+
+  sessions.set(workspaceRoot, session)
+  await initialize(session)
+  return session
+}
+
+export function releaseLspSession(workspaceRoot: string): void {
+  const session = sessions.get(workspaceRoot)
+  if (!session) return
+  session.refCount -= 1
+  if (session.refCount <= 0) {
+    session.cleanupTimer = setTimeout(() => {
+      const s = sessions.get(workspaceRoot)
+      if (s && s.refCount <= 0) {
+        killSession(s)
+        sessions.delete(workspaceRoot)
+      }
+    }, CLEANUP_DELAY)
+  }
+}
+
+// --- LSP operations ---
+
+function filePathToUri(filePath: string): string {
+  return pathToFileURL(filePath).href
+}
+
+function languageIdForFile(filePath: string): string {
+  if (filePath.endsWith('.ts')) return 'typescript'
+  if (filePath.endsWith('.tsx')) return 'typescriptreact'
+  if (filePath.endsWith('.js')) return 'javascript'
+  if (filePath.endsWith('.jsx')) return 'javascriptreact'
+  return 'typescript'
+}
+
+export async function lspOpenDocument(session: LspSession, filePath: string, content: string): Promise<void> {
+  sendNotification(session, 'textDocument/didOpen', {
+    textDocument: {
+      uri: filePathToUri(filePath),
+      languageId: languageIdForFile(filePath),
+      version: 1,
+      text: content
+    }
+  })
+}
+
+export async function lspCloseDocument(session: LspSession, filePath: string): Promise<void> {
+  sendNotification(session, 'textDocument/didClose', {
+    textDocument: { uri: filePathToUri(filePath) }
+  })
+}
+
+export async function lspDefinition(
+  session: LspSession,
+  filePath: string,
+  line: number,
+  character: number
+): Promise<unknown> {
+  return sendRequest(session, 'textDocument/definition', {
+    textDocument: { uri: filePathToUri(filePath) },
+    position: { line, character }
+  })
+}
+
+export async function lspReferences(
+  session: LspSession,
+  filePath: string,
+  line: number,
+  character: number
+): Promise<unknown> {
+  return sendRequest(session, 'textDocument/references', {
+    textDocument: { uri: filePathToUri(filePath) },
+    position: { line, character },
+    context: { includeDeclaration: true }
+  })
+}
+
+export async function lspHover(
+  session: LspSession,
+  filePath: string,
+  line: number,
+  character: number
+): Promise<unknown> {
+  return sendRequest(session, 'textDocument/hover', {
+    textDocument: { uri: filePathToUri(filePath) },
+    position: { line, character }
+  })
+}
+
+export async function lspImplementation(
+  session: LspSession,
+  filePath: string,
+  line: number,
+  character: number
+): Promise<unknown> {
+  return sendRequest(session, 'textDocument/implementation', {
+    textDocument: { uri: filePathToUri(filePath) },
+    position: { line, character }
+  })
+}
+
+export async function lspDocumentSymbol(session: LspSession, filePath: string): Promise<unknown> {
+  return sendRequest(session, 'textDocument/documentSymbol', {
+    textDocument: { uri: filePathToUri(filePath) }
+  })
+}
+
+export async function lspWorkspaceSymbol(session: LspSession, query: string): Promise<unknown> {
+  return sendRequest(session, 'workspace/symbol', { query })
+}
+
+export type { LspSession }


### PR DESCRIPTION
## Summary

Adds an **`lsp` AI tool** that lets the agent query a language server for code navigation. Currently supports **TypeScript / JavaScript** via `typescript-language-server`. This is the AI-tool-only version (no editor integration); a follow-up can add it to the Monaco/CodeMirror editor once that lands.

### Supported operations

| Operation | Input | Returns |
|-----------|-------|---------|
| `goToDefinition` | filePath, line, character | Location[] |
| `findReferences` | filePath, line, character | Location[] |
| `hover` | filePath, line, character | Hover (type info / docs) |
| `documentSymbol` | filePath | Symbols in file |
| `workspaceSymbol` | query | Symbols across project |
| `goToImplementation` | filePath, line, character | Location[] |

Positions are **1-based** (as editors display them); the tool converts to 0-based internally and back to 1-based in output.

### Architecture

```
Agent calls `lsp` tool
  → builtin-lsp-tool.ts (LocalTool definition)
    → lsp-client.ts (JSON-RPC 2.0 over stdio)
      → spawn('typescript-language-server', ['--stdio'])
```

**No external LSP client library** (`vscode-languageserver-protocol` / `vscode-jsonrpc`). The client implements minimal Content-Length framing and request/response matching in ~200 lines — this avoids adding a new dependency to `kun/` and keeps the PR self-contained.

### Files

| File | Lines | Description |
|------|-------|-------------|
| `kun/src/adapters/tool/lsp-client.ts` | ~330 | Session management (reference-counted per workspace, 30s idle cleanup), JSON-RPC framing, initialize handshake, didOpen/didClose, 6 query methods |
| `kun/src/adapters/tool/builtin-lsp-tool.ts` | ~270 | LocalTool definition: hand-written JSON Schema (Kun convention), position conversion, result simplification (file:// → path, symbol kind numbers → names) |
| `kun/src/adapters/tool/builtin-tools.ts` | +2 | Register in `buildBuiltinLocalTools()` |

### Key design decisions

1. **No new `kun/` dependency.** JSON-RPC framing is hand-rolled (~100 lines) rather than pulling in `vscode-languageserver-protocol`. The framing logic is straightforward (Content-Length header + body) and has no edge cases for the query-only operations we support.
2. **Reference-counted sessions.** Like the bash tool's session map, LSP servers are keyed by workspace root and kept alive between tool calls. The last release schedules a 30s cleanup timer; a new acquire cancels it. This avoids respawning the server on every call.
3. **Graceful degradation.** If `typescript-language-server` isn't installed, the tool returns a helpful error (`Install with: npm install -g typescript-language-server typescript`) instead of crashing the agent loop.
4. **Read-only.** All operations are queries — `policy: 'auto'`, `toolKind: 'tool_call'`. No approval needed.
5. **Result simplification.** Raw LSP responses contain `file://` URIs, 0-based positions, and numeric symbol kinds. The tool converts these to plain paths, 1-based positions, and human-readable kind names so the output is compact for the agent's context window.

### Prerequisites

The user (or their project) must have `typescript-language-server` installed:
```bash
npm install -g typescript-language-server typescript
```
Or locally: `npm install -D typescript-language-server typescript` (the tool checks `node_modules/.bin/` first).

## Verification

- [x] `kun/` typecheck passes (`tsc --noEmit`)
- [x] Root project typecheck passes
- [x] `kun/` tool tests pass (24/24)
- [x] No new test failures introduced (3 pre-existing failures in compaction tests are unrelated to this PR — verified they fail on clean `develop` too)

## Future work (not in this PR)

- Support more languages (pyright, gopls, rust-analyzer) — the client is language-agnostic; just needs a config table + binary detection
- Editor integration (completion, go-to-definition in Monaco/CodeMirror)
- Automatic server installation prompt when missing
