### PR TITLE
[codex] Fix duplicate Streamdown markdown text

### DIFF
--- a/src/renderer/src/components/chat/StreamdownAssistant.tsx
+++ b/src/renderer/src/components/chat/StreamdownAssistant.tsx
@@ -161,15 +161,14 @@ export function StreamdownAssistant({ text, streaming, className }: Props): Reac
   return (
     <Streamdown
       className={className}
-      mode={streaming ? 'streaming' : 'static'}
-      parseIncompleteMarkdown={streaming}
-      isAnimating={streaming}
-      // Streamdown's own per-char animation must stay OFF: it diffs old vs
-      // new chars by position in a count that excludes code/pre text, so
-      // every time an inline-code chip closes during streaming the
-      // positions shift and already-visible text re-animates from
-      // transparent — the patchy "missing text" look. The pacing hook
-      // above is the typewriter; revealed chars render crisp immediately.
+      mode="static"
+      parseIncompleteMarkdown={false}
+      isAnimating={false}
+      // The pacing hook above is the typewriter. Keep Streamdown's own
+      // streaming/remend pipeline disabled here: in long Markdown responses
+      // with GFM tables, its block repair path can leave stale text fragments
+      // next to the repaired block, producing copied DOM text such as
+      // "Work Workstreamstream".
       animated={false}
       remarkPlugins={[remarkGfm]}
       rehypePlugins={rehypePlugins}


### PR DESCRIPTION
## Summary

Fixes duplicated visible/copied markdown text in assistant responses by keeping the local typewriter pacing but rendering Streamdown with static parsing instead of its streaming/remend repair pipeline.

This targets the issue reported in https://github.com/KunAgent/Kun/issues/369. The screenshot shows duplicated text outside the table as well as the table source failing to settle cleanly, so the change avoids the streaming markdown repair path that can leave stale text fragments next to repaired GFM blocks.

## Validation

- `npm test -- src/renderer/src/components/chat/StreamdownAssistant.test.ts`
- `npm run typecheck` was run after rebasing onto `develop`; it currently fails on existing unrelated type errors in `src/renderer/src/store/chat-store-thread-actions.test.ts` (`onDeltas` on `never`).
- `npm run lint` was run after rebasing onto `develop`; it currently fails on an existing unrelated `no-dupe-keys` error in `src/main/kun-process.ts` and existing hook dependency warnings.
