### PR TITLE
fix(image): preserve attachment paths for image edits / 修复图生图附件路径传递

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, relative, resolve } from 'node:path'
 import type { ModelClient, ModelRequest, ModelStreamChunk, ModelToolSpec } from '../ports/model-client.js'
 import type {
   ToolHost,
@@ -982,6 +983,12 @@ export class AgentLoop {
         ? [goalRecoveryInstruction]
         : []),
       ...(activeTodoInstruction ? [activeTodoInstruction] : []),
+      ...imageGenerationReferenceInstructions({
+        imageAttachments: attachments.imageAttachments,
+        textFallbacks: attachments.textFallbacks,
+        workspace: thread?.workspace ?? '',
+        tools: effectiveToolSpecs
+      }),
       ...memoryInstructions(memories),
       ...skillResolution.instructions,
       ...(userInputDisabled ? [userInputUnavailableInstruction()] : []),
@@ -2345,7 +2352,8 @@ export class AgentLoop {
           mimeType: attachment.mimeType,
           dataBase64: attachment.data.toString('base64'),
           ...(attachment.width ? { width: attachment.width } : {}),
-          ...(attachment.height ? { height: attachment.height } : {})
+          ...(attachment.height ? { height: attachment.height } : {}),
+          ...(attachment.localFilePath ? { localFilePath: attachment.localFilePath } : {})
         })
         continue
       }
@@ -2452,6 +2460,47 @@ function attachmentRequestPipelineDetails(input: {
     ),
     textFallbackMimeTypes: [...new Set(input.textFallbacks.map((attachment) => attachment.mimeType))]
   }
