### PR TITLE
fix(tray): resize menu-bar icon to point size (#363)

### DIFF
--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -80,3 +80,29 @@ export function pickTrayIcon(
 ): Electron.NativeImage {
   return primary.isEmpty() ? fallback : primary
 }
+
+/**
+ * 菜单栏(macOS)/托盘(Windows、Linux)合适的图标点尺寸。kun_tray.png 源图
+ * 接近 954x994,远大于菜单栏高度。
+ */
+export const TRAY_ICON_SIZE = 18
+
+/**
+ * 把托盘图缩到菜单栏合适的尺寸。
+ *
+ * macOS 菜单栏按图标的"点尺寸"绘制,不会自动把大图缩到菜单栏高度 —— 直接把
+ * 一张 ~954x994 的源图塞给 `Tray` 会显示成一个超大图标(见 #363)。Windows 会
+ * 缩放,所以这个 bug 只在 macOS 暴露,但统一缩放对各平台都更可控。
+ *
+ * 缩放失败(得到空图)时原样返回输入,交给上层的 `isEmpty` 兜底,绝不把一个
+ * 空图当成功结果返回。
+ */
+export function prepareTrayIcon(image: Electron.NativeImage): Electron.NativeImage {
+  if (image.isEmpty()) return image
+  const resized = image.resize({
+    width: TRAY_ICON_SIZE,
+    height: TRAY_ICON_SIZE,
+    quality: 'best'
+  })
+  return resized.isEmpty() ? image : resized
+}

--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -152,4 +152,44 @@ describe('app icon loader', () => {
       expect(mod.pickTrayIcon(tray, main)).toBe(main)
     })
   })
+
+  describe('prepareTrayIcon', () => {
+    // resize 返回一个非空的"缩放后"图;用对象身份区分输入/输出
+    function fakeResizable(empty: boolean, resizeResult?: Electron.NativeImage): Electron.NativeImage {
+      return {
+        isEmpty: () => empty,
+        resize: vi.fn(() => resizeResult ?? ({ isEmpty: () => false } as Electron.NativeImage))
+      } as unknown as Electron.NativeImage
+    }
+
+    it('resizes a non-empty icon down to the menu-bar point size', () => {
+      const resized = { isEmpty: () => false } as Electron.NativeImage
+      const source = fakeResizable(false, resized)
+
+      const result = mod.prepareTrayIcon(source)
+
+      expect(result).toBe(resized)
+      expect((source as unknown as { resize: ReturnType<typeof vi.fn> }).resize).toHaveBeenCalledWith({
+        width: mod.TRAY_ICON_SIZE,
+        height: mod.TRAY_ICON_SIZE,
+        quality: 'best'
+      })
+    })
+
+    it('returns the empty input untouched without attempting a resize', () => {
+      const source = fakeResizable(true)
+      const result = mod.prepareTrayIcon(source)
+
+      expect(result).toBe(source)
+      expect((source as unknown as { resize: ReturnType<typeof vi.fn> }).resize).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the original image when resize yields an empty image', () => {
+      // 缩放退化成空图时绝不返回空图,回退到原图交给上层 isEmpty 兜底。
+      const emptyResized = { isEmpty: () => true } as Electron.NativeImage
+      const source = fakeResizable(false, emptyResized)
+
+      expect(mod.prepareTrayIcon(source)).toBe(source)
+    })
+  })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,7 +10,7 @@ import {
 import kunLogoPng from '../asset/img/kun.png?url'
 import kunMacLogoPng from '../asset/img/kun_mac.png?url'
 import kunTrayPng from '../asset/img/kun_tray.png?url'
-import { createAppIcon, pickTrayIcon } from './app-icon'
+import { createAppIcon, pickTrayIcon, prepareTrayIcon } from './app-icon'
 import { configureLinuxWaylandImeSwitches } from './app-command-line'
 import { configureAppIdentity } from './app-identity'
 import { runLegacyKunDataMigration } from './legacy-data-migration'
@@ -375,7 +375,8 @@ function syncTray(settings: AppSettingsV1): void {
   if (!tray) {
     // Tray 优先用专门的托盘图(在 16x16/24x24 任务栏尺寸下更清晰的剪影);
     // 托盘图加载失败时回退到主应用图,这样不会看到 electron 默认占位。
-    const traySource = pickTrayIcon(trayIcon, appIcon)
+    // 再缩到菜单栏合适的点尺寸 —— macOS 菜单栏不会自动缩放大图(见 #363)。
+    const traySource = prepareTrayIcon(pickTrayIcon(trayIcon, appIcon))
     tray = new Tray(traySource.isEmpty() ? nativeImage.createEmpty() : traySource)
     tray.on('click', revealMainWindow)
     tray.on('double-click', revealMainWindow)


### PR DESCRIPTION
## Problem

Closes #363

On macOS the menu-bar (tray) icon renders enormously oversized on launch (v0.2.13, macOS 26.5.1).

## Root cause

`src/asset/img/kun_tray.png` is ~954x994px. macOS draws the menu-bar icon at the image's *point size* and does not auto-scale large images down to the menu-bar height, so the raw source image renders huge. (Windows scales the tray image, which is why the bug only surfaces on macOS.)

The tray creation path in `syncTray` passed the source straight to `new Tray(...)` without any resize — unlike the existing `workspace-editors.ts` icon path which already resizes via `image.resize({ quality: 'best' })`.

## Fix

- Add a pure, testable `prepareTrayIcon()` helper (and `TRAY_ICON_SIZE`) in `app-icon.ts` that resizes the source down to a menu-bar-appropriate point size, falling back to the original image if resize yields an empty image.
- Apply it in `index.ts` before constructing the `Tray`.

## Tests

- 3 new unit tests for `prepareTrayIcon` (normal resize / empty passthrough / empty-resize fallback).
- `vitest run src/main/index.test.ts` -> 13 passed; `tsc --noEmit` clean.

## Notes

- Kept the icon colorful (did not force a macOS template/monochrome image), since the issue is only about size. Can add `setTemplateImage(true)` in a follow-up if a monochrome menu-bar style is preferred.
- The large source PNG is unchanged (size-only fix); a dedicated small asset can follow.
