### PR TITLE
fix(renderer): show visible route fallback / 显示可见路由加载状态

### DIFF
--- a/src/renderer/src/AppShell.test.ts
+++ b/src/renderer/src/AppShell.test.ts
@@ -19,4 +19,16 @@ describe('AppShell', () => {
     expect(html).toContain('flex min-h-0 flex-1 flex-col')
     expect(html).not.toContain('ds-windows-titlebar')
   })
+
+  it('renders a visible route fallback instead of a blank shell while lazy views load', () => {
+    vi.stubGlobal('window', {
+      kunGui: { platform: 'win32' }
+    })
+
+    const html = renderToStaticMarkup(createElement(AppShell))
+
+    expect(html).toContain('role="status"')
+    expect(html).toContain('Loading')
+    expect(html).toContain('bg-ds-card')
+  })
 })

--- a/src/renderer/src/AppShell.tsx
+++ b/src/renderer/src/AppShell.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useEffect } from 'react'
 import { useChatStore } from './store/chat-store'
 import { supportsDesktopTitleBar, WindowsTitleBar } from './components/WindowsTitleBar'
 import { RuntimeStatusBanner } from './components/RuntimeStatusBanner'
+import i18n from './i18n'
 
 const Workbench = lazy(() =>
   import('./components/Workbench').then((module) => ({ default: module.Workbench }))
@@ -16,7 +17,18 @@ const InitialSetupDialog = lazy(() =>
 )
 
 function RouteFallback(): React.ReactElement {
-  return <div className="h-full bg-ds-main" />
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex h-full min-h-0 items-center justify-center bg-ds-main text-ds-muted"
+    >
+      <div className="flex items-center gap-2 rounded-full border border-ds-border-muted bg-ds-card px-4 py-2 text-[13px] shadow-sm">
+        <span className="h-2 w-2 animate-pulse rounded-full bg-accent" aria-hidden />
+        <span>{i18n.t('loading')}</span>
+      </div>
+    </div>
+  )
 }
 
 export default function AppShell(): React.ReactElement {


### PR DESCRIPTION
## Summary / 摘要
- Replace the route-level blank Suspense fallback with a visible loading state.
- 将路由级 Suspense 的纯空白 fallback 改成可见的加载状态。
- Keep the existing app error boundary in place so render failures still show the recovery UI instead of an empty shell.
- 保留现有应用错误边界，让渲染错误继续显示可恢复界面，而不是停在空白外壳。

## Why / 原因
- #345 reports a blank white screen while the model is processing. The report does not include renderer logs yet, so this PR fixes the confirmed blank fallback path first and makes the app state visible while lazy views are loading.
- #345 反馈模型处理中出现白屏，但目前没有 renderer 日志。这个 PR 先修掉可以确认的空白 fallback 路径，让懒加载视图期间至少有明确的界面状态。

## Tests / 测试
- `npm.cmd test -- src/renderer/src/AppShell.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`

Part of #345.