### PR TITLE
improve provider cache telemetry / 改进供应商缓存遥测

### DIFF
--- a/kun/src/adapters/model/compat-model-client.ts
+++ b/kun/src/adapters/model/compat-model-client.ts
@@ -1396,18 +1396,23 @@ export class CompatModelClient implements ModelClient {
     const promptDetails = usage.prompt_tokens_details as
       | { cached_tokens?: number }
       | undefined
+    const inputDetails = usage.input_tokens_details as
+      | { cached_tokens?: number }
+      | undefined
     const nativeHit = Number(usage.prompt_cache_hit_tokens ?? 0) || 0
     const nativeMiss = Number(usage.prompt_cache_miss_tokens ?? 0) || 0
     const hasNativeCache = nativeHit > 0 || nativeMiss > 0
-    const cachedTokens = Number(promptDetails?.cached_tokens ?? 0) || 0
+    const cachedTokens = Number(promptDetails?.cached_tokens ?? inputDetails?.cached_tokens ?? 0) || 0
     const cacheRead = Number(usage.cache_read_input_tokens ?? 0) || 0
     const cacheCreation = Number(usage.cache_creation_input_tokens ?? 0) || 0
     // Anthropic-protocol usage (MiniMax et al.) reports input_tokens
     // EXCLUDING cache reads/writes; OpenAI-style prompt_tokens includes
-    // everything and marks the cached subset in prompt_tokens_details.
+    // everything and marks the cached subset in prompt_tokens_details or
+    // Responses API input_tokens_details.
     const anthropicUsage = usage.prompt_tokens === undefined &&
       usage.prompt_eval_count === undefined &&
-      usage.input_tokens !== undefined
+      usage.input_tokens !== undefined &&
+      inputDetails?.cached_tokens === undefined
     const reportedPromptTokens = Number(usage.prompt_tokens ?? usage.prompt_eval_count ?? usage.input_tokens ?? 0) || 0
     const promptTokens = anthropicUsage
       ? reportedPromptTokens + cacheRead + cacheCreation
@@ -1937,7 +1942,7 @@ function applyReasoningEffort(
   }
   switch (normalized) {
     case 'off':
-      if (nativeDeepSeek) body.thinking = { type: 'disabled' }
+      if (includeThinking) body.thinking = { type: 'disabled' }
       break
     case 'low':
     case 'medium':

--- a/kun/tests/model-client.test.ts
+++ b/kun/tests/model-client.test.ts
@@ -187,6 +187,50 @@ describe('CompatModelClient', () => {
     ])
   })
 
+  it('maps Responses API cached input token details into cache telemetry', async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(JSON.stringify({
+        id: 'resp_cache',
+        status: 'completed',
+        output_text: 'cached',
+        usage: {
+          input_tokens: 400,
+          output_tokens: 20,
+          total_tokens: 420,
+          input_tokens_details: { cached_tokens: 300 }
+        }
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    const client = new CompatModelClient({
+      baseUrl: 'https://example.com/api/v1',
+      apiKey: 'k',
+      model: 'gpt-5-mini',
+      endpointFormat: 'responses',
+      fetchImpl,
+      nonStreaming: true
+    })
+
+    const chunks: ModelStreamChunk[] = []
+    for await (const chunk of client.stream(buildRequest(new AbortController().signal))) {
+      chunks.push(chunk)
+    }
+
+    const usageChunk = chunks.find((chunk) => chunk.kind === 'usage')
+    const usage = usageChunk && usageChunk.kind === 'usage' ? usageChunk.usage : null
+    expect(usage).not.toBeNull()
+    expect(usage).toMatchObject({
+      promptTokens: 400,
+      completionTokens: 20,
+      totalTokens: 420,
+      cachedTokens: 300,
+      cacheHitTokens: 300,
+      cacheMissTokens: 100
+    })
+    expect(usage?.cacheHitRate).toBeCloseTo(0.75)
+  })
+
   it('uses the Anthropic Messages API format when selected', async () => {
     const sentUrls: string[] = []
     const sentBodies: Array<Record<string, unknown>> = []


### PR DESCRIPTION
## Summary / 摘要

- Map Responses API `input_tokens_details.cached_tokens` into Kun cache telemetry.
- 将 Responses API 的 `input_tokens_details.cached_tokens` 映射到 Kun 的缓存命中遥测。
- Keep Responses input token accounting OpenAI-style when cached input details are present, instead of treating it like Anthropic cache read/write usage.
- 当存在 cached input details 时，保持 Responses 的 OpenAI 风格 input token 统计，不再误按 Anthropic cache read/write 语义处理。
- Restore explicit `reasoningEffort: off` router control by sending `thinking: { type: "disabled" }` when the endpoint allows thinking controls; Azure endpoints remain stripped.
- 恢复显式 `reasoningEffort: off` 的路由控制：在端点允许 thinking 控制时发送 `thinking: { type: "disabled" }`；Azure 端点仍会剥离该字段。

## Why / 原因

- Responses-compatible providers report prompt-cache hits under `input_tokens_details.cached_tokens`, while the existing mapper only looked at Chat Completions `prompt_tokens_details.cached_tokens`.
- Responses 兼容供应商会通过 `input_tokens_details.cached_tokens` 报告 prompt cache 命中，而原有映射只读取 Chat Completions 的 `prompt_tokens_details.cached_tokens`。
- This made cache-heavy Responses turns look like all misses in the GUI usage counters.
- 这会让命中缓存较多的 Responses 调用在 GUI 用量统计中看起来像全部未命中。

## Tests / 测试

- `npm.cmd test -- tests/model-client.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`
