### PR TITLE
fix(tray): resize tray icon across platforms / 修复多平台托盘图标尺寸

### DIFF
--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -105,3 +105,28 @@ export function pickTrayIcon(
 ): Electron.NativeImage {
   return primary.isEmpty() ? fallback : primary
 }
+
+export function trayIconSize(platform: NodeJS.Platform = process.platform): number {
+  return platform === 'darwin' ? 22 : 16
+}
+
+export function prepareTrayIcon(
+  image: Electron.NativeImage,
+  platform: NodeJS.Platform = process.platform
+): Electron.NativeImage {
+  if (image.isEmpty()) return image
+
+  const size = trayIconSize(platform)
+  const resized = image.resize({
+    width: size,
+    height: size,
+    quality: 'best'
+  })
+  const result = resized.isEmpty() ? image : resized
+
+  if (platform === 'darwin') {
+    result.setTemplateImage(false)
+  }
+
+  return result
+}

--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -158,4 +158,72 @@ describe('app icon loader', () => {
       expect(mod.pickTrayIcon(tray, main)).toBe(main)
     })
   })
+
+  describe('prepareTrayIcon', () => {
+    type FakeNativeImage = Electron.NativeImage & {
+      resize: ReturnType<typeof vi.fn>
+      setTemplateImage: ReturnType<typeof vi.fn>
+    }
+
+    function fakeResized(empty: boolean): FakeNativeImage {
+      return {
+        isEmpty: () => empty,
+        resize: vi.fn(),
+        setTemplateImage: vi.fn()
+      } as unknown as FakeNativeImage
+    }
+
+    function fakeImage(empty: boolean, resizeResult?: Electron.NativeImage): FakeNativeImage {
+      const fallbackResizeResult = fakeResized(false)
+      return {
+        isEmpty: () => empty,
+        resize: vi.fn(() => resizeResult ?? fallbackResizeResult),
+        setTemplateImage: vi.fn()
+      } as unknown as FakeNativeImage
+    }
+
+    it('uses a 22px tray icon target on macOS', () => {
+      expect(mod.trayIconSize('darwin')).toBe(22)
+    })
+
+    it('uses a 16px tray icon target outside macOS', () => {
+      expect(mod.trayIconSize('win32')).toBe(16)
+      expect(mod.trayIconSize('linux')).toBe(16)
+    })
+
+    it('resizes a non-empty tray image to the platform target size', () => {
+      const resized = fakeResized(false)
+      const source = fakeImage(false, resized)
+
+      expect(mod.prepareTrayIcon(source, 'win32')).toBe(resized)
+      expect(source.resize).toHaveBeenCalledWith({
+        width: 16,
+        height: 16,
+        quality: 'best'
+      })
+    })
+
+    it('keeps a macOS color tray icon out of template mode', () => {
+      const resized = fakeResized(false)
+      const source = fakeImage(false, resized)
+
+      expect(mod.prepareTrayIcon(source, 'darwin')).toBe(resized)
+      expect(resized.setTemplateImage).toHaveBeenCalledWith(false)
+    })
+
+    it('does not resize an empty image', () => {
+      const source = fakeImage(true)
+
+      expect(mod.prepareTrayIcon(source, 'darwin')).toBe(source)
+      expect(source.resize).not.toHaveBeenCalled()
+      expect(source.setTemplateImage).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the original image when resizing fails', () => {
+      const emptyResized = fakeResized(true)
+      const source = fakeImage(false, emptyResized)
+
+      expect(mod.prepareTrayIcon(source, 'win32')).toBe(source)
+    })
+  })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,7 +10,7 @@ import {
 import kunLogoPng from '../asset/img/kun.png?url'
 import kunMacLogoPng from '../asset/img/kun_mac.png?url'
 import kunTrayPng from '../asset/img/kun_tray.png?url'
-import { createAppIcon, pickTrayIcon } from './app-icon'
+import { createAppIcon, pickTrayIcon, prepareTrayIcon } from './app-icon'
 import { configureLinuxWaylandImeSwitches } from './app-command-line'
 import { configureAppIdentity } from './app-identity'
 import { runLegacyKunDataMigration } from './legacy-data-migration'
@@ -202,6 +202,7 @@ let managedRuntimesStoppedForQuit = false
 let managedRuntimesStopPromise: Promise<void> | null = null
 let appBehavior: AppBehaviorConfigV1 = normalizeAppBehaviorSettings()
 let tray: Tray | null = null
+let trayMenu: Menu | null = null
 let isQuitting = false
 let closeWindowPromptOpen = false
 
@@ -404,6 +405,7 @@ function syncTray(settings: AppSettingsV1): void {
     if (tray) {
       tray.destroy()
       tray = null
+      trayMenu = null
     }
     return
   }
@@ -411,27 +413,31 @@ function syncTray(settings: AppSettingsV1): void {
   if (!tray) {
     // Tray 优先用专门的托盘图(在 16x16/24x24 任务栏尺寸下更清晰的剪影);
     // 托盘图加载失败时回退到主应用图,这样不会看到 electron 默认占位。
-    const traySource = pickTrayIcon(trayIcon, appIcon)
+    const traySource = prepareTrayIcon(pickTrayIcon(trayIcon, appIcon))
     tray = new Tray(traySource.isEmpty() ? nativeImage.createEmpty() : traySource)
     tray.on('click', revealMainWindow)
     tray.on('double-click', revealMainWindow)
+    if (process.platform === 'darwin') {
+      tray.on('right-click', () => {
+        if (trayMenu) tray?.popUpContextMenu(trayMenu)
+      })
+    }
   }
 
   const labels = trayLabels(settings.locale)
   tray.setToolTip(labels.tooltip)
-  tray.setContextMenu(
-    Menu.buildFromTemplate([
-      { label: labels.show, click: revealMainWindow },
-      { type: 'separator' },
-      {
-        label: labels.quit,
-        click: () => {
-          isQuitting = true
-          app.quit()
-        }
+  trayMenu = Menu.buildFromTemplate([
+    { label: labels.show, click: revealMainWindow },
+    { type: 'separator' },
+    {
+      label: labels.quit,
+      click: () => {
+        isQuitting = true
+        app.quit()
       }
-    ])
-  )
+    }
+  ])
+  tray.setContextMenu(process.platform === 'darwin' ? null : trayMenu)
 }
 
 async function saveWindowCloseActionPreference(closeAction: WindowCloseAction): Promise<void> {


### PR DESCRIPTION
## Summary / 摘要
- Resize the selected tray icon before creating the Electron `Tray`, so oversized source assets do not render huge in the macOS menu bar.
- 在创建 Electron `Tray` 前缩放已选托盘图标，避免大尺寸源图在 macOS 菜单栏异常放大。
- Use a platform target size: 22px on macOS and 16px on Windows/Linux.
- 按平台使用目标尺寸：macOS 为 22px，Windows/Linux 为 16px。
- Keep macOS left-click behavior focused on revealing the main window by showing the tray menu from the right-click handler; Windows/Linux continue to use the native context-menu path.
- macOS 上通过右键事件弹出托盘菜单，让左键继续唤醒主窗口；Windows/Linux 继续使用原生托盘菜单路径。

## Why / 原因
- PR #367 targeted the same symptom but was opened against `master`; PR #383 is open but mixes the size fix with broader tray behavior changes. This keeps the replacement scoped to the icon sizing bug and minimal cross-platform tray behavior needed around it.
- #367 解决的是同一问题但 base 是 `master`；#383 仍在打开状态，但把尺寸修复和更多托盘行为改动混在一起。本 PR 保持更小范围，只修图标尺寸以及与其相关的基础多平台托盘行为。

## Tests / 测试
- `npm.cmd test -- src/main/index.test.ts`
- `git diff --check`

## Notes / 说明
- `npm.cmd run typecheck` currently fails on existing upstream type errors outside this change, including `src/renderer/src/store/chat-store-thread-actions.test.ts` `onDeltas`, several `src/main/claw-runtime.test.ts` mock typings, `src/main/feishu-streamer.test.ts`, and duplicate key in `src/main/kun-process.ts`.
- 当前 `npm.cmd run typecheck` 会被本次改动之外的 upstream 既有类型错误阻塞，包括 `src/renderer/src/store/chat-store-thread-actions.test.ts` 的 `onDeltas`、多处 `src/main/claw-runtime.test.ts` mock 类型、`src/main/feishu-streamer.test.ts` 以及 `src/main/kun-process.ts` 重复键。

Fixes #363
