### PR TITLE
fix(main): harden audited edge cases / 加固审计边界场景

### DIFF
--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -1,9 +1,25 @@
 import { readFileSync } from 'node:fs'
-import { dirname, isAbsolute, join, win32 } from 'node:path'
+import { dirname, isAbsolute, relative, resolve, sep, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { nativeImage } from 'electron'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function usesWin32PathRules(baseDir: string): boolean {
+  return (win32.isAbsolute(baseDir) && !baseDir.startsWith('/')) ||
+    baseDir.startsWith('\\\\')
+}
+
+function isInsideDirectory(candidate: string, baseDir: string, useWin32: boolean): boolean {
+  const relativePath = useWin32 ? win32.relative(baseDir, candidate) : relative(baseDir, candidate)
+  const separator = useWin32 ? '\\' : sep
+  const absoluteRelativePath = useWin32 ? win32.isAbsolute(relativePath) : isAbsolute(relativePath)
+  return relativePath === '' || (
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${separator}`) &&
+    !absoluteRelativePath
+  )
+}
 
 /**
  * 解析 Vite/Rollup 给出的资产 URL,得到一个真实可读的文件系统路径。
@@ -28,7 +44,15 @@ export function resolveAppIconPath(source: string, baseDir: string = __dirname):
   // 前导斜杠剥掉,再判断 absoluteness。Windows 风格的真绝对路径(带盘符或 UNC)
   // 不以斜杠开头,原样透传。
   const normalized = source.replace(/^\/+/, '')
-  return isAbsolute(normalized) || win32.isAbsolute(normalized) ? normalized : join(baseDir, normalized)
+  if (isAbsolute(normalized) || win32.isAbsolute(normalized)) return normalized
+
+  const useWin32 = usesWin32PathRules(baseDir)
+  const resolvedBaseDir = useWin32 ? win32.resolve(baseDir) : resolve(baseDir)
+  const resolved = useWin32 ? win32.resolve(resolvedBaseDir, normalized) : resolve(resolvedBaseDir, normalized)
+  if (!isInsideDirectory(resolved, resolvedBaseDir, useWin32)) {
+    throw new Error('App icon path escapes the bundle directory.')
+  }
+  return resolved
 }
 
 /**
@@ -48,14 +72,15 @@ export function createAppIcon(source: string): Electron.NativeImage {
     return nativeImage.createFromDataURL(source)
   }
 
-  const absolute = resolveAppIconPath(source)
+  let absolute = ''
   try {
+    absolute = resolveAppIconPath(source)
     return nativeImage.createFromBuffer(readFileSync(absolute))
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     console.warn(
       '[kun-gui] failed to load app icon from',
-      absolute,
+      absolute || source,
       '-',
       message
     )

--- a/src/main/claw-runtime-helpers.test.ts
+++ b/src/main/claw-runtime-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  feishuSenderLabel,
   finalAssistantReplyText,
   imCompletionReplyForPush,
   IM_COMPLETED_NO_TEXT_REPLY,
@@ -77,5 +78,18 @@ describe('imCompletionReplyForPush', () => {
     ])
     expect(reply).toContain('a.md')
     expect(reply).toContain('b.png')
+  })
+})
+
+describe('feishuSenderLabel', () => {
+  it('falls back when sender fields are missing', () => {
+    expect(feishuSenderLabel({} as Parameters<typeof feishuSenderLabel>[0])).toBe('feishu-user')
+  })
+
+  it('prefers senderName over senderId', () => {
+    expect(feishuSenderLabel({
+      senderName: ' Alice ',
+      senderId: 'ou_123'
+    } as Parameters<typeof feishuSenderLabel>[0])).toBe('Alice')
   })
 })

--- a/src/main/claw-runtime-helpers.ts
+++ b/src/main/claw-runtime-helpers.ts
@@ -107,7 +107,9 @@ export function sanitizePathSegment(raw: string, fallback: string): string {
 }
 
 export function feishuSenderLabel(message: NormalizedMessage): string {
-  return message.senderName?.trim() || message.senderId.trim() || 'feishu-user'
+  const senderName = typeof message.senderName === 'string' ? message.senderName.trim() : ''
+  const senderId = typeof message.senderId === 'string' ? message.senderId.trim() : ''
+  return senderName || senderId || 'feishu-user'
 }
 
 export function buildFeishuPrompt(message: NormalizedMessage): string {

--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -88,9 +88,12 @@ type IncomingRemoteSession = Pick<
 >
 
 function hasFeishuPlatformCredential(channel: ClawImChannelV1): channel is FeishuClawChannel {
-  return channel.platformCredential?.kind === 'feishu' &&
-    !!channel.platformCredential.appId.trim() &&
-    !!channel.platformCredential.appSecret.trim()
+  const credential = channel.platformCredential
+  return credential?.kind === 'feishu' &&
+    typeof credential.appId === 'string' &&
+    credential.appId.trim() !== '' &&
+    typeof credential.appSecret === 'string' &&
+    credential.appSecret.trim() !== ''
 }
 
 function isMissingThreadResult(result: { ok: boolean; status: number; body: string }): boolean {

--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -55,7 +55,7 @@ describe('app icon loader', () => {
     it('joins a relative source with the provided baseDir', () => {
       const resolved = mod.resolveAppIconPath('chunks/kun-XXXX.png', '/app/bundle')
       // 路径分隔符因平台而异(Windows 是 \,其它是 /),用 toMatch 避免硬编码
-      expect(resolved.replace(/\\/g, '/')).toBe('/app/bundle/chunks/kun-XXXX.png')
+      expect(resolved.replace(/\\/g, '/')).toMatch(/(?:^[A-Za-z]:)?\/app\/bundle\/chunks\/kun-XXXX\.png$/)
     })
 
     it('strips a leading slash before joining with baseDir (dev mode quirk)', () => {
@@ -74,6 +74,12 @@ describe('app icon loader', () => {
     it('passes a data: URL through unchanged', () => {
       const dataUrl = 'data:image/png;base64,iVBORw0KGgo='
       expect(mod.resolveAppIconPath(dataUrl, '/ignored')).toBe(dataUrl)
+    })
+
+    it('rejects relative sources that escape the bundle directory', () => {
+      expect(() => mod.resolveAppIconPath('../secret.png', '/app/bundle')).toThrow(
+        /bundle directory/
+      )
     })
   })
 

--- a/src/main/kun-base-url.test.ts
+++ b/src/main/kun-base-url.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { getKunBaseUrl, normalizeLocalKunHost } from './kun-base-url'
+
+describe('getKunBaseUrl', () => {
+  it('uses 127.0.0.1 by default', () => {
+    expect(getKunBaseUrl(8899)).toBe('http://127.0.0.1:8899')
+  })
+
+  it('formats IPv6 loopback hosts for URL use', () => {
+    expect(getKunBaseUrl(8899, '::1')).toBe('http://[::1]:8899')
+    expect(getKunBaseUrl(8899, '[::1]')).toBe('http://[::1]:8899')
+  })
+
+  it('accepts localhost aliases only', () => {
+    expect(normalizeLocalKunHost('localhost')).toBe('localhost')
+    expect(() => getKunBaseUrl(8899, 'example.com')).toThrow(/local host/)
+  })
+})

--- a/src/main/kun-base-url.ts
+++ b/src/main/kun-base-url.ts
@@ -4,5 +4,18 @@
  * settings (default 8899).
  */
 export function getKunBaseUrl(port: number, host = '127.0.0.1'): string {
-  return `http://${host}:${port}`
+  const normalizedHost = normalizeLocalKunHost(host)
+  return `http://${formatHostForUrl(normalizedHost)}:${port}`
+}
+
+export function normalizeLocalKunHost(host: string): string {
+  const normalized = host.trim().toLowerCase()
+  if (normalized === 'localhost') return 'localhost'
+  if (normalized === '127.0.0.1') return '127.0.0.1'
+  if (normalized === '::1' || normalized === '[::1]') return '::1'
+  throw new Error(`Kun local host must be localhost, 127.0.0.1, or ::1; got "${host}".`)
+}
+
+function formatHostForUrl(host: string): string {
+  return host.includes(':') ? `[${host}]` : host
 }

--- a/src/main/kun-runtime-supervisor.test.ts
+++ b/src/main/kun-runtime-supervisor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { RestartBudget } from './kun-runtime-supervisor'
+import { MAX_RESTART_DELAY_MS, RestartBudget } from './kun-runtime-supervisor'
 
 function budgetAt(times: { value: number }): RestartBudget {
   return new RestartBudget({
@@ -59,5 +59,33 @@ describe('RestartBudget', () => {
 
     const verdict = budget.note()
     expect(verdict).toEqual({ allowed: true, attempt: 1, delayMs: 1_000 })
+  })
+
+  it('clamps restart delays to the maximum timer delay', () => {
+    const budget = new RestartBudget({
+      windowMs: 60_000,
+      maxRestarts: 3,
+      baseDelayMs: Number.MAX_SAFE_INTEGER,
+      delayFactor: Number.MAX_SAFE_INTEGER,
+      now: () => 0
+    })
+
+    expect(budget.note()).toEqual({
+      allowed: true,
+      attempt: 1,
+      delayMs: MAX_RESTART_DELAY_MS
+    })
+  })
+
+  it('falls back from non-finite numeric options', () => {
+    const budget = new RestartBudget({
+      windowMs: Number.NaN,
+      maxRestarts: Number.NaN,
+      baseDelayMs: Number.NaN,
+      delayFactor: Number.NaN,
+      now: () => 0
+    })
+
+    expect(budget.note()).toEqual({ allowed: true, attempt: 1, delayMs: 1_000 })
   })
 })

--- a/src/main/kun-runtime-supervisor.ts
+++ b/src/main/kun-runtime-supervisor.ts
@@ -22,6 +22,12 @@ export type RestartBudgetOptions = {
   now?: () => number
 }
 
+export const MAX_RESTART_DELAY_MS = 2_147_483_647
+
+function finiteNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
 /**
  * Sliding-window restart budget: allows up to `maxRestarts` attempts per
  * `windowMs`, with exponential backoff delays (base, base*factor, ...).
@@ -37,10 +43,10 @@ export class RestartBudget {
   private attempts: number[] = []
 
   constructor(options: RestartBudgetOptions) {
-    this.windowMs = Math.max(1, options.windowMs)
-    this.maxRestarts = Math.max(1, options.maxRestarts)
-    this.baseDelayMs = Math.max(0, options.baseDelayMs ?? 1_000)
-    this.delayFactor = Math.max(1, options.delayFactor ?? 3)
+    this.windowMs = Math.max(1, finiteNumber(options.windowMs, 60_000))
+    this.maxRestarts = Math.max(1, finiteNumber(options.maxRestarts, 3))
+    this.baseDelayMs = Math.max(0, finiteNumber(options.baseDelayMs, 1_000))
+    this.delayFactor = Math.max(1, finiteNumber(options.delayFactor, 3))
     this.now = options.now ?? (() => Date.now())
   }
 
@@ -56,7 +62,10 @@ export class RestartBudget {
     return {
       allowed: true,
       attempt,
-      delayMs: Math.round(this.baseDelayMs * Math.pow(this.delayFactor, attempt - 1))
+      delayMs: Math.min(
+        MAX_RESTART_DELAY_MS,
+        Math.round(this.baseDelayMs * Math.pow(this.delayFactor, attempt - 1))
+      )
     }
   }
 


### PR DESCRIPTION
## Summary / 摘要
- Harden a small set of low-risk audit findings from #334 without changing product behavior.
- 针对 #334 中可以独立落地、风险较低的审计项做防御性加固，不改变现有产品行为。

## Changes / 变更
- Keep app icon relative asset paths inside the bundle directory and fall back to an empty icon on invalid paths.
- 将应用图标的相对资源路径限制在 bundle 目录内；非法路径继续回退为空图标。
- Restrict Kun local base URL hosts to loopback aliases and format IPv6 loopback correctly.
- 限制 Kun 本地 Base URL 只接受 loopback 主机，并正确格式化 IPv6 loopback。
- Make Feishu/Lark sender and credential reads tolerant of malformed runtime data.
- 让飞书/Lark 的 sender 和凭据读取能容忍运行时异常数据。
- Clamp restart backoff delays and ignore non-finite numeric options.
- 限制重启退避延迟上限，并忽略非有限数配置。

## Tests / 测试
- `npm.cmd test -- src/main/index.test.ts src/main/kun-base-url.test.ts src/main/kun-runtime-supervisor.test.ts src/main/claw-runtime-helpers.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`

Part of #334.