### PR TITLE
fix(loop): recover empty post-tool continuations / 修复工具执行后空响应误完成

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -272,6 +272,7 @@ function goalContinuationInstruction(goal: ThreadGoal | undefined): string | nul
 const GOAL_NO_TOOL_REPEAT_SIMILARITY = 0.85
 const GOAL_NO_TOOL_REPEAT_MIN_LENGTH = 12
 const GOAL_NO_TOOL_REPEAT_MAX_RECOVERY_STEPS = 3
+const EMPTY_POST_TOOL_MAX_RECOVERY_STEPS = 1
 
 function goalNoToolRecoveryInstruction(recoveryStep: number): string {
   return [
@@ -281,6 +282,15 @@ function goalNoToolRecoveryInstruction(recoveryStep: number): string {
     `- If the objective is actually achieved, call ${UPDATE_GOAL_TOOL_NAME} with status "complete" after verifying the current state.`,
     `- If the strict blocked audit is satisfied, call ${UPDATE_GOAL_TOOL_NAME} with status "blocked".`,
     '- Otherwise, continue with new substantive work or call an available tool to make concrete progress.'
+  ].join('\n')
+}
+
+function emptyPostToolRecoveryInstruction(): string {
+  return [
+    'Tool continuation recovery:',
+    '- The previous model response ended without a final answer after tool execution.',
+    '- Continue the task now: inspect the tool result, call additional tools if needed, or provide a clear final answer.',
+    '- Do not stop with an empty response.'
   ].join('\n')
 }
 
@@ -506,6 +516,7 @@ export class AgentLoop {
   private readonly toolCatalogSnapshots = new Map<string, ToolCatalogSnapshot>()
   private readonly lastNoToolTextByTurn = new Map<string, string>()
   private readonly goalNoToolRecoveryStepsByTurn = new Map<string, number>()
+  private readonly emptyPostToolRecoveryStepsByTurn = new Map<string, number>()
   private readonly turnFailures = new Map<string, TurnFailure>()
   /** Turns that executed at least one real (non-goal-status) tool call. */
   private readonly turnMadeProgress = new Set<string>()
@@ -643,6 +654,7 @@ export class AgentLoop {
       this.lastNoToolTextByTurn.delete(turnId)
       this.goalNoToolRecoveryStepsByTurn.delete(turnId)
       this.turnMadeProgress.delete(turnId)
+      this.emptyPostToolRecoveryStepsByTurn.delete(turnId)
       this.turnFailures.delete(turnId)
       await this.runTurnEndHooks(threadId, turnId, finalStatus ?? 'failed', finalError)
     }
@@ -1163,6 +1175,9 @@ export class AgentLoop {
         ? [goalRecoveryInstruction]
         : []),
       ...(activeTodoInstruction ? [activeTodoInstruction] : []),
+      ...((this.emptyPostToolRecoveryStepsByTurn.get(turnId) ?? 0) > 0
+        ? [emptyPostToolRecoveryInstruction()]
+        : []),
       ...memoryInstructions(memories),
       ...skillResolution.instructions,
       ...(userInputDisabled ? [userInputUnavailableInstruction()] : []),
@@ -1490,6 +1505,52 @@ export class AgentLoop {
         )
         return 'failed'
       }
+      const hasCurrentTurnFileChange = historyItems.some(
+        (item) =>
+          item.turnId === turnId &&
+          item.kind === 'tool_call' &&
+          item.toolKind === 'file_change' &&
+          item.toolName !== CREATE_PLAN_TOOL_NAME
+      )
+      if (
+        stopReason === 'stop' &&
+        !textAccumulator.value.trim() &&
+        hasCurrentTurnFileChange
+      ) {
+        const recoverySteps = (this.emptyPostToolRecoveryStepsByTurn.get(turnId) ?? 0) + 1
+        if (recoverySteps <= EMPTY_POST_TOOL_MAX_RECOVERY_STEPS) {
+          this.emptyPostToolRecoveryStepsByTurn.set(turnId, recoverySteps)
+          return 'continue'
+        }
+
+        const message =
+          'Model stopped without a final answer after tool execution, including after a recovery retry.'
+        this.rememberTurnFailure(turnId, {
+          error: message,
+          code: 'empty_post_tool_continuation',
+          severity: 'error'
+        })
+        await this.opts.events.record({
+          kind: 'error',
+          threadId,
+          turnId,
+          message,
+          code: 'empty_post_tool_continuation',
+          severity: 'error'
+        })
+        await this.opts.turns.applyItem(
+          threadId,
+          makeErrorItem({
+            id: this.opts.ids.next('item_error'),
+            turnId,
+            threadId,
+            message,
+            code: 'empty_post_tool_continuation',
+            severity: 'error'
+          })
+        )
+        return 'failed'
+      }
       if (stopReason === 'stop' && activeGoalInstruction) {
         const previousText = this.lastNoToolTextByTurn.get(turnId)
         if (isRepeatedNoToolAssistantText(previousText, textAccumulator.value)) {
@@ -1534,6 +1595,7 @@ export class AgentLoop {
     // repetition window so unrelated later status texts are not compared.
     this.lastNoToolTextByTurn.delete(turnId)
     this.goalNoToolRecoveryStepsByTurn.delete(turnId)
+    this.emptyPostToolRecoveryStepsByTurn.delete(turnId)
     const dispatched = await this.dispatchToolCalls({
       calls: completedToolCalls,
       threadId,

--- a/kun/tests/loop.test.ts
+++ b/kun/tests/loop.test.ts
@@ -331,6 +331,7 @@ describe('AgentLoop', () => {
           yield { kind: 'completed', stopReason: 'tool_calls' }
           return
         }
+        yield { kind: 'assistant_text_delta', text: 'done' }
         yield { kind: 'completed', stopReason: 'stop' }
       }
     })
@@ -353,6 +354,106 @@ describe('AgentLoop', () => {
       .flatMap((turn) => turn.items)
       .find((item) => item.kind === 'tool_call' && item.callId === 'call_echo')
     expect(toolCall).toMatchObject({ kind: 'tool_call', status: 'completed' })
+  })
+
+  it('retries an empty model continuation after a file change', async () => {
+    let calls = 0
+    const requests: ModelRequest[] = []
+    const writeHelper = LocalToolHost.defineTool({
+      name: 'write_helper',
+      description: 'Write a helper script.',
+      inputSchema: { type: 'object', properties: {} },
+      policy: 'auto',
+      toolKind: 'file_change',
+      execute: async () => ({ output: { ok: true } })
+    })
+    const h = makeHarness(
+      {
+        provider: 'empty-after-tool',
+        model: 'empty-after-tool',
+        async *stream(request): AsyncIterable<ModelStreamChunk> {
+          requests.push(request)
+          calls += 1
+          if (calls === 1) {
+            yield {
+              kind: 'tool_call_complete',
+              callId: 'call_write_helper',
+              toolName: 'write_helper',
+              arguments: {}
+            }
+            yield { kind: 'completed', stopReason: 'tool_calls' }
+            return
+          }
+          if (calls === 2) {
+            yield { kind: 'completed', stopReason: 'stop' }
+            return
+          }
+          yield { kind: 'assistant_text_delta', text: 'analysis complete' }
+          yield { kind: 'completed', stopReason: 'stop' }
+        }
+      },
+      { tools: [writeHelper] }
+    )
+    await bootstrapThread(h)
+
+    const status = await h.loop.runTurn(h.threadId, h.turnId)
+    const items = await h.sessionStore.loadItems(h.threadId)
+
+    expect(status).toBe('completed')
+    expect(calls).toBe(3)
+    expect(requests[2]?.contextInstructions?.join('\n')).toContain('Tool continuation recovery')
+    expect(items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'assistant_text',
+        text: 'analysis complete'
+      })
+    ]))
+  })
+
+  it('fails visibly when the model repeats an empty post-tool continuation', async () => {
+    let calls = 0
+    const writeHelper = LocalToolHost.defineTool({
+      name: 'write_helper',
+      description: 'Write a helper script.',
+      inputSchema: { type: 'object', properties: {} },
+      policy: 'auto',
+      toolKind: 'file_change',
+      execute: async () => ({ output: { ok: true } })
+    })
+    const h = makeHarness(
+      {
+        provider: 'repeated-empty-after-tool',
+        model: 'repeated-empty-after-tool',
+        async *stream(): AsyncIterable<ModelStreamChunk> {
+          calls += 1
+          if (calls === 1) {
+            yield {
+              kind: 'tool_call_complete',
+              callId: 'call_write_helper',
+              toolName: 'write_helper',
+              arguments: {}
+            }
+            yield { kind: 'completed', stopReason: 'tool_calls' }
+            return
+          }
+          yield { kind: 'completed', stopReason: 'stop' }
+        }
+      },
+      { tools: [writeHelper] }
+    )
+    await bootstrapThread(h)
+
+    const status = await h.loop.runTurn(h.threadId, h.turnId)
+    const items = await h.sessionStore.loadItems(h.threadId)
+
+    expect(status).toBe('failed')
+    expect(calls).toBe(3)
+    expect(items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'error',
+        code: 'empty_post_tool_continuation'
+      })
+    ]))
   })
 
   it('keeps running past the legacy eight-step ceiling until the model stops', async () => {
@@ -1269,6 +1370,7 @@ describe('AgentLoop', () => {
             yield { kind: 'completed', stopReason: 'tool_calls' }
             return
           }
+          yield { kind: 'assistant_text_delta', text: 'done' }
           yield { kind: 'completed', stopReason: 'stop' }
         }
       },


### PR DESCRIPTION
## Summary / 摘要

- Retry once when a model returns an empty `stop` response immediately after a file-changing tool call.
- 文件变更工具执行后，如果模型直接以空响应结束，则自动恢复一次继续执行。
- If the retry is still empty, fail the turn with a visible runtime error instead of marking the task completed.
- 若恢复后仍为空响应，则明确标记任务失败并记录错误，不再误显示为已完成。

## Root cause / 原因

The loop treated every empty `stop` response as a valid completion. In workflows where the model first writes a helper script and is expected to run or inspect it next, a provider can occasionally return an empty continuation. That left the helper script unused while the UI reported success.

循环此前会把所有空的 `stop` 响应视为正常完成。在先写辅助脚本、随后还需要运行或读取结果的流程中，模型供应商偶尔会返回空 continuation，导致脚本没有被执行，但界面已经显示任务完成。

## Changes / 修改

- Limit recovery to current-turn `file_change` tool calls, excluding plan creation.
- Add a focused recovery instruction on the retry request.
- Emit `empty_post_tool_continuation` when the model repeats the empty response.
- Cover successful recovery and repeated-empty failure with loop tests.

- 恢复范围仅限当前轮次的 `file_change` 工具调用，并排除创建计划。
- 恢复请求会加入明确的继续执行提示。
- 连续两次空响应时记录 `empty_post_tool_continuation` 错误。
- 补充恢复成功和重复空响应失败的循环测试。

## Tests / 测试

- `cd kun && npm.cmd test -- tests/loop.test.ts --testTimeout=10000` (71 passed)
- `cd kun && npm.cmd run typecheck`
- `git diff --check`

Fixes #357
