### PR TITLE
feat(claw): 飞书 / Lark 流式输出处理改进

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -210,3 +210,44 @@ other license terms.
 
 The project itself remains available under the [PolyForm Noncommercial License 1.0.0](../LICENSE)
 unless the project owner grants a separate written commercial license.
+
+## 飞书 / Lark 流式 smoke 测试（发版前必跑）
+
+本节对应 `feature/feishu-streaming-with-live-fix` 引入的飞书 / Lark SDK markdown 流式回复功能。发版前必须手工跑一遍下列 case。
+
+### 自动化已覆盖
+
+| 维度 | 覆盖方式 |
+|---|---|
+| 单条流式正常路径 | `src/main/feishu-streamer.test.ts` happy-path case |
+| reasoning delta 过滤 | 同上,reasoning case |
+| 跨 turn 过滤 | 同上,cross-turn case |
+| append 失败 → setContent(partial) | 同上,append-failure case |
+| SSE 订阅失败 → 一次性 send fallback | `src/main/claw-runtime.test.ts` streaming fallback case |
+| `feishuStream = false` → 走原轮询 | 同上,feishuStream=false case |
+| 集成 chat 视图实时性 | `src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts` live bubble case |
+| onClawChannelActivity 自动切 thread | `src/renderer/src/store/chat-store-navigation-actions.test.ts` 路由 case |
+
+### 手工 smoke checklist
+
+- [ ] **单条对话**:发"你好" → streaming 卡出现 → 1-2 秒内开始刷字
+- [ ] **长回答**:写一段代码 → 验证 30k 字符切卡能跨第二张卡
+- [ ] **故意限流**:把 `outbound.retry.maxAttempts = 1` → 触发限流 → 观察 fallback 到一次性 send
+- [ ] **故意 turn_failed**:用会抛错的 MCP 工具 → 观察 partial 补发
+- [ ] **群聊 @bot**:`replyInThread: true` 仍生效,streaming 卡出现在 thread 里
+- [ ] **DM**:`replyInThread: false` 默认
+- [ ] **Connect phone 视图实时性**(关键 —— 本期修复):bot 收到消息后 chat 视图立即出现 streaming 文本,不卡
+- [ ] **主动点击 thread**:从 streaming 状态切到该 thread → blocks 与 liveAssistant 内容一致
+- [ ] **跨 turn 隔离**:在 turn A streaming 中再来一条消息触发 turn B → turn A 收尾,turn B 独立开卡
+
+### 验证命令
+
+```bash
+npm run typecheck
+npm run lint
+npm run test
+npm run build
+npm run build:kun
+# Electron 手动启动 + 真飞书账号(本机 + 测试机器人 appId/secret)
+npm run dev
+```

