### PR TITLE
feat(image): route attached images into edits / 将附件图片用于图生图

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, relative, resolve } from 'node:path'
 import type { ModelClient, ModelRequest, ModelStreamChunk, ModelToolSpec } from '../ports/model-client.js'
 import type {
   ToolHost,
@@ -977,6 +978,12 @@ export class AgentLoop {
         ? [goalRecoveryInstruction]
         : []),
       ...(activeTodoInstruction ? [activeTodoInstruction] : []),
+      ...buildImageGenerationReferenceInstructions({
+        imageAttachments: attachments.imageAttachments,
+        textFallbacks: attachments.textFallbacks,
+        workspace: thread?.workspace ?? '',
+        tools: effectiveToolSpecs
+      }),
       ...memoryInstructions(memories),
       ...skillResolution.instructions,
       ...(userInputDisabled ? [userInputUnavailableInstruction()] : []),
@@ -2340,7 +2347,8 @@ export class AgentLoop {
           mimeType: attachment.mimeType,
           dataBase64: attachment.data.toString('base64'),
           ...(attachment.width ? { width: attachment.width } : {}),
-          ...(attachment.height ? { height: attachment.height } : {})
+          ...(attachment.height ? { height: attachment.height } : {}),
+          ...(attachment.localFilePath ? { localFilePath: attachment.localFilePath } : {})
         })
         continue
       }
@@ -2646,6 +2654,53 @@ function sanitizeProviderBaseUrl(baseUrl: string): string {
 
 function autoModelRouteKey(threadId: string, turnId: string): string {
   return `${threadId}:${turnId}`
+}
+
+type ImageReferenceAttachment = {
+  name: string
+  mimeType: string
+  localFilePath?: string
+}
+
+export function buildImageGenerationReferenceInstructions(input: {
+  imageAttachments: readonly ImageReferenceAttachment[]
+  textFallbacks: readonly ImageReferenceAttachment[]
+  workspace: string
+  tools: readonly Pick<ModelToolSpec, 'name'>[]
+}): string[] {
+  if (!input.tools.some((tool) => tool.name === 'generate_image')) return []
+  const references = [
+    ...input.imageAttachments,
+    ...input.textFallbacks
+  ]
+    .map((attachment) => ({
+      name: attachment.name,
+      path: imageReferencePath(attachment.localFilePath, input.workspace),
+      mimeType: attachment.mimeType
+    }))
+    .filter((attachment): attachment is { name: string; path: string; mimeType: string } =>
+      Boolean(attachment.path) && attachment.mimeType.startsWith('image/')
+    )
+  if (references.length === 0) return []
+
+  return [
+    [
+      'Image-to-image reference images are available for this turn:',
+      ...references.map((reference) => `- ${reference.name}: ${reference.path}`),
+      'When the user asks to edit, restyle, transform, redraw, or use an attached image as the source image, call `generate_image` with `reference_image_paths` set to the matching workspace-relative path(s). Do not describe the attachment first and then call text-to-image unless the user explicitly asks for a description instead of an image edit.'
+    ].join('\n')
+  ]
+}
+
+function imageReferencePath(localFilePath: string | undefined, workspace: string): string | null {
+  const workspaceRoot = workspace.trim()
+  const rawPath = localFilePath?.trim()
+  if (!workspaceRoot || !rawPath) return null
+  const workspaceAbsolute = resolve(workspaceRoot)
+  const fileAbsolute = isAbsolute(rawPath) ? resolve(rawPath) : resolve(workspaceAbsolute, rawPath)
+  const relativePath = relative(workspaceAbsolute, fileAbsolute)
+  if (!relativePath || relativePath.startsWith('..') || isAbsolute(relativePath)) return null
+  return relativePath.replace(/\\/g, '/')
 }
 
 function memoryInstructions(memories: Array<{ id: string; content: string; scope: string }>): string[] {

--- a/kun/src/ports/model-client.ts
+++ b/kun/src/ports/model-client.ts
@@ -71,6 +71,7 @@ export type ModelInputAttachment = {
   dataBase64: string
   width?: number
   height?: number
+  localFilePath?: string
 }
 
 export type ModelTextAttachmentFallback = {

--- a/kun/tests/agent-loop-image-reference.test.ts
+++ b/kun/tests/agent-loop-image-reference.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { buildImageGenerationReferenceInstructions } from '../src/loop/agent-loop.js'
+
+describe('image generation reference instructions', () => {
+  it('lists workspace-relative image paths when generate_image is available', () => {
+    const instructions = buildImageGenerationReferenceInstructions({
+      workspace: '/workspace/app',
+      tools: [{ name: 'generate_image' }],
+      imageAttachments: [
+        {
+          name: 'source.png',
+          mimeType: 'image/png',
+          localFilePath: '/workspace/app/assets/source.png'
+        }
+      ],
+      textFallbacks: []
+    })
+
+    expect(instructions).toHaveLength(1)
+    expect(instructions[0]).toContain('reference_image_paths')
+    expect(instructions[0]).toContain('assets/source.png')
+  })
+
+  it('does not add guidance when the image tool is not available', () => {
+    expect(buildImageGenerationReferenceInstructions({
+      workspace: '/workspace/app',
+      tools: [{ name: 'read' }],
+      imageAttachments: [
+        { name: 'source.png', mimeType: 'image/png', localFilePath: '/workspace/app/source.png' }
+      ],
+      textFallbacks: []
+    })).toEqual([])
+  })
+
+  it('does not expose local paths outside the workspace', () => {
+    const instructions = buildImageGenerationReferenceInstructions({
+      workspace: '/workspace/app',
+      tools: [{ name: 'generate_image' }],
+      imageAttachments: [
+        { name: 'clip.png', mimeType: 'image/png', localFilePath: '/tmp/clip.png' }
+      ],
+      textFallbacks: []
+    })
+
+    expect(instructions).toEqual([])
+  })
+})


### PR DESCRIPTION
﻿## Summary / 摘要
- Route attached workspace images into image-generation turns as reusable reference paths.
- 将已附加的工作区图片传递给图像生成回合，作为可复用的参考图路径。
- Tell the agent to call `generate_image` with `reference_image_paths` when the user asks for edit/restyle/transform workflows.
- 当用户要求编辑、重绘、风格化或基于附件生成图片时，提示智能体使用 `reference_image_paths` 调用 `generate_image`。
- Keep local temp paths outside the workspace out of the prompt.
- 不把工作区外的本地临时路径写入提示，避免泄露本机路径。

## Why / 原因
- The current flow can see attached images, but img2img requests may still be handled as describe-then-text-to-image.
- 当前流程能看到附件图片，但图生图请求可能仍被当作“先描述图片，再文生图”处理。
- This keeps the request aligned with the existing `generate_image.reference_image_paths` contract.
- 这让请求与现有 `generate_image.reference_image_paths` 契约保持一致。

## Tests / 测试
- `cd kun; npm.cmd test -- tests/agent-loop-image-reference.test.ts tests/image-gen-tool-provider.test.ts`
- `cd kun; npm.cmd run typecheck`
- `git diff --check`

Part of #339
