### PR TITLE
fix(claw): limit phone agent model choices / 限制手机端模型列表

### DIFF
--- a/src/renderer/src/components/chat/SidebarClawDialog.tsx
+++ b/src/renderer/src/components/chat/SidebarClawDialog.tsx
@@ -26,6 +26,7 @@ import type {
 } from '@shared/app-settings'
 import type { ClawImInstallQrResult } from '@shared/kun-gui-api'
 import { confirmDialog } from '../../lib/confirm-dialog'
+import { clawModelSelectOptions, mergeClawModelOptions } from '../../lib/claw-model-options'
 import {
   ClawProviderLogo,
   clawProviderDisplayLabel
@@ -131,6 +132,7 @@ export function ClawAddImDialog({
   const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false)
   const [officialInstallTarget, setOfficialInstallTarget] = useState<ClawInstallTarget>('feishu')
   const [channelModel, setChannelModel] = useState<string>('auto')
+  const [configuredModelOptions, setConfiguredModelOptions] = useState<string[]>(['auto'])
   const [channelWorkspaceRoot, setChannelWorkspaceRoot] = useState('')
   const [channelEnabled, setChannelEnabled] = useState(true)
   const [showSecret, setShowSecret] = useState(false)
@@ -239,6 +241,7 @@ export function ClawAddImDialog({
         setSecret(settings.claw.im.secret.trim())
         setResponseTimeoutSec(Math.round(settings.claw.im.responseTimeoutMs / 1000))
         setRunMode(settings.claw.im.mode)
+        setConfiguredModelOptions(clawModelSelectOptions(settings))
       })
       .catch((e: unknown) => {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e))
@@ -269,6 +272,10 @@ export function ClawAddImDialog({
       existingChannel?.id
     ),
     [effectiveProvider, existingChannel?.id, officialInstallTarget, resolvedPlatformCredential]
+  )
+  const channelModelOptions = useMemo(
+    () => mergeClawModelOptions(configuredModelOptions, channelModel),
+    [channelModel, configuredModelOptions]
   )
   const bindingPayload = useMemo(() => {
     const payload: Record<string, unknown> = {
@@ -618,7 +625,7 @@ export function ClawAddImDialog({
   }
 
   const dialogViewContext = {
-    activeStep, activeStepConfig, activeStepIndex, advancedSettingsOpen, agentProfile, atLastStep, bindingPayload, busy, channelEnabled, channelModel, channelWorkspaceRoot, copied, copyBindingPayload, credentialStatusText,
+    activeStep, activeStepConfig, activeStepIndex, advancedSettingsOpen, agentProfile, atLastStep, bindingPayload, busy, channelEnabled, channelModel, channelModelOptions, channelWorkspaceRoot, copied, copyBindingPayload, credentialStatusText,
     defaultWorkspacePreview, effectiveProvider, editableChannels, endpoint, enterManageConfigure, error, existingChannel, goToPreviousStep, handleDeleteChannel, handlePrimaryAction,
     imEnabled, imPath, imPort, installQr, isManageSelection, loadingConfig, mode, navigationDisabled, noEditableChannel, officialInstallTarget, onClose, onDeleteChannel,
     primaryActionLabel, providerConfigured, providerListTitle, qrValue, requiresOfficialInstall, resolvedPlatformCredential, responseTimeoutSec, returnToManageSelection, runMode,

--- a/src/renderer/src/components/chat/SidebarClawDialogStepContent.tsx
+++ b/src/renderer/src/components/chat/SidebarClawDialogStepContent.tsx
@@ -21,6 +21,7 @@ export function ClawStepContent({ ctx }: { ctx: Record<string, any> }): ReactEle
     bindingPayload,
     channelEnabled,
     channelModel,
+    channelModelOptions,
     channelWorkspaceRoot,
     clawConnectionStatusKey,
     copied,
@@ -115,9 +116,9 @@ export function ClawStepContent({ ctx }: { ctx: Record<string, any> }): ReactEle
                             onChange={(event) => setChannelModel(event.target.value)}
                             className="mt-1.5 w-full rounded-xl border border-ds-border bg-ds-card px-3 py-2.5 text-[13px] text-ds-ink outline-none transition focus:border-accent/60"
                           >
-                            <option value="auto">auto</option>
-                            <option value="deepseek-v4-pro">deepseek-v4-pro</option>
-                            <option value="deepseek-v4-flash">deepseek-v4-flash</option>
+                            {channelModelOptions.map((model: string) => (
+                              <option key={model} value={model}>{model}</option>
+                            ))}
                           </select>
                         </label>
                         <label className="block min-w-0">

--- a/src/renderer/src/components/settings-section-claw.test.ts
+++ b/src/renderer/src/components/settings-section-claw.test.ts
@@ -73,13 +73,18 @@ function buildSettings(): AppSettingsV1 {
   }
   settings.claw.enabled = true
   settings.claw.im.workspaceRoot = '/tmp/claw'
+  settings.provider.providers = [{
+    ...settings.provider.providers[0],
+    models: ['team-chat-model'],
+    modelProfiles: {}
+  }]
   settings.claw.channels = [
     {
       id: 'channel_1',
       provider: 'feishu',
       label: 'Team helper',
       enabled: true,
-      model: 'auto',
+      model: 'team-chat-model',
       threadId: 'thr_1',
       workspaceRoot: '',
       agentProfile: {
@@ -121,6 +126,7 @@ describe('ClawSettingsSection', () => {
     expect(html).toContain('Personality')
     expect(html).toContain('Reply rules')
     expect(html).toContain('Start with the conclusion.')
-    expect(html).toContain('<option value="deepseek-v4-pro"')
+    expect(html).toContain('<option value="team-chat-model"')
+    expect(html).not.toContain('<option value="deepseek-v4-pro"')
   })
 })

--- a/src/renderer/src/components/settings-section-claw.tsx
+++ b/src/renderer/src/components/settings-section-claw.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react'
 import {
-  CLAW_MODEL_IDS,
   type AppSettingsPatch,
   type AppSettingsV1,
   type ClawImAgentProfileV1,
@@ -8,6 +7,7 @@ import {
   type ClawModel
 } from '@shared/app-settings'
 import { SettingsCard, SettingRow, Toggle } from './settings-controls'
+import { clawModelSelectOptions } from '../lib/claw-model-options'
 
 type ClawSettingsContext = {
   t: (key: string, values?: Record<string, unknown>) => string
@@ -200,7 +200,7 @@ export function ClawSettingsSection({ ctx }: { ctx: ClawSettingsContext }): Reac
                       value={channel.model}
                       onChange={(e) => updateChannel(form, update, channel.id, { model: e.target.value as ClawModel })}
                     >
-                      {CLAW_MODEL_IDS.map((model) => (
+                      {clawModelSelectOptions(form, channel.model).map((model) => (
                         <option key={model} value={model}>{model}</option>
                       ))}
                     </select>

--- a/src/renderer/src/lib/claw-model-options.test.ts
+++ b/src/renderer/src/lib/claw-model-options.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultClawSettings,
+  defaultKeyboardShortcuts,
+  defaultKunRuntimeSettings,
+  defaultModelProviderSettings,
+  defaultScheduleSettings,
+  defaultWriteSettings,
+  type AppSettingsV1
+} from '@shared/app-settings'
+import { clawModelSelectOptions, mergeClawModelOptions } from './claw-model-options'
+
+function buildSettings(models: string[]): AppSettingsV1 {
+  const provider = defaultModelProviderSettings()
+  provider.providers = [
+    {
+      ...provider.providers[0],
+      models,
+      modelProfiles: {}
+    }
+  ]
+  return {
+    version: 1,
+    locale: 'en',
+    theme: 'system',
+    uiFontScale: 'medium',
+    provider,
+    agents: { kun: defaultKunRuntimeSettings() },
+    workspaceRoot: '/tmp/workspace',
+    log: { enabled: true, retentionDays: 7 },
+    notifications: { turnComplete: true },
+    appBehavior: { openAtLogin: false, startMinimized: false, closeToTray: false },
+    keyboardShortcuts: defaultKeyboardShortcuts(),
+    write: defaultWriteSettings(),
+    claw: defaultClawSettings(),
+    schedule: defaultScheduleSettings(),
+    guiUpdate: { channel: 'stable' },
+    codePromptPrefix: '',
+    disabledSkillIds: []
+  }
+}
+
+describe('claw model options', () => {
+  it('uses configured text models instead of provider preset catalogs', () => {
+    expect(clawModelSelectOptions(buildSettings(['team-chat-model']))).toEqual([
+      'auto',
+      'team-chat-model'
+    ])
+  })
+
+  it('keeps the current channel model when editing older settings', () => {
+    expect(mergeClawModelOptions(['team-chat-model'], 'legacy-channel-model')).toEqual([
+      'auto',
+      'team-chat-model',
+      'legacy-channel-model'
+    ])
+  })
+})

--- a/src/renderer/src/lib/claw-model-options.ts
+++ b/src/renderer/src/lib/claw-model-options.ts
@@ -1,0 +1,26 @@
+import {
+  DEFAULT_CLAW_MODEL,
+  listModelProviderModelIds,
+  type AppSettingsV1
+} from '@shared/app-settings'
+
+export function mergeClawModelOptions(
+  modelIds: readonly string[],
+  currentModel = ''
+): string[] {
+  const options = new Set<string>([DEFAULT_CLAW_MODEL])
+  for (const modelId of modelIds) {
+    const trimmed = modelId.trim()
+    if (trimmed && trimmed !== DEFAULT_CLAW_MODEL) options.add(trimmed)
+  }
+  const current = currentModel.trim()
+  if (current && current !== DEFAULT_CLAW_MODEL) options.add(current)
+  return [...options]
+}
+
+export function clawModelSelectOptions(
+  settings: AppSettingsV1,
+  currentModel = ''
+): string[] {
+  return mergeClawModelOptions(listModelProviderModelIds(settings), currentModel)
+}


### PR DESCRIPTION
﻿## Summary / 摘要

English:
- Limit phone-agent model dropdowns to the chat models the user has configured.
- Keep `auto` and the currently saved channel model available so old channels can still be edited safely.

中文：
- 将手机端 agent 的模型下拉限制为用户已经添加的聊天模型。
- 保留 `auto` 和当前 channel 已保存的模型，避免编辑旧配置时当前值消失。

Fixes #337

## Changes / 修改

English:
- Added a shared helper for Claw phone-agent model select options.
- Updated the add/edit phone connection dialog to use configured model options instead of hard-coded defaults.
- Updated Settings > phone-agent management to use the same option source.
- Added focused tests for configured-model filtering and legacy current-model preservation.

中文：
- 新增 Claw 手机 agent 模型下拉的共享 helper。
- 将新增/编辑手机连接对话框改为使用已配置模型选项，不再使用固定默认模型。
- 将设置页里的手机 agent 管理列表同步到同一套模型来源。
- 增加已配置模型过滤和旧模型保留的单元测试。

## Tests / 验证

- `npm.cmd test -- src/renderer/src/lib/claw-model-options.test.ts src/renderer/src/components/settings-section-claw.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`
