### PR TITLE
fix: send Anthropic Messages effort

### DIFF
--- a/kun/src/adapters/model/compat-model-client.ts
+++ b/kun/src/adapters/model/compat-model-client.ts
@@ -2006,8 +2006,27 @@ function applyAnthropicReasoningEffort(
   if (reasoning?.requestProtocol !== 'anthropic-thinking') return
   const resolved = resolveReasoningEffort(effort, reasoning)
   if (!resolved) return
-  body.thinking = {
-    type: resolved === 'off' ? 'disabled' : 'adaptive'
+  if (resolved === 'off') {
+    body.thinking = { type: 'disabled' }
+    return
+  }
+  body.thinking = { type: 'adaptive' }
+  const outputEffort = anthropicOutputEffortForReasoningEffort(resolved)
+  if (outputEffort) body.output_config = { effort: outputEffort }
+}
+
+function anthropicOutputEffortForReasoningEffort(
+  effort: NormalizedReasoningEffort
+): 'low' | 'medium' | 'high' | 'max' | null {
+  switch (effort) {
+    case 'low':
+    case 'medium':
+    case 'high':
+    case 'max':
+      return effort
+    case 'auto':
+    case 'off':
+      return null
   }
 }
 

--- a/kun/tests/model-client.test.ts
+++ b/kun/tests/model-client.test.ts
@@ -350,6 +350,53 @@ describe('CompatModelClient', () => {
     expect(sentBodies[0]?.thinking).toEqual({ type: 'adaptive' })
   })
 
+  it('sends Anthropic Messages effort with adaptive thinking from a model reasoning profile', async () => {
+    const sentBodies: Array<Record<string, unknown>> = []
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      sentBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+      return new Response(JSON.stringify({
+        id: 'msg_effort',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn'
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    }
+    const client = new CompatModelClient({
+      baseUrl: 'https://example.com/anthropic',
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+      endpointFormat: 'messages',
+      fetchImpl,
+      nonStreaming: true,
+      modelCapabilities: (model) => ({
+        id: model,
+        inputModalities: ['text'],
+        outputModalities: ['text'],
+        supportsToolCalling: true,
+        contextWindowTokens: 1_000_000,
+        messageParts: ['text'],
+        reasoning: {
+          supportedEfforts: ['off', 'low', 'medium', 'high', 'max'],
+          defaultEffort: 'max',
+          requestProtocol: 'anthropic-thinking'
+        }
+      })
+    })
+    const request = buildRequest(new AbortController().signal)
+    request.model = 'deepseek-v4-pro'
+    request.reasoningEffort = 'max'
+    for await (const _chunk of client.stream(request)) {
+      // drain
+    }
+
+    expect(sentBodies[0]?.thinking).toEqual({ type: 'adaptive' })
+    expect(sentBodies[0]?.output_config).toEqual({ effort: 'max' })
+  })
+
   it('does not send thinking controls for MiniMax M2.x built-in reasoning profiles', async () => {
     const sentBodies: Array<Record<string, unknown>> = []
     const fetchImpl: typeof fetch = async (_url, init) => {


### PR DESCRIPTION
## Summary

- send `output_config.effort` for Anthropic Messages adaptive thinking requests
- keep `off` mapped to `thinking: { type: "disabled" }`
- add a model client regression test for `/v1/messages` reasoning effort

## Root cause

The UI and runtime preserved the selected reasoning effort, but the Anthropic Messages adapter collapsed every non-off effort into `thinking: { type: "adaptive" }`. That enabled adaptive thinking, but dropped the concrete effort level, so compatible upstream services could show an empty reasoning strength.

Anthropic's current docs state that adaptive thinking is enabled with `thinking: { type: "adaptive" }`, while thinking depth is controlled by the `output_config.effort` parameter:

- https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
- https://platform.claude.com/docs/en/build-with-claude/effort

Fixes #281

## Validation

- `npm --prefix kun test -- tests/model-client.test.ts`
- `npm --prefix kun run build`