+}
+
+function imageGenerationReferenceInstructions(input: {
+  imageAttachments: readonly ModelInputAttachment[]
+  textFallbacks: readonly ModelTextAttachmentFallback[]
+  workspace: string
+  tools: readonly Pick<ModelToolSpec, 'name'>[]
+}): string[] {
+  if (!input.tools.some((tool) => tool.name === 'generate_image')) return []
+
+  const references = [...input.imageAttachments, ...input.textFallbacks]
+    .filter((attachment) => attachment.mimeType.startsWith('image/'))
+    .map((attachment) => ({
+      name: attachment.name,
+      path: workspaceRelativeAttachmentPath(attachment.localFilePath, input.workspace)
+    }))
+    .filter((attachment): attachment is { name: string; path: string } => Boolean(attachment.path))
+
+  if (references.length === 0) return []
+
+  return [[
+    'Image-to-image reference images are available for this turn:',
+    ...references.map((reference) => `- ${reference.name}: ${reference.path}`),
+    'For image edits, restyles, redraws, or transformations, call `generate_image` with the matching workspace-relative path(s) in `reference_image_paths`.'
+  ].join('\n')]
+}
+
+function workspaceRelativeAttachmentPath(
+  localFilePath: string | undefined,
+  workspace: string
+): string | null {
+  const workspaceRoot = workspace.trim()
+  const rawPath = localFilePath?.trim()
+  if (!workspaceRoot || !rawPath) return null
+
+  const workspaceAbsolute = resolve(workspaceRoot)
+  const fileAbsolute = isAbsolute(rawPath) ? resolve(rawPath) : resolve(workspaceAbsolute, rawPath)
+  const relativePath = relative(workspaceAbsolute, fileAbsolute)
+  if (!relativePath || relativePath.startsWith('..') || isAbsolute(relativePath)) return null
+
+  return relativePath.replace(/\\/g, '/')
 }
 
 function normalizeApprovalPolicy(

--- a/kun/src/ports/model-client.ts
+++ b/kun/src/ports/model-client.ts
@@ -71,6 +71,7 @@ export type ModelInputAttachment = {
   dataBase64: string
   width?: number
   height?: number
+  localFilePath?: string
 }
 
 export type ModelTextAttachmentFallback = {

--- a/kun/tests/attachment-store.test.ts
+++ b/kun/tests/attachment-store.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/contracts/capabilities.js'
 import { modelCapabilitiesForModel } from '../src/loop/model-context-profile.js'
 import type { ModelClient, ModelRequest } from '../src/ports/model-client.js'
+import type { LocalTool } from '../src/adapters/tool/local-tool-host.js'
 import { dispatchRequest } from '../src/server/http-server.js'
 import { bootstrapThread, makeHarness } from './loop-test-harness.js'
 import { buildHarness, readJson } from './http-server-test-harness.js'
@@ -173,12 +174,14 @@ describe('Attachment store and multimodal input', () => {
 
   it('resolves image attachments for vision models and text fallbacks for text-only models', async () => {
     const store = createStore()
+    const workspace = join(dir, 'workspace')
+    const localFilePath = join(workspace, 'assets', 'shot.png')
     const attachment = await store.create({
       name: 'shot.png',
       data: png(1, 1),
-      localFilePath: '/tmp/picked/shot.png',
+      localFilePath,
       threadId: 'thr_1',
-      workspace: '/tmp/ws'
+      workspace
     })
     const seenRequests: ModelRequest[] = []
     const model: ModelClient = {
@@ -189,12 +192,23 @@ describe('Attachment store and multimodal input', () => {
         yield { kind: 'completed', stopReason: 'stop' }
       }
     }
+    const generateImageTool: LocalTool = {
+      name: 'generate_image',
+      description: 'Generate or edit an image.',
+      inputSchema: { type: 'object' },
+      toolKind: 'tool_call',
+      policy: 'auto',
+      async execute() {
+        return { output: { ok: true } }
+      }
+    }
     const h = makeHarness(model, {
       attachmentStore: store,
-      modelCapabilities: () => visionCapabilities()
+      modelCapabilities: () => visionCapabilities(),
+      tools: [generateImageTool]
     })
     await bootstrapThread(h, {
-      workspace: '/tmp/ws',
+      workspace,
       request: { prompt: 'look', attachmentIds: [attachment.id], model: 'vision-model' }
     })
 
@@ -203,15 +217,18 @@ describe('Attachment store and multimodal input', () => {
     expect(seenRequests.at(-1)?.attachments?.[0]).toMatchObject({
       id: attachment.id,
       mimeType: 'image/png',
-      dataBase64: expect.any(String)
+      dataBase64: expect.any(String),
+      localFilePath
     })
+    expect(seenRequests.at(-1)?.contextInstructions?.join('\n')).toContain('reference_image_paths')
+    expect(seenRequests.at(-1)?.contextInstructions?.join('\n')).toContain('assets/shot.png')
 
     const textOnly = makeHarness(model, {
       attachmentStore: store,
       modelCapabilities: () => ({ ...visionCapabilities(), inputModalities: ['text'] })
     })
     await bootstrapThread(textOnly, {
-      workspace: '/tmp/ws',
+      workspace,
       request: { prompt: 'look', attachmentIds: [attachment.id], model: 'text-only' }
     })
     expect(await textOnly.loop.runTurn(textOnly.threadId, textOnly.turnId)).toBe('completed')
@@ -220,7 +237,7 @@ describe('Attachment store and multimodal input', () => {
       id: attachment.id,
       mimeType: 'image/png',
       dataBase64: expect.any(String),
-      localFilePath: '/tmp/picked/shot.png',
+      localFilePath,
       wasCompressed: false
     })
   })


### PR DESCRIPTION
## Summary / 摘要
- Preserve `localFilePath` when the real attachment loader builds `ModelInputAttachment` objects for vision-capable models.
- 视觉模型走真实附件加载器时，将 `localFilePath` 保留到 `ModelInputAttachment`。
- Add a per-turn instruction that points `generate_image` at workspace-relative `reference_image_paths` for image edit, restyle, redraw, and transform requests.
- 对图片编辑、风格化、重绘和转换请求，提示 `generate_image` 使用工作区相对路径的 `reference_image_paths`。
- Keep paths outside the active workspace out of model instructions.
- 工作区外的本地路径不会进入模型指令。

## Why / 原因
- The previous PR #349 added image-reference guidance, but its test constructed `imageAttachments` manually. The production vision-model path dropped `localFilePath`, so the guidance became a no-op on the main image input path.
- 之前的 #349 增加了参考图提示，但测试手工构造了 `imageAttachments`。实际视觉模型链路丢失了 `localFilePath`，导致主路径上的提示没有生效。
- This version fixes the loader itself and verifies the full path from `FileAttachmentStore` through `AgentLoop` to the final `ModelRequest`.
- 本次直接修复 loader，并通过 `FileAttachmentStore -> AgentLoop -> ModelRequest` 的完整路径验证行为。

## Tests / 测试
- `cd kun && npm.cmd test -- tests/attachment-store.test.ts tests/image-gen-tool-provider.test.ts`
- `cd kun && npm.cmd run typecheck`
- `git diff --check`

Fixes #339
