### PR TITLE
[codex] Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
-name: Bug report
-description: Report a reproducible bug or regression in Kun
+name: Bug report / 缺陷反馈
+description: Report a reproducible bug or regression in Kun / 反馈 Kun 中可复现的缺陷或回归问题
 title: "[Bug] "
 labels:
   - bug
@@ -7,67 +7,86 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping us improve Kun.
-        Please include enough detail for someone else to reproduce the issue.
+        Thanks for helping us improve Kun. Please include enough detail for someone else to reproduce the issue.
+
+        感谢帮助我们改进 Kun。请尽量提供足够的信息，方便维护者复现问题。
   - type: textarea
     id: summary
     attributes:
-      label: Summary
-      description: What happened?
-      placeholder: A concise description of the bug.
+      label: Summary / 问题摘要
+      description: What happened? / 发生了什么？
+      placeholder: A concise description of the bug. / 请简要描述这个问题。
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
-      label: Steps to reproduce
-      description: Share the exact steps we should follow.
+      label: Steps to reproduce / 复现步骤
+      description: Share the exact steps we should follow. / 请提供可以复现问题的具体步骤。
       placeholder: |
         1. Open ...
         2. Click ...
         3. See error ...
+
+        中文示例：
+        1. 打开 ...
+        2. 点击 ...
+        3. 看到错误 ...
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
-      label: Expected behavior
-      placeholder: What did you expect to happen?
+      label: Expected behavior / 预期行为
+      placeholder: What did you expect to happen? / 你原本期望发生什么？
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
-      label: Actual behavior
-      placeholder: What actually happened?
+      label: Actual behavior / 实际行为
+      placeholder: What actually happened? / 实际发生了什么？
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: Kun version
+      label: Kun version / Kun 版本
       placeholder: e.g. v0.1.0
     validations:
       required: true
   - type: input
     id: os
     attributes:
-      label: Operating system
+      label: Operating system / 操作系统
       placeholder: e.g. macOS 15.5, Windows 11, Ubuntu 24.04
     validations:
       required: true
   - type: textarea
     id: logs
     attributes:
-      label: Logs or screenshots
-      description: Paste relevant logs, stack traces, or screenshots if available.
+      label: Logs or screenshots / 日志或截图
+      description: |
+        Please upload the latest log files, stack traces, or screenshots if available. You can find Kun logs in:
+
+        - macOS: `~/Library/Application Support/Kun/logs`
+        - Windows: `C:\Users\<YourUserName>\AppData\Roaming\Kun\logs`
+        - Linux: `~/.config/Kun/logs`
+
+        If you changed the default Linux config directory, check `<your config directory>/Kun/logs` instead.
+
+        Please attach the latest `kun-YYYY-MM-DD.log` file. If you upgraded from an older DeepSeek GUI version, also attach the latest `deepseek-gui-YYYY-MM-DD.log` file if it exists.
+      placeholder: |
+        Drag log files or screenshots here, or paste relevant log snippets.
+
+        可以把日志文件或截图拖到这里，也可以粘贴相关日志片段。
       render: shell
   - type: checkboxes
     id: terms
     attributes:
-      label: Checklist
+      label: Checklist / 检查清单
       options:
-        - label: I searched existing issues before opening this report.
+        - label: I searched existing issues before opening this report. / 我已经搜索过现有 issues。
           required: true
-        - label: I removed sensitive information from logs and screenshots.
+        - label: I removed sensitive information from logs and screenshots. / 我已经从日志和截图中移除了敏感信息。
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Security vulnerability report
+  - name: Security vulnerability report / 安全漏洞反馈
     url: mailto:security@deepseek-gui.com
-    about: Please report security issues privately instead of opening a public issue.
-  - name: Contribution guide
+    about: Please report security issues privately instead of opening a public issue. / 请通过私密渠道反馈安全问题，不要创建公开 issue。
+  - name: Contribution guide / 贡献指南
     url: https://github.com/KunAgent/Kun/blob/master/docs/CONTRIBUTING.md