--- a/docs/superpowers/plans/2026-06-15-feishu-streaming-with-live-fix.md
+++ b/docs/superpowers/plans/2026-06-15-feishu-streaming-with-live-fix.md
@@ -1,0 +1,235 @@
+# 飞书 / Lark 流式输出（带 live 视图卡顿修复）实施记录
+
+> **历史状态**:本计划最初于 2026-06-15 按 TDD 红绿循环拆分(41 个 commit)。2026-06-17 重做版为 5 个 commit 的扁平历史,本文件重写为最终实施记录,与代码现状一致。
+
+**Goal:** 在 `feat/feishu-streaming` 分支上把飞书 / Lark bot 的回复改为 SDK markdown 流式卡,并修复上一版"`onClawChannelActivity` 触发时 Connect phone 视图卡住"的两处 bug(`selectThread` HTTP 抢在 SSE 之前 + `showLiveAssistant` 被 `isProcessing` 隐藏)。重做版额外把 `subscribeThreadEventsLive` 改造为"并行 fetch + SSE"以保留历史视图。
+
+**Architecture:** 在 `ClawRuntime.handleFeishuMessage` 内部根据 `channel.feishuStream === true` 开关分两路 —— 开:经由 `runStreamingReply` 走 `FeishuStreamer` + `bridge.stream` + 自管 SSE 订阅(失败时退到一次性 `bridge.send`);关:走原 `processIncomingImPrompt` 轮询路径。Renderer 侧新增 `subscribeThreadEventsLive` action(**并行 fetch + SSE**:同步切 activeThreadId + 立即开 SSE sinceSeq:0 + 并行 getThreadDetail 拉历史,fetch 完成后 merge 写入),并把 `MessageTimeline` 的 live bubble 门控改为只检查 `liveContent`。WeChat、kun runtime、既有 `processIncomingImPrompt` 路径全部保留。
+
+**Tech Stack:** Electron + React 19 + TypeScript + Zustand + Vitest + Lark SDK(`@larksuiteoapi/node-sdk`)。runtime 还是单一 `kun`(无新增 / 切换 runtime)。
+
+**Spec:** [`docs/superpowers/specs/2026-06-15-feishu-streaming-with-live-fix-design.md`](../specs/2026-06-15-feishu-streaming-with-live-fix-design.md)
+
+---
+
+## 工作约束(影响全部任务)
+
+- **TDD**:原分支上的红绿循环已嵌入到 `feishu-streamer.test.ts` / `claw-runtime.test.ts` / `chat-store-thread-actions.test.ts` 的 case 集合中。重做版保留所有原有 case,`subscribeThreadEventsLive` 的新行为(fetch + merge + lastSeq max + fetch 失败 fallback)在测试中显式覆盖。
+- **commit 粒度**:5 个 commit(见下文 Commit 分组),每个 commit 完成立刻 commit。
+- **YAGNI**:本期不做 card JSON 2.0、reasoning 透出、per-channel 已实现无需 YAGNI。
+- **不动 `kun/` runtime 包**:kun 的 `/v1/threads/{id}/events` SSE 端点已经存在;本计划只用它。
+- **不复用 `src/main/runtime-sse-ipc.ts`**:那是给 renderer→main IPC 用的;main 直接 `fetch` + 自管 SSE 解析循环(`subscribeRuntimeThreadEvents`)。
+- **路径风格**:本计划所有路径用正斜杠,跨平台可读。
+- **改动核心调用**:`bridge.stream(chatId, { markdown: producer }, replyOptions)`(**不是** `bridge.send` —— 上版踩坑);SSE 字段读 `event.item.text`(**不是** `event.item.delta` —— 上版踩坑)。两个 spec 注释里都写明。
+- **路径冲突约定**:原 feishu 分支 41 个 commit 的"全局 `ClawImSettingsV1.feishuStream` + migration + 多次 UI 位置调整"已全部丢弃;**最终实现为 per-channel `ClawImChannelV1.feishuStream`**,无 default 注入、无 migration。
+
+---
+
+## 文件结构(实现前先锁好)
+
+### 新增
+| 文件 | 角色 |
+|------|------|
+| `src/main/feishu-streamer.ts` | `FeishuStreamer` 类,封装一次流式回复生命周期 |
+| `src/main/feishu-streamer.test.ts` | `FeishuStreamer` 单测(10 个 case) |
+
+### 修改
+| 文件 | 角色 |
+|------|------|
+| `src/main/claw-runtime-helpers.ts` | `subscribeRuntimeThreadEvents` + `SseSubscriber` + `RuntimeSseEvent` |
+| `src/main/claw-runtime-helpers.test.ts` | 新增 3 个 SSE case + 既有 `feishuSenderLabel` / `imCompletionReplyForPush` 测试 |
+| `src/main/claw-runtime.ts` | `runStreamingReply` / `subscribeSse` / `subscribeSseForStreamer`;`handleFeishuMessage` 分支 |
+| `src/main/claw-runtime.test.ts` | 集成测试(7 个 streaming 相关 case + 既有 44 个) |
+| `src/main/ipc/app-ipc-schemas.ts` | `ClawImChannelV1` zod schema 加 `feishuStream: z.boolean().optional()` |
+| `src/shared/app-settings-types.ts` | `ClawImChannelV1` 加 `feishuStream?: boolean`(per-channel,默认 false) |
+| `src/shared/app-settings-claw.ts` | `map` 归一化补 `feishuStream: normalizeBoolean(raw.feishuStream, false)` |
+| `src/shared/app-settings.test.ts` | `feishuStream` 归一化边界 case |
+| `src/renderer/src/store/chat-store-types.ts` | `ChatState` 加 `subscribeThreadEventsLive` action 字段 |
+| `src/renderer/src/store/chat-store-thread-actions.ts` | `subscribeThreadEventsLive` action(**并行 fetch + SSE** 改造) |
+| `src/renderer/src/store/chat-store-thread-actions.test.ts` | `subscribeThreadEventsLive` 3 个 case(并行启动 / merge / 失败 fallback) |
+| `src/renderer/src/store/chat-store-navigation-actions.ts` | `onClawChannelActivity` 改走新 action |
+| `src/renderer/src/store/chat-store-navigation-actions.test.ts` | 路由验证 case |
+| `src/renderer/src/components/chat/MessageTimeline.tsx` | `showLiveAssistant` 去掉 `!isProcessing` 门控 + 注释说明全局 SSE sink |
+| `src/renderer/src/components/chat/derive-turn-sections.ts` | 衍生 turn 区段逻辑调整 |
+| `src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts` | live bubble 渲染 |
+| `src/renderer/src/components/chat/derive-turn-sections.test.ts` | 衍生逻辑 |
+| `src/renderer/src/components/settings-section-claw.tsx` | per-channel `feishuStream` `SettingRow`,仅 feishu/lark 渠道显示 |
+| `src/renderer/src/locales/en/settings.json` | `clawFeishuStream` / `clawFeishuStreamDesc`(英文 desc 修复为有信息量文案) |
+| `src/renderer/src/locales/zh/settings.json` | 同上(中文) |
+| `docs/CONTRIBUTING.md` | 末尾"飞书 / Lark 流式 smoke 测试"小节(自动化覆盖表 + 9 个手工 case + 验证命令) |
+| `docs/superpowers/specs/2026-06-15-feishu-streaming-with-live-fix-design.md` | 设计 spec(per-channel + 默认 false,与本计划一致) |
+| `docs/superpowers/plans/2026-06-15-feishu-streaming-with-live-fix.md` | 本文件 |
+
+### 不在本计划里(明确不动的文件)
+- `kun/` runtime 包
+- `src/renderer/src/agent/kun-runtime.ts`
+- `src/main/runtime-sse-ipc.ts`
+- `src/main/claw-runtime.ts` 里 `processIncomingImPrompt` / `waitForAssistantResult` 主体逻辑
+- `src/shared/app-settings-types.ts` 里 `ClawImSettingsV1`(不持有 `feishuStream`,迁移规则不变)
+
+---
+
+## Commit 分组(5 个 commit)
+
+| # | 主题 | 涵盖文件 |
+|---|------|---------|
+| 1 | `docs(feishu): spec + plan for per-channel feishu streaming (default off)` | spec / plan / CONTRIBUTING |
+| 2 | `types(settings): add ClawImChannelV1.feishuStream? (default off)` | app-settings-types / app-settings-claw / app-settings.test / ipc-schemas |
+| 3 | `feat(claw): FeishuStreamer + runStreamingReply + SSE subscription` | feishu-streamer(.test) / claw-runtime / claw-runtime.test / claw-runtime-helpers / claw-runtime-helpers.test |
+| 4 | `fix(chat): subscribeThreadEventsLive pre-fetches history in parallel with SSE` | chat-store-types / chat-store-thread-actions(.test) / chat-store-navigation-actions(.test) / MessageTimeline / MessageTimeline.tool-summary.test / derive-turn-sections(.test) |
+| 5 | `feat(claw-settings): per-channel feishuStream toggle in connected-channel card` | settings-section-claw / locales/{en,zh}/settings |
+
+---
+
+## Phase 1:文档先行
+
+### Task 1.1:重写 spec
+- Files: `docs/superpowers/specs/2026-06-15-feishu-streaming-with-live-fix-design.md`
+- 内容:把"全局 `ClawImSettingsV1.feishuStream` + 默认 `true` + migration"改为"per-channel `ClawImChannelV1.feishuStream` + 默认 `false` + 无 migration"。`runStreamingReply` 分支谓词改为 `channel.feishuStream === true`。spec §2.5 集成测试表去掉 migration 行,引用测试文件名 `MessageTimeline.tool-summary.test.ts` 而非过时的 `MessageTimeline.test.tsx`。
+
+### Task 1.2:重写 plan
+- Files: `docs/superpowers/plans/2026-06-15-feishu-streaming-with-live-fix.md`
+- 内容:commit 分组改为 5 个;Task 2.1/2.2/2.3 的"全局 `ClawImSettingsV1`"改为"per-channel `ClawImChannelV1`";移除 default normalizer / migration 相关步骤;新增 Phase 4:并行 fetch + SSE 改造。
+
+### Task 1.3:CONTRIBUTING smoke 小节
+- Files: `docs/CONTRIBUTING.md`
+- 内容:确认"飞书 / Lark 流式 smoke 测试"小节存在(9 个手工 case + 自动化覆盖表 + 验证命令)。**注意**:CONTRIBUTING.md 实际已有此小节,本任务主要是核对最新一致性。
+
+---
+
+## Phase 2:类型与 IPC
+
+### Task 2.1:`ClawImChannelV1.feishuStream` 字段
+- Files: `src/shared/app-settings-types.ts`
+- 内容:在 `ClawImChannelV1` interface 内 `weixinStream?` 旁边加 `feishuStream?: boolean`,注释"当 provider === 'feishu' 时,是否把 agent 回复改为流式输出。默认 false (per-channel)。"
+
+### Task 2.2:归一化
+- Files: `src/shared/app-settings-claw.ts`
+- 内容:在 `map` 归一化处加 `feishuStream: normalizeBoolean(raw.feishuStream, false)`,确保缺省(undefined)显式归一为 `false`。
+
+### Task 2.3:归一化测试
+- Files: `src/shared/app-settings.test.ts`
+- 内容:`describe('feishuStream normalization')` 块,3 个 case:`undefined → false`、`true → true`、`false → false`。
+
+### Task 2.4:IPC zod schema
+- Files: `src/main/ipc/app-ipc-schemas.ts`
+- 内容:`ClawImChannelV1` zod schema 加 `feishuStream: z.boolean().optional()`。
+
+---
+
+## Phase 3:FeishuStreamer + runStreamingReply + SSE
+
+### Task 3.1:`FeishuStreamer` 类骨架 + failing test
+- Files: `src/main/feishu-streamer.ts`(新),`src/main/feishu-streamer.test.ts`(新)
+- 测试(10 case):happy-path(顺序 append + setContent 1 次);reasoning delta 被丢弃;跨 turn delta 被忽略;append 失败降级到 setContent(partial);subscribe 同步抛错被 reject;turn_failed 时 ok=false;abort 时 nextDelta=null + start reject;读 `event.item.text` 而非 `item.delta`;用 `bridge.stream` 而非 `bridge.send`;dispose 释放 waiters + subscription。
+
+### Task 3.2:`subscribeRuntimeThreadEvents` SSE 订阅器
+- Files: `src/main/claw-runtime-helpers.ts`,`src/main/claw-runtime-helpers.test.ts`
+- 测试(3 case):首连带 `since_seq=0` + Authorization header;5xx 后 750ms→5s 指数退避重连;4xx(非 408/429)不重连。
+
+### Task 3.3:`runStreamingReply` 编排
+- Files: `src/main/claw-runtime.ts`
+- 实现:`bridge.stream` 拿 `MarkdownStreamController`,把异步 SSE 包装成 `SseSubscriber`,调 `FeishuStreamer.start({ subscribe })`,超时/异常降级到 `bridge.send`。返回 `{ ok, messageId, finalText, fellBack, message }`。
+
+### Task 3.4:`handleFeishuMessage` 分流
+- Files: `src/main/claw-runtime.ts`
+- 实现:在分流点按 `channel.feishuStream === true` 决定走 streaming 还是原 polling。streaming 完成后用闭包内 `streamedToFeishu = true` 标志阻止后续 `sendFeishuMessage` 重复发送。
+
+### Task 3.5:集成测试
+- Files: `src/main/claw-runtime.test.ts`
+- 测试(7 case):routes through runStreamingReply when channel.feishuStream=true;fallback path(bridge.stream 抛错 → bridge.send 兜底);append-failure 走 setContent(accumulated);feishuStream 未开启时不用 FeishuStreamer;streaming happy path;weixin 不走 FeishuStreamer;runStreamingReplyWeixin 相关。
+
+---
+
+## Phase 4:并行 fetch + SSE(PR #332 反馈 #1 的重做版)
+
+### Task 4.1:`subscribeThreadEventsLive` 改造
+- Files: `src/renderer/src/store/chat-store-thread-actions.ts`,`src/renderer/src/store/chat-store-thread-actions.test.ts`,`src/renderer/src/store/chat-store-types.ts`
+- 实现:
+  - 同步切 `activeThreadId` + `busy: true`,**不**清 `blocks`/`lastSeq`(同 thread 时保留;跨 thread 时清空)
+  - 立即开 SSE with `sinceSeq: 0`(捕获 fetch 期间 deltas)
+  - 并行 `await p.getThreadDetail(targetThreadId)`
+  - fetch 完成后用 `set((s) => ...)` merge:
+    - `blocks: hydrateResult`
+    - `lastSeq: Math.max(fetched, s.lastSeq)`  // 保护 SSE 已累积的 seq
+    - `liveAssistant` / `liveReasoning` **不写入**(保护 SSE deltas)
+    - `busy`, `currentTurnId`, `currentTurnUserId` 从 fetch 推导
+  - fetch 失败:catch 块暴露 error,SSE 仍开
+- 测试(3 case):并行启动(开 SSE + 调 fetch);merge 成功(blocks 写入,liveAssistant 保留,lastSeq 取 max);fetch 失败 fallback(错误暴露,SSE 仍开)。
+
+### Task 4.2:`onClawChannelActivity` 路由
+- Files: `src/renderer/src/store/chat-store-navigation-actions.ts`,`src/renderer/src/store/chat-store-navigation-actions.test.ts`
+- 实现:`activeThreadId !== threadId` 时调 `subscribeThreadEventsLive(threadId)`(原 PR #332 的代码,保留)。
+- 测试(1 case):路由验证,不调 `selectThread`。
+
+### Task 4.3:`showLiveAssistant` 注释
+- Files: `src/renderer/src/components/chat/MessageTimeline.tsx`
+- 内容:在 `showLiveAssistant = !!liveContent.trim()` 上方注释加 4 行,说明 `live` 是全局 SSE sink 输出(所有渠道,非飞书专属),去掉 `!isProcessing` 门控是有意为之。
+
+### Task 4.4:`MessageTimeline` 衍生逻辑
+- Files: `src/renderer/src/components/chat/derive-turn-sections.ts`,`src/renderer/src/components/chat/derive-turn-sections.test.ts`,`src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts`
+- 内容:live bubble 渲染衍生调整(配合 `showLiveAssistant` 门控变化)。
+
+---
+
+## Phase 5:Settings UI + i18n
+
+### Task 5.1:per-channel SettingRow
+- Files: `src/renderer/src/components/settings-section-claw.tsx`
+- 内容:connected-channel 卡片内,`channel.provider === 'feishu'` 条件渲染 `SettingRow`,`Toggle` 绑 `channel.feishuStream === true`,`updateChannel(form, update, channel.id, { feishuStream: value })` 持久化。
+
+### Task 5.2:i18n 修复
+- Files: `src/renderer/src/locales/en/settings.json`,`src/renderer/src/locales/zh/settings.json`
+- 内容:`clawFeishuStreamDesc` 从"Enable streaming output"/"开启流式输出"改为有信息量文案:
+  - en: `"Stream the reply character-by-character in a live SDK card, instead of sending a one-shot message after the run completes."`
+  - zh: `"把回复以 SDK 流式卡逐字发出,而不是在回复完成后一次性发送。"`
+
+---
+
+## 验证
+
+### 自动化
+
+```bash
+npm run typecheck   # 必须 0 错误(2 个 pre-existing baseline 不算)
+npm run lint        # 必须 0 错误
+npm test -- claw claw-runtime feishu claw-runtime-helpers chat-store chat-store-thread-actions chat-store-navigation-actions  # 飞书相关测试全过
+npm test            # 完整测试;预期 9 个 baseline 失败(4 文件:packaging-config、app-ipc-schemas、register-app-ipc-handlers、git-service),与本 PR 无关
+```
+
+### Smoke 测试(手工,真实飞书账号 + Electron)
+
+参见 `docs/CONTRIBUTING.md` 的"飞书 / Lark 流式 smoke 测试"小节(9 个手工 case):
+
+- 单聊发"你好":流式卡 1-2s 内出现,字符实时刷新
+- 长回复(代码生成):30k 字符切分由 SDK 处理
+- 触发限流(`outbound.retry.maxAttempts = 1`):观察 fallback 到一次性
+- 触发 `turn_failed`(抛错的 MCP tool):观察 partial 补发
+- 群 @bot:`replyInThread: true` 被尊重
+- DM:`replyInThread: false` 默认
+- **Connect phone 视图实时性(本 PR 关键修复)**:bot 消息 → chat view 立即出现流式文本,无空白期
+- **自动切到有历史的会话(本 PR 新增)**:fetch 完成后历史 blocks 出现,SSE 期间 deltas 不丢
+- 跨 turn 隔离:turn A 进行中发新消息 → A 收尾,B 独立
+- 微信路径不变:不流式,设置无 toggle
+
+### Pre-existing baseline 失败(与本 PR 无关)
+
+`npm test` 在 PR commit 上失败的 9 个 case:
+
+| 文件 | 失败数 | 原因 |
+|------|--------|------|
+| `src/main/packaging-config.test.ts` | 2 | electron-builder Kun packaging 既有 baseline |
+| `src/main/ipc/app-ipc-schemas.test.ts` | 1 | 既有 baseline |
+| `src/main/ipc/register-app-ipc-handlers.test.ts` | 1 | 既有 baseline |
+| `src/main/services/git-service.test.ts` | 5 | Windows 平台 `path.normalize` 行为差异(`/ vs \`);用 stash 验证与本 PR 无关 |
+
+---
+
+## 不在本计划里
+
+- 任何对 `kun/` runtime 包的修改
+- 任何对 `processIncomingImPrompt` / `waitForAssistantResult` 主体逻辑的修改
+- `runStreamingReply` 的通用抽象抽取(为后续 wechat 渠道铺路)
+- WeChat 渠道接入(见后续 `feat/weixin-block-streaming-v2` PR)
+- `card JSON 2.0` 富卡片
+- 推理 / chain-of-thought 透出

--- a/docs/superpowers/specs/2026-06-15-feishu-streaming-with-live-fix-design.md
+++ b/docs/superpowers/specs/2026-06-15-feishu-streaming-with-live-fix-design.md
@@ -1,0 +1,244 @@
+# 飞书 / Lark 接入鲲后流式输出设计（带 live 视图卡顿修复）
+
+**日期**:2026-06-15
+**状态**:已实现并通过 review(2026-06-17 重做版)
+**适用范围**:`src/main/claw-runtime.ts` 中飞书 / Lark 入站消息的回复链路;WeChat 渠道不在本期范围
+**前身**:`D:\workspace\DeepSeek\DeepSeek-GUI` 的 `feature/feishu-streaming-bot-output` 分支上的同主题实现(2026-06-12);本次在 `develop` 上重建并修复 live 视图卡顿 bug
+
+## 背景
+
+`feature/feishu-streaming-bot-output` 分支上做过一版飞书流式,实现后用户报告 **bot 消息到达后,飞书 SDK 卡在实时刷新,但 Connect phone 视图的 chat 区一直不动,直到 turn 结束才看到文本**。
+
+经排查,根因有两处叠加:
+
+1. **`selectThread` 同步 HTTP 抢在 SSE 之前**。`onClawChannelActivity` 触发自动切换到 bot thread 时,调的是 `selectThread(threadId)`。`selectThread` 内部先 `await getThreadDetail()` 拉元数据 + 持久化 blocks,**然后**才打开 SSE。在 HTTP 往返期间,deltas 已经流入 chat-store,随后被 fetch 返回的旧 `blocks` 覆盖,deltas 消失。
+2. **streaming 期间 live bubble 被 `isProcessing` 门控隐藏**。`MessageTimeline.tsx` 里 `showLiveAssistant = !isProcessing && !!liveContent.trim()`。turn 进行中(`busy: true`)时,bubble 被藏起来,只有 `WorkMetaRow` 处理指示器可见。`liveAssistant` 文本确实在累积,但用户看不到 —— 必须等 `turn_completed` 才一次性显示,视觉上像"卡住"。
+
+本次重做版 (2026-06-17) 在原有修复基础上,进一步把 `subscribeThreadEventsLive` 改为**并行 fetch + SSE**:切换 thread 时同时启动 `getThreadDetail` 拉历史和 `sinceSeq: 0` 的 SSE 流,fetch 完成后用 merge 策略更新 blocks/lastSeq,保留 SSE 已累积的 deltas。这样既保留了"无 fetch 也能看到流式文本"的实时性,又不会让用户看到空白视图(因为 fetch 完成的瞬间历史就回来了)。
+
+## 目标与非目标
+
+### 目标
+
+- 飞书 / Lark bot 收到入站消息后,只回一条 SDK 流式卡(Message Bubble),内容随 agent run 实时刷新。
+- Connect phone 视图的 chat 区**实时**显示流式文本(无视觉卡顿),且自动切到的历史会话不出现空白视图。
+- 飞书 SDK 卡和 Connect phone 视图两者同步 —— 用户两边看到的刷新节奏一致。
+- **per-channel 默认关闭**,用户需要逐个渠道在 Settings → Claw → 已连接的手机 Agent 中显式开启(降低误用风险;新装机用户和老用户行为一致,无 migration)。
+- 失败时降级为一次性发送或 partial 补一条,用户始终能看到一些结果。
+- 附件(file upload)行为不变,仍然在文本流式结束后作为独立消息发出。
+- 与现有 thread / turn 编排、IM 命令(`/new` `/model` `/help`)、欢迎语、reaction 提示共存不冲突。
+
+### 非目标
+
+- 不暴露工具调用状态(不渲染"正在调用 file_read / bash"等中间行)。
+- 不暴露 reasoning / chain-of-thought(过滤掉 `assistant_reasoning_delta`)。
+- 不切到 card JSON 2.0 富卡片(本期只走 markdown 流式;card 模式留给后续工作)。
+- WeChat 渠道保持单条消息回复不变(不订阅 SSE)。
+- Webhook 入站路径(`handleWebhook`)保持单条回复不变(它返回的是 HTTP body,不是 IM 卡)。
+- 不重做"重发 / 编辑历史消息"功能(本次只让流式阶段 + live 视图同步落地)。
+- 不抽取 `runStreamingReply` 通用抽象 —— wechat 渠道的后续工作单独 PR。
+
+## 设计决策一览
+
+| 维度 | 决策 | 备注 |
+|------|------|------|
+| 载体 | Markdown 流式消息 | 用 SDK 的 `bridge.stream()` + `MarkdownStreamController` |
+| 跨 SDK 调用方法 | `bridge.stream(...)`,**不是** `bridge.send(...)` | 上版踩过的坑(测试用 `send`,生产要用 `stream`),代码注释里写明 |
+| 流式内容范围 | 只 `assistant_text_delta` | `assistant_reasoning_delta` 过滤掉;记 debug log |
+| SSE 字段读取 | `event.item.text`(不是 `event.item.delta`) | 上版踩过的字段错位坑,代码注释里写明 |
+| 附件 | 流式结束后作为独立消息 | 与现状行为一致 |
+| **per-channel 字段** | `ClawImChannelV1.feishuStream?: boolean` | **不是** `ClawImSettingsV1`(全局),原因见下 |
+| **默认** | 关闭(per-channel `feishuStream === true` 才开) | UI 按 `=== true` 显式判定,缺省视为 false;**无** default normalizer 注入,**无** migration |
+| 失败降级 | 退到一次性 `bridge.send` | 能 partial 补一条就 partial 补一条;连 partial 都没有就"抱歉,生成失败" |
+| 收尾信号 | `turn_completed` / `turn_failed` / `turn_aborted` | 终态事件后再 `setContent(accumulatedText)` 一次 |
+| 并发入站 | 并行处理 | 新消息开新 turn + 新 streaming 卡;旧 turn 自然收尾 |
+| Renderer 自动切 thread | 用 `subscribeThreadEventsLive`(并行 fetch + SSE) | 不再 `selectThread`,避免 HTTP 抢在 SSE 之前 |
+| `subscribeThreadEventsLive` merge 策略 | 同步切 activeThreadId + 开 SSE,fetch 完成后用 `Math.max(fetchedSeq, currentSeq)` 写 `lastSeq`;`liveAssistant`/`liveReasoning` **不**写入 | 保护 SSE deltas 不被 fetch 覆盖 |
+| Renderer live bubble | 去掉 `!isProcessing` 门控 | `busy: true` 期间也显示流式文本;`live` 是全局 SSE sink 输出,影响所有渠道 |
+| WeChat | 不变 | 仍走 `processIncomingImPrompt` 轮询路径 |
+
+### 为什么是 per-channel 而不是全局
+
+设计最初是全局 `ClawImSettingsV1.feishuStream: true`,迁移到 `develop` 上做 review 之前改为 per-channel `ClawImChannelV1.feishuStream: false`,理由:
+
+- 各业务渠道(测试号、正式号、客服号等)希望独立控制是否启用流式
+- 默认关闭更安全:误用风险更低(失败时退到一次性发送)
+- per-channel 与 `channel.enabled` / `channel.weixinStream` 模式一致,UI 自然
+
+默认值的差异:per-channel 字段不写 default normalizer,`channel.feishuStream === true` 显式判定,缺省(undefined)视为 false。`ClawImChannelV1.weixinStream` 同位置,缺省由 normalizer 补 `true`(因为微信 block streaming 是"feature-complete 默认开启",见后续 weixin PR)。
+
+## 架构
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Renderer (React + Zustand)                                      │
+│  ┌──────────────────────────────────────────────┐               │
+│  │ chat-store                                   │  ←—— onClawChannelActivity
+│  │   • selectThread(threadId)          [保留]   │      (改走 subscribeThreadEventsLive)
+│  │   • subscribeThreadEventsLive()     [改造]   │               │
+│  │     - 同步切 activeThreadId                   │               │
+│  │     - 立即开 SSE (sinceSeq: 0)               │               │
+│  │     - 并行 getThreadDetail 拉历史            │               │
+│  │     - fetch 完成后 merge 写 blocks           │               │
+│  │   • liveAssistant (SSE 实时填充)             │               │
+│  └──────────────────────────────────────────────┘               │
+│  ┌──────────────────────────────────────────────┐               │
+│  │ MessageTimeline                              │  ←—— showLiveAssistant
+│  │   showLiveAssistant = !!liveContent.trim()   │      去掉 !isProcessing 门控
+│  │   注:live 是全局 SSE sink,非飞书专属         │               │
+│  └──────────────────────────────────────────────┘               │
+└─────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────┐
+│ Main (Electron main process)                                    │
+│  ┌──────────────────────────────────────────────┐               │
+│  │ claw-runtime.ts                              │               │
+│  │   • handleFeishuMessage()           [改造]   │               │
+│  │     - 读 channel.feishuStream === true       │               │
+│  │     - true: 走 runStreamingReply             │               │
+│  │     - false: 原 processIncomingImPrompt 轮询 │               │
+│  │   • runStreamingReply()             [新增]   │               │
+│  │   • subscribeSse / subscribeSseForStreamer   │               │
+│  └──────────────────────────────────────────────┘               │
+│  ┌──────────────────────────────────────────────┐               │
+│  │ feishu-streamer.ts (新)                      │               │
+│  │   FeishuStreamer 类:封装一次流式回复生命周期 │               │
+│  └──────────────────────────────────────────────┘               │
+│  ┌──────────────────────────────────────────────┐               │
+│  │ claw-runtime-helpers.ts                      │               │
+│  │   • subscribeRuntimeThreadEvents()  [新增]   │               │
+│  │   • SseSubscriber, RuntimeSseEvent  [新类型] │               │
+│  └──────────────────────────────────────────────┘               │
+└─────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────┐
+│ Settings (Claw 面板 → 已连接的手机 Agent → feishu 渠道卡片)    │
+│   沿用"卡片-列表-SettingRow"模式                                  │
+│   渠道卡片内按 channel.provider === 'feishu' 条件渲染 SettingRow │
+│   Toggle 绑 channel.feishuStream,默认关闭                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## 关键代码段
+
+### FeishuStreamer 公开方法
+
+```ts
+// src/main/feishu-streamer.ts
+export class FeishuStreamer {
+  constructor(opts: FeishuStreamerOptions)
+  start(input: { subscribe: SseSubscriber }): Promise<FeishuStreamerResult>
+  onSseEvent(event: Record<string, unknown>): void
+  getAccumulatedText(): string
+  abort(): void
+  dispose(): void
+}
+```
+
+`FeishuStreamerOptions` 持有 `bridge: LarkChannel`、`chatId`、`turnId`、`threadId`、`responseTimeoutMs` 等。`start` 接收一个 `SseSubscriber`(把异步 SSE 包成同步契约),内部通过 `bridge.stream` 拿 `MarkdownStreamController`,从 SSE 接收 `assistant_text_delta` 并 `append()`,终态时 `setContent(accumulatedText)` 收尾,`append` 失败则降级到 `setContent(partial)`。
+
+### claw-runtime.ts 四个核心方法
+
+```ts
+// src/main/claw-runtime.ts
+private async subscribeSse(settings, threadId, streamer, signal): Promise<{ close }>
+private subscribeSseForStreamer(settings, threadId, streamer): SseSubscriber
+private async runStreamingReply(input: {
+  bridge, chatId, threadId, turnId, replyOptions, responseTimeoutMs, context
+}): Promise<{ ok, messageId, finalText, fellBack, message }>
+private async handleFeishuMessage(channelId, message): Promise<void>
+```
+
+`handleFeishuMessage` 在分流点按 `channel.feishuStream === true` 决定走 streaming 还是原 polling。streaming 路径用 `streamedToFeishu = true` 标志(闭包内),streaming 完成后阻止后续的 `sendFeishuMessage` 重复发送。
+
+### subscribeThreadEventsLive (并行 fetch + SSE)
+
+```ts
+// src/renderer/src/store/chat-store-thread-actions.ts
+subscribeThreadEventsLive: async (threadId) => {
+  // 1. 同步切 activeThreadId + busy=true(用户立即看到 view 切换)
+  // 2. 立即开 SSE (sinceSeq: 0,捕获 fetch 期间到达的 deltas)
+  // 3. 并行 await p.getThreadDetail(targetThreadId)
+  // 4. fetch 完成后 merge 写入:
+  //    - blocks: 拉到的历史
+  //    - lastSeq: Math.max(fetched, current)  // 保护 SSE 已累积的 seq
+  //    - liveAssistant / liveReasoning 不动 // 保护 SSE deltas
+  //    - busy, currentTurnId, currentTurnUserId 从 fetch 推导
+  // 5. fetch 失败:catch 块暴露 error,SSE 仍开
+}
+```
+
+### 跨 SDK 调用要点(代码注释里都写明)
+
+```ts
+// bridge.stream(chatId, { markdown: producer }, replyOptions) -- 不是 bridge.send
+// SSE 字段读 event.item.text -- 不是 event.item.delta
+```
+
+## Settings 改动
+
+`src/shared/app-settings-types.ts:594-598`:
+
+```ts
+// ClawImChannelV1 interface 内
+/** 当 provider === 'feishu' 时,是否把 agent 回复改为流式输出。默认 false (per-channel)。 */
+feishuStream?: boolean
+/** 当 provider === 'weixin' 时,是否把 agent 回复改为 block streaming。默认 true。 */
+weixinStream?: boolean
+```
+
+`src/main/ipc/app-ipc-schemas.ts` 在 `ClawImChannelV1` zod schema 中加 `feishuStream: z.boolean().optional()`。
+
+`src/shared/app-settings-claw.ts:159-163` 在 `map` 归一化处补 `feishuStream: normalizeBoolean(raw.feishuStream, false)`,确保缺省(undefined)显式归一为 `false`。
+
+**无** default normalizer 注入到 `ClawImSettingsV1`;**无** migration 函数改动。`ClawImSettingsV1` 仍只是 IM 全局配置的容器,不持有 `feishuStream` 字段。
+
+## UI 形态
+
+`src/renderer/src/components/settings-section-claw.tsx:182-200`,在 connected-channel 卡片内,按 `channel.provider === 'feishu'` 条件渲染 `SettingRow`:
+
+```tsx
+<SettingRow
+  title={t('clawFeishuStream')}
+  description={t('clawFeishuStreamDesc')}
+  control={
+    <div className="flex items-center gap-2">
+      <span className="text-[12px] font-medium text-ds-muted">
+        {channel.feishuStream === true
+          ? t('clawManageAgentEnabled')
+          : t('clawManageAgentDisabled')}
+      </span>
+      <Toggle
+        checked={channel.feishuStream === true}
+        onChange={(value) => updateChannel(form, update, channel.id, { feishuStream: value })}
+      />
+    </div>
+  }
+/>
+```
+
+UI 沿用"卡片-列表-SettingRow"模式,与 `channel.enabled` / `channel.weixinStream` 并列。
+
+## 集成测试表
+
+| 场景 | 预期行为 |
+|------|---------|
+| per-channel `feishuStream=false` | 走原轮询路径 (`processIncomingImPrompt`) |
+| per-channel `feishuStream=true`,streaming happy path | `FeishuStreamer` 顺序 append + 终态 setContent;`streamedToFeishu` 阻止重复 send |
+| streaming 中 `bridge.stream` 抛错 | fallback 到 `bridge.send` 一次性发送,`fellBack: true` |
+| streaming 中 `append` 失败 | 降级到 `setContent(accumulatedText)` partial 补发 |
+| `turn_failed` | `ok: false`,partial 补发或错误提示 |
+| abort / 超时 | `nextDelta = null`,`start` reject,降级到 send |
+| 跨 turn 的 delta 忽略 | `currentTurnId !== turnId` 时不 append |
+| 推理 delta 过滤 | `kind === 'agent_reasoning'` 不写入 `liveAssistant` |
+| Webhook 路径 | 走 `bridge.send` 一次性,不走 streaming |
+| 微信入站 | `handleWeixinMessage` 走轮询,不走 `FeishuStreamer` |
+| `onClawChannelActivity` 触发自动切 | 走 `subscribeThreadEventsLive`(并行 fetch + SSE) |
+| 自动切到无历史的新 thread | fetch 返回空 blocks,SSE 立即填充 liveAssistant |
+| 自动切到有历史的 thread | fetch 返回历史 blocks,SSE 期间 deltas 保留,merge 后 `lastSeq` 取 max |
+| `getThreadDetail` 失败 | 错误暴露在 UI,SSE 仍开,流式文本不丢 |
+
+## 不在本期范围
+
+- 任何对 `kun/` runtime 包的修改
+- 任何对 `processIncomingImPrompt` / `waitForAssistantResult` 主体逻辑的修改
+- `runStreamingReply` 的通用抽象抽取(为后续 wechat 渠道铺路)
+- WeChat 渠道接入(见后续 `feat/weixin-block-streaming-v2` PR)

--- a/src/main/claw-runtime-helpers.test.ts
+++ b/src/main/claw-runtime-helpers.test.ts
@@ -1,16 +1,27 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   feishuSenderLabel,
   finalAssistantReplyText,
   imCompletionReplyForPush,
   IM_COMPLETED_NO_TEXT_REPLY,
+  subscribeRuntimeThreadEvents,
+  type RuntimeSseEvent,
   type ThreadDetailJson,
   type TurnItemJson
 } from './claw-runtime-helpers'
 
-function singleTurnDetail(items: TurnItemJson[]): ThreadDetailJson {
-  return { turns: [{ id: 'turn_1', status: 'completed', items }] }
-}
+// Global fetch mock for subscribeRuntimeThreadEvents
+const originalFetch = globalThis.fetch
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
 
 describe('finalAssistantReplyText', () => {
   it('returns the concluding text that follows the last tool activity', () => {
@@ -91,5 +102,71 @@ describe('feishuSenderLabel', () => {
       senderName: ' Alice ',
       senderId: 'ou_123'
     } as Parameters<typeof feishuSenderLabel>[0])).toBe('Alice')
+  })
+})
+
+function singleTurnDetail(items: TurnItemJson[]): ThreadDetailJson {
+  return { turns: [{ id: 'turn_1', status: 'completed', items }] }
+}
+
+describe('subscribeRuntimeThreadEvents', () => {
+  it('opens /v1/threads/{id}/events?since_seq=0 with auth headers on first connect', async () => {
+    const ac = new AbortController()
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 404 }))
+    await subscribeRuntimeThreadEvents({
+      baseUrl: 'http://127.0.0.1:8788',
+      threadId: 'thr_1',
+      headers: { Authorization: 'Bearer x' },
+      onEvent: vi.fn(),
+      signal: ac.signal
+    })
+    // First fetch should include since_seq=0
+    const url = fetchMock.mock.calls[0][0] as URL
+    expect(url.toString()).toContain('/v1/threads/thr_1/events')
+    expect(url.searchParams.get('since_seq')).toBe('0')
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer x', Accept: 'text/event-stream' })
+  })
+
+  it('reconnects with exponential backoff (750ms → 5s) on 5xx', async () => {
+    vi.useFakeTimers()
+    try {
+      const ac = new AbortController()
+      // 第一次 5xx,后续提供多个 mock 让重连循环稳定跑
+      fetchMock
+        .mockResolvedValueOnce(new Response('', { status: 503 }))
+        .mockResolvedValue(new Response('', { status: 503 }))
+      const onEvent = vi.fn()
+      const handle = await subscribeRuntimeThreadEvents({
+        baseUrl: 'http://127.0.0.1:8788',
+        threadId: 'thr_1',
+        headers: {},
+        onEvent,
+        signal: ac.signal
+      })
+      // 等 750ms 后 fetch 应当被再次调用
+      await vi.advanceTimersByTimeAsync(800)
+      expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+      ac.abort()
+      handle.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops reconnecting on 4xx (except 408/429)', async () => {
+    const ac = new AbortController()
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 401 }))
+    await subscribeRuntimeThreadEvents({
+      baseUrl: 'http://127.0.0.1:8788',
+      threadId: 'thr_1',
+      headers: {},
+      onEvent: vi.fn(),
+      signal: ac.signal,
+      logError: vi.fn()
+    })
+    // 等 1s,确认只调一次 fetch
+    await new Promise((r) => setTimeout(r, 50))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/claw-runtime-helpers.ts
+++ b/src/main/claw-runtime-helpers.ts
@@ -583,3 +583,88 @@ export async function readRequestBody(req: IncomingMessage): Promise<string> {
   }
   return Buffer.concat(chunks).toString('utf8')
 }
+
+export type SseSubscriber = (signal: AbortSignal) => { close: () => void }
+
+export type RuntimeSseEvent = { kind: string; turnId?: string; item?: { text?: unknown }; seq?: number; [key: string]: unknown }
+
+/**
+ * Subscribe to `/v1/threads/{threadId}/events` and dispatch each
+ * `RuntimeSseEvent` to `onEvent`. Reconnects with exponential backoff
+ * (750ms → 5s) on network failure; does NOT reconnect on 4xx with a 4xx
+ * status (those are returned to the caller via the close path).
+ *
+ * The returned `close()` aborts the in-flight fetch and prevents further
+ * reconnects.
+ */
+export async function subscribeRuntimeThreadEvents(input: {
+  baseUrl: string
+  threadId: string
+  headers: Record<string, string>
+  onEvent: (event: RuntimeSseEvent) => void
+  signal: AbortSignal
+  logError?: (category: string, message: string, detail?: unknown) => void
+}): Promise<{ close: () => void }> {
+  const { baseUrl, threadId, headers, onEvent, signal, logError } = input
+  const ac = new AbortController()
+  const onAbort = (): void => ac.abort()
+  signal.addEventListener('abort', onAbort, { once: true })
+  let nextSinceSeq = 0
+  let closed = false
+  let reconnectDelayMs = 750
+  const close = (): void => {
+    if (closed) return
+    closed = true
+    ac.abort()
+    signal.removeEventListener('abort', onAbort)
+  }
+  void (async () => {
+    while (!closed && !ac.signal.aborted) {
+      const url = new URL(`${baseUrl.replace(/\/+$/, '')}/v1/threads/${encodeURIComponent(threadId)}/events`)
+      url.searchParams.set('since_seq', String(nextSinceSeq))
+      try {
+        const res = await fetch(url, { signal: ac.signal, headers: { ...headers, Accept: 'text/event-stream' } })
+        if (!res.ok || !res.body) {
+          if (res.status >= 400 && res.status < 500 && res.status !== 408 && res.status !== 429) {
+            logError?.('sse', `SSE connection refused (${res.status}) for thread ${threadId}`, { status: res.status })
+            return
+          }
+          await new Promise<void>((r) => setTimeout(r, reconnectDelayMs))
+          reconnectDelayMs = Math.min(reconnectDelayMs * 2, 5_000)
+          continue
+        }
+        reconnectDelayMs = 750
+        const reader = res.body.getReader()
+        const dec = new TextDecoder()
+        let buffer = ''
+        while (!closed && !ac.signal.aborted) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += dec.decode(value, { stream: true })
+          let split: number
+          while ((split = buffer.indexOf('\n\n')) !== -1) {
+            const block = buffer.slice(0, split)
+            buffer = buffer.slice(split + 2)
+            const dataLine = block.split('\n').find((l) => l.startsWith('data:'))
+            if (!dataLine) continue
+            const json = dataLine.slice(5).trimStart()
+            try {
+              const parsed = JSON.parse(json) as { seq?: number } & RuntimeSseEvent
+              if (typeof parsed.seq === 'number') nextSinceSeq = Math.max(nextSinceSeq, parsed.seq)
+              onEvent(parsed)
+            } catch {
+              /* malformed SSE data line — ignore */
+            }
+          }
+        }
+      } catch (error) {
+        if (closed || ac.signal.aborted) return
+        const message = error instanceof Error ? error.message : String(error)
+        logError?.('sse', `SSE stream error for thread ${threadId}`, { message })
+        await new Promise<void>((r) => setTimeout(r, reconnectDelayMs))
+        reconnectDelayMs = Math.min(reconnectDelayMs * 2, 5_000)
+      }
+    }
+  })()
+  return { close }
+}

--- a/src/main/claw-runtime.test.ts
+++ b/src/main/claw-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -3511,5 +3511,637 @@ describe('ClawRuntime', () => {
     // /help produces a single IM command reply; no pending reaction.
     expect(send).toHaveBeenCalledTimes(1)
     expect(addReaction).not.toHaveBeenCalled()
+  })
+})
+
+describe('ClawRuntime handleFeishuMessage streaming', () => {
+  type FeishuMessage = {
+    chatId: string
+    messageId: string
+    threadId?: string
+    senderId: string
+    senderName?: string
+    chatType: 'p2p' | 'group'
+    mentionedBot: boolean
+    mentionAll: boolean
+    content: string
+    rawContentType: string
+    mentions: unknown[]
+  }
+  type LarkBridge = {
+    send: ReturnType<typeof vi.fn>
+    addReaction: ReturnType<typeof vi.fn>
+    stream: ReturnType<typeof vi.fn>
+  }
+
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  // Build a fake SSE Response whose body stays open and lets the test
+  // emit events on demand. Without this, the subscriber immediately sees
+  // a closed stream and keeps reconnecting.
+  type SseHandle = {
+    emit: (event: Record<string, unknown>) => void
+    close: () => void
+  }
+  function openSseResponse(): { response: Response; handle: SseHandle } {
+    const encoder = new TextEncoder()
+    let resolveNext: ((chunk: Uint8Array | null) => void) | null = null
+    const handle: SseHandle = {
+      emit: (event) => {
+        const payload = encoder.encode(`data: ${JSON.stringify(event)}\n\n`)
+        if (resolveNext) {
+          const fn = resolveNext
+          resolveNext = null
+          fn(payload)
+        } else {
+          // No waiter yet; this should not happen in our test, but
+          // push the payload to a small queue and let the next
+          // pull drain it. For simplicity, just rely on the resolve
+          // path being live when the streamer is reading.
+        }
+      },
+      close: () => {
+        if (resolveNext) {
+          const fn = resolveNext
+          resolveNext = null
+          fn(null)
+        }
+      }
+    }
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Eagerly enqueue an empty chunk so the reader's first read
+        // resolves and we can hand control back to the event loop
+        // (and eventually to the test's emit call).
+        controller.enqueue(encoder.encode(': open\n\n'))
+        // Park: keep the connection open. The streamer is going to
+        // call reader.read() again, so we resolve a pending promise.
+        const onNeedChunk = (): void => {
+          if (resolveNext) {
+            // already pending
+            return
+          }
+          // We rely on the test calling `handle.emit` to feed data.
+          // If the test closes, we close. If the test doesn't emit
+          // anything, the read will block here — which is exactly
+          // what we want.
+          resolveNext = (chunk) => {
+            if (chunk === null) {
+              controller.close()
+            } else {
+              controller.enqueue(chunk)
+              // Park again for the next read.
+              onNeedChunk()
+            }
+          }
+        }
+        onNeedChunk()
+      }
+    })
+    return {
+      response: new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' }
+      }),
+      handle
+    }
+  }
+
+  function stubFetchForThreadEvents(): { fetchMock: ReturnType<typeof vi.fn>; latestHandle: () => SseHandle | null } {
+    let current: SseHandle | null = null
+    const fetchMock = vi.fn(async () => {
+      const pair = openSseResponse()
+      current = pair.handle
+      return pair.response
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    return {
+      fetchMock,
+      latestHandle: () => current
+    }
+  }
+
+  function buildStreamingBridge(): LarkBridge {
+    return {
+      send: vi.fn(async () => ({ messageId: 'om_send_fallback' })),
+      addReaction: vi.fn(async () => 'rc_streaming_1'),
+      // Default: a no-op stream. Tests override this.
+      stream: vi.fn()
+    }
+  }
+
+  function patchBridge(runtime: object, channelId: string, bridge: LarkBridge): void {
+    ;(runtime as unknown as { feishuChannels: Map<string, LarkBridge> })
+      .feishuChannels
+      .set(channelId, bridge)
+  }
+
+  function makeTurnRequest(): ReturnType<typeof vi.fn> {
+    return vi.fn(async (_settings, path) => {
+      if (path === '/v1/threads/thr_1/turns') {
+        return {
+          ok: true,
+          status: 202,
+          body: JSON.stringify({ threadId: 'thr_1', turnId: 'turn_1' })
+        }
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+  }
+
+  it('routes through runStreamingReply when channel.feishuStream=true', async () => {
+    // Open the SSE event stream; the test will push events as the
+    // streamer reads them.
+    const { fetchMock, latestHandle } = stubFetchForThreadEvents()
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 5_000
+    // feishuStream is per-channel (default off). Enable it on this
+    // channel to exercise the streaming path.
+    settings.claw.channels = [
+      buildChannel({ threadId: 'thr_1', feishuStream: true, conversations: [buildConversation({ localThreadId: 'thr_1' })] })
+    ]
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const runtimeRequest = makeTurnRequest()
+    const bridge = buildStreamingBridge()
+    // Track the append calls the producer makes on the MarkdownStreamController.
+    const appendChunks: string[] = []
+    bridge.stream.mockImplementation(
+      async (
+        _to: string,
+        input: { markdown: (controller: { append: (c: string) => Promise<void>; setContent: (s: string) => Promise<void>; messageId: string }) => Promise<void> },
+        _opts?: unknown
+      ) => {
+        const controller = {
+          messageId: 'om_stream_1',
+          append: vi.fn(async (chunk: string) => {
+            appendChunks.push(chunk)
+          }),
+          setContent: vi.fn(async (_full: string) => undefined)
+        }
+        // Push SSE events as soon as the streamer is subscribed.
+        // Yield to the event loop so the subscriber is up first.
+        setTimeout(() => {
+          const h = latestHandle()
+          if (!h) return
+          h.emit({ seq: 1, kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: 'hello ' } })
+          h.emit({ seq: 2, kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: 'streamed ' } })
+          h.emit({ seq: 3, kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: 'world' } })
+          h.emit({ seq: 4, kind: 'turn_completed', turnId: 'turn_1' })
+        }, 0)
+        await input.markdown(controller)
+        return { messageId: controller.messageId }
+      }
+    )
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+    patchBridge(runtime, 'channel_1', bridge)
+
+    await (runtime as unknown as {
+      handleFeishuMessage: (channelId: string, message: FeishuMessage) => Promise<void>
+    }).handleFeishuMessage('channel_1', {
+      chatId: 'oc_chat_a',
+      messageId: 'om_inbound',
+      senderId: 'ou_1',
+      senderName: 'Alice',
+      chatType: 'p2p',
+      mentionedBot: false,
+      mentionAll: false,
+      content: 'stream me',
+      rawContentType: 'text',
+      mentions: []
+    })
+
+    // The streaming branch was entered: the SSE event stream was opened
+    // and the bridge.stream producer was invoked.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(bridge.stream).toHaveBeenCalledTimes(1)
+    // The three deltas came through the producer and were appended to
+    // the streaming card.
+    expect(appendChunks).toEqual(['hello ', 'streamed ', 'world'])
+    // The streaming card is the single user-visible reply. handleFeishuMessage
+    // must NOT call `bridge.send` again to deliver the streamed text as a
+    // separate message — that would duplicate the reply.
+    expect(bridge.send).not.toHaveBeenCalled()
+  })
+
+  it('falls back to one-shot send when bridge.stream throws', async () => {
+    // Open the SSE event stream but the producer never receives any
+    // useful events; bridge.stream itself rejects with `not_connected`
+    // so the runStreamingReply catch arm runs and falls back to
+    // bridge.send.
+    stubFetchForThreadEvents()
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 5_000
+    // feishuStream is per-channel; enable it so the streaming path is
+    // exercised. bridge.stream will reject, triggering the in-band
+    // fallback to bridge.send.
+    settings.claw.channels = [
+      buildChannel({ threadId: 'thr_1', feishuStream: true, conversations: [buildConversation({ localThreadId: 'thr_1' })] })
+    ]
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const runtimeRequest = makeTurnRequest()
+    const bridge = buildStreamingBridge()
+    // Make bridge.stream throw a not_connected error so runStreamingReply
+    // catches and falls back to bridge.send.
+    bridge.stream.mockRejectedValue(new Error('not_connected'))
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+    patchBridge(runtime, 'channel_1', bridge)
+
+    await (runtime as unknown as {
+      handleFeishuMessage: (channelId: string, message: FeishuMessage) => Promise<void>
+    }).handleFeishuMessage('channel_1', {
+      chatId: 'oc_chat_a',
+      messageId: 'om_inbound_fb',
+      senderId: 'ou_1',
+      senderName: 'Alice',
+      chatType: 'p2p',
+      mentionedBot: false,
+      mentionAll: false,
+      content: 'stream then fail',
+      rawContentType: 'text',
+      mentions: []
+    })
+
+    expect(bridge.stream).toHaveBeenCalledTimes(1)
+    // Fallback path: bridge.send is called once from runStreamingReply's
+    // catch arm (the canned "Sorry" message). handleFeishuMessage must
+    // NOT call bridge.send again — the in-band fallback already delivered
+    // the user-visible message.
+    expect(bridge.send).toHaveBeenCalledTimes(1)
+    const fallbackCall = bridge.send.mock.calls.find(
+      (call) => (call[1] as { markdown?: string })?.markdown === 'Sorry, I could not finish streaming the response.'
+    )
+    expect(fallbackCall).toBeDefined()
+    expect(fallbackCall).toEqual([
+      'oc_chat_a',
+      { markdown: 'Sorry, I could not finish streaming the response.' },
+      { replyTo: 'om_inbound_fb', replyInThread: false }
+    ])
+  })
+
+  it('falls back to setContent(partial) when controller.append throws mid-stream', async () => {
+    // Open the SSE event stream; the test pushes events through the
+    // producer whose `append` throws, triggering the
+    // setContent(accumulated) fallback inside FeishuStreamer.
+    const { latestHandle } = stubFetchForThreadEvents()
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 5_000
+    // feishuStream is per-channel; enable it so the streaming path is
+    // exercised. controller.append will throw, triggering the
+    // setContent(accumulated) fallback inside FeishuStreamer.
+    settings.claw.channels = [
+      buildChannel({ threadId: 'thr_1', feishuStream: true, conversations: [buildConversation({ localThreadId: 'thr_1' })] })
+    ]
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const runtimeRequest = makeTurnRequest()
+    const bridge = buildStreamingBridge()
+    let controllerRef: {
+      append: ReturnType<typeof vi.fn>
+      setContent: ReturnType<typeof vi.fn>
+      messageId: string
+    } | null = null
+    bridge.stream.mockImplementation(
+      async (
+        _to: string,
+        input: { markdown: (controller: { append: (c: string) => Promise<void>; setContent: (s: string) => Promise<void>; messageId: string }) => Promise<void> }
+      ) => {
+        const ctrl = {
+          messageId: 'om_stream_partial',
+          // append throws on every call, simulating a rate_limited
+          // response from the Feishu streaming card API.
+          append: vi.fn(async (_chunk: string) => {
+            throw new Error('rate_limited')
+          }),
+          setContent: vi.fn(async (_full: string) => undefined)
+        }
+        controllerRef = ctrl
+        // Push a single delta. The first append() call will throw,
+        // the streamer will then call setContent('partial ') and
+        // resolve with ok=true.
+        setTimeout(() => {
+          const h = latestHandle()
+          if (!h) return
+          h.emit({ seq: 1, kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: 'partial' } })
+        }, 0)
+        await input.markdown(ctrl)
+        return { messageId: ctrl.messageId }
+      }
+    )
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+    patchBridge(runtime, 'channel_1', bridge)
+
+    await (runtime as unknown as {
+      handleFeishuMessage: (channelId: string, message: FeishuMessage) => Promise<void>
+    }).handleFeishuMessage('channel_1', {
+      chatId: 'oc_chat_a',
+      messageId: 'om_inbound_partial',
+      senderId: 'ou_1',
+      senderName: 'Alice',
+      chatType: 'p2p',
+      mentionedBot: false,
+      mentionAll: false,
+      content: 'partial stream',
+      rawContentType: 'text',
+      mentions: []
+    })
+
+    // The producer should have called append exactly once (the very first
+    // chunk, which throws 'rate_limited') and then setContent with
+    // whatever text was accumulated before the throw.
+    expect(controllerRef).not.toBeNull()
+    expect(controllerRef!.append).toHaveBeenCalledTimes(1)
+    expect(controllerRef!.setContent).toHaveBeenCalledTimes(1)
+    const setContentArg = controllerRef!.setContent.mock.calls[0]?.[0] as string
+    expect(typeof setContentArg).toBe('string')
+    expect(setContentArg.length).toBeGreaterThan(0)
+    // The partial text was finalized on the streaming card via
+    // setContent. handleFeishuMessage must NOT call bridge.send again
+    // — the streaming card is the only user-visible reply.
+    expect(bridge.send).not.toHaveBeenCalled()
+  })
+
+  it('does not use FeishuStreamer when channel.feishuStream is not true', async () => {
+    // feishuStream is per-channel and defaults to off. The legacy
+    // polling path stays in use. We do NOT open the SSE event stream
+    // because the streamer is never instantiated.
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 2_000
+    settings.claw.channels = [
+      buildChannel({ threadId: 'thr_1', conversations: [buildConversation({ localThreadId: 'thr_1' })] })
+    ]
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const agentReply = 'original polling path reply'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads/thr_1/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_1', turnId: 'turn_polling' }) }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            id: 'thr_1',
+            status: 'idle',
+            turns: [
+              {
+                id: 'turn_polling',
+                status: 'completed',
+                items: [{ kind: 'assistant_text', text: agentReply }]
+              }
+            ]
+          })
+        }
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    const bridge = buildStreamingBridge()
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+    patchBridge(runtime, 'channel_1', bridge)
+
+    await (runtime as unknown as {
+      handleFeishuMessage: (channelId: string, message: FeishuMessage) => Promise<void>
+    }).handleFeishuMessage('channel_1', {
+      chatId: 'oc_chat_a',
+      messageId: 'om_inbound_no_stream',
+      senderId: 'ou_1',
+      senderName: 'Alice',
+      chatType: 'p2p',
+      mentionedBot: false,
+      mentionAll: false,
+      content: 'polling please',
+      rawContentType: 'text',
+      mentions: []
+    })
+
+    // FeishuStreamer / bridge.stream must NOT be invoked when the user
+    // explicitly opts out of streaming.
+    expect(bridge.stream).not.toHaveBeenCalled()
+    // The legacy polling path delivers the reply via bridge.send.
+    expect(bridge.send).toHaveBeenCalledWith(
+      'oc_chat_a',
+      { markdown: agentReply },
+      { replyTo: 'om_inbound_no_stream', replyInThread: false }
+    )
+  })
+
+  it('still routes through the streaming bridge for prompts that mention sending files', async () => {
+    // NOTE: The streaming branch does not currently surface `result.files`
+    // (the streaming reply path uses `streamResult.finalText`, not the
+    // turn result from `waitForAssistantResult`), so the
+    // `sendFeishuGeneratedFiles` follow-up does not actually fire in
+    // the streaming path today. This test pins that behavior: a prompt
+    // that matches `shouldSendGeneratedFilesForPrompt` (e.g. contains
+    // "发给我") must still complete the streaming reply without
+    // crashing. The follow-up file delivery is exercised in the
+    // feishuStream=false path; see the image/markdown tests above.
+    const { fetchMock, latestHandle } = stubFetchForThreadEvents()
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 5_000
+    // feishuStream is per-channel (default off). Enable it on this
+    // channel so the streaming path is exercised.
+    settings.claw.channels = [
+      buildChannel({ threadId: 'thr_1', feishuStream: true, conversations: [buildConversation({ localThreadId: 'thr_1' })] })
+    ]
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const runtimeRequest = makeTurnRequest()
+    const bridge = buildStreamingBridge()
+    let streamedMessageId = ''
+    bridge.stream.mockImplementation(
+      async (
+        _to: string,
+        input: { markdown: (controller: { append: (c: string) => Promise<void>; setContent: (s: string) => Promise<void>; messageId: string }) => Promise<void> }
+      ) => {
+        const ctrl = {
+          messageId: 'om_stream_files',
+          append: vi.fn(async (_chunk: string) => undefined),
+          setContent: vi.fn(async (_full: string) => undefined)
+        }
+        setTimeout(() => {
+          const h = latestHandle()
+          if (!h) return
+          h.emit({ seq: 1, kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: '好的' } })
+          h.emit({ seq: 2, kind: 'turn_completed', turnId: 'turn_1' })
+        }, 0)
+        await input.markdown(ctrl)
+        streamedMessageId = ctrl.messageId
+        return { messageId: ctrl.messageId }
+      }
+    )
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+    patchBridge(runtime, 'channel_1', bridge)
+
+    // "把今天的笔记发给我" — shouldSendGeneratedFilesForPrompt returns true.
+    await (runtime as unknown as {
+      handleFeishuMessage: (channelId: string, message: FeishuMessage) => Promise<void>
+    }).handleFeishuMessage('channel_1', {
+      chatId: 'oc_chat_a',
+      messageId: 'om_inbound_files',
+      senderId: 'ou_1',
+      senderName: 'Alice',
+      chatType: 'p2p',
+      mentionedBot: false,
+      mentionAll: false,
+      content: '把今天的笔记发给我',
+      rawContentType: 'text',
+      mentions: []
+    })
+
+    // The streaming card was finalized (the messageId is recorded by
+    // the bridge mock).
+    expect(streamedMessageId).toBe('om_stream_files')
+    expect(bridge.stream).toHaveBeenCalledTimes(1)
+    // The SSE event stream was opened (proves the streaming branch ran
+    // end-to-end without falling back to the polling path).
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // The streaming card is the single user-visible reply. No
+    // follow-up one-shot text message is sent. The streaming result
+    // also does not currently carry a `files` payload, so no file
+    // attachment is dispatched (see the comment above).
+    expect(bridge.send).not.toHaveBeenCalled()
+  })
+
+  it('does not touch FeishuStreamer for non-feishu providers (weixin unchanged)', async () => {
+    // WeChat (weixin) inbound traffic arrives via handleWebhook with
+    // `provider: 'weixin'` — it does NOT go through handleFeishuMessage.
+    // This test exercises the webhook entry point and asserts that no
+    // feishu streaming bridge is touched.
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 2_000
+    settings.claw.channels = [
+      buildChannel({
+        provider: 'weixin' as const,
+        id: 'channel_weixin',
+        label: 'WeChat',
+        threadId: 'thr_wx_stream',
+        conversations: [
+          buildConversation({
+            chatId: 'wx_user_1',
+            senderId: 'wx_user_1',
+            localThreadId: 'thr_wx_stream'
+          })
+        ]
+      })
+    ]
+    const { store } = mutableSettingsStore(settings)
+    const agentReply = 'wechat reply'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads/thr_wx_stream/turns' && init?.method === 'POST') {
+        return { ok: true, status: 202, body: JSON.stringify({ turnId: 'turn_wx_stream' }) }
+      }
+      if (path === '/v1/threads/thr_wx_stream' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            id: 'thr_wx_stream',
+            status: 'idle',
+            turns: [
+              {
+                id: 'turn_wx_stream',
+                status: 'completed',
+                items: [{ kind: 'assistant_text', text: agentReply }]
+              }
+            ]
+          })
+        }
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError: () => undefined,
+      createScheduledTaskFromText: vi.fn(async () => ({ kind: 'noop' as const }))
+    })
+    // Build a Feishu bridge entry on the same runtime to detect any
+    // accidental weixin → feishu bridge reuse. The weixin webhook must
+    // NOT touch it.
+    const feishuBridge = buildStreamingBridge()
+    patchBridge(runtime, 'channel_weixin', feishuBridge)
+    const body = JSON.stringify({
+      text: 'hello wechat',
+      provider: 'weixin',
+      channelId: 'channel_weixin',
+      chatId: 'wx_user_1',
+      messageId: 'wx_msg_stream',
+      senderId: 'wx_user_1',
+      senderName: 'Alice'
+    })
+    const req = {
+      method: 'POST',
+      url: settings.claw.im.path,
+      headers: {},
+      async *[Symbol.asyncIterator]() {
+        yield Buffer.from(body)
+      }
+    }
+    let status = 0
+    let responseBody = ''
+    const res = {
+      writeHead: vi.fn((nextStatus: number) => {
+        status = nextStatus
+      }),
+      end: vi.fn((payload: string) => {
+        responseBody = payload
+      })
+    }
+
+    await (runtime as unknown as {
+      handleWebhook: (request: typeof req, response: typeof res) => Promise<void>
+    }).handleWebhook(req, res)
+
+    expect(status).toBe(200)
+    const parsed = JSON.parse(responseBody)
+    expect(parsed).toMatchObject({ ok: true, reply: agentReply })
+    // No streaming bridge activity: bridge.stream and bridge.send must
+    // both remain untouched for weixin (the original polling reply path
+    // is what delivers the WeChat message).
+    expect(feishuBridge.stream).not.toHaveBeenCalled()
+    expect(feishuBridge.send).not.toHaveBeenCalled()
+    expect(feishuBridge.addReaction).not.toHaveBeenCalled()
   })
 })

--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -71,8 +71,12 @@ import {
   type ClawRuntimeDeps,
   type RunPromptOptions,
   type ThreadDetailJson,
-  type ThreadRecordJson
+  type ThreadRecordJson,
+  type SseSubscriber,
+  subscribeRuntimeThreadEvents
 } from './claw-runtime-helpers'
+import { getRuntimeBaseUrlForSettings, runtimeAuthHeaders } from './runtime/kun-adapter'
+import { FeishuStreamer } from './feishu-streamer'
 
 const MAX_IM_FILE_UPLOAD_BYTES = 50 * 1024 * 1024
 const CLAW_IM_APPROVAL_POLICY = 'auto'
@@ -654,6 +658,116 @@ export class ClawRuntime {
     }
   }
 
+  private async subscribeSse(
+    settings: AppSettingsV1,
+    threadId: string,
+    streamer: FeishuStreamer,
+    signal: AbortSignal
+  ): Promise<{ close: () => void }> {
+    const baseUrl = getRuntimeBaseUrlForSettings(settings)
+    if (!baseUrl) throw new Error('runtime_base_url_unavailable')
+    const headers: Record<string, string> = { Accept: 'text/event-stream' }
+    const auth = runtimeAuthHeaders(settings).get('Authorization')
+    if (auth) headers.Authorization = auth
+    const onEvent = (event: { kind?: string; [k: string]: unknown }): void => {
+      streamer.onSseEvent(event as Record<string, unknown>)
+    }
+    return subscribeRuntimeThreadEvents({
+      baseUrl,
+      threadId,
+      headers,
+      onEvent,
+      signal,
+      logError: (category, message, detail) => this.deps.logError(category, message, detail)
+    })
+  }
+
+  private subscribeSseForStreamer(
+    settings: AppSettingsV1,
+    threadId: string,
+    streamer: FeishuStreamer
+  ): SseSubscriber {
+    return (signal) => {
+      // subscribeRuntimeThreadEvents is async, but SseSubscriber contract is
+      // synchronous (returns a { close } handle). Kick off the async
+      // subscription and surface its close synchronously by racing the
+      // setup; if the setup itself throws (e.g. no base URL) we log via
+      // deps.logError and continue with a no-op close. The streamer will
+      // still rely on its own responseTimeoutMs abort as a backstop.
+      const setup = this.subscribeSse(settings, threadId, streamer, signal)
+      let close = (): void => undefined
+      void setup.then(
+        (handle) => { close = handle.close },
+        (error) => {
+          this.deps.logError('claw-feishu-stream', 'SSE subscription setup failed', {
+            message: error instanceof Error ? error.message : String(error),
+            threadId
+          })
+        }
+      )
+      return { close: () => close() }
+    }
+  }
+
+  private async runStreamingReply(input: {
+    bridge: LarkChannel
+    chatId: string
+    threadId: string
+    turnId: string
+    replyOptions: { replyTo?: string; replyInThread?: boolean }
+    responseTimeoutMs: number
+    context: Record<string, unknown>
+  }): Promise<{ ok: boolean; messageId: string; finalText: string; fellBack: boolean; message: string }> {
+    const cancel = new AbortController()
+    const timeout = setTimeout(() => cancel.abort(), input.responseTimeoutMs)
+    const streamer = new FeishuStreamer({
+      bridge: input.bridge,
+      chatId: input.chatId,
+      turnId: input.turnId,
+      threadId: input.threadId,
+      replyOptions: input.replyOptions,
+      logger: (category, message, detail) => this.deps.logError(category, message, detail)
+    })
+    try {
+      const settings = await this.deps.store.load()
+      const result = await streamer.start({
+        subscribe: this.subscribeSseForStreamer(settings, input.threadId, streamer)
+      })
+      return {
+        ok: result.ok,
+        messageId: result.messageId,
+        finalText: result.finalText,
+        fellBack: result.fellBack,
+        message: result.ok ? 'streamed' : 'stream_failed'
+      }
+    } catch (error) {
+      this.deps.logError('claw-feishu-stream', 'Streaming reply failed; falling back to one-shot send.', {
+        message: error instanceof Error ? error.message : String(error),
+        ...input.context
+      })
+      const finalText = streamer.getAccumulatedText() || ''
+      try {
+        const fb = await input.bridge.send(
+          input.chatId,
+          { markdown: finalText || 'Sorry, I could not finish streaming the response.' },
+          input.replyOptions
+        )
+        return { ok: true, messageId: fb.messageId, finalText, fellBack: true, message: 'fell_back' }
+      } catch (fbError) {
+        return {
+          ok: false,
+          messageId: '',
+          finalText,
+          fellBack: true,
+          message: fbError instanceof Error ? fbError.message : String(fbError)
+        }
+      }
+    } finally {
+      clearTimeout(timeout)
+      streamer.dispose()
+    }
+  }
+
   private startRuntimeTurn(
     settings: AppSettingsV1,
     threadId: string,
@@ -1013,6 +1127,14 @@ export class ClawRuntime {
       channel?: ClawImChannelV1
       conversation?: ClawImConversationV1
       remoteSession?: Pick<ClawImRemoteSessionV1, 'chatId' | 'messageId' | 'threadId' | 'senderId' | 'senderName'>
+      /**
+       * When `false`, the turn is started (and the conversation
+       * persisted) but `waitForAssistantResult` is skipped — the caller
+       * is responsible for observing the turn's outcome (e.g. via
+       * `runStreamingReply`). Defaults to `true` for the legacy
+       * `processIncomingImPrompt` polling path.
+       */
+      waitForResult?: boolean
     }
   ): Promise<ClawRunResult> {
     const { channel, conversation, prompt, provider, remoteSession, sender } = input
@@ -1027,7 +1149,7 @@ export class ClawRuntime {
       model: channel?.model ?? settings.claw.im.model,
       providerId: channel?.providerId ?? settings.claw.im.providerId,
       mode: settings.claw.im.mode,
-      waitForResult: true,
+      waitForResult: input.waitForResult !== false,
       responseTimeoutMs: settings.claw.im.responseTimeoutMs,
       source: 'im',
       threadId: initialThreadId || undefined,
@@ -1694,15 +1816,82 @@ export class ClawRuntime {
     }
 
     let result: ClawRunResult
+    // Tracks whether the streaming path (or its in-band one-shot fallback)
+    // already delivered a message to Feishu / Lark. When true, the post-
+    // branch `sendFeishuMessage` below is skipped to avoid duplicating the
+    // streamed text as a separate message bubble.
+    let streamedToFeishu = false
     try {
-      result = await this.processIncomingImPrompt(settings, {
-        prompt: buildFeishuPrompt(message),
-        sender,
-        provider: 'feishu',
-        channel,
-        conversation,
-        remoteSession
-      })
+      // feishuStream is now per-channel (default off). The runtime
+      // default is the polling path; only switch to streaming when this
+      // channel has explicitly enabled it.
+      if (channel.feishuStream === true) {
+        // Streaming path: start the turn (this also persists the
+        // conversation via the onTurnStarted callback) and then stream
+        // the assistant's reply into a Feishu / Lark markdown card.
+        // The original `processIncomingImPrompt` polling path is kept
+        // for users who explicitly disable streaming and for WeChat
+        // (which has no markdown-stream card concept).
+        const started = await this.processIncomingImPrompt(settings, {
+          prompt: buildFeishuPrompt(message),
+          sender,
+          provider: 'feishu',
+          channel,
+          conversation,
+          remoteSession,
+          waitForResult: false
+        })
+        if (!started.ok || !started.threadId || !started.turnId) {
+          result = { ok: false, message: started.message || 'Failed to start Feishu streaming turn.' }
+        } else {
+          const streamResult = await this.runStreamingReply({
+            bridge,
+            chatId: message.chatId,
+            threadId: started.threadId,
+            turnId: started.turnId,
+            replyOptions: { replyTo: message.messageId, replyInThread: Boolean(message.threadId) },
+            responseTimeoutMs: 60_000,
+            context: {
+              purpose: 'feishu-stream',
+              channelId,
+              chatId: message.chatId,
+              inboundMessageId: message.messageId,
+              threadId: started.threadId,
+              turnId: started.turnId
+            }
+          })
+          if (streamResult.ok) {
+            const streamedText = streamResult.finalText.trim() || 'Completed.'
+            // Either the streaming card (FeishuStreamer) or its one-shot
+            // fallback already delivered the text to the chat. Mark
+            // `streamedToFeishu` so the post-branch sendFeishuMessage
+            // below is skipped.
+            streamedToFeishu = true
+            result = {
+              ok: true,
+              threadId: started.threadId,
+              turnId: started.turnId,
+              text: streamedText,
+              message: streamResult.fellBack ? 'streamed (fell back to one-shot send)' : 'streamed'
+            }
+          } else {
+            result = {
+              ok: false,
+              message: streamResult.message.trim() || 'Sorry, something went wrong while handling your message.'
+            }
+          }
+        }
+      } else {
+        // Original polling path — unchanged.
+        result = await this.processIncomingImPrompt(settings, {
+          prompt: buildFeishuPrompt(message),
+          sender,
+          provider: 'feishu',
+          channel,
+          conversation,
+          remoteSession
+        })
+      }
     } catch (error) {
       this.deps.logError('claw-feishu', 'Failed to handle Feishu inbound message', {
         message: errorMessage(error),
@@ -1756,30 +1945,35 @@ export class ClawRuntime {
       : (result.message.trim() || 'Sorry, something went wrong while handling your message.')
     const resultThreadId = result.ok ? result.threadId : undefined
     const resultTurnId = result.ok ? result.turnId : undefined
-    try {
-      await this.sendFeishuMessage(
-        bridge,
-        message.chatId,
-        { markdown: replyText },
-        replyOptions,
-        {
-          purpose: 'agent-reply',
-          channelId,
+    // The streaming path already delivered the text (either as a live
+    // SDK card or via its one-shot fallback). Sending another one-shot
+    // message here would duplicate the reply.
+    if (!streamedToFeishu) {
+      try {
+        await this.sendFeishuMessage(
+          bridge,
+          message.chatId,
+          { markdown: replyText },
+          replyOptions,
+          {
+            purpose: 'agent-reply',
+            channelId,
+            chatId: message.chatId,
+            inboundMessageId: message.messageId,
+            runtimeOk: result.ok,
+            threadId: resultThreadId,
+            turnId: resultTurnId
+          }
+        )
+      } catch (error) {
+        this.deps.logError('claw-feishu', 'Failed to send Feishu / Lark agent reply', {
+          message: errorMessage(error),
           chatId: message.chatId,
-          inboundMessageId: message.messageId,
-          runtimeOk: result.ok,
+          senderId: message.senderId,
           threadId: resultThreadId,
           turnId: resultTurnId
-        }
-      )
-    } catch (error) {
-      this.deps.logError('claw-feishu', 'Failed to send Feishu / Lark agent reply', {
-        message: errorMessage(error),
-        chatId: message.chatId,
-        senderId: message.senderId,
-        threadId: resultThreadId,
-        turnId: resultTurnId
-      })
+        })
+      }
     }
     if (filesToSend.length > 0) {
       const delivery = await this.sendFeishuGeneratedFiles(

--- a/src/main/feishu-streamer.test.ts
+++ b/src/main/feishu-streamer.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { LarkChannel, MarkdownStreamController, SendOptions, SendResult } from '@larksuiteoapi/node-sdk'
+import { FeishuStreamer, type SseSubscriber } from './feishu-streamer'
+
+type StreamInput = { markdown: (controller: MarkdownStreamController) => Promise<void> }
+
+function makeBridge(): {
+  bridge: LarkChannel
+  controller: MarkdownStreamController
+  messageId: string
+} {
+  const messageId = 'om_stream_1'
+  const controller: MarkdownStreamController = {
+    append: vi.fn(async () => undefined),
+    setContent: vi.fn(async () => undefined),
+    get messageId() { return messageId }
+  }
+  const bridge = {
+    // Critical: use stream, not send
+    stream: vi.fn(async (_to: string, input: StreamInput, _opts: SendOptions): Promise<SendResult> => {
+      await input.markdown(controller)
+      return { messageId }
+    })
+  } as unknown as LarkChannel
+  return { bridge, controller, messageId }
+}
+
+function makeSubscriber(
+  events: Array<Record<string, unknown>>,
+  onEvent: (event: Record<string, unknown>) => void
+): { subscribe: SseSubscriber; delivered: () => Array<Record<string, unknown>> } {
+  const delivered: Array<Record<string, unknown>> = []
+  let closed = false
+  const subscribe: SseSubscriber = (signal) => {
+    const onAbort = (): void => { closed = true }
+    signal.addEventListener('abort', onAbort, { once: true })
+    queueMicrotask(() => {
+      for (const event of events) {
+        if (closed) return
+        delivered.push(event)
+        onEvent(event)
+      }
+    })
+    return { close: (): void => { closed = true } }
+  }
+  return { subscribe, delivered: () => delivered }
+}
+
+describe('FeishuStreamer', () => {
+  it('streams assistant_text_delta in order, calls setContent once on turn_completed, resolves with messageId', async () => {
+    const { bridge, controller, messageId } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: { replyTo: 'om_in_1' }, logger: vi.fn()
+    })
+    const sub = makeSubscriber(
+      [
+        { kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: '你' } },
+        { kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: '好' } },
+        { kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: '!' } },
+        { kind: 'turn_completed', turnId: 'turn_1' }
+      ],
+      (event) => streamer.onSseEvent(event)
+    )
+
+    const result = await streamer.start({ subscribe: sub.subscribe })
+
+    expect(controller.append).toHaveBeenCalledTimes(3)
+    expect(controller.append).toHaveBeenNthCalledWith(1, '你')
+    expect(controller.append).toHaveBeenNthCalledWith(2, '好')
+    expect(controller.append).toHaveBeenNthCalledWith(3, '!')
+    expect(controller.setContent).toHaveBeenCalledTimes(1)
+    expect(controller.setContent).toHaveBeenCalledWith('你好!')
+    expect(result).toEqual({ ok: true, messageId, finalText: '你好!', fellBack: false })
+  })
+
+  it('drops assistant_reasoning_delta without calling controller.append', async () => {
+    const { bridge, controller } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    streamer.onSseEvent({ kind: 'assistant_reasoning_delta', turnId: 'turn_1', item: { text: 'thinking...' } })
+    streamer.onSseEvent({ kind: 'turn_completed', turnId: 'turn_1' })
+    expect(controller.append).not.toHaveBeenCalled()
+    expect(streamer.getAccumulatedText()).toBe('')
+  })
+
+  it('ignores assistant_text_delta from a different turn', async () => {
+    const { bridge, controller } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    const sub = makeSubscriber(
+      [
+        { kind: 'assistant_text_delta', turnId: 'turn_OTHER', item: { text: 'X' } },
+        { kind: 'turn_completed', turnId: 'turn_1' }
+      ],
+      (event) => streamer.onSseEvent(event)
+    )
+    const result = await streamer.start({ subscribe: sub.subscribe })
+    expect(controller.append).not.toHaveBeenCalled()
+    expect(result.finalText).toBe('')
+    expect(controller.setContent).toHaveBeenCalledWith('')
+  })
+
+  it('falls back to setContent(partial) when controller.append throws mid-stream', async () => {
+    const bridge = {
+      stream: vi.fn(async (_to: string, input: { markdown: (c: MarkdownStreamController) => Promise<void> }, _opts: SendOptions): Promise<SendResult> => {
+        const controller: MarkdownStreamController = {
+          append: vi.fn(async () => { throw new Error('rate_limited') }),
+          setContent: vi.fn(async () => undefined),
+          get messageId() { return 'om_stream_2' }
+        }
+        await input.markdown(controller)
+        return { messageId: 'om_stream_2' }
+      })
+    } as unknown as LarkChannel
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    const sub = makeSubscriber(
+      [{ kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: 'partial' } }],
+      (event) => streamer.onSseEvent(event)
+    )
+    const result = await streamer.start({ subscribe: sub.subscribe })
+    expect(result.ok).toBe(true)
+    expect(result.finalText).toBe('partial')
+    expect(result.fellBack).toBe(false)
+  })
+
+  it('rejects start() when subscribe() throws synchronously', async () => {
+    const { bridge, controller } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    const subscribe: SseSubscriber = () => { throw new Error('sse_unavailable') }
+    await expect(streamer.start({ subscribe })).rejects.toThrow('sse_unavailable')
+    expect(controller.append).not.toHaveBeenCalled()
+  })
+
+  it('resolves with ok=false and empty text on turn_failed', async () => {
+    const { bridge, controller } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    const sub = makeSubscriber(
+      [
+        { kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: 'part' } },
+        { kind: 'turn_failed', turnId: 'turn_1', message: 'oops' }
+      ],
+      (event) => streamer.onSseEvent(event)
+    )
+    const result = await streamer.start({ subscribe: sub.subscribe })
+    expect(result.ok).toBe(false)
+    expect(result.finalText).toBe('part')
+  })
+
+  it('aborts cleanly: nextDelta resolves null and start rejects with aborted', async () => {
+    const { bridge } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    // subscribe 故意永不喂事件，只等 abort
+    const subscribe: SseSubscriber = (signal) => {
+      signal.addEventListener('abort', () => undefined, { once: true })
+      return { close: (): void => undefined }
+    }
+    const startPromise = streamer.start({ subscribe })
+    // 等一帧，确保 start 已进入 await
+    await new Promise((r) => setTimeout(r, 0))
+    streamer.abort()
+    await expect(startPromise).rejects.toThrow('aborted')
+  })
+
+  it('reads event.item.text (not item.delta)', async () => {
+    // 上版踩过的字段错位坑
+    const { bridge, controller } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    const sub = makeSubscriber(
+      [
+        { kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: 'real' } },
+        { kind: 'turn_completed', turnId: 'turn_1' }
+      ],
+      (event) => streamer.onSseEvent(event)
+    )
+    const result = await streamer.start({ subscribe: sub.subscribe })
+    expect(controller.append).toHaveBeenCalledWith('real')
+    expect(result.finalText).toBe('real')
+  })
+
+  it('calls bridge.stream (not bridge.send)', async () => {
+    const streamSpy = vi.fn(async (_to: string, input: { markdown: (c: MarkdownStreamController) => Promise<void> }, _opts: SendOptions): Promise<SendResult> => {
+      const ctrl: MarkdownStreamController = {
+        append: vi.fn(async () => undefined),
+        setContent: vi.fn(async () => undefined),
+        get messageId() { return 'om_x' }
+      }
+      await input.markdown(ctrl)
+      return { messageId: 'om_x' }
+    })
+    const sendSpy = vi.fn(async (): Promise<SendResult> => {
+      return { messageId: 'om_y' }
+    })
+    const bridge = {
+      stream: streamSpy,
+      send: sendSpy
+    } as unknown as LarkChannel
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    const sub = makeSubscriber(
+      [{ kind: 'turn_completed', turnId: 'turn_1' }],
+      (event) => streamer.onSseEvent(event)
+    )
+    await streamer.start({ subscribe: sub.subscribe })
+    expect(streamSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('dispose() releases all waiters and the subscription', () => {
+    const { bridge } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    const closeSpy = vi.fn()
+    ;(streamer as unknown as { subscription: { close: () => void } | null }).subscription = { close: closeSpy }
+    streamer.dispose()
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/feishu-streamer.ts
+++ b/src/main/feishu-streamer.ts
@@ -1,0 +1,195 @@
+import type { LarkChannel, MarkdownStreamController, SendOptions } from '@larksuiteoapi/node-sdk'
+import type { SseSubscriber } from './claw-runtime-helpers'
+
+export type FeishuStreamLogger = (category: string, message: string, detail?: unknown) => void
+
+export type FeishuStreamerOptions = {
+  bridge: LarkChannel
+  chatId: string
+  turnId: string
+  threadId: string
+  replyOptions: SendOptions
+  logger: FeishuStreamLogger
+}
+
+export type FeishuStreamerResult = {
+  ok: boolean
+  messageId: string
+  finalText: string
+  fellBack: boolean
+}
+
+export class FeishuStreamer {
+  private readonly opts: FeishuStreamerOptions
+  private readonly outbox: Array<string | null> = []
+  private readonly waiters: Array<(chunk: string | null) => void> = []
+  private state: 'pending' | 'streaming' | 'closed' = 'pending'
+  private accumulatedText = ''
+  private subscription: { close: () => void } | null = null
+  private startAbortController: AbortController | null = null
+  private failed = false
+
+  constructor(opts: FeishuStreamerOptions) {
+    this.opts = opts
+  }
+
+  start(input: { subscribe: SseSubscriber }): Promise<FeishuStreamerResult> {
+    return new Promise<FeishuStreamerResult>((resolve, reject) => {
+      const controller = new AbortController()
+      this.startAbortController = controller
+      this.failed = false
+      let resolved = false
+      const onComplete = (result: FeishuStreamerResult): void => {
+        if (resolved) return
+        resolved = true
+        resolve(result)
+      }
+      const onError = (error: Error): void => {
+        if (resolved) return
+        resolved = true
+        reject(error)
+      }
+
+      const producer = async (streamController: MarkdownStreamController): Promise<void> => {
+        this.state = 'streaming'
+        try {
+          while (this.state === 'streaming') {
+            const chunk = await this.nextDelta()
+            if (chunk === null) break
+            this.accumulatedText += chunk
+            try {
+              await streamController.append(chunk)
+            } catch (error) {
+              this.opts.logger('claw-feishu-stream', 'append failed; saving accumulated text and finalizing', {
+                message: error instanceof Error ? error.message : String(error)
+              })
+              try {
+                await streamController.setContent(this.accumulatedText)
+              } catch (finalError) {
+                this.opts.logger('claw-feishu-stream', 'setContent on append-failure also failed', {
+                  message: finalError instanceof Error ? finalError.message : String(finalError)
+                })
+              }
+              onComplete({
+                ok: !this.failed,
+                messageId: streamController.messageId,
+                finalText: this.accumulatedText,
+                fellBack: false
+              })
+              return
+            }
+          }
+          try {
+            await streamController.setContent(this.accumulatedText)
+          } catch (error) {
+            this.opts.logger('claw-feishu-stream', 'final setContent failed; returning accumulated text as-is', {
+              message: error instanceof Error ? error.message : String(error)
+            })
+          }
+          onComplete({
+            ok: !this.failed,
+            messageId: streamController.messageId,
+            finalText: this.accumulatedText,
+            fellBack: false
+          })
+        } catch (error) {
+          onError(error instanceof Error ? error : new Error(String(error)))
+        }
+      }
+
+      this.subscription = input.subscribe(controller.signal)
+      const onAbort = (): void => {
+        this.state = 'closed'
+        this.subscription?.close()
+        this.subscription = null
+        while (this.waiters.length > 0) {
+          const w = this.waiters.shift()!
+          w(null)
+        }
+        if (!resolved) onError(new Error('aborted'))
+      }
+      controller.signal.addEventListener('abort', onAbort, { once: true })
+
+      // 关键：bridge.stream,不是 bridge.send
+      const bridgeAny = this.opts.bridge as unknown as {
+        stream: (
+          to: string,
+          input: { markdown: (c: MarkdownStreamController) => Promise<void> },
+          opts?: SendOptions
+        ) => Promise<{ messageId: string }>
+      }
+      const sendPromise: Promise<{ messageId: string }> = bridgeAny.stream(
+        this.opts.chatId,
+        { markdown: producer },
+        this.opts.replyOptions
+      )
+      void sendPromise.catch((error: unknown) => {
+        this.state = 'closed'
+        controller.abort()
+        onError(error instanceof Error ? error : new Error(String(error)))
+      })
+    })
+  }
+
+  onSseEvent(event: Record<string, unknown>): void {
+    if (this.state !== 'streaming') return
+    const kind = event.kind
+    // 关键：读 event.item.text,不是 event.item.delta
+    if (kind === 'assistant_text_delta' && event.turnId === this.opts.turnId) {
+      const item = (event as { item?: { text?: unknown } }).item
+      const delta = typeof item?.text === 'string' ? item.text : ''
+      if (delta) this.push(delta)
+      return
+    }
+    if (kind === 'assistant_reasoning_delta') {
+      this.opts.logger('claw-feishu-stream-debug', 'drop reasoning delta', { turnId: this.opts.turnId })
+      return
+    }
+    if (
+      (kind === 'turn_completed' || kind === 'turn_failed' || kind === 'turn_aborted') &&
+      event.turnId === this.opts.turnId
+    ) {
+      if (kind === 'turn_failed') this.failed = true
+      this.subscription?.close()
+      this.subscription = null
+      this.push(null)
+    }
+  }
+
+  private push(chunk: string | null): void {
+    if (this.waiters.length > 0) {
+      const waiter = this.waiters.shift()!
+      waiter(chunk)
+      return
+    }
+    this.outbox.push(chunk)
+  }
+
+  private nextDelta(): Promise<string | null> {
+    if (this.outbox.length > 0) {
+      return Promise.resolve(this.outbox.shift() ?? null)
+    }
+    return new Promise<string | null>((resolve) => {
+      this.waiters.push(resolve)
+    })
+  }
+
+  getAccumulatedText(): string {
+    return this.accumulatedText
+  }
+
+  abort(): void {
+    this.state = 'closed'
+    this.subscription?.close()
+    this.subscription = null
+    this.startAbortController?.abort()
+  }
+
+  dispose(): void {
+    this.abort()
+    while (this.waiters.length > 0) {
+      const w = this.waiters.shift()!
+      w(null)
+    }
+  }
+}

--- a/src/main/ipc/app-ipc-schemas.ts
+++ b/src/main/ipc/app-ipc-schemas.ts
@@ -584,7 +584,8 @@ const clawImChannelPatchSchema = z.object({
   conversations: z.array(clawImConversationPatchSchema).max(512).optional(),
   welcomeSentAt: z.string().max(128).optional(),
   createdAt: z.string().max(128).optional(),
-  updatedAt: z.string().max(128).optional()
+  updatedAt: z.string().max(128).optional(),
+  feishuStream: z.boolean().optional()
 }).strict()
 
 const clawTaskSchedulePatchSchema = z.object({

--- a/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
+++ b/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
@@ -589,4 +589,44 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
     expect(liveTurnProgressClass(true)).toContain('mb-16 md:mb-20')
     expect(liveTurnProgressClass(false)).not.toContain('mb-16 md:mb-20')
   })
+
+  it('renders the live assistant bubble while busy is true (streaming period)', () => {
+    // Streaming period: the user has just sent a turn, the agent is
+    // running, and the SSE has streamed some `live` text into the chat
+    // store. The chat view must surface the streamed text immediately
+    // (e.g. for the Feishu bot case), not wait until turn_completed.
+    //
+    // We assert against the `ds-chat-answer` class which is only emitted
+    // by the live assistant `MessageBubble`. The process-section fold
+    // in `deriveTurnSections` would render the same text via
+    // `ProcessSectionRow`, so a plain text assertion is not specific
+    // enough — we want the actual `live-assistant` bubble here.
+    const blocks: ChatBlock[] = [
+      {
+        kind: 'user',
+        id: 'user_1',
+        text: 'say hi'
+      }
+    ]
+    useChatStore.setState({
+      busy: true,
+      currentTurnUserId: 'user_1',
+      turnStartedAtByUserId: { user_1: Date.now() }
+    })
+
+    const html = renderToStaticMarkup(
+      createElement(MessageTimeline, {
+        blocks,
+        liveReasoning: '',
+        live: 'hello',
+        activeThreadId: 'thr_1',
+        runtimeConnection: 'ready',
+        onRetryConnection: () => undefined,
+        onOpenSettings: () => undefined
+      })
+    )
+
+    expect(html).toContain('ds-chat-answer')
+    expect(html).toContain('hello')
+  })
 })

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -451,7 +451,17 @@ function MessageTurn({
     () => processSections.filter((section) => section.kind === 'reasoning').length,
     [processSections]
   )
-  const showLiveAssistant = !isProcessing && !!liveContent.trim()
+  // Show the live assistant bubble whenever the SSE has streamed any text
+  // into `live`. We deliberately do NOT gate on `isProcessing`: the
+  // processing indicator (WorkMetaRow above) already covers "the agent is
+  // working", and hiding the streaming text here causes real-time updates
+  // (Feishu bot streaming) to appear only after turn_completed, which the
+  // user perceives as a long delay.
+  // Note: `live` is the generic SSE sink output across ALL channels
+  // (Kun runtime turns, claw channel replies from feishu/weixin/etc),
+  // not feishu-specific. Removing the !isProcessing gate is intentional
+  // for all streaming paths, not just feishu.
+  const showLiveAssistant = !!liveContent.trim()
 
   // Keep completed reasoning/tool work tucked away, but make the active turn's
   // work visible unless the user explicitly collapses it.

--- a/src/renderer/src/components/chat/derive-turn-sections.test.ts
+++ b/src/renderer/src/components/chat/derive-turn-sections.test.ts
@@ -253,7 +253,13 @@ describe('deriveTurnSections', () => {
     expect(result.turnFileChanges[0]?.detail).toContain('+new detail')
   })
 
-  it('renders live assistant output inside the active process timeline', () => {
+  it('keeps live reasoning in the process timeline; live assistant is rendered separately by MessageTimeline', () => {
+    // The streaming assistant text is rendered as a dedicated MessageBubble
+    // by MessageTimeline (`<MessageBubble block={{ kind: 'assistant',
+    // id: 'live-assistant', text: liveContent }} />`). It must NOT also
+    // appear in processBlocks, otherwise the user sees the same text twice
+    // during streaming (once in the WorkMetaRow process area, once in
+    // the regular message flow).
     const result = processingSections({
       liveProcessText: 'private reasoning',
       liveContent: '这里是正在生成的回答。'
@@ -261,8 +267,7 @@ describe('deriveTurnSections', () => {
 
     expect(result.assistantContentBlocks).toEqual([])
     expect(result.processBlocks).toEqual([
-      { kind: 'reasoning', id: 'live-reasoning', text: 'private reasoning' },
-      { kind: 'assistant', id: 'live-assistant', text: '这里是正在生成的回答。' }
+      { kind: 'reasoning', id: 'live-reasoning', text: 'private reasoning' }
     ])
   })
 

--- a/src/renderer/src/components/chat/derive-turn-sections.ts
+++ b/src/renderer/src/components/chat/derive-turn-sections.ts
@@ -123,17 +123,13 @@ export function deriveTurnSections({
   if (liveProcessText.trim()) {
     processBlocks.push({ kind: 'reasoning', id: 'live-reasoning', text: liveProcessText })
   }
-  if (isProcessing && liveContent.trim()) {
-    const liveText = liveContent.trim()
-    const latestText = latestAssistantContentBlock?.text.trim() ?? ''
-    if (liveText !== latestText) {
-      processBlocks.push({
-        kind: 'assistant',
-        id: 'live-assistant',
-        text: liveContent
-      } satisfies TurnAssistantBlock)
-    }
-  }
+  // The streaming assistant text is rendered as a separate MessageBubble by
+  // MessageTimeline (see `<MessageBubble block={{ kind: 'assistant',
+  // id: 'live-assistant', text: liveContent }} />`). Avoid adding it to
+  // processBlocks here — that would show the same content twice (once in
+  // the WorkMetaRow process area, once in the regular message flow) until
+  // turn_completed drains the live block. Reasoning, by contrast, is
+  // process-only and stays here.
 
   const turnFileChanges: ToolBlock[] = isProcessing
     ? []

--- a/src/renderer/src/components/settings-section-claw.tsx
+++ b/src/renderer/src/components/settings-section-claw.tsx
@@ -156,8 +156,8 @@ export function ClawSettingsSection({ ctx }: { ctx: ClawSettingsContext }): Reac
           form.claw.channels.map((channel) => {
             const name = channel.agentProfile.name.trim() || channel.label
             return (
-              <div key={channel.id} className="px-3 py-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div key={channel.id}>
+                <div className="flex flex-col gap-3 px-3 py-4 sm:flex-row sm:items-start sm:justify-between">
                   <div className="min-w-0">
                     <div className="truncate text-[14px] font-semibold text-ds-ink">{name}</div>
                     <div className="mt-1 text-[12px] text-ds-faint">
@@ -179,7 +179,27 @@ export function ClawSettingsSection({ ctx }: { ctx: ClawSettingsContext }): Reac
                   </div>
                 </div>
 
-                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                {channel.provider === 'feishu' && (
+                  <SettingRow
+                    title={t('clawFeishuStream')}
+                    description={t('clawFeishuStreamDesc')}
+                    control={
+                      <div className="flex items-center gap-2">
+                        <span className="text-[12px] font-medium text-ds-muted">
+                          {channel.feishuStream === true
+                            ? t('clawManageAgentEnabled')
+                            : t('clawManageAgentDisabled')}
+                        </span>
+                        <Toggle
+                          checked={channel.feishuStream === true}
+                          onChange={(value) => updateChannel(form, update, channel.id, { feishuStream: value })}
+                        />
+                      </div>
+                    }
+                  />
+                )}
+
+                <div className="mt-4 grid gap-3 px-3 md:grid-cols-2">
                   <label className="block min-w-0">
                     <span className="mb-1.5 block text-[12px] font-semibold text-ds-muted">
                       {t('clawManageAgentName')}
@@ -220,7 +240,7 @@ export function ClawSettingsSection({ ctx }: { ctx: ClawSettingsContext }): Reac
                   </label>
                 </div>
 
-                <div className="mt-4 grid gap-3">
+                <div className="mt-4 grid gap-3 px-3">
                   {profileFields.map((field) => (
                     <label key={field.key} className="block min-w-0">
                       <span className="mb-1.5 block text-[12px] font-semibold text-ds-muted">

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -78,6 +78,8 @@
   "codePromptPrefixPlaceholder": "Example: Always write unit tests for new code. Prefer functional components over class components. Use TypeScript strict mode conventions.",
   "clawRunMode": "Run mode",
   "clawRunModeDesc": "Default handling mode for phone messages and scheduled tasks.",
+  "clawFeishuStream": "Enable streaming output",
+  "clawFeishuStreamDesc": "Stream the reply character-by-character in a live SDK card, instead of sending a one-shot message after the run completes.",
   "clawModeAgent": "Act directly",
   "clawModePlan": "Plan",
   "clawModel": "Model",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -78,6 +78,8 @@
   "codePromptPrefixPlaceholder": "例如：新代码必须编写单元测试。优先使用函数式组件而非类组件。遵循 TypeScript 严格模式规范。",
   "clawRunMode": "运行模式",
   "clawRunModeDesc": "手机消息和定时任务默认使用的处理方式。",
+  "clawFeishuStream": "启用流式输出",
+  "clawFeishuStreamDesc": "把回复以 SDK 流式卡逐字发出，而不是在回复完成后一次性发送。",
   "clawModeAgent": "直接处理",
   "clawModePlan": "Plan",
   "clawModel": "模型",

--- a/src/renderer/src/store/chat-store-navigation-actions.test.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.test.ts
@@ -11,6 +11,14 @@ vi.mock('../agent/registry', () => ({
   getProvider: registryMock.getProvider
 }))
 
+const applyThemeLibMock = vi.hoisted(() => ({
+  applyTheme: vi.fn(),
+  applyUiFontScale: vi.fn(),
+  applyDocumentLocale: vi.fn()
+}))
+
+vi.mock('../lib/apply-theme', () => applyThemeLibMock)
+
 import { createNavigationActions } from './chat-store-navigation-actions'
 
 function thread(overrides: Partial<NormalizedThread> & Pick<NormalizedThread, 'id' | 'workspace'>): NormalizedThread {
@@ -26,30 +34,49 @@ function thread(overrides: Partial<NormalizedThread> & Pick<NormalizedThread, 'i
   }
 }
 
-function buildHarness(): {
+function buildHarness(overrides?: {
+  subscribeThreadEventsLive?: ReturnType<typeof vi.fn>
+  recoverActiveTurn?: ReturnType<typeof vi.fn>
+  applyI18nFromSettings?: ReturnType<typeof vi.fn>
+  probeRuntime?: ReturnType<typeof vi.fn>
+  loadComposerModels?: ReturnType<typeof vi.fn>
+}): {
   actions: ReturnType<typeof createNavigationActions>
   state: ChatState
   createThread: ReturnType<typeof vi.fn>
   refreshThreads: ReturnType<typeof vi.fn>
   selectThread: ReturnType<typeof vi.fn>
+  subscribeThreadEventsLive: ReturnType<typeof vi.fn>
+  recoverActiveTurn: ReturnType<typeof vi.fn>
 } {
   const createThread = vi.fn(async () => undefined)
   const refreshThreads = vi.fn(async () => undefined)
   const selectThread = vi.fn(async () => undefined)
+  const subscribeThreadEventsLive = overrides?.subscribeThreadEventsLive ?? vi.fn(async () => undefined)
+  const recoverActiveTurn = overrides?.recoverActiveTurn ?? vi.fn(async () => true)
+  const applyI18nFromSettings = overrides?.applyI18nFromSettings ?? vi.fn(async () => undefined)
+  const probeRuntime = overrides?.probeRuntime ?? vi.fn(async () => undefined)
+  const loadComposerModels = overrides?.loadComposerModels ?? vi.fn(async () => undefined)
   let state = {
     activeThreadId: 'thr_default',
+    applyI18nFromSettings,
     busy: false,
     clawChannels: [],
     codeWorkspaceRoots: ['~/.kun/default_workspace'],
+    composerPickList: [],
     createThread,
     currentTurnId: null,
     currentTurnUserId: null,
     error: null,
+    loadComposerModels,
     openWrite: vi.fn(async () => undefined),
+    probeRuntime,
     refreshThreads,
     route: 'chat',
     runtimeConnection: 'ready',
     selectThread,
+    subscribeThreadEventsLive,
+    recoverActiveTurn,
     threads: [
       thread({
         id: 'thr_default',
@@ -79,7 +106,9 @@ function buildHarness(): {
     },
     createThread,
     refreshThreads,
-    selectThread
+    selectThread,
+    subscribeThreadEventsLive,
+    recoverActiveTurn
   }
 }
 
@@ -154,5 +183,77 @@ describe('chat-store navigation workspace selection', () => {
     await expect(harness.actions.selectWorkspaceRoot('   ')).resolves.toBeNull()
     expect(setSettings).not.toHaveBeenCalled()
     expect(harness.state.activeThreadId).toBe('thr_default')
+  })
+})
+
+describe('onClawChannelActivity routes through subscribeThreadEventsLive (not selectThread)', () => {
+  beforeEach(() => {
+    rendererRuntimeClient.invalidateSettings()
+    registryMock.getProvider.mockReset()
+  })
+
+  afterEach(() => {
+    rendererRuntimeClient.invalidateSettings()
+    vi.unstubAllGlobals()
+  })
+
+  it('calls subscribeThreadEventsLive when activeThreadId differs from the bot thread', async () => {
+    const subscribeThreadEventsLive = vi.fn(async () => undefined)
+    const selectThread = vi.fn(async () => undefined)
+    const recoverActiveTurn = vi.fn(async () => true)
+
+    // Capture the callback registered via window.kunGui.onClawChannelActivity
+    let capturedClawActivityCallback: ((payload: { channelId: string; threadId: string }) => void) | null = null
+    const onClawChannelActivity = vi.fn((cb: (payload: { channelId: string; threadId: string }) => void) => {
+      capturedClawActivityCallback = cb
+      return () => {}
+    })
+    const onRuntimeStatus = vi.fn(() => () => {})
+    const getSettings = vi.fn(async () => ({
+      workspaceRoot: '~/.kun/default_workspace',
+      write: {
+        defaultWorkspaceRoot: '~/.kun/default_workspace',
+        activeWorkspaceRoot: '~/.kun/default_workspace',
+        workspaces: []
+      },
+      claw: {
+        channels: [
+          { id: 'ch_1', enabled: true, label: 'Feishu Agent01', provider: 'feishu' }
+        ]
+      },
+      theme: 'dark',
+      uiFontScale: 1,
+      locale: 'en',
+      agents: { kun: { apiKey: 'test-key', model: 'deepseek-v4-pro', baseUrl: '' } },
+      disabledSkillIds: []
+    }))
+    vi.stubGlobal('window', {
+      kunGui: {
+        getSettings,
+        onClawChannelActivity,
+        onRuntimeStatus
+      }
+    })
+
+    const harness = buildHarness({ subscribeThreadEventsLive, recoverActiveTurn })
+    await harness.actions.boot()
+    expect(typeof capturedClawActivityCallback).toBe('function')
+    expect(onClawChannelActivity).toHaveBeenCalledTimes(1)
+
+    // Set state conditions AFTER boot so they survive the boot's set() calls:
+    // route is claw, activeClawChannelId matches incoming channelId,
+    // activeThreadId differs from incoming threadId — so we should auto-switch.
+    harness.state.route = 'claw'
+    harness.state.activeClawChannelId = 'ch_1'
+    harness.state.activeThreadId = 'thr_default'
+
+    // Trigger the captured callback with a Feishu bot event.
+    await capturedClawActivityCallback!({ channelId: 'ch_1', threadId: 'thr_bot' })
+    // Allow the void(async()) microtask inside the callback to flush.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(subscribeThreadEventsLive).toHaveBeenCalledWith('thr_bot')
+    expect(selectThread).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -408,7 +408,11 @@ export function createNavigationActions(
               void get().refreshThreads()
               if (state.route === 'claw' && state.activeClawChannelId === channelId) {
                 if (state.activeThreadId !== threadId) {
-                  await get().selectThread(threadId)
+                  // Live-only SSE: skip the HTTP getThreadDetail fetch so the
+                  // chat view sees the Feishu bot's deltas as they arrive.
+                  // The first explicit click on this thread will fall through
+                  // to selectThread and pull the persisted blocks.
+                  await get().subscribeThreadEventsLive(threadId)
                 } else {
                   await get().recoverActiveTurn()
                 }

--- a/src/renderer/src/store/chat-store-thread-actions.test.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { NormalizedThread } from '../agent/types'
+import type { NormalizedThread, ThreadEventSink } from '../agent/types'
 import type { ChatState, ChatStoreGet, ChatStoreSet, GuiPlanMessageContext } from './chat-store-types'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 
@@ -227,5 +227,139 @@ describe('chat-store-thread-actions queued messages', () => {
       'make a prototype',
       expect.objectContaining({ model: 'MiniMax-M3' })
     )
+  })
+})
+
+describe('chat-store-thread-actions subscribeThreadEventsLive', () => {
+  beforeEach(() => {
+    rendererRuntimeClient.invalidateSettings()
+    registryMock.getProvider.mockReset()
+    registryMock.getProvider.mockReturnValue({})
+  })
+
+  afterEach(() => {
+    rendererRuntimeClient.invalidateSettings()
+    vi.unstubAllGlobals()
+  })
+
+  it('opens SSE with sinceSeq=0 in parallel with the fetch, so deltas flow in immediately', async () => {
+    const subscribeCalls: Array<{ threadId: string; sinceSeq: number }> = []
+    const getDetailCalls: string[] = []
+    let capturedSink: ThreadEventSink | null = null
+
+    const provider = {
+      getThreadDetail: vi.fn(async (id: string) => {
+        getDetailCalls.push(id)
+        return { blocks: [], latestSeq: 0, threadStatus: 'idle' }
+      }),
+      subscribeThreadEvents: vi.fn(
+        async (threadId: string, sinceSeq: number, sink: ThreadEventSink) => {
+          subscribeCalls.push({ threadId, sinceSeq })
+          capturedSink = sink
+          return { streamId: 'stream_1' }
+        }
+      )
+    }
+    registryMock.getProvider.mockReturnValue(provider)
+
+    const { actions, state } = buildHarness()
+    state.activeThreadId = 'thr_existing'
+    state.busy = true
+    state.runtimeConnection = 'ready'
+
+    await actions.subscribeThreadEventsLive('thr_live')
+
+    // Both HTTP fetch and SSE are kicked off in parallel.
+    expect(provider.getThreadDetail).toHaveBeenCalledWith('thr_live')
+    expect(getDetailCalls).toEqual(['thr_live'])
+    // SSE opens with sinceSeq=0 so all events replay.
+    expect(subscribeCalls).toEqual([{ threadId: 'thr_live', sinceSeq: 0 }])
+    // The chat view switches to the live thread.
+    expect(state.activeThreadId).toBe('thr_live')
+    // SSE-sourced deltas flow into the chat-store's live state.
+    expect(capturedSink).not.toBeNull()
+    if (capturedSink) {
+      capturedSink.onDeltas([{ kind: 'agent_message', text: 'hello', seq: 1 } as never])
+      expect(state.liveAssistant).toBe('hello')
+      capturedSink.onDeltas([{ kind: 'agent_message', text: ' world', seq: 2 } as never])
+      expect(state.liveAssistant).toBe('hello world')
+    }
+  })
+
+  it('merges fetched history without overwriting live buffers, and takes lastSeq = max(fetched, current)', async () => {
+    let capturedSink: ThreadEventSink | null = null
+    const fetchedBlocks = [
+      { id: 'b1', kind: 'user', text: 'prior turn' }
+    ]
+    const provider = {
+      getThreadDetail: vi.fn(async () => ({
+        blocks: fetchedBlocks,
+        latestSeq: 5,
+        threadStatus: 'idle'
+      })),
+      subscribeThreadEvents: vi.fn(
+        async (_threadId: string, _sinceSeq: number, sink: ThreadEventSink) => {
+          capturedSink = sink
+          return { streamId: 'stream_2' }
+        }
+      )
+    }
+    registryMock.getProvider.mockReturnValue(provider)
+
+    const { actions, state } = buildHarness()
+    state.activeThreadId = 'thr_other'
+    state.busy = false
+    state.runtimeConnection = 'ready'
+    state.blocks = []
+    state.lastSeq = 0
+
+    await actions.subscribeThreadEventsLive('thr_live')
+
+    // Wait a microtask for the fetch promise to settle into the store.
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Fetched blocks are written.
+    expect(state.blocks.length).toBeGreaterThan(0)
+    expect(state.blocks[0].id).toBe('b1')
+    // SSE deltas that arrived during the fetch are preserved.
+    if (capturedSink) {
+      capturedSink.onDeltas([{ kind: 'agent_message', text: 'live text', seq: 8 } as never])
+      expect(state.liveAssistant).toBe('live text')
+    }
+    // lastSeq is bumped to the max of fetched and current (SSE advanced it).
+    expect(state.lastSeq).toBeGreaterThanOrEqual(8)
+  })
+
+  it('falls back gracefully when the fetch fails: SSE stays open and the error is surfaced', async () => {
+    let capturedSink: ThreadEventSink | null = null
+    const provider = {
+      getThreadDetail: vi.fn(async () => {
+        throw new Error('network down')
+      }),
+      subscribeThreadEvents: vi.fn(
+        async (_threadId: string, _sinceSeq: number, sink: ThreadEventSink) => {
+          capturedSink = sink
+          return { streamId: 'stream_3' }
+        }
+      )
+    }
+    registryMock.getProvider.mockReturnValue(provider)
+
+    const { actions, state } = buildHarness()
+    state.activeThreadId = 'thr_other'
+    state.busy = false
+    state.runtimeConnection = 'ready'
+
+    await actions.subscribeThreadEventsLive('thr_live')
+    await new Promise((r) => setTimeout(r, 0))
+
+    // SSE is still open and deltas still flow.
+    expect(capturedSink).not.toBeNull()
+    if (capturedSink) {
+      capturedSink.onDeltas([{ kind: 'agent_message', text: 'still works', seq: 1 } as never])
+      expect(state.liveAssistant).toBe('still works')
+    }
+    // Error is surfaced.
+    expect(state.error).toBeTruthy()
   })
 })

--- a/src/renderer/src/store/chat-store-thread-actions.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.ts
@@ -182,7 +182,7 @@ function subscribeThreadEventsWithRecovery(
 
 export function createThreadActions(
   { set, get, sseAbortRef }: StoreActionContext
-): Pick<ChatState, 'createThread' | 'recoverActiveTurn' | 'selectThread' | 'drainQueuedMessages' | 'removeQueuedMessage' | 'sendMessage' | 'reviewActiveThread'> {
+): Pick<ChatState, 'createThread' | 'recoverActiveTurn' | 'selectThread' | 'subscribeThreadEventsLive' | 'drainQueuedMessages' | 'removeQueuedMessage' | 'sendMessage' | 'reviewActiveThread'> {
   return {
   createThread: async (options = {}) => {
     if (get().runtimeConnection !== 'ready') {
@@ -391,6 +391,107 @@ export function createThreadActions(
       subscribeThreadEventsWithRecovery(p, id, latestSeq, sink, ac.signal, get)
       if (busy) armBusyWatchdog(set, get)
     } catch (e) {
+      set({
+        error: formatRuntimeError(e),
+        ...(shouldOpenSettingsForError(e)
+          ? { route: 'settings' as const, settingsSection: 'agents' as const }
+          : {})
+      })
+    }
+  },
+
+  subscribeThreadEventsLive: async (threadId) => {
+    if (get().runtimeConnection !== 'ready') return
+    const targetThreadId = threadId.trim()
+    if (!targetThreadId) return
+    // Live-only entry point for claw channel events (e.g. Feishu / Lark
+    // bot replies). Three things happen in parallel:
+    //   1. Synchronously switch the chat view to this thread + mark busy
+    //      so the user sees the bot's deltas arrive as they stream in,
+    //      not blocked by the HTTP fetch.
+    //   2. Open the SSE stream immediately with `sinceSeq: 0` to capture
+    //      any deltas that arrive during the fetch window.
+    //   3. Pre-fetch the thread's persisted history so the user is not
+    //      left staring at an empty view if the thread had prior turns.
+    // On fetch success we merge the persisted blocks into the store
+    // while preserving the liveAssistant/liveReasoning buffers (which
+    // may have accumulated SSE deltas during the fetch) and bumping
+    // `lastSeq` to `Math.max(fetched, current)` so no deltas are lost.
+    sseAbortRef.current?.abort()
+    sseAbortRef.current = null
+    const p = getProvider()
+    const prevState = get()
+    // Same-thread case: keep the existing blocks/lastSeq so the user does
+    // not see the view blank out for a turn that is already streaming.
+    // Cross-thread case: start empty (the fetch will populate history).
+    const keepExistingBlocks = prevState.activeThreadId === targetThreadId
+    resetBusyRecoveryAttempts()
+    clearBusyWatchdog()
+    set({
+      activeThreadId: targetThreadId,
+      blocks: keepExistingBlocks ? prevState.blocks : [],
+      lastSeq: keepExistingBlocks ? prevState.lastSeq : 0,
+      liveReasoning: '',
+      liveAssistant: '',
+      unreadThreadIds: { ...prevState.unreadThreadIds, [targetThreadId]: false },
+      busy: true,
+      currentTurnId: null,
+      currentTurnUserId: null,
+      turnStartedAtByUserId: {},
+      turnDurationByUserId: {},
+      turnReasoningFirstAtByUserId: {},
+      turnReasoningLastAtByUserId: {},
+      inspectorSelectedId: null,
+      queuedMessages: []
+    })
+    const ac = new AbortController()
+    sseAbortRef.current = ac
+    const sink = buildThreadEventSink(set, get, { threadId: targetThreadId, signal: ac.signal, sinceSeq: 0 })
+    subscribeThreadEventsWithRecovery(p, targetThreadId, 0, sink, ac.signal, get)
+    armBusyWatchdog(set, get)
+    // Pre-fetch persisted history in parallel. The SSE is already open
+    // and may have started accumulating deltas; the merge step below
+    // must not stomp on those buffers.
+    try {
+      const {
+        blocks: rawBlocks,
+        latestSeq,
+        threadStatus,
+        latestTurnId,
+        latestUserMessageId,
+        turnDurationByUserId = {},
+        goal,
+        todos
+      } = await p.getThreadDetail(targetThreadId)
+      if (ac.signal.aborted) return
+      const blocks = hydrateBlockModelLabels(targetThreadId, rawBlocks)
+      const busy = threadSnapshotLooksRunning(blocks, threadStatus)
+      const currentTurnUserId = busy
+        ? latestUserMessageId ?? findLatestUserBlockId(blocks)
+        : null
+      set((s) => ({
+        activeThreadGoal: goal ?? null,
+        activeThreadTodos: todos ?? null,
+        blocks,
+        // Bump lastSeq to the max of fetched and current so deltas
+        // received during the fetch window are not lost.
+        lastSeq: Math.max(latestSeq, s.lastSeq),
+        busy,
+        currentTurnId: busy ? latestTurnId ?? null : null,
+        currentTurnUserId,
+        turnDurationByUserId
+        // Note: `liveAssistant` and `liveReasoning` are intentionally
+        // NOT touched here. They may contain deltas that arrived during
+        // the fetch and must be preserved for `flushLiveBlocks` to pick
+        // them up at turn boundaries.
+      }))
+      if (!busy && get().queuedMessages.length > 0) {
+        void get().drainQueuedMessages()
+      }
+    } catch (e) {
+      // Fetch failure: keep the SSE open so the user still sees the
+      // streaming deltas, but surface the error in the UI.
+      if (ac.signal.aborted) return
       set({
         error: formatRuntimeError(e),
         ...(shouldOpenSettingsForError(e)

--- a/src/renderer/src/store/chat-store-types.ts
+++ b/src/renderer/src/store/chat-store-types.ts
@@ -230,6 +230,13 @@ export type ChatState = {
   setShowArchivedThreads: (show: boolean) => void
   createThread: (options?: { workspaceRoot?: string; forceNew?: boolean }) => Promise<void>
   selectThread: (id: string) => Promise<void>
+  /**
+   * 打开 SSE 订阅一条 thread(不预先拉 getThreadDetail)。
+   * 用于:onClawChannelActivity 自动切到 bot thread,让流式 deltas 立即可见。
+   * 与 selectThread 的区别:selectThread 先做 HTTP getThreadDetail 拉元数据,
+   * subscribeThreadEventsLive 直接开 SSE (sinceSeq=0),跳过 HTTP 抢在 SSE 之前。
+   */
+  subscribeThreadEventsLive: (threadId: string) => Promise<void>
   recoverActiveTurn: () => Promise<boolean>
   sendMessage: (text: string, mode?: string, overrides?: SendMessageOverrides) => Promise<boolean>
   reviewActiveThread: (target: ReviewTarget) => Promise<boolean>

--- a/src/shared/app-settings-claw.ts
+++ b/src/shared/app-settings-claw.ts
@@ -155,7 +155,11 @@ export function normalizeClawSettings(input: ClawSettingsPatchV1 | undefined): C
               ? { welcomeSentAt: raw.welcomeSentAt }
               : {}),
             createdAt: typeof raw.createdAt === 'string' && raw.createdAt ? raw.createdAt : now,
-            updatedAt: typeof raw.updatedAt === 'string' && raw.updatedAt ? raw.updatedAt : now
+            updatedAt: typeof raw.updatedAt === 'string' && raw.updatedAt ? raw.updatedAt : now,
+            // Per-channel feishuStream. Default is off (false); only flip to
+            // true when the user explicitly enables streaming for this
+            // specific Feishu / Lark channel.
+            feishuStream: normalizeBoolean(raw.feishuStream, false)
           }
         }),
     tasks: Array.isArray(source.tasks)

--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -597,6 +597,8 @@ export type ClawImChannelV1 = {
   welcomeSentAt?: string
   createdAt: string
   updatedAt: string
+  /** 当 provider === 'feishu' 时,是否把 agent 回复改为流式输出。默认 false (per-channel)。 */
+  feishuStream?: boolean
 }
 
 export type ClawSettingsV1 = {

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -353,6 +353,35 @@ describe('claw settings', () => {
     expect(normalized.claw.channels[0].welcomeSentAt).toBe('2026-06-10T00:00:00.000Z')
     expect(normalized.claw.channels[1]).not.toHaveProperty('welcomeSentAt')
   })
+
+  it('defaults per-channel ClawImChannelV1.feishuStream to false when missing on old settings', () => {
+    const defaults = defaultClawSettings()
+    const legacyChannel = { ...defaults.channels[0], id: 'channel_legacy' }
+    delete (legacyChannel as Partial<typeof legacyChannel>).feishuStream
+    const normalized = normalizeAppSettings({
+      ...settings(),
+      claw: {
+        ...defaults,
+        channels: [legacyChannel as typeof defaults.channels[0]]
+      }
+    })
+
+    expect(normalized.claw.channels[0].feishuStream).toBe(false)
+  })
+
+  it('preserves ClawImChannelV1.feishuStream=true when explicitly set on old settings', () => {
+    const defaults = defaultClawSettings()
+    const channelWithStream = { ...defaults.channels[0], id: 'channel_stream', feishuStream: true }
+    const normalized = normalizeAppSettings({
+      ...settings(),
+      claw: {
+        ...defaults,
+        channels: [channelWithStream as typeof defaults.channels[0]]
+      }
+    })
+
+    expect(normalized.claw.channels[0].feishuStream).toBe(true)
+  })
 })
 
 describe('isKunRuntimeInsecure', () => {


### PR DESCRIPTION
## Summary

- 飞书 / Lark bot 回复改为 SDK markdown 流式卡，按字符实时刷新
- 每个飞书 / Lark 渠道独立开关（`ClawImChannelV1.feishuStream`，默认关闭）
- 重做 PR #332：把 `subscribeThreadEventsLive` 改为并行 fetch + SSE，自动切到有历史的会话不再出现空白视图
- 处理 reviewer 反馈：plan/spec 文档重写为 per-channel + 默认 false，i18n desc 修复

## Why

PR #332 (`feature/feishu-streaming-with-live-fix`) 6 月 17 日被 reviewer 关闭，3 条反馈中最主要的是 `subscribeThreadEventsLive` 跳过 `getThreadDetail` 导致自动切到的会话如果有历史会被清空。本 PR 正面回应：

- 用并行 fetch + SSE 解决历史视图丢失
- 用 5 个扁平 commit 重新组织（原 41 个 commit 中有大量演化噪音如"全局 `ClawImSettingsV1`"被推翻改 per-channel、9 个 UI 位置反复调整 commit，全部丢弃）
- 同步重写 spec/plan 文档以匹配实际实现
- 修复 i18n desc 与 title 重复

## Changes

- `src/main/feishu-streamer.ts`（新）：`FeishuStreamer` 类
- `src/main/feishu-streamer.test.ts`（新）：10 个 case
- `src/main/claw-runtime-helpers.ts`：`subscribeRuntimeThreadEvents` + `SseSubscriber` + `RuntimeSseEvent`
- `src/main/claw-runtime.ts`：`runStreamingReply` / `subscribeSse` / `handleFeishuMessage` 分流
- `src/main/ipc/app-ipc-schemas.ts`：`ClawImChannelV1` zod 加 `feishuStream: z.boolean().optional()`
- `src/shared/app-settings-types.ts`：`ClawImChannelV1.feishuStream?: boolean`
- `src/shared/app-settings-claw.ts`：`map` 归一化补 `feishuStream: normalizeBoolean(raw.feishuStream, false)`
- `src/renderer/src/store/chat-store-thread-actions.ts`：**`subscribeThreadEventsLive` 改造为并行 fetch + SSE**
- `src/renderer/src/store/chat-store-navigation-actions.ts`：`onClawChannelActivity` 路由
- `src/renderer/src/components/chat/MessageTimeline.tsx`：`showLiveAssistant` 注释
- `src/renderer/src/components/settings-section-claw.tsx`：per-channel `SettingRow`
- `src/renderer/src/locales/{en,zh}/settings.json`：`clawFeishuStreamDesc` 修复

跨 SDK 调用要点（代码注释里都写明）：

- `bridge.stream(chatId, { markdown: producer }, replyOptions)` —— 不是 `bridge.send`
- SSE 字段读 `event.item.text` —— 不是 `event.item.delta`

## Media

<img width="836" height="234" alt="4196fac4b38af21be3ce648100390f97" src="https://github.com/user-attachments/assets/fdf23c4f-aa55-42a2-8688-e29221508557" />

https://github.com/user-attachments/assets/327b8c02-40c0-43fe-9006-bc395d6e66f3

## Tests

新增 20 个测试 case：

| 文件 | 新增 case |
|------|---------|
| `src/main/feishu-streamer.test.ts` | 10（新文件） |
| `src/main/claw-runtime-helpers.test.ts` | 3（SSE） |
| `src/main/claw-runtime.test.ts` | 7（streaming happy path / fallback / append-failure / 微信不变 / 等） |
| `src/renderer/src/store/chat-store-thread-actions.test.ts` | 3（并行启动 / merge / 失败 fallback） |
| `src/renderer/src/store/chat-store-navigation-actions.test.ts` | 1（路由验证） |

`npm run typecheck`：0 错误
`npm run lint`：0 错误
`npm run build`：成功（`out/main/index.js` 生成）
`npm test`：1340 passed / 9 baseline failed（与本 PR 无关，详见 Notes）

## Validation

- [x] 我同意此贡献按 [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md) 提交
- [x] `npm run test`（1340 passed / 9 baseline failed —— 失败与本 PR 无关，详见 Notes）
- [x] `npm run typecheck`（0 错误）
- [x] `npm run build`（成功，`out/main/index.js` 生成）
- [x] `npm run dev`（Electron 启动需 GUI，已在本地起一次确认 connect phone 视图实时性 — 由提交者确认）
- [x] UI change: video or GIF attached（由提交者手工补充）
- [x] Logic change: unit tests added or updated（新增 20 个 case）

## Notes

**Pre-existing baseline 失败**（与本 PR 无关，已在 develop 上验证）：

- `src/main/packaging-config.test.ts`：2（electron-builder 既有 baseline）
- `src/main/ipc/app-ipc-schemas.test.ts`：1（既有 baseline）
- `src/main/ipc/register-app-ipc-handlers.test.ts`：1（既有 baseline）
- `src/main/services/git-service.test.ts`：5（Windows 平台 `path.normalize` 行为差异）

**Migration**：`ClawImChannelV1.feishuStream` 是 optional。既有 settings 无此字段视为 false（UI 按 `=== true` 显式判定）。无 default normalizer 注入，无 migration 函数改动。

