### PR TITLE
fix(tools): add read path recovery guidance / 增加 read 路径恢复提示

### DIFF
--- a/kun/src/adapters/tool/builtin-read-tool.ts
+++ b/kun/src/adapters/tool/builtin-read-tool.ts
@@ -34,7 +34,21 @@ export function createReadLocalTool(options: ReadLocalToolOptions = {}): LocalTo
     policy: 'auto',
     execute: async (args, context) => withToolBoundary(async () => {
       const rawPath = typeof args.path === 'string' ? args.path : ''
-      if (!rawPath.trim()) return { output: { error: 'path is required' }, isError: true }
+      if (!rawPath.trim()) {
+        return {
+          output: {
+            code: 'missing_path',
+            error: 'path is required',
+            hint: 'Pass a workspace-relative file path to read. If the target file is unknown, use ls, find, or grep first.',
+            expected_argument: { path: 'relative/path/from/workspace' },
+            examples: [
+              { path: 'README.md' },
+              { path: 'src/main.ts' }
+            ]
+          },
+          isError: true
+        }
+      }
       const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
       await statOp(absolutePath)
       const fileBuffer = await readFileOp(absolutePath)

--- a/kun/tests/builtin-tools.test.ts
+++ b/kun/tests/builtin-tools.test.ts
@@ -226,6 +226,32 @@ describe('Kun built-in tools', () => {
     expect(String((editResult.item as { output?: { error?: string } }).output?.error)).toContain('truncated')
   })
 
+  it('gives recovery guidance when read is called without a path', async () => {
+    const result = await host.execute(
+      {
+        callId: 'call_read_missing_path',
+        toolName: 'read',
+        arguments: {}
+      },
+      buildContext(workspace)
+    )
+
+    expect(result.item).toMatchObject({
+      kind: 'tool_result',
+      toolName: 'read',
+      isError: true,
+      output: {
+        code: 'missing_path',
+        error: 'path is required',
+        expected_argument: { path: 'relative/path/from/workspace' }
+      }
+    })
+    const output = result.item.kind === 'tool_result'
+      ? result.item.output as { hint?: string }
+      : {}
+    expect(String(output.hint)).toContain('ls, find, or grep')
+  })
+
   it('blocks host shell execution in workspace-write sandbox mode', async () => {
     const result = await host.execute(
       {


### PR DESCRIPTION
﻿## Summary / 摘要
- Add structured recovery guidance when the built-in `read` tool is called without a `path` argument.
- 当内置 `read` 工具缺少 `path` 参数时，返回结构化恢复提示，而不是只有裸 `path is required`。
- Tell the model to pass a workspace-relative path or use `ls` / `find` / `grep` first when the target file is unknown.
- 明确提示模型传入工作区相对路径；如果目标文件未知，先用 `ls` / `find` / `grep` 查找。

## Why / 原因
- The error in #341 is a recoverable tool-call argument error. A single occurrence does not stop the agent, but repeated bare errors can waste turns and make the UI look noisy.
- #341 里的错误属于可恢复的工具参数错误；单次出现不会中断智能体，但反复出现裸错误会浪费轮次，也会让界面看起来很乱。

## Tests / 测试
- `npm.cmd test -- tests/builtin-tools.test.ts -t "gives recovery guidance"`
- `npm.cmd run typecheck` (in `kun/`)
- `git diff --check`

## Notes / 说明
- I also ran the full `tests/builtin-tools.test.ts` file on Windows. It still has existing unrelated failures around fd backend selection, bash timing, Windows path separators, and temp directory EBUSY cleanup. The new focused read-tool case passed.
- 我也在 Windows 上跑过完整 `tests/builtin-tools.test.ts`，其中仍有和本次改动无关的既有失败：fd 后端选择、bash timing、Windows 路径分隔符、临时目录 EBUSY 清理。新增的 read 工具用例已通过。

Part of #341.
