### PR TITLE
feat(ui): add cursor spotlight preference / 增加鼠标跟随高光开关

### DIFF
--- a/src/main/ipc/app-ipc-schemas.ts
+++ b/src/main/ipc/app-ipc-schemas.ts
@@ -430,6 +430,10 @@ const appBehaviorPatchSchema = z.object({
   closeToTray: z.boolean().optional()
 }).strict()
 
+const uiEffectsPatchSchema = z.object({
+  cursorSpotlight: z.boolean().optional()
+}).strict()
+
 const keyboardShortcutCommandIds = KEYBOARD_SHORTCUT_COMMANDS.map((command) => command.id) as [
   typeof KEYBOARD_SHORTCUT_COMMANDS[number]['id'],
   ...Array<typeof KEYBOARD_SHORTCUT_COMMANDS[number]['id']>
@@ -708,6 +712,7 @@ const settingsPatchObjectSchema = z.object({
   log: logPatchSchema.optional(),
   notifications: notificationsPatchSchema.optional(),
   appBehavior: appBehaviorPatchSchema.optional(),
+  uiEffects: uiEffectsPatchSchema.optional(),
   keyboardShortcuts: keyboardShortcutsPatchSchema.optional(),
   write: writeSettingsPatchSchema.optional(),
   claw: clawSettingsPatchSchema.optional(),

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -19,6 +19,7 @@ import {
   mergeScheduleSettings,
   mergeWriteSettings,
   normalizeAppBehaviorSettings,
+  normalizeUiEffectsSettings,
   normalizeKeyboardShortcuts,
   migrateLegacyAppSettings,
   normalizeAppSettings,
@@ -208,6 +209,7 @@ const defaultSettings = (): AppSettingsV1 => ({
     turnComplete: true
   },
   appBehavior: normalizeAppBehaviorSettings(),
+  uiEffects: normalizeUiEffectsSettings(),
   keyboardShortcuts: normalizeKeyboardShortcuts(),
   guiUpdate: {
     channel: DEFAULT_GUI_UPDATE_CHANNEL
@@ -234,6 +236,10 @@ function buildMergedSettings(parsed: Partial<AppSettingsV1>): AppSettingsV1 {
     appBehavior: normalizeAppBehaviorSettings({
       ...defaults.appBehavior,
       ...migrated.appBehavior
+    }),
+    uiEffects: normalizeUiEffectsSettings({
+      ...(defaults.uiEffects ?? {}),
+      ...(migrated.uiEffects ?? {})
     }),
     keyboardShortcuts: normalizeKeyboardShortcuts(migrated.keyboardShortcuts),
     write: mergeWriteSettings(defaults.write, migrated.write),
@@ -403,6 +409,10 @@ export class JsonSettingsStore {
       appBehavior: normalizeAppBehaviorSettings({
         ...cur.appBehavior,
         ...(partial.appBehavior ?? {})
+      }),
+      uiEffects: normalizeUiEffectsSettings({
+        ...(cur.uiEffects ?? {}),
+        ...(partial.uiEffects ?? {})
       }),
       keyboardShortcuts: normalizeKeyboardShortcuts({
         bindings: {

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -24,7 +24,7 @@ import type {
   CoreRuntimeToolDiagnosticsJson
 } from '../agent/kun-contract'
 import type { WriteInlineCompletionDebugEntry } from '@shared/write-inline-completion'
-import { applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
+import { applyCursorSpotlight, applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
 import { formatWorkspacePickerError } from '../lib/format-workspace-picker-error'
 import type { SkillRootListItem } from '@shared/kun-gui-api'
 import { normalizeWorkspaceRoot } from '../lib/workspace-path'
@@ -124,6 +124,7 @@ export function SettingsView(): ReactElement {
   const permissionsSectionRef = useRef<HTMLDivElement | null>(null)
   const formTheme = form?.theme
   const formUiFontScale = form?.uiFontScale
+  const formCursorSpotlight = form?.uiEffects?.cursorSpotlight
   const writeTypography = form?.write?.typography
   const formWorkspaceRoot = form?.workspaceRoot
   const formKun = form ? getKunRuntimeSettings(form) : null
@@ -172,6 +173,11 @@ export function SettingsView(): ReactElement {
     applyTheme(formTheme)
     applyUiFontScale(formUiFontScale)
   }, [formTheme, formUiFontScale])
+
+  useEffect(() => {
+    if (typeof formCursorSpotlight !== 'boolean') return
+    applyCursorSpotlight(formCursorSpotlight)
+  }, [formCursorSpotlight])
 
   // Live-preview the Write editor typography as the form changes, mirroring the
   // theme/scale preview above. Keyed on the scalar fields so it only re-applies

--- a/src/renderer/src/components/WindowsTitleBar.tsx
+++ b/src/renderer/src/components/WindowsTitleBar.tsx
@@ -277,7 +277,7 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
   }
 
   return (
-    <div ref={rootRef} className="ds-windows-titlebar ds-drag">
+    <div ref={rootRef} className="ds-windows-titlebar ds-drag" data-cursor-spotlight-target>
       <div className="ds-windows-titlebar-content">
         <img src={kunLogo} alt="" aria-hidden="true" className="ds-windows-titlebar-icon" />
         <nav className="ds-windows-menu ds-no-drag" aria-label={t('windowsMenuAriaLabel')}>
@@ -288,6 +288,7 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
                 <button
                   type="button"
                   className={`ds-windows-menu-button ${open ? 'is-open' : ''}`}
+                  data-cursor-spotlight-target
                   aria-haspopup="menu"
                   aria-expanded={open}
                   onClick={() => setActiveMenuId(open ? null : menu.id)}
@@ -327,6 +328,7 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
         <button
           type="button"
           className="ds-window-control-btn"
+          data-cursor-spotlight-target
           aria-label={t('windowsMenuMinimize')}
           onClick={handleMinimize}
         >
@@ -335,6 +337,7 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
         <button
           type="button"
           className="ds-window-control-btn"
+          data-cursor-spotlight-target
           aria-label={t('windowsMenuToggleMaximize')}
           onClick={handleToggleMaximize}
         >
@@ -343,6 +346,7 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
         <button
           type="button"
           className="ds-window-control-btn ds-window-control-btn--close"
+          data-cursor-spotlight-target
           aria-label={t('windowsMenuClose')}
           onClick={handleClose}
         >

--- a/src/renderer/src/components/chat/Sidebar.tsx
+++ b/src/renderer/src/components/chat/Sidebar.tsx
@@ -311,6 +311,7 @@ function FocusModeToggle({
       aria-checked={enabled}
       aria-label={ariaLabel}
       title={`${title} · ${status}`}
+      data-cursor-spotlight-target
       onClick={onToggle}
       className={`group inline-flex h-8 w-[112px] shrink-0 items-center justify-between overflow-hidden rounded-[10px] border px-2.5 text-[12px] font-medium outline-none transition focus-visible:ring-2 focus-visible:ring-accent/25 ${
         enabled

--- a/src/renderer/src/components/settings-section-general.tsx
+++ b/src/renderer/src/components/settings-section-general.tsx
@@ -152,6 +152,16 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                   }
                 />
                 <SettingRow
+                  title={t('cursorSpotlight')}
+                  description={t('cursorSpotlightDesc')}
+                  control={
+                    <Toggle
+                      checked={form.uiEffects?.cursorSpotlight !== false}
+                      onChange={(v) => update({ uiEffects: { cursorSpotlight: v } })}
+                    />
+                  }
+                />
+                <SettingRow
                   title={t('workspaceRoot')}
                   description={t('workspaceRootDesc')}
                   control={

--- a/src/renderer/src/components/settings-utils.ts
+++ b/src/renderer/src/components/settings-utils.ts
@@ -10,6 +10,7 @@ import {
   mergeScheduleSettings,
   mergeWriteSettings,
   normalizeAppBehaviorSettings,
+  normalizeUiEffectsSettings,
   normalizeClawSettings,
   normalizeGuiUpdateChannel,
   normalizeKeyboardShortcuts,
@@ -61,6 +62,10 @@ export function mergeSettings(current: AppSettingsV1, patch: SettingsPatch): App
       ...safeCurrent.appBehavior,
       ...(patch.appBehavior ?? {})
     }),
+    uiEffects: normalizeUiEffectsSettings({
+      ...(safeCurrent.uiEffects ?? {}),
+      ...(patch.uiEffects ?? {})
+    }),
     keyboardShortcuts: normalizeKeyboardShortcuts({
       bindings: {
         ...safeCurrent.keyboardShortcuts.bindings,
@@ -103,6 +108,7 @@ export function coerceRendererSettings(settings: AppSettingsV1): AppSettingsV1 {
       turnComplete: raw.notifications?.turnComplete !== false
     },
     appBehavior: normalizeAppBehaviorSettings(raw.appBehavior),
+    uiEffects: normalizeUiEffectsSettings(raw.uiEffects),
     keyboardShortcuts: normalizeKeyboardShortcuts(raw.keyboardShortcuts),
     write: normalizeWriteSettings(raw.write),
     claw: normalizeClawSettings(raw.claw),

--- a/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
+++ b/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
@@ -111,6 +111,7 @@ export function SidebarCommandRow({
     <button
       type="button"
       disabled={disabled}
+      data-cursor-spotlight-target
       title={disabled ? disabledHint : undefined}
       onClick={onClick}
       className={cx(
@@ -200,6 +201,7 @@ export function SidebarIconButton({
     <button
       type="button"
       disabled={disabled}
+      data-cursor-spotlight-target
       onPointerDown={(event) => {
         if (stopPropagation) event.stopPropagation()
       }}
@@ -315,6 +317,7 @@ export function SidebarTreeRow({
 
   return (
     <div
+      data-cursor-spotlight-target
       className={cx(
         'group relative flex w-full items-center overflow-hidden rounded-[8px] text-[13px] font-normal transition',
         outlined

--- a/src/renderer/src/lib/apply-theme.test.ts
+++ b/src/renderer/src/lib/apply-theme.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { applyDocumentLocale } from './apply-theme'
+import { applyCursorSpotlight, applyDocumentLocale } from './apply-theme'
 
 describe('applyDocumentLocale', () => {
   afterEach(() => {
@@ -37,5 +37,28 @@ describe('applyDocumentLocale', () => {
 
     applyDocumentLocale('en')
     expect(writes).toBe(0)
+  })
+})
+
+describe('applyCursorSpotlight', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('mirrors the setting onto a document attribute', () => {
+    const attributes = new Map<string, string>()
+    vi.stubGlobal('document', {
+      documentElement: {
+        setAttribute: (name: string, value: string) => {
+          attributes.set(name, value)
+        }
+      }
+    })
+
+    applyCursorSpotlight(true)
+    expect(attributes.get('data-cursor-spotlight')).toBe('on')
+
+    applyCursorSpotlight(false)
+    expect(attributes.get('data-cursor-spotlight')).toBe('off')
   })
 })

--- a/src/renderer/src/lib/apply-theme.ts
+++ b/src/renderer/src/lib/apply-theme.ts
@@ -49,6 +49,10 @@ export function applyUiFontScale(scale: UiFontScale): void {
   root.style.setProperty('--ds-ui-scale', factor)
 }
 
+export function applyCursorSpotlight(enabled: boolean): void {
+  document.documentElement.setAttribute('data-cursor-spotlight', enabled ? 'on' : 'off')
+}
+
 /**
  * Pushes the Write editor typography onto CSS variables consumed by the rich
  * editor, the CodeMirror live appearance, and the markdown preview. Setting the

--- a/src/renderer/src/lib/cursor-spotlight.ts
+++ b/src/renderer/src/lib/cursor-spotlight.ts
@@ -1,0 +1,20 @@
+let installed = false
+
+export function installCursorSpotlightTracking(): void {
+  if (installed || typeof document === 'undefined') return
+  installed = true
+
+  document.addEventListener(
+    'pointermove',
+    (event) => {
+      const target = event.target instanceof Element
+        ? event.target.closest<HTMLElement>('[data-cursor-spotlight-target]')
+        : null
+      if (!target) return
+      const rect = target.getBoundingClientRect()
+      target.style.setProperty('--spotlight-x', `${event.clientX - rect.left}px`)
+      target.style.setProperty('--spotlight-y', `${event.clientY - rect.top}px`)
+    },
+    { passive: true }
+  )
+}

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -125,6 +125,8 @@
   "fontScaleMedium": "Medium",
   "fontScaleLarge": "Large",
   "fontScaleCurrent": "Current: {{value}}",
+  "cursorSpotlight": "Cursor-follow spotlight",
+  "cursorSpotlightDesc": "Show a subtle hover glow that follows the pointer on the title bar and sidebar. Turn it off on slower devices.",
   "turnCompleteNotification": "Reply completion notifications",
   "turnCompleteNotificationDesc": "Show a native Windows/macOS notification when the AI assistant finishes replying.",
   "desktopBehavior": "Desktop behavior",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -125,6 +125,8 @@
   "fontScaleMedium": "中",
   "fontScaleLarge": "大",
   "fontScaleCurrent": "当前：{{value}}",
+  "cursorSpotlight": "鼠标跟随高光",
+  "cursorSpotlightDesc": "在置顶栏和侧边栏显示跟随鼠标的柔和悬停高光。电脑性能较弱时可以关闭。",
   "turnCompleteNotification": "回复完成通知",
   "turnCompleteNotificationDesc": "AI 助手回复完成时，显示 Windows/macOS 系统通知。",
   "desktopBehavior": "桌面行为",

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -11,8 +11,10 @@ import './styles/write-editor.css'
 import './styles/write-rich-editor.css'
 import App from './App'
 import './i18n'
+import { installCursorSpotlightTracking } from './lib/cursor-spotlight'
 
 document.documentElement.dataset.platform = window.kunGui?.platform ?? 'unknown'
+installCursorSpotlightTracking()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/renderer/src/store/chat-store-app-actions.test.ts
+++ b/src/renderer/src/store/chat-store-app-actions.test.ts
@@ -77,6 +77,7 @@ function buildHarness(fetchModelsResult: FetchModelsResult): {
       },
       applyTheme: () => undefined,
       applyUiFontScale: () => undefined,
+      applyCursorSpotlight: () => undefined,
       applyWriteTypography: () => undefined,
       applyDocumentLocale: () => undefined,
       workspaceLabelFromPath: (workspaceRoot) => workspaceRoot,

--- a/src/renderer/src/store/chat-store-app-actions.ts
+++ b/src/renderer/src/store/chat-store-app-actions.ts
@@ -24,6 +24,7 @@ type CreateAppActionsOptions = {
   setComposerModelLoadPromise: (promise: Promise<void> | null) => void
   applyTheme: (theme: AppSettingsV1['theme']) => void
   applyUiFontScale: (scale: AppSettingsV1['uiFontScale']) => void
+  applyCursorSpotlight: (enabled: boolean) => void
   applyWriteTypography: (typography: AppSettingsV1['write']['typography']) => void
   applyDocumentLocale: (locale: AppSettingsV1['locale']) => void
   workspaceLabelFromPath: (workspaceRoot: string) => string
@@ -59,6 +60,7 @@ export function createAppActions(options: CreateAppActionsOptions): Pick<
     setComposerModelLoadPromise,
     applyTheme,
     applyUiFontScale,
+    applyCursorSpotlight,
     applyWriteTypography,
     applyDocumentLocale,
     workspaceLabelFromPath,
@@ -188,6 +190,7 @@ export function createAppActions(options: CreateAppActionsOptions): Pick<
       const workspaceRoot = normalizeWorkspaceRoot(settings.workspaceRoot)
       applyTheme(settings.theme)
       applyUiFontScale(settings.uiFontScale)
+      applyCursorSpotlight(settings.uiEffects?.cursorSpotlight !== false)
       if (settings.write?.typography) applyWriteTypography(settings.write.typography)
       set({
         workspaceRoot,

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -2,7 +2,7 @@ import type { NormalizedThread } from '../agent/types'
 import { getProvider } from '../agent/registry'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 import i18n from '../i18n'
-import { applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
+import { applyCursorSpotlight, applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
 import { formatWorkspacePickerError } from '../lib/format-workspace-picker-error'
 import { formatRuntimeError, getRuntimeErrorCode } from '../lib/format-runtime-error'
 import {
@@ -367,6 +367,7 @@ export function createNavigationActions(
         const needsInitialSetup = !getActiveAgentApiKey(settings).trim()
         applyTheme(settings.theme)
         applyUiFontScale(settings.uiFontScale)
+        applyCursorSpotlight(settings.uiEffects?.cursorSpotlight !== false)
         if (settings.write?.typography) applyWriteTypography(settings.write.typography)
         await get().applyI18nFromSettings(settings.locale)
         if (!runtimeStatusUnsubscribe && typeof window.kunGui.onRuntimeStatus === 'function') {

--- a/src/renderer/src/store/chat-store.ts
+++ b/src/renderer/src/store/chat-store.ts
@@ -3,7 +3,7 @@ import type { NormalizedThread } from '../agent/types'
 import { getProvider } from '../agent/registry'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 import i18n from '../i18n'
-import { applyDocumentLocale, applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
+import { applyCursorSpotlight, applyDocumentLocale, applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
 import { formatWorkspacePickerError } from '../lib/format-workspace-picker-error'
 import { formatRuntimeError, getRuntimeErrorCode } from '../lib/format-runtime-error'
 import {
@@ -194,6 +194,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     },
     applyTheme,
     applyUiFontScale,
+    applyCursorSpotlight,
     applyWriteTypography,
     applyDocumentLocale,
     workspaceLabelFromPath,

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -89,6 +89,8 @@
   --ds-scrollbar-thumb: rgba(84, 103, 140, 0.24);
   --ds-scrollbar-thumb-hover: rgba(84, 103, 140, 0.34);
   --ds-selection: rgba(59, 130, 216, 0.2);
+  --ds-cursor-spotlight: rgba(133, 193, 241, 0.28);
+  --ds-cursor-spotlight-strong: rgba(108, 162, 221, 0.18);
   --ds-shadow-card-soft: 0 10px 28px rgba(20, 47, 95, 0.06);
   --ds-shadow-card-strong: 0 14px 36px rgba(20, 47, 95, 0.09);
   --ds-shadow-chip: inset 0 1px 0 rgba(255, 255, 255, 0.78);
@@ -198,6 +200,8 @@
   --ds-scrollbar-thumb: rgba(151, 178, 215, 0.28);
   --ds-scrollbar-thumb-hover: rgba(171, 198, 233, 0.38);
   --ds-selection: rgba(111, 176, 232, 0.26);
+  --ds-cursor-spotlight: rgba(111, 176, 232, 0.2);
+  --ds-cursor-spotlight-strong: rgba(151, 192, 235, 0.12);
   --ds-shadow-card-soft: 0 16px 42px rgba(2, 6, 16, 0.22);
   --ds-shadow-card-strong: 0 22px 56px rgba(2, 6, 16, 0.3);
   --ds-shadow-chip: inset 0 1px 0 rgba(151, 192, 235, 0.06);
@@ -289,6 +293,8 @@
   --ds-scrollbar-thumb: rgba(117, 96, 63, 0.24);
   --ds-scrollbar-thumb-hover: rgba(117, 96, 63, 0.34);
   --ds-selection: rgba(216, 115, 13, 0.2);
+  --ds-cursor-spotlight: rgba(250, 204, 21, 0.24);
+  --ds-cursor-spotlight-strong: rgba(216, 115, 13, 0.14);
   --ds-shadow-card-soft: 0 10px 28px rgba(96, 64, 18, 0.06);
   --ds-shadow-card-strong: 0 14px 36px rgba(96, 64, 18, 0.09);
   --ds-shadow-chip: inset 0 1px 0 rgba(255, 255, 255, 0.78);
@@ -380,6 +386,8 @@
   --ds-scrollbar-thumb: rgba(214, 188, 142, 0.28);
   --ds-scrollbar-thumb-hover: rgba(233, 208, 162, 0.38);
   --ds-selection: rgba(242, 177, 61, 0.26);
+  --ds-cursor-spotlight: rgba(242, 177, 61, 0.18);
+  --ds-cursor-spotlight-strong: rgba(238, 198, 128, 0.1);
   --ds-shadow-card-soft: 0 16px 42px rgba(12, 7, 2, 0.22);
   --ds-shadow-card-strong: 0 22px 56px rgba(12, 7, 2, 0.3);
   --ds-shadow-chip: inset 0 1px 0 rgba(238, 198, 128, 0.06);
@@ -595,6 +603,54 @@ html {
 .ds-window-control-btn--close:hover {
   background: #c42b1c;
   color: #ffffff;
+}
+
+[data-cursor-spotlight-target] {
+  --spotlight-x: 50%;
+  --spotlight-y: 50%;
+  isolation: isolate;
+  overflow: hidden;
+  position: relative;
+}
+
+[data-cursor-spotlight-target] > * {
+  position: relative;
+  z-index: 1;
+}
+
+[data-cursor-spotlight-target]::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  background:
+    radial-gradient(
+      148px circle at var(--spotlight-x) var(--spotlight-y),
+      var(--ds-cursor-spotlight),
+      var(--ds-cursor-spotlight-strong) 34%,
+      transparent 68%
+    );
+  transition: opacity 160ms ease;
+}
+
+[data-cursor-spotlight='on'] [data-cursor-spotlight-target]:hover::before,
+[data-cursor-spotlight='on'] [data-cursor-spotlight-target]:focus-visible::before,
+[data-cursor-spotlight='on'] [data-cursor-spotlight-target]:focus-within::before,
+[data-cursor-spotlight='on'] .ds-windows-menu-button.is-open::before {
+  opacity: 1;
+}
+
+[data-cursor-spotlight='off'] [data-cursor-spotlight-target]::before {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-cursor-spotlight-target]::before {
+    transition: none;
+  }
 }
 
 [data-theme='dark'] .ds-windows-titlebar {

--- a/src/shared/app-settings-normalize.ts
+++ b/src/shared/app-settings-normalize.ts
@@ -7,6 +7,7 @@ import {
   type GuiUpdateConfigV1,
   type NotificationConfigV1,
   type ScheduleSettingsPatchV1,
+  type UiEffectsConfigV1,
   type WriteSettingsPatchV1
 } from './app-settings-types'
 import { normalizeKeyboardShortcuts, type KeyboardShortcutsConfigV1 } from './keyboard-shortcuts'
@@ -35,6 +36,7 @@ export function normalizeAppSettings(settings: AppSettingsV1): AppSettingsV1 {
     keyboardShortcuts?: Partial<KeyboardShortcutsConfigV1>
     notifications?: Partial<NotificationConfigV1>
     provider?: Parameters<typeof normalizeModelProviderSettings>[0]
+    uiEffects?: Partial<UiEffectsConfigV1>
     write?: WriteSettingsPatchV1
     claw?: ClawSettingsPatchV1
     schedule?: ScheduleSettingsPatchV1
@@ -82,6 +84,7 @@ export function normalizeAppSettings(settings: AppSettingsV1): AppSettingsV1 {
       turnComplete: maybeSettings.notifications?.turnComplete !== false
     },
     appBehavior: normalizeAppBehaviorSettings(maybeSettings.appBehavior),
+    uiEffects: normalizeUiEffectsSettings(maybeSettings.uiEffects),
     keyboardShortcuts: normalizeKeyboardShortcuts(maybeSettings.keyboardShortcuts),
     write: normalizeWriteSettings(maybeSettings.write),
     claw: normalizeClawSettings(maybeSettings.claw),
@@ -102,6 +105,14 @@ function normalizeDisabledSkillIds(value: unknown): string[] {
     .filter((id): id is string => typeof id === 'string')
     .map((id) => id.trim().replace(/^\/?skill:/i, '').trim())
     .filter(Boolean))]
+}
+
+export function normalizeUiEffectsSettings(
+  settings?: Partial<UiEffectsConfigV1>
+): UiEffectsConfigV1 {
+  return {
+    cursorSpotlight: settings?.cursorSpotlight !== false
+  }
 }
 
 export function normalizeAppBehaviorSettings(

--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -428,6 +428,10 @@ export type AppBehaviorConfigV1 = {
   closeToTray: boolean
 }
 
+export type UiEffectsConfigV1 = {
+  cursorSpotlight: boolean
+}
+
 export type ScheduleSkillSettingsV1 = {
   defaultNames: string[]
   extraDirs: string[]
@@ -808,6 +812,7 @@ export type AppSettingsV1 = {
   log: LogConfigV1
   notifications: NotificationConfigV1
   appBehavior: AppBehaviorConfigV1
+  uiEffects?: UiEffectsConfigV1
   keyboardShortcuts: KeyboardShortcutsConfigV1
   write: WriteSettingsV1
   claw: ClawSettingsV1
@@ -826,6 +831,7 @@ export type AppSettingsPatch = Partial<
   log?: Partial<LogConfigV1>
   notifications?: Partial<NotificationConfigV1>
   appBehavior?: Partial<AppBehaviorConfigV1>
+  uiEffects?: Partial<UiEffectsConfigV1>
   keyboardShortcuts?: Partial<KeyboardShortcutsConfigV1>
   write?: WriteSettingsPatchV1
   claw?: ClawSettingsPatchV1

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -253,6 +253,26 @@ describe('app behavior settings', () => {
   })
 })
 
+describe('ui effects settings', () => {
+  it('defaults cursor spotlight to on while preserving an explicit off', () => {
+    const withoutEffects = {
+      ...settings(),
+      uiEffects: undefined
+    } as unknown as AppSettingsV1
+
+    expect(normalizeAppSettings(withoutEffects).uiEffects).toEqual({
+      cursorSpotlight: true
+    })
+
+    expect(normalizeAppSettings({
+      ...settings(),
+      uiEffects: { cursorSpotlight: false }
+    }).uiEffects).toEqual({
+      cursorSpotlight: false
+    })
+  })
+})
+
 describe('keyboard shortcut settings', () => {
   it('defaults shortcut overrides to empty', () => {
     const raw = {


### PR DESCRIPTION
﻿## Summary / 摘要
- Add a cursor-follow spotlight effect for the Windows/Linux title bar and sidebar rows.
- 为 Windows/Linux 置顶栏和侧边栏行增加鼠标跟随高光效果。
- Add a persisted `uiEffects.cursorSpotlight` preference, defaulting on and exposed in Settings > General > Basics.
- 新增持久化设置 `uiEffects.cursorSpotlight`，默认开启，并放在“设置 > 通用 > 基础设置”。
- Keep the effect CSS-driven and localized to hovered elements; users can turn it off on slower machines.
- 效果由 CSS 驱动且只作用于悬停元素，性能较弱的设备可以关闭。

## Tests / 测试
- `npm.cmd test -- src/shared/app-settings.test.ts src/renderer/src/lib/apply-theme.test.ts src/renderer/src/store/chat-store-app-actions.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`
