### PR TITLE
fix(shortcuts): accept common zoom-in key variants / 修复常见放大快捷键变体

### DIFF
--- a/src/shared/keyboard-shortcuts.test.ts
+++ b/src/shared/keyboard-shortcuts.test.ts
@@ -12,12 +12,16 @@ describe('keyboard shortcuts', () => {
   it('normalizes common shortcut strings', () => {
     expect(normalizeKeyboardShortcut('shift + tab')).toBe('Shift+Tab')
     expect(normalizeKeyboardShortcut('ctrl++')).toBe('Ctrl++')
+    expect(normalizeKeyboardShortcut('ctrl+=')).toBe('Ctrl++')
+    expect(normalizeKeyboardShortcut('ctrl+shift++')).toBe('Ctrl++')
     expect(normalizeKeyboardShortcut('control + shift + i')).toBe('Ctrl+Shift+I')
   })
 
   it('converts keyboard events to shortcut strings', () => {
     expect(keyboardEventToShortcut({ key: 'Tab', shiftKey: true })).toBe('Shift+Tab')
     expect(keyboardEventToShortcut({ key: '+', ctrlKey: true })).toBe('Ctrl++')
+    expect(keyboardEventToShortcut({ key: '=', ctrlKey: true })).toBe('Ctrl++')
+    expect(keyboardEventToShortcut({ key: '+', ctrlKey: true, shiftKey: true })).toBe('Ctrl++')
     expect(keyboardEventToShortcut({ key: 'Shift', shiftKey: true })).toBeNull()
   })
 

--- a/src/shared/keyboard-shortcuts.ts
+++ b/src/shared/keyboard-shortcuts.ts
@@ -196,7 +196,12 @@ export function normalizeKeyboardShortcut(value: unknown): string | null {
   const normalizedKey = normalizeShortcutKey(key)
   if (!normalizedKey || MODIFIER_KEYS.has(normalizedKey)) return null
   const orderedModifiers = ['Ctrl', 'Shift', 'Alt', 'Meta']
-    .filter((modifier) => modifiers.includes(modifier as 'Ctrl' | 'Shift' | 'Alt' | 'Meta'))
+    .filter((modifier) =>
+      modifiers.includes(modifier as 'Ctrl' | 'Shift' | 'Alt' | 'Meta') &&
+      // On many keyboards the plus key is reported through Shift+=. Treat
+      // Shift as part of typing "+" rather than a separate shortcut modifier.
+      !(normalizedKey === '+' && modifier === 'Shift')
+    )
   return [...orderedModifiers, normalizedKey].join('+')
 }
 
@@ -205,7 +210,7 @@ export function keyboardEventToShortcut(event: KeyboardShortcutEventLike): strin
   if (!key || MODIFIER_KEYS.has(key)) return null
   const modifiers = [
     event.ctrlKey ? 'Ctrl' : '',
-    event.shiftKey ? 'Shift' : '',
+    event.shiftKey && key !== '+' ? 'Shift' : '',
     event.altKey ? 'Alt' : '',
     event.metaKey ? 'Meta' : ''
   ].filter(Boolean)
@@ -239,6 +244,7 @@ function normalizeShortcutKey(rawKey: string): string | null {
   const key = rawKey.trim()
   if (!key) return null
   if (key === ' ') return 'Space'
+  if (key === '=') return '+'
   if (key.length === 1) return key.toUpperCase()
   const lower = key.toLowerCase()
   if (lower === 'esc') return 'Escape'


### PR DESCRIPTION
﻿## Summary / 摘要

English:
- Fix window zoom-in shortcuts so common keyboard layouts trigger zoom in reliably.
- Normalize `Ctrl+=`, `Ctrl++`, and `Ctrl+Shift++` to the same shortcut, matching how the plus key is reported on Windows keyboards.

中文：
- 修复窗口放大快捷键在常见键盘布局下无法触发的问题。
- 将 `Ctrl+=`、`Ctrl++`、`Ctrl+Shift++` 统一解析为同一个放大快捷键，兼容 Windows 上加号键的不同上报方式。

Fixes #328

## Changes / 修改

English:
- Treat `=` as the keyboard alias for `+` in shortcut parsing.
- Ignore the physical Shift modifier when it is only used to type `+`.
- Add focused coverage for zoom-in shortcut variants.

中文：
- 在快捷键解析中把 `=` 作为 `+` 的键盘别名处理。
- 当 Shift 只是用于输入 `+` 时，不再把它当成额外快捷键修饰键。
- 增加放大快捷键变体的单元测试。

## Tests / 验证

- `npm.cmd test -- src/shared/keyboard-shortcuts.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`
