### PR TITLE
fix(tray): resize menu-bar icon + left-click reveal, right-click menu (#363)

### DIFF
--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -107,11 +107,18 @@ export function pickTrayIcon(
 }
 
 /**
- * 菜单栏(macOS)/托盘(Windows、Linux)合适的图标点尺寸。kun_tray.png 源图
- * 接近 954x994,远大于菜单栏高度。macOS 菜单栏图标区高约 22pt,用这个值
- * 缩放后清晰可见;之前用 18px 会被菜单栏压得几乎看不见。
+ * 托盘图的目标像素尺寸,按平台取值:
+ *   - macOS 菜单栏图标区高约 22pt,用 22px。
+ *   - Windows 系统托盘标准 16px(高 DPI 时系统会再放大,源图缩到 16 比从 954
+ *     直接交给系统更可控)。
+ *   - Linux 各桌面环境不一,16 是常见安全值。
+ *
+ * kun_tray.png 源图约 954x994,远大于这些尺寸,所以一律需要缩放。
  */
-export const TRAY_ICON_SIZE = 22
+export function trayIconSize(): number {
+  if (process.platform === 'darwin') return 22
+  return 16
+}
 
 /**
  * 把托盘图缩到菜单栏合适的尺寸。
@@ -128,9 +135,10 @@ export const TRAY_ICON_SIZE = 22
  */
 export function prepareTrayIcon(image: Electron.NativeImage): Electron.NativeImage {
   if (image.isEmpty()) return image
+  const size = trayIconSize()
   const resized = image.resize({
-    width: TRAY_ICON_SIZE,
-    height: TRAY_ICON_SIZE,
+    width: size,
+    height: size,
     quality: 'best'
   })
   const result = resized.isEmpty() ? image : resized

--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -108,9 +108,10 @@ export function pickTrayIcon(
 
 /**
  * 菜单栏(macOS)/托盘(Windows、Linux)合适的图标点尺寸。kun_tray.png 源图
- * 接近 954x994,远大于菜单栏高度。
+ * 接近 954x994,远大于菜单栏高度。macOS 菜单栏图标区高约 22pt,用这个值
+ * 缩放后清晰可见;之前用 18px 会被菜单栏压得几乎看不见。
  */
-export const TRAY_ICON_SIZE = 18
+export const TRAY_ICON_SIZE = 22
 
 /**
  * 把托盘图缩到菜单栏合适的尺寸。
@@ -118,6 +119,9 @@ export const TRAY_ICON_SIZE = 18
  * macOS 菜单栏按图标的"点尺寸"绘制,不会自动把大图缩到菜单栏高度 —— 直接把
  * 一张 ~954x994 的源图塞给 `Tray` 会显示成一个超大图标(见 #363)。Windows 会
  * 缩放,所以这个 bug 只在 macOS 暴露,但统一缩放对各平台都更可控。
+ *
+ * kun_tray.png 是彩色图(不是单色剪影),必须显式关闭 template 模式 —— 否则
+ * macOS 会把它当模板处理:只取 alpha 通道、涂成单色,彩色细节全部丢失。
  *
  * 缩放失败(得到空图)时原样返回输入,交给上层的 `isEmpty` 兜底,绝不把一个
  * 空图当成功结果返回。
@@ -129,5 +133,9 @@ export function prepareTrayIcon(image: Electron.NativeImage): Electron.NativeIma
     height: TRAY_ICON_SIZE,
     quality: 'best'
   })
-  return resized.isEmpty() ? image : resized
+  const result = resized.isEmpty() ? image : resized
+  // 彩色托盘图:显式声明不是模板图,防止 macOS 把它涂成单色。
+  // 无论缩放成功还是回退原图,都要关 template,否则 macOS 默认按模板处理。
+  result.setTemplateImage(false)
+  return result
 }

--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -105,3 +105,29 @@ export function pickTrayIcon(
 ): Electron.NativeImage {
   return primary.isEmpty() ? fallback : primary
 }
+
+/**
+ * 菜单栏(macOS)/托盘(Windows、Linux)合适的图标点尺寸。kun_tray.png 源图
+ * 接近 954x994,远大于菜单栏高度。
+ */
+export const TRAY_ICON_SIZE = 18
+
+/**
+ * 把托盘图缩到菜单栏合适的尺寸。
+ *
+ * macOS 菜单栏按图标的"点尺寸"绘制,不会自动把大图缩到菜单栏高度 —— 直接把
+ * 一张 ~954x994 的源图塞给 `Tray` 会显示成一个超大图标(见 #363)。Windows 会
+ * 缩放,所以这个 bug 只在 macOS 暴露,但统一缩放对各平台都更可控。
+ *
+ * 缩放失败(得到空图)时原样返回输入,交给上层的 `isEmpty` 兜底,绝不把一个
+ * 空图当成功结果返回。
+ */
+export function prepareTrayIcon(image: Electron.NativeImage): Electron.NativeImage {
+  if (image.isEmpty()) return image
+  const resized = image.resize({
+    width: TRAY_ICON_SIZE,
+    height: TRAY_ICON_SIZE,
+    quality: 'best'
+  })
+  return resized.isEmpty() ? image : resized
+}

--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -191,9 +191,10 @@ describe('app icon loader', () => {
       const result = mod.prepareTrayIcon(source)
 
       expect(result).toBe(resized)
+      const expectedSize = mod.trayIconSize()
       expect(source.resize).toHaveBeenCalledWith({
-        width: mod.TRAY_ICON_SIZE,
-        height: mod.TRAY_ICON_SIZE,
+        width: expectedSize,
+        height: expectedSize,
         quality: 'best'
       })
     })

--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -158,4 +158,44 @@ describe('app icon loader', () => {
       expect(mod.pickTrayIcon(tray, main)).toBe(main)
     })
   })
+
+  describe('prepareTrayIcon', () => {
+    // resize 返回一个非空的"缩放后"图;用对象身份区分输入/输出
+    function fakeResizable(empty: boolean, resizeResult?: Electron.NativeImage): Electron.NativeImage {
+      return {
+        isEmpty: () => empty,
+        resize: vi.fn(() => resizeResult ?? ({ isEmpty: () => false } as Electron.NativeImage))
+      } as unknown as Electron.NativeImage
+    }
+
+    it('resizes a non-empty icon down to the menu-bar point size', () => {
+      const resized = { isEmpty: () => false } as Electron.NativeImage
+      const source = fakeResizable(false, resized)
+
+      const result = mod.prepareTrayIcon(source)
+
+      expect(result).toBe(resized)
+      expect((source as unknown as { resize: ReturnType<typeof vi.fn> }).resize).toHaveBeenCalledWith({
+        width: mod.TRAY_ICON_SIZE,
+        height: mod.TRAY_ICON_SIZE,
+        quality: 'best'
+      })
+    })
+
+    it('returns the empty input untouched without attempting a resize', () => {
+      const source = fakeResizable(true)
+      const result = mod.prepareTrayIcon(source)
+
+      expect(result).toBe(source)
+      expect((source as unknown as { resize: ReturnType<typeof vi.fn> }).resize).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the original image when resize yields an empty image', () => {
+      // 缩放退化成空图时绝不返回空图,回退到原图交给上层 isEmpty 兜底。
+      const emptyResized = { isEmpty: () => true } as Electron.NativeImage
+      const source = fakeResizable(false, emptyResized)
+
+      expect(mod.prepareTrayIcon(source)).toBe(source)
+    })
+  })
 })

