### PR TITLE
fix(memory): enable memory capability by default in GUI-managed config

### DIFF
--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -338,6 +338,7 @@ describe('syncGuiManagedKunConfig', () => {
     expect(parsed.runtime.toolStorm).toMatchObject({ enabled: true, windowSize: 8, threshold: 3 })
     expect(parsed.runtime.toolArgumentRepair).toMatchObject({ maxStringBytes: 524288 })
     expect(parsed.capabilities.attachments).toMatchObject({ enabled: true })
+    expect(parsed.capabilities.memory).toMatchObject({ enabled: true })
     expect(parsed.capabilities.web).toMatchObject({ enabled: true, fetchEnabled: true })
     expect(parsed.capabilities.mcp.search).toMatchObject({ enabled: false, mode: 'auto' })
     expect(parsed.capabilities.imageGen).toEqual({

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -385,6 +385,7 @@ export async function syncGuiManagedKunConfig(
   const mcp = objectValue(capabilities.mcp)
   const search = objectValue(mcp.search)
   const attachments = objectValue(capabilities.attachments)
+  const memory = objectValue(capabilities.memory)
   const web = objectValue(capabilities.web)
   const skills = objectValue(capabilities.skills)
   const imageGen = objectValue(capabilities.imageGen)
@@ -408,6 +409,10 @@ export async function syncGuiManagedKunConfig(
       attachments: {
         ...attachments,
         enabled: attachments.enabled === false ? false : true
+      },
+      memory: {
+        ...memory,
+        enabled: memory.enabled === false ? false : true
       },
       web: {
         ...web,


### PR DESCRIPTION
## 问题

系统提示词与 README 都声明 Agent 具备 \`memory_create\` / \`memory_update\` / \`memory_delete\` 工具,且每轮会注入相关记忆指令,但实际调用返回 \`unknown tool\`,跨会话记忆完全不可用。

相关 issue: refs #330, refs #331

## 根因

记忆功能在 \`kun/\` 运行时其实是**完整实现**的(工具定义、\`FileMemoryStore\`、每轮检索与注入、注册逻辑都在),并非 issue 所述缺少后端。真正的缺陷是 GUI 侧的配置 gating:

- 记忆工具仅在 \`memoryStore\` 存在时注册(\`kun/src/server/runtime-factory.ts\`)。
- \`memoryStore\` 仅在 \`capabilities.memory.enabled === true\` 时构建。
- \`MemoryCapabilityConfig\` 继承 \`enabled\` 默认 \`false\`(\`capabilities.ts\`)。
- 在 \`src/main/kun-process.ts\` 中,GUI 会强制启用 attachments / web / skills,**唯独漏了 memory**,且没有 UI 开关可手动开启。

结果:模型被告知拥有记忆工具,但 store 从未构建、工具从未注册,任何调用都报 \`unknown tool\`。

## 修复

让 memory 沿用 attachments / web 相同的「默认启用、可显式 \`enabled: false\` 退出」模式:

\`\`\`ts
const memory = objectValue(capabilities.memory)
...
memory: {
  ...memory,
  enabled: memory.enabled === false ? false : true
},
\`\`\`

## 测试

- \`src/main/kun-process.test.ts\`:新增断言 GUI 配置写出 \`memory.enabled: true\`,23 个测试全过
- \`tsc -p tsconfig.node.json\`:无错误