### PR TITLE
support linked skill directories / 支持链接形式的 skills 目录

### DIFF
--- a/kun/src/skills/skill-runtime.ts
+++ b/kun/src/skills/skill-runtime.ts
@@ -1,5 +1,5 @@
-import { type Dirent } from 'node:fs'
 import { readdir, readFile, stat } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
 import { basename, extname, join, resolve } from 'node:path'
 import { z } from 'zod'
 import type { SkillsCapabilityConfig } from '../contracts/capabilities.js'
@@ -334,8 +334,8 @@ async function packageCandidates(root: string): Promise<string[]> {
   }
   const entries = await readdir(root, { withFileTypes: true })
   for (const entry of entries) {
-    const dir = join(root, entry.name)
-    if (!(await entryIsDirectory(entry, dir))) continue
+    const dir = await directoryPathForEntry(root, entry)
+    if (!dir) continue
     if (await exists(join(dir, 'skill.json')) || await exists(join(dir, 'SKILL.md'))) {
       candidates.add(dir)
     }
@@ -344,20 +344,22 @@ async function packageCandidates(root: string): Promise<string[]> {
 }
 
 /**
- * Whether a directory entry is — or resolves to — a directory. `readdir` with
+ * Return the directory path for entries that are — or resolve to — directories.
+ * `readdir` with
  * `withFileTypes` describes the link itself, so a symlinked skill package (e.g.
  * the per-skill links `cc switch` drops into `.claude/skills`) reports
  * `isDirectory() === false` and would be skipped. Follow such links via `stat`
  * so those packages are still discovered. Also covers filesystems that report
  * an unknown `d_type`. (#320)
  */
-async function entryIsDirectory(entry: Dirent, path: string): Promise<boolean> {
-  if (entry.isDirectory()) return true
-  if (entry.isFile()) return false
+async function directoryPathForEntry(root: string, entry: Dirent): Promise<string | null> {
+  const path = join(root, entry.name)
+  if (entry.isDirectory()) return path
+  if (entry.isFile()) return null
   try {
-    return (await stat(path)).isDirectory()
+    return (await stat(path)).isDirectory() ? path : null
   } catch {
-    return false
+    return null
   }
 }
 

--- a/kun/tests/skill-runtime.test.ts
+++ b/kun/tests/skill-runtime.test.ts
@@ -45,6 +45,36 @@ describe('SkillRuntime', () => {
     expect(diagnostics.validationErrors[0]?.message).toMatch(/expected string/i)
   })
 
+  it('loads skills from linked package directories', async () => {
+    const realSkill = join(root, '..', 'cc-switch-store', 'linked-review')
+    const linkedSkill = join(root, 'linked-review')
+    await mkdir(realSkill, { recursive: true })
+    await writeFile(join(realSkill, 'SKILL.md'), [
+      '---',
+      'name: linked-review',
+      'description: Loaded through a directory link.',
+      '---',
+      '',
+      'Review through the linked skill.'
+    ].join('\n'), 'utf8')
+    await linkDirectory(realSkill, linkedSkill)
+
+    const runtime = await createRuntime()
+    const diagnostics = runtime.diagnostics()
+
+    expect(diagnostics.skills).toContainEqual(expect.objectContaining({
+      id: 'linked-review',
+      name: 'linked-review',
+      description: 'Loaded through a directory link.',
+      root: linkedSkill,
+      legacy: true
+    }))
+    const loaded = runtime.loadSkillById('linked-review')
+    expect('error' in loaded).toBe(false)
+    if ('error' in loaded) return
+    expect(loaded.instruction).toContain('Review through the linked skill.')
+  })
+
   it('uses Chinese legacy frontmatter names for diagnostics without changing folder ids', async () => {
     const skillRoot = join(root, 'tdd')
     await mkdir(skillRoot, { recursive: true })
@@ -354,5 +384,9 @@ describe('SkillRuntime', () => {
     const entryName = typeof manifest.entry === 'string' ? manifest.entry : 'SKILL.md'
     await writeFile(join(dir, 'skill.json'), JSON.stringify(manifest), 'utf8')
     await writeFile(join(dir, entryName), entry, 'utf8')
+  }
+
+  async function linkDirectory(target: string, path: string): Promise<void> {
+    await symlink(target, path, process.platform === 'win32' ? 'junction' : 'dir')
   }
 })

--- a/src/main/services/skill-service.ts
+++ b/src/main/services/skill-service.ts
@@ -307,18 +307,20 @@ async function collectSkillRoots(root: string, roots: string[], depth: number, m
     return
   }
   const entries = await readdir(root, { withFileTypes: true }).catch(() => [])
-  await Promise.all(entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => collectSkillRoots(join(root, entry.name), roots, depth + 1, maxDepth)))
+  await Promise.all(entries.map(async (entry) => {
+    const child = await directoryPathForEntry(root, entry)
+    if (!child) return
+    await collectSkillRoots(child, roots, depth + 1, maxDepth)
+  }))
 }
 
 function skillRootHasPackages(root: string): boolean {
   if (existsSync(join(root, 'SKILL.md')) || existsSync(join(root, 'skill.json'))) return true
   try {
-    return readdirSync(root, { withFileTypes: true }).some((entry) =>
-      entryIsDirectorySync(entry, join(root, entry.name)) &&
-      (existsSync(join(root, entry.name, 'SKILL.md')) || existsSync(join(root, entry.name, 'skill.json')))
-    )
+    return readdirSync(root, { withFileTypes: true }).some((entry) => {
+      const dir = directoryPathForEntrySync(root, entry)
+      return Boolean(dir && (existsSync(join(dir, 'SKILL.md')) || existsSync(join(dir, 'skill.json'))))
+    })
   } catch {
     return false
   }
@@ -331,8 +333,8 @@ async function packageCandidates(root: string): Promise<string[]> {
   }
   const entries = await readdir(root, { withFileTypes: true })
   for (const entry of entries) {
-    const dir = join(root, entry.name)
-    if (!(await entryIsDirectory(entry, dir))) continue
+    const dir = await directoryPathForEntry(root, entry)
+    if (!dir) continue
     if (existsSync(join(dir, 'skill.json')) || existsSync(join(dir, 'SKILL.md'))) {
       candidates.add(dir)
     }
@@ -341,30 +343,33 @@ async function packageCandidates(root: string): Promise<string[]> {
 }
 
 /**
- * Whether a directory entry is — or resolves to — a directory. `readdir`/
+ * Return the directory path for entries that are — or resolve to — directories.
+ * `readdir`/
  * `readdirSync` with `withFileTypes` describe the link itself, so a symlinked
  * skill package (e.g. the per-skill links `cc switch` drops into
  * `.claude/skills`) reports `isDirectory() === false` and would be skipped.
  * Follow such links via `stat` so those packages are still discovered. Also
  * covers filesystems that report an unknown `d_type`. (#320)
  */
-async function entryIsDirectory(entry: Dirent, path: string): Promise<boolean> {
-  if (entry.isDirectory()) return true
-  if (entry.isFile()) return false
+async function directoryPathForEntry(root: string, entry: Dirent): Promise<string | null> {
+  const path = join(root, entry.name)
+  if (entry.isDirectory()) return path
+  if (entry.isFile()) return null
   try {
-    return (await stat(path)).isDirectory()
+    return (await stat(path)).isDirectory() ? path : null
   } catch {
-    return false
+    return null
   }
 }
 
-function entryIsDirectorySync(entry: Dirent, path: string): boolean {
-  if (entry.isDirectory()) return true
-  if (entry.isFile()) return false
+function directoryPathForEntrySync(root: string, entry: Dirent): string | null {
+  const path = join(root, entry.name)
+  if (entry.isDirectory()) return path
+  if (entry.isFile()) return null
   try {
-    return statSync(path).isDirectory()
+    return statSync(path).isDirectory() ? path : null
   } catch {
-    return false
+    return null
   }
 }
 


### PR DESCRIPTION
## Summary / 摘要
- Follow directory symlinks and Windows junctions when discovering skill packages in the GUI skill service and Kun runtime.
- 保留链接路径作为 skill root，同时用 stat 跟随到真实目录识别 `SKILL.md` / `skill.json`。
- Add regression tests for `.claude/skills/<linked-skill>` discovery and runtime loading.

Fixes #320

## Scope / 范围
- This PR only fixes linked skill package directories under existing skill roots.
- 本 PR 不处理 #321 的插件页/设置页联动问题，避免把两个 issue 混在一个 PR。

## Tests / 测试
- `npm.cmd test -- src/main/services/skill-service.test.ts`
- `npm.cmd test -- tests/skill-runtime.test.ts` (in `kun`)
- `npm.cmd run typecheck`
- `git diff --check HEAD~1 HEAD`
- `npm.cmd run build`