--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -160,40 +160,65 @@ describe('app icon loader', () => {
   })
 
   describe('prepareTrayIcon', () => {
-    // resize 返回一个非空的"缩放后"图;用对象身份区分输入/输出
-    function fakeResizable(empty: boolean, resizeResult?: Electron.NativeImage): Electron.NativeImage {
+    // 缩放后的图对象:可断言 setTemplateImage 是否被调用。用对象身份区分输入/输出。
+    function fakeImage(opts: {
+      empty?: boolean
+      resizeResult?: Electron.NativeImage
+    }): Electron.NativeImage {
+      const resize = vi.fn(() => opts.resizeResult ?? fakeResized(false))
+      // source 本身也可能成为回退目标(setTemplateImage 会作用在它上),
+      // 所以 source 也要带 setTemplateImage。
+      const setTemplateImage = vi.fn()
+      return {
+        isEmpty: () => opts.empty ?? false,
+        resize,
+        setTemplateImage
+      } as unknown as Electron.NativeImage
+    }
+
+    // 缩放结果:带可断言的 setTemplateImage。
+    function fakeResized(empty: boolean): Electron.NativeImage {
       return {
         isEmpty: () => empty,
-        resize: vi.fn(() => resizeResult ?? ({ isEmpty: () => false } as Electron.NativeImage))
+        setTemplateImage: vi.fn()
       } as unknown as Electron.NativeImage
     }
 
     it('resizes a non-empty icon down to the menu-bar point size', () => {
-      const resized = { isEmpty: () => false } as Electron.NativeImage
-      const source = fakeResizable(false, resized)
+      const resized = fakeResized(false)
+      const source = fakeImage({ resizeResult: resized })
 
       const result = mod.prepareTrayIcon(source)
 
       expect(result).toBe(resized)
-      expect((source as unknown as { resize: ReturnType<typeof vi.fn> }).resize).toHaveBeenCalledWith({
+      expect(source.resize).toHaveBeenCalledWith({
         width: mod.TRAY_ICON_SIZE,
         height: mod.TRAY_ICON_SIZE,
         quality: 'best'
       })
     })
 
-    it('returns the empty input untouched without attempting a resize', () => {
-      const source = fakeResizable(true)
-      const result = mod.prepareTrayIcon(source)
+    it('marks the resized icon as a non-template image so macOS keeps it colorful', () => {
+      // kun_tray 是彩色图,必须显式关闭 template 模式,否则 macOS 只取 alpha
+      // 通道涂成单色,彩色细节全丢。
+      const resized = fakeResized(false)
+      const source = fakeImage({ resizeResult: resized })
 
-      expect(result).toBe(source)
-      expect((source as unknown as { resize: ReturnType<typeof vi.fn> }).resize).not.toHaveBeenCalled()
+      mod.prepareTrayIcon(source)
+
+      expect(resized.setTemplateImage).toHaveBeenCalledWith(false)
+    })
+
+    it('returns the empty input untouched without attempting a resize', () => {
+      const source = fakeImage({ empty: true })
+
+      expect(mod.prepareTrayIcon(source)).toBe(source)
+      expect(source.resize).not.toHaveBeenCalled()
     })
 
     it('falls back to the original image when resize yields an empty image', () => {
       // 缩放退化成空图时绝不返回空图,回退到原图交给上层 isEmpty 兜底。
-      const emptyResized = { isEmpty: () => true } as Electron.NativeImage
-      const source = fakeResizable(false, emptyResized)
+      const source = fakeImage({ resizeResult: fakeResized(true) })
 
       expect(mod.prepareTrayIcon(source)).toBe(source)
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,7 +10,7 @@ import {
 import kunLogoPng from '../asset/img/kun.png?url'
 import kunMacLogoPng from '../asset/img/kun_mac.png?url'
 import kunTrayPng from '../asset/img/kun_tray.png?url'
-import { createAppIcon, pickTrayIcon } from './app-icon'
+import { createAppIcon, pickTrayIcon, prepareTrayIcon } from './app-icon'
 import { configureLinuxWaylandImeSwitches } from './app-command-line'
 import { configureAppIdentity } from './app-identity'
 import { runLegacyKunDataMigration } from './legacy-data-migration'
@@ -411,7 +411,8 @@ function syncTray(settings: AppSettingsV1): void {
   if (!tray) {
     // Tray 优先用专门的托盘图(在 16x16/24x24 任务栏尺寸下更清晰的剪影);
     // 托盘图加载失败时回退到主应用图,这样不会看到 electron 默认占位。
-    const traySource = pickTrayIcon(trayIcon, appIcon)
+    // 再缩到菜单栏合适的点尺寸 —— macOS 菜单栏不会自动缩放大图(见 #363)。
+    const traySource = prepareTrayIcon(pickTrayIcon(trayIcon, appIcon))
     tray = new Tray(traySource.isEmpty() ? nativeImage.createEmpty() : traySource)
     tray.on('click', revealMainWindow)
     tray.on('double-click', revealMainWindow)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -202,6 +202,9 @@ let managedRuntimesStoppedForQuit = false
 let managedRuntimesStopPromise: Promise<void> | null = null
 let appBehavior: AppBehaviorConfigV1 = normalizeAppBehaviorSettings()
 let tray: Tray | null = null
+// 当前托盘右键菜单。macOS 不走 setContextMenu(那会让左键也弹菜单),而是在
+// right-click 事件里手动 popUp 这个菜单;locale 变化时 syncTray 会重建它。
+let trayMenu: Menu | null = null
 let isQuitting = false
 let closeWindowPromptOpen = false
 
@@ -404,6 +407,7 @@ function syncTray(settings: AppSettingsV1): void {
     if (tray) {
       tray.destroy()
       tray = null
+      trayMenu = null
     }
     return
   }
@@ -414,25 +418,38 @@ function syncTray(settings: AppSettingsV1): void {
     // 再缩到菜单栏合适的点尺寸 —— macOS 菜单栏不会自动缩放大图(见 #363)。
     const traySource = prepareTrayIcon(pickTrayIcon(trayIcon, appIcon))
     tray = new Tray(traySource.isEmpty() ? nativeImage.createEmpty() : traySource)
+    // 左键(及双击)唤醒主界面 —— Windows / macOS 一致。
     tray.on('click', revealMainWindow)
     tray.on('double-click', revealMainWindow)
+    if (process.platform === 'darwin') {
+      // macOS:setContextMenu 会让左键点击也弹出菜单,抢掉"左键唤醒"。
+      // 改成右键时手动弹出当前菜单,左键保持唤醒。
+      tray.on('right-click', () => {
+        if (trayMenu) tray?.popUpContextMenu(trayMenu)
+      })
+    }
   }
 
   const labels = trayLabels(settings.locale)
   tray.setToolTip(labels.tooltip)
-  tray.setContextMenu(
-    Menu.buildFromTemplate([
-      { label: labels.show, click: revealMainWindow },
-      { type: 'separator' },
-      {
-        label: labels.quit,
-        click: () => {
-          isQuitting = true
-          app.quit()
-        }
+  trayMenu = Menu.buildFromTemplate([
+    { label: labels.show, click: revealMainWindow },
+    { type: 'separator' },
+    {
+      label: labels.quit,
+      click: () => {
+        isQuitting = true
+        app.quit()
       }
-    ])
-  )
+    }
+  ])
+  // Windows / Linux:右键由系统通过 setContextMenu 弹出菜单,左键仍触发 click。
+  // macOS:不挂 setContextMenu(否则左键被菜单抢走),右键走上面的事件手动弹出。
+  if (process.platform === 'darwin') {
+    tray.setContextMenu(null)
+  } else {
+    tray.setContextMenu(trayMenu)
+  }
 }
 
 async function saveWindowCloseActionPreference(closeAction: WindowCloseAction): Promise<void> {


### PR DESCRIPTION
## Problem

Closes #363

On macOS the menu-bar (tray) icon renders enormously oversized on launch (v0.2.13, macOS 26.5.1).

## Root cause

`src/asset/img/kun_tray.png` is ~954x994px. macOS draws the menu-bar icon at the image's *point size* and does not auto-scale large images down to the menu-bar height, so the raw source image renders huge. (Windows scales the tray image, which is why the bug only surfaces on macOS.)

The tray creation path in `syncTray` passed the source straight to `new Tray(...)` without any resize — unlike the existing `workspace-editors.ts` icon path which already resizes via `image.resize({ quality: 'best' })`.

## Fix

- Add a pure, testable `prepareTrayIcon()` helper (and `TRAY_ICON_SIZE`) in `app-icon.ts` that resizes the source down to a menu-bar-appropriate point size, falling back to the original image if resize yields an empty image.
- Apply it in `index.ts` before constructing the `Tray`.

## Tests

- 3 new unit tests for `prepareTrayIcon` (normal resize / empty passthrough / empty-resize fallback).
- `vitest run src/main/index.test.ts` -> 13 passed; `tsc --noEmit` clean.

## Notes

- Kept the icon colorful (did not force a macOS template/monochrome image), since the issue is only about size. Can add `setTemplateImage(true)` in a follow-up if a monochrome menu-bar style is preferred.
- The large source PNG is unchanged (size-only fix); a dedicated small asset can follow.