-    about: Read the contribution workflow and validation expectations before opening a PR.
+    about: Read the contribution workflow and validation expectations before opening a PR. / 创建 PR 前请阅读贡献流程和验证要求。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
-name: Feature request
-description: Suggest a product improvement, workflow enhancement, or new capability
+name: Feature request / 功能建议
+description: Suggest a product improvement, workflow enhancement, or new capability / 建议产品改进、工作流优化或新能力
 title: "[Feature] "
 labels:
   - enhancement
@@ -7,38 +7,39 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for sharing an idea.
-        The best requests explain the problem first, then the proposed solution.
+        Thanks for sharing an idea. The best requests explain the problem first, then the proposed solution.
+
+        感谢分享想法。建议先说明你遇到的问题，再描述期望的解决方案。
   - type: textarea
     id: problem
     attributes:
-      label: Problem or opportunity
-      description: What pain point are you trying to solve?
-      placeholder: Tell us what is hard, missing, or frustrating today.
+      label: Problem or opportunity / 问题或机会
+      description: What pain point are you trying to solve? / 你希望解决什么痛点？
+      placeholder: Tell us what is hard, missing, or frustrating today. / 请说明当前哪里不好用、缺少什么，或什么地方让你困扰。
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed solution
-      description: What would you like to see?
-      placeholder: Describe the ideal behavior, UI, or workflow.
+      label: Proposed solution / 建议方案
+      description: What would you like to see? / 你希望看到什么样的改进？
+      placeholder: Describe the ideal behavior, UI, or workflow. / 请描述你理想中的行为、界面或工作流。
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives considered
-      placeholder: Share any workarounds or alternative ideas you considered.
+      label: Alternatives considered / 已考虑的替代方案
+      placeholder: Share any workarounds or alternative ideas you considered. / 请分享你考虑过的临时方案或其他想法。
   - type: textarea
     id: context
     attributes:
-      label: Additional context
-      placeholder: Add screenshots, references, or related issues if helpful.
+      label: Additional context / 补充信息
+      placeholder: Add screenshots, references, or related issues if helpful. / 可以补充截图、参考资料或相关 issues。
   - type: checkboxes
     id: terms
     attributes:
-      label: Checklist
+      label: Checklist / 检查清单
       options:
-        - label: I searched existing issues before opening this request.
+        - label: I searched existing issues before opening this request. / 我已经搜索过现有 issues。
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,35 @@
-## Summary
+## Summary / 概要
 
 - 
 
-## Why
+## Why / 背景
 
 - 
 
-## Changes
+## Changes / 变更
 
 - 
 
-## Media
+## Media / 截图或录屏
 
 - UI changes: attach a video or GIF here.
+- 界面变更：请在这里附上视频或 GIF。
 
-## Tests
+## Tests / 测试
 
 - Logic changes: list unit tests added or updated.
+- 逻辑变更：请列出新增或更新的单元测试。
 
-## Validation
+## Validation / 验证
 
-- [ ] I agree that this contribution is submitted under the [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md).
+- [ ] I agree that this contribution is submitted under the [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md). / 我同意本贡献遵循 [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md) 提交。
 - [ ] `npm run test`
 - [ ] `npm run typecheck`
 - [ ] `npm run build`
-- [ ] `npm run dev` (if runtime or UI behavior changed)
-- [ ] UI change: video or GIF attached
-- [ ] Logic change: unit tests added or updated
+- [ ] `npm run dev` (if runtime or UI behavior changed / 如果运行时或界面行为有变化)
+- [ ] UI change: video or GIF attached / 界面变更：已附上视频或 GIF
+- [ ] Logic change: unit tests added or updated / 逻辑变更：已新增或更新单元测试
 
-## Notes
+## Notes / 备注
 
 - 


### PR DESCRIPTION
## Summary

- Adds Chinese copy to GitHub issue and PR templates.
- Updates the bug report template to show user-friendly macOS, Windows, and Linux log paths.
- Asks reporters to attach the latest Kun log file, including legacy DeepSeek GUI logs when present.

## Why

Bug reports need clearer guidance for users to find and upload logs across desktop platforms. The other contribution templates also needed Chinese text so Chinese-speaking users can fill them out more reliably.

## Validation

- `ruby -e "require 'yaml'; ARGV.each { |file| YAML.load_file(file); puts \\"ok #{file}\\" }" .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml`\n- `git diff --check`