### PR TITLE
[codex] isolate model selection per thread

### DIFF
--- a/src/renderer/src/store/chat-store-app-actions.test.ts
+++ b/src/renderer/src/store/chat-store-app-actions.test.ts
@@ -11,6 +11,7 @@ import { createAppActions } from './chat-store-app-actions'
 
 const COMPOSER_MODEL_STORAGE_KEY = 'kun.composerModel'
 const COMPOSER_PROVIDER_STORAGE_KEY = 'kun.composerProviderId'
+const THREAD_COMPOSER_SELECTION_STORAGE_KEY = 'kun.threadComposerSelection.v1'
 
 function createMemoryStorage(): Storage {
   const items = new Map<string, string>()
@@ -39,6 +40,8 @@ function buildHarness(fetchModelsResult: FetchModelsResult): {
   state: ChatState
 } {
   let state = {
+    activeThreadId: null,
+    threads: [],
     composerModel: '',
     composerProviderId: '',
     composerPickList: mergeComposerPickList(false, []),
@@ -136,6 +139,119 @@ describe('chat-store app actions composer model loading', () => {
     expect(window.kunGui.saveSettingsSilent).toHaveBeenCalledWith({
       agents: { kun: { model: 'MiniMax-M2' } }
     })
+  })
+
+  it('keeps active-thread model changes out of the global Kun default', () => {
+    const { actions, state } = buildHarness({
+      ok: true,
+      modelIds: ['MiniMax-M2'],
+      defaultModelId: 'deepseek-v4-pro',
+      modelGroups: [{
+        providerId: 'minimax',
+        label: 'MiniMax',
+        modelIds: ['MiniMax-M2']
+      }]
+    })
+    state.activeThreadId = 'thread-a'
+    state.threads = [{
+      id: 'thread-a',
+      title: 'Thread A',
+      workspace: '/tmp/project',
+      model: 'deepseek-v4-pro',
+      status: 'idle',
+      mode: 'agent',
+      updatedAt: '2026-06-01T00:00:00.000Z'
+    }]
+    state.composerModelGroups = [{
+      providerId: 'minimax',
+      label: 'MiniMax',
+      modelIds: ['MiniMax-M2']
+    }]
+
+    actions.setComposerModel('MiniMax-M2', 'minimax')
+
+    expect(state.composerModel).toBe('MiniMax-M2')
+    expect(state.composerProviderId).toBe('minimax')
+    expect(localStorage.getItem(COMPOSER_MODEL_STORAGE_KEY)).toBeNull()
+    expect(localStorage.getItem(COMPOSER_PROVIDER_STORAGE_KEY)).toBeNull()
+    expect(JSON.parse(localStorage.getItem(THREAD_COMPOSER_SELECTION_STORAGE_KEY) ?? '{}')).toEqual({
+      'thread-a': { model: 'MiniMax-M2', providerId: 'minimax' }
+    })
+    expect(window.kunGui.saveSettingsSilent).not.toHaveBeenCalled()
+  })
+
+  it('restores a model selection from the active thread instead of the global picker', async () => {
+    localStorage.setItem(COMPOSER_MODEL_STORAGE_KEY, 'deepseek-v4-flash')
+    localStorage.setItem(
+      THREAD_COMPOSER_SELECTION_STORAGE_KEY,
+      JSON.stringify({ 'thread-a': { model: 'MiniMax-M2', providerId: 'minimax' } })
+    )
+    const { actions, state } = buildHarness({
+      ok: true,
+      modelIds: ['MiniMax-M2'],
+      defaultModelId: 'deepseek-v4-pro',
+      modelGroups: [{
+        providerId: 'minimax',
+        label: 'MiniMax',
+        modelIds: ['MiniMax-M2']
+      }]
+    })
+    state.activeThreadId = 'thread-a'
+    state.threads = [{
+      id: 'thread-a',
+      title: 'Thread A',
+      workspace: '/tmp/project',
+      model: 'deepseek-v4-pro',
+      status: 'idle',
+      mode: 'agent',
+      updatedAt: '2026-06-01T00:00:00.000Z'
+    }]
+
+    await actions.loadComposerModels()
+
+    expect(state.composerModel).toBe('MiniMax-M2')
+    expect(state.composerProviderId).toBe('minimax')
+    expect(localStorage.getItem(COMPOSER_MODEL_STORAGE_KEY)).toBe('deepseek-v4-flash')
+  })
+
+  it('does not restore a per-thread selection filtered out of the composer menu', async () => {
+    localStorage.setItem(
+      THREAD_COMPOSER_SELECTION_STORAGE_KEY,
+      JSON.stringify({ 'thread-a': { model: 'Kwai-Kolors/Kolors', providerId: 'minimax' } })
+    )
+    const { actions, state } = buildHarness({
+      ok: true,
+      modelIds: ['Kwai-Kolors/Kolors'],
+      defaultModelId: 'deepseek-v4-pro',
+      modelGroups: [{
+        providerId: 'minimax',
+        label: 'MiniMax',
+        modelIds: ['Kwai-Kolors/Kolors'],
+        modelProfiles: {
+          'kwai-kolors/kolors': {
+            inputModalities: ['text'],
+            outputModalities: ['image'],
+            supportsToolCalling: false,
+            messageParts: ['text']
+          }
+        }
+      }]
+    })
+    state.activeThreadId = 'thread-a'
+    state.threads = [{
+      id: 'thread-a',
+      title: 'Thread A',
+      workspace: '/tmp/project',
+      model: 'deepseek-v4-pro',
+      status: 'idle',
+      mode: 'agent',
+      updatedAt: '2026-06-01T00:00:00.000Z'
+    }]
+
+    await actions.loadComposerModels()
+
+    expect(state.composerModel).toBe('deepseek-v4-pro')
+    expect(state.composerProviderId).toBe('')
   })
 
   it('does not overwrite a stored custom model when only fallback models are available', async () => {

--- a/src/renderer/src/store/chat-store-app-actions.ts
+++ b/src/renderer/src/store/chat-store-app-actions.ts
@@ -3,8 +3,12 @@ import type { AppSettingsV1 } from '@shared/app-settings'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 import type { ChatState, ChatStoreGet, ChatStoreSet, InitialSetupMode, PluginHostRoute, SettingsRouteSection } from './chat-store-types'
 import {
+  composerModelSelectable,
   persistComposerProviderId,
   providerIdForComposerModel,
+  providerIdMatchesComposerModel,
+  readThreadComposerSelection,
+  rememberThreadComposerSelection,
   readStoredComposerProviderId
 } from './chat-store-helpers'
 
@@ -63,12 +67,17 @@ export function createAppActions(options: CreateAppActionsOptions): Pick<
     setError: (message) => set({ error: message }),
 
     setComposerModel: (modelId, providerId) => {
-      persistComposerModel(modelId)
       const nextProviderId = providerId?.trim() || providerIdForComposerModel(get().composerModelGroups, modelId)
-      persistComposerProviderId(nextProviderId)
+      const activeThreadId = get().activeThreadId
+      if (activeThreadId) {
+        rememberThreadComposerSelection(activeThreadId, modelId, nextProviderId)
+      } else {
+        persistComposerModel(modelId)
+        persistComposerProviderId(nextProviderId)
+      }
       set({ composerModel: modelId, composerProviderId: nextProviderId })
       const trimmed = modelId.trim()
-      if (trimmed && trimmed.toLowerCase() !== 'auto' && typeof window.kunGui !== 'undefined') {
+      if (!activeThreadId && trimmed && trimmed.toLowerCase() !== 'auto' && typeof window.kunGui !== 'undefined') {
         void window.kunGui.saveSettingsSilent({ agents: { kun: { model: trimmed } } })
       }
     },
@@ -80,26 +89,43 @@ export function createAppActions(options: CreateAppActionsOptions): Pick<
         const res = await window.kunGui.fetchUpstreamModels()
         const pick = mergeComposerPickList(res.ok, res.ok ? res.modelIds : [])
         const groups = res.ok ? res.modelGroups ?? [] : []
-        const allowed = new Set(pick)
         const runtimeDefault = res.ok ? res.defaultModelId?.trim() ?? '' : ''
         set((state) => {
+          const isSelectable = (model: string): boolean => composerModelSelectable(pick, groups, model)
+          const activeThread = state.activeThreadId
+            ? state.threads.find((thread) => thread.id === state.activeThreadId) ?? null
+            : null
+          const threadSelection = activeThread ? readThreadComposerSelection(activeThread.id) : null
           const currentModel = state.composerModel.trim()
           const normalizedCurrentModel = currentModel.toLowerCase() === 'auto' ? '' : currentModel
           const storedModel = readStoredComposerModel(pick)
-          let model = normalizedCurrentModel
-          let shouldPersist = model !== state.composerModel
-          if (model === '' || !allowed.has(model)) {
-            model = storedModel
+          let model = activeThread
+            ? threadSelection?.model?.trim() || activeThread.model.trim()
+            : normalizedCurrentModel
+          let shouldPersist = !activeThread && model !== state.composerModel
+          if (model === '' || !isSelectable(model)) {
+            model = activeThread ? '' : storedModel
             shouldPersist = false
           }
-          if (model === '' || !allowed.has(model)) {
+          if (model === '' || !isSelectable(model)) {
             model = fallbackComposerModel(pick, runtimeDefault)
             shouldPersist = false
           }
           if (shouldPersist) persistComposerModel(model)
-          const storedProviderId = readStoredComposerProviderId(groups, model)
-          const providerId = storedProviderId || providerIdForComposerModel(groups, model)
-          if (providerId !== state.composerProviderId) persistComposerProviderId(providerId)
+          const threadProviderId =
+            threadSelection && providerIdMatchesComposerModel(groups, threadSelection.providerId, model)
+              ? threadSelection.providerId
+              : ''
+          const storedProviderId = activeThread ? '' : readStoredComposerProviderId(groups, model)
+          const providerId = threadProviderId || storedProviderId || providerIdForComposerModel(groups, model)
+          if (!activeThread && providerId !== state.composerProviderId) persistComposerProviderId(providerId)
+          if (
+            activeThread &&
+            (!threadSelection || threadSelection.model !== model || threadSelection.providerId !== providerId) &&
+            composerModelSelectable(pick, groups, model)
+          ) {
+            rememberThreadComposerSelection(activeThread.id, model, providerId)
+          }
           return {
             composerPickList: pick,
             composerModel: model,

--- a/src/renderer/src/store/chat-store-helpers.test.ts
+++ b/src/renderer/src/store/chat-store-helpers.test.ts
@@ -3,6 +3,7 @@ import type { ClawImChannelV1 } from '@shared/app-settings'
 import { CLAW_MANAGED_INSTRUCTIONS_HEADING } from '@shared/app-settings'
 import {
   MAX_TURN_MODEL_LABELS,
+  MAX_THREAD_COMPOSER_SELECTIONS,
   MAX_CODE_WORKSPACE_ROOTS,
   clawThreadIdsFromChannels,
   clawThreadTitleLooksManaged,
@@ -12,12 +13,16 @@ import {
   isClawThread,
   mergeComposerPickList,
   newClawChannel,
+  normalizeThreadComposerSelectionMap,
   normalizeTurnModelMap,
+  readThreadComposerSelection,
   reconcileCodeWorkspaceRoots,
+  rememberThreadComposerSelection,
   rememberTurnModel
 } from './chat-store-helpers'
 
 const TURN_MODEL_STORAGE_KEY = 'kun.turnModelLabel'
+const THREAD_COMPOSER_SELECTION_STORAGE_KEY = 'kun.threadComposerSelection.v1'
 
 function createMemoryStorage(): Storage {
   const items = new Map<string, string>()
@@ -246,5 +251,44 @@ describe('chat-store Claw helpers', () => {
       { kind: 'user', id: 'item-new', text: 'hello', modelLabel: 'deepseek-chat' },
       { kind: 'assistant', id: 'assistant-1', text: 'hi' }
     ])
+  })
+
+  it('normalizes and caps per-thread composer selections', () => {
+    const raw: Record<string, unknown> = {
+      'bad-empty-model': { model: '' },
+      'bad-number': 42
+    }
+    for (let index = 0; index < MAX_THREAD_COMPOSER_SELECTIONS + 5; index += 1) {
+      raw[`thread-${index}`] = {
+        model: ` model-${index} `,
+        providerId: ` provider-${index} `
+      }
+    }
+
+    const normalized = normalizeThreadComposerSelectionMap(raw)
+
+    expect(Object.keys(normalized)).toHaveLength(MAX_THREAD_COMPOSER_SELECTIONS)
+    expect(normalized['thread-0']).toBeUndefined()
+    expect(normalized['thread-5']).toEqual({ model: 'model-5', providerId: 'provider-5' })
+    expect(normalized['bad-empty-model']).toBeUndefined()
+    expect(normalized['bad-number']).toBeUndefined()
+  })
+
+  it('persists composer model selections independently per thread', () => {
+    rememberThreadComposerSelection(' thread-a ', ' deepseek-v4-pro ', ' deepseek ')
+    rememberThreadComposerSelection(' thread-b ', ' MiniMax-M2 ', ' minimax ')
+
+    expect(readThreadComposerSelection('thread-a')).toEqual({
+      model: 'deepseek-v4-pro',
+      providerId: 'deepseek'
+    })
+    expect(readThreadComposerSelection('thread-b')).toEqual({
+      model: 'MiniMax-M2',
+      providerId: 'minimax'
+    })
+    expect(JSON.parse(localStorage.getItem(THREAD_COMPOSER_SELECTION_STORAGE_KEY) ?? '{}')).toMatchObject({
+      'thread-a': { model: 'deepseek-v4-pro', providerId: 'deepseek' },
+      'thread-b': { model: 'MiniMax-M2', providerId: 'minimax' }
+    })
   })
 })

--- a/src/renderer/src/store/chat-store-helpers.ts
+++ b/src/renderer/src/store/chat-store-helpers.ts
@@ -4,6 +4,8 @@ import type { ModelProviderModelGroup } from '@shared/kun-gui-api'
 import {
   CLAW_MANAGED_INSTRUCTIONS_HEADING,
   CLAW_MODEL_IDS,
+  isComposerChatModelId,
+  modelProfileSupportsTextChat,
   type ClawImAgentProfileV1,
   type ClawImChannelV1,
   type ClawImPlatformCredentialV1,
@@ -21,10 +23,17 @@ import { readBrowserStorageItem, writeBrowserStorageItem } from '../lib/browser-
 
 const COMPOSER_MODEL_STORAGE_KEY = 'kun.composerModel'
 const COMPOSER_PROVIDER_STORAGE_KEY = 'kun.composerProviderId'
+const THREAD_COMPOSER_SELECTION_STORAGE_KEY = 'kun.threadComposerSelection.v1'
 const TURN_MODEL_STORAGE_KEY = 'kun.turnModelLabel'
 const CODE_WORKSPACE_ROOTS_STORAGE_KEY = 'kun.codeWorkspaceRoots.v1'
 export const MAX_CODE_WORKSPACE_ROOTS = 30
+export const MAX_THREAD_COMPOSER_SELECTIONS = 500
 export const MAX_TURN_MODEL_LABELS = 500
+
+export type ThreadComposerSelection = {
+  model: string
+  providerId: string
+}
 
 export const CLAW_COMPOSER_MODEL_IDS = [...CLAW_MODEL_IDS]
 
@@ -63,6 +72,44 @@ export function persistComposerProviderId(providerId: string): void {
   }
 }
 
+export function readThreadComposerSelection(threadId: string): ThreadComposerSelection | null {
+  const thread = threadId.trim()
+  if (!thread) return null
+  return loadThreadComposerSelectionMap()[thread] ?? null
+}
+
+export function rememberThreadComposerSelection(
+  threadId: string,
+  model: string,
+  providerId = ''
+): void {
+  const thread = threadId.trim()
+  const nextModel = model.trim()
+  if (!thread || !nextModel) return
+  const map = loadThreadComposerSelectionMap()
+  delete map[thread]
+  map[thread] = {
+    model: nextModel,
+    providerId: providerId.trim()
+  }
+  saveThreadComposerSelectionMap(map)
+}
+
+export function normalizeThreadComposerSelectionMap(raw: unknown): Record<string, ThreadComposerSelection> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const entries: Array<[string, ThreadComposerSelection]> = []
+  for (const [rawKey, rawValue] of Object.entries(raw as Record<string, unknown>)) {
+    const key = rawKey.trim()
+    if (!key || !rawValue || typeof rawValue !== 'object' || Array.isArray(rawValue)) continue
+    const value = rawValue as Record<string, unknown>
+    const model = typeof value.model === 'string' ? value.model.trim() : ''
+    const providerId = typeof value.providerId === 'string' ? value.providerId.trim() : ''
+    if (!model) continue
+    entries.push([key, { model, providerId }])
+  }
+  return Object.fromEntries(entries.slice(-MAX_THREAD_COMPOSER_SELECTIONS))
+}
+
 export function providerIdForComposerModel(
   modelGroups: readonly ModelProviderModelGroup[],
   modelId: string
@@ -75,7 +122,50 @@ export function providerIdForComposerModel(
 function modelGroupHasModel(group: ModelProviderModelGroup, modelId: string): boolean {
   const normalized = normalizeComposerModelId(modelId)
   if (!normalized) return false
-  return group.modelIds.some((id) => normalizeComposerModelId(id) === normalized)
+  return group.modelIds.some((id) => normalizeComposerModelId(id) === normalized) ||
+    Boolean(modelProfileForComposerModel(group, modelId)?.aliases?.some(
+      (alias: string) => normalizeComposerModelId(alias) === normalized
+    ))
+}
+
+export function composerModelAllowed(pickList: readonly string[], modelId: string): boolean {
+  const normalized = normalizeComposerModelId(modelId)
+  if (!normalized) return false
+  return pickList.some((id) => normalizeComposerModelId(id) === normalized)
+}
+
+export function composerModelSelectable(
+  pickList: readonly string[],
+  modelGroups: readonly ModelProviderModelGroup[],
+  modelId: string
+): boolean {
+  if (!composerModelAllowed(pickList, modelId)) return false
+  if (!isComposerChatModelId(modelId)) return false
+  const group = modelGroups.find((item) => modelGroupHasModel(item, modelId))
+  if (!group) return true
+  return modelProfileSupportsTextChat(modelProfileForComposerModel(group, modelId))
+}
+
+export function providerIdMatchesComposerModel(
+  modelGroups: readonly ModelProviderModelGroup[],
+  providerId: string,
+  modelId: string
+): boolean {
+  const provider = providerId.trim()
+  if (!provider) return false
+  const group = modelGroups.find((item) => item.providerId === provider)
+  return group ? modelGroupHasModel(group, modelId) : false
+}
+
+function modelProfileForComposerModel(
+  group: Pick<ModelProviderModelGroup, 'modelProfiles'>,
+  modelId: string
+): NonNullable<ModelProviderModelGroup['modelProfiles']>[string] | undefined {
+  const model = modelId.trim()
+  const key = normalizeComposerModelId(model)
+  if (!key) return undefined
+  const profiles = group.modelProfiles ?? {}
+  return profiles[key] ?? profiles[model]
 }
 
 function normalizeComposerModelId(modelId: string): string {
@@ -343,4 +433,21 @@ export function normalizeTurnModelMap(raw: unknown): Record<string, string> {
 
 function saveTurnModelMap(map: Record<string, string>): void {
   writeBrowserStorageItem(TURN_MODEL_STORAGE_KEY, JSON.stringify(normalizeTurnModelMap(map)))
+}
+
+function loadThreadComposerSelectionMap(): Record<string, ThreadComposerSelection> {
+  try {
+    const raw = readBrowserStorageItem(THREAD_COMPOSER_SELECTION_STORAGE_KEY)
+    if (!raw) return {}
+    return normalizeThreadComposerSelectionMap(JSON.parse(raw))
+  } catch {
+    return {}
+  }
+}
+
+function saveThreadComposerSelectionMap(map: Record<string, ThreadComposerSelection>): void {
+  writeBrowserStorageItem(
+    THREAD_COMPOSER_SELECTION_STORAGE_KEY,
+    JSON.stringify(normalizeThreadComposerSelectionMap(map))
+  )
 }

--- a/src/renderer/src/store/chat-store-thread-actions.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.ts
@@ -31,14 +31,18 @@ import {
 import type { ChatState, ChatStoreGet, ChatStoreSet } from './chat-store-types'
 import {
   activeClawChannel,
+  composerModelSelectable,
   compactCodeWorkspaceRoots,
   forgetCodeWorkspaceRoot,
   hydrateBlockModelLabels,
   isClawThread,
   optimisticUserModelLabel,
+  providerIdForComposerModel,
+  providerIdMatchesComposerModel,
   readCodeWorkspaceRoots,
-  readStoredComposerModel,
+  readThreadComposerSelection,
   rememberCodeWorkspaceRoots,
+  rememberThreadComposerSelection,
   rememberTurnModel
 } from './chat-store-helpers'
 import {
@@ -130,6 +134,31 @@ async function ensureRuntimeProviderForSend(input: {
   } catch (error) {
     input.set({ runtimeConnection: 'offline' })
     throw error
+  }
+}
+
+function composerSelectionForThread(
+  state: ChatState,
+  thread: Pick<NormalizedThread, 'id' | 'model'> | null | undefined
+): { model: string; providerId: string } | null {
+  if (!thread) return null
+  const pickList = state.composerPickList
+  const stored = readThreadComposerSelection(thread.id)
+  const storedModel = stored?.model.trim() ?? ''
+  const threadModel = thread.model.trim()
+  const model = composerModelSelectable(pickList, state.composerModelGroups, storedModel)
+    ? storedModel
+    : composerModelSelectable(pickList, state.composerModelGroups, threadModel)
+      ? threadModel
+      : ''
+  if (!model) return null
+  const storedProviderId =
+    stored && providerIdMatchesComposerModel(state.composerModelGroups, stored.providerId, model)
+      ? stored.providerId
+      : ''
+  return {
+    model,
+    providerId: storedProviderId || providerIdForComposerModel(state.composerModelGroups, model)
   }
 }
 
@@ -326,6 +355,8 @@ export function createThreadActions(
       const currentTurnUserId = busy
         ? latestUserMessageId ?? findLatestUserBlockId(blocks)
         : null
+      const threadSnap = get().threads.find((thread) => thread.id === id) ?? null
+      const composerSelection = composerSelectionForThread(get(), threadSnap)
       set({
         watchTurnCompletion: nextWatch,
         unreadThreadIds: nextUnread,
@@ -345,7 +376,13 @@ export function createThreadActions(
         turnReasoningFirstAtByUserId: {},
         turnReasoningLastAtByUserId: {},
         inspectorSelectedId: null,
-        queuedMessages: []
+        queuedMessages: [],
+        ...(composerSelection
+          ? {
+              composerModel: composerSelection.model,
+              composerProviderId: composerSelection.providerId
+            }
+          : {})
       })
       syncTurnCompletionPoll(set, get)
       const ac = new AbortController()
@@ -568,6 +605,9 @@ export function createThreadActions(
           throw new Error('Failed to resolve target thread id.')
         }
         activeThreadId = threadId
+        if (composerModel) {
+          rememberThreadComposerSelection(threadId, composerModel, composerProviderId)
+        }
         set((s) => ({
           activeThreadId: threadId,
           codeWorkspaceRoots: rememberCodeWorkspaceRoots(s.codeWorkspaceRoots, [workspaceRoot, createdThread?.workspace]),
@@ -609,6 +649,9 @@ export function createThreadActions(
     try {
       const seqAtSend = get().lastSeq
       const channel = get().route === 'claw' ? activeClawChannel(get()) : null
+      if (!channel && composerModel) {
+        rememberThreadComposerSelection(activeThreadId, composerModel, composerProviderId)
+      }
       await ensureRuntimeProviderForSend({
         providerId: channel ? undefined : composerProviderId,
         model: composerModel,


### PR DESCRIPTION
## Summary

- Re-submit the per-thread composer model selection fix on top of the latest `develop`.
- Store composer model/provider selections per thread instead of only globally.
- Restore the active thread's saved model selection when models load or when switching threads.
- Adapt restoration to the latest configured-provider composer filtering so non-chat models are not restored into the picker state.

## Follow-up from closed PR

Supersedes #262, which was closed due to conflicts with newer PRs. This branch is based on the latest `develop` and includes an extra regression test for selections filtered out by the current composer menu rules.

## Root cause

The composer model state was backed by a single global store/localStorage entry, so selecting a model in one conversation changed the picker state used by other conversations.

## Validation

- `npm test -- src/renderer/src/store/chat-store-helpers.test.ts src/renderer/src/store/chat-store-app-actions.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts`
- `npm run typecheck`