### PR TITLE
feat(updater): show release notes after updates / 更新后显示版本说明

### DIFF
--- a/src/main/gui-updater.test.ts
+++ b/src/main/gui-updater.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type MockUpdater = EventEmitter & {
@@ -16,6 +17,10 @@ type MockUpdater = EventEmitter & {
 let updater: MockUpdater
 let nativeUpdater: EventEmitter
 let originalEnv: NodeJS.ProcessEnv
+let appVersion: string
+let mockedFiles: Map<string, string>
+let showMessageBox: ReturnType<typeof vi.fn>
+let openExternal: ReturnType<typeof vi.fn>
 
 function createUpdater(): MockUpdater {
   return Object.assign(new EventEmitter(), {
@@ -37,15 +42,33 @@ beforeEach(() => {
   vi.resetModules()
   updater = createUpdater()
   nativeUpdater = new EventEmitter()
+  appVersion = '0.1.0'
+  mockedFiles = new Map()
+  showMessageBox = vi.fn().mockResolvedValue({ response: 1 })
+  openExternal = vi.fn().mockResolvedValue(undefined)
+  vi.doMock('node:fs/promises', () => ({
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn(async (path: string) => {
+      const value = mockedFiles.get(String(path))
+      if (value === undefined) throw Object.assign(new Error('not found'), { code: 'ENOENT' })
+      return value
+    }),
+    writeFile: vi.fn(async (path: string, value: string) => {
+      mockedFiles.set(String(path), String(value))
+    })
+  }))
   vi.doMock('electron', () => ({
     app: {
       isPackaged: true,
       getAppPath: () => '/tmp/deepseek-gui-updater-test-app',
       getPath: () => '/tmp/deepseek-gui-updater-test-user-data',
-      getVersion: () => '0.1.0'
+      getVersion: () => appVersion,
+      getLocale: () => 'en-US'
     },
     autoUpdater: nativeUpdater,
-    BrowserWindow: class {}
+    BrowserWindow: class {},
+    dialog: { showMessageBox },
+    shell: { openExternal }
   }))
   vi.doMock('electron-updater', () => ({
     default: { autoUpdater: updater },
@@ -60,6 +83,7 @@ afterEach(() => {
   vi.unstubAllGlobals()
   vi.doUnmock('electron')
   vi.doUnmock('electron-updater')
+  vi.doUnmock('node:fs/promises')
   vi.resetModules()
 })
 
@@ -220,5 +244,58 @@ describe('installGuiUpdate', () => {
     finishCleanup()
     await expect(installing).resolves.toEqual({ ok: true })
     expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true)
+  })
+})
+
+describe('showPostUpdateReleaseNotes', () => {
+  const versionStatePath = join(
+    '/tmp/deepseek-gui-updater-test-user-data',
+    'gui-version-state.json'
+  )
+
+  it('records the first launched version without showing a notice', async () => {
+    const module = await import('./gui-updater')
+    module.initializeGuiUpdater(() => null, () => 'stable')
+
+    await module.showPostUpdateReleaseNotes()
+
+    expect(showMessageBox).not.toHaveBeenCalled()
+    expect(JSON.parse(mockedFiles.get(versionStatePath) ?? '{}')).toEqual({
+      lastSeenVersion: '0.1.0'
+    })
+  })
+
+  it('shows downloaded release notes once after the version changes', async () => {
+    appVersion = '0.2.0'
+    mockedFiles.set(
+      versionStatePath,
+      JSON.stringify({
+        lastSeenVersion: '0.1.0',
+        pendingUpdate: {
+          version: '0.2.0',
+          releaseNotes: '修复更新流程并改进启动体验。'
+        }
+      })
+    )
+    showMessageBox.mockResolvedValue({ response: 0 })
+    const module = await import('./gui-updater')
+    module.initializeGuiUpdater(() => null, () => 'stable', undefined, () => 'zh')
+
+    await module.showPostUpdateReleaseNotes()
+    await module.showPostUpdateReleaseNotes()
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+    expect(showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Kun 已更新',
+        message: '已更新到 Kun 0.2.0',
+        detail: '修复更新流程并改进启动体验。',
+        buttons: ['查看更新日志', '稍后']
+      })
+    )
+    expect(openExternal).toHaveBeenCalledWith('https://deepseek-gui.com/changelog')
+    expect(JSON.parse(mockedFiles.get(versionStatePath) ?? '{}')).toEqual({
+      lastSeenVersion: '0.2.0'
+    })
   })
 })

--- a/src/main/gui-updater.ts
+++ b/src/main/gui-updater.ts
@@ -1,4 +1,5 @@
-import { app, autoUpdater as nativeAutoUpdater, BrowserWindow } from 'electron'
+import { app, autoUpdater as nativeAutoUpdater, BrowserWindow, dialog, shell } from 'electron'
+import type { MessageBoxOptions } from 'electron'
 import { existsSync, readFileSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
@@ -40,12 +41,24 @@ let configuredChannel: GuiUpdateChannel = normalizeGuiUpdateChannel(
 )
 let configuredFeedUrl = ''
 let getSelectedChannel: (() => GuiUpdateChannel | Promise<GuiUpdateChannel>) | null = null
+let getSelectedLocale: (() => 'en' | 'zh' | Promise<'en' | 'zh'>) | null = null
 let beforeInstallUpdate: (() => void | Promise<void>) | null = null
 let beforeInstallUpdatePromise: Promise<void> | null = null
+let pendingVersionStateWrite: Promise<void> | null = null
 let backgroundCheckTimer: NodeJS.Timeout | null = null
 let backgroundCheckPromise: Promise<void> | null = null
 
 const GUI_UPDATE_SCHEDULE_FILE = 'gui-update-schedule.json'
+const GUI_VERSION_STATE_FILE = 'gui-version-state.json'
+const DEFAULT_CHANGELOG_URL = 'https://deepseek-gui.com/changelog'
+
+type GuiVersionState = {
+  lastSeenVersion?: string
+  pendingUpdate?: {
+    version: string
+    releaseNotes?: string
+  }
+}
 
 function trimSlashes(value: string): string {
   return value.replace(/^\/+|\/+$/g, '')
@@ -130,6 +143,61 @@ async function resolveUpdateFeedUrl(channel: GuiUpdateChannel): Promise<string> 
 
 function guiUpdateSchedulePath(): string {
   return join(app.getPath('userData'), GUI_UPDATE_SCHEDULE_FILE)
+}
+
+function guiVersionStatePath(): string {
+  return join(app.getPath('userData'), GUI_VERSION_STATE_FILE)
+}
+
+async function readGuiVersionState(): Promise<GuiVersionState> {
+  try {
+    const raw = await readFile(guiVersionStatePath(), 'utf8')
+    const parsed = JSON.parse(raw) as GuiVersionState
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+async function writeGuiVersionState(state: GuiVersionState): Promise<void> {
+  const path = guiVersionStatePath()
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, JSON.stringify(state, null, 2), 'utf8')
+}
+
+function changelogUrl(): string {
+  return envWithLegacyFallback('KUN_CHANGELOG_URL', 'DEEPSEEK_GUI_CHANGELOG_URL') || DEFAULT_CHANGELOG_URL
+}
+
+function normalizeReleaseNotes(value: unknown): string | undefined {
+  if (typeof value === 'string') return value.trim() || undefined
+  if (!Array.isArray(value)) return undefined
+  const notes = value
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object' || !('note' in entry)) return ''
+      return typeof entry.note === 'string' ? entry.note.trim() : ''
+    })
+    .filter(Boolean)
+  return notes.length > 0 ? notes.join('\n\n') : undefined
+}
+
+async function recordPendingUpdate(updateInfo: UpdateInfo): Promise<void> {
+  const state = await readGuiVersionState()
+  await writeGuiVersionState({
+    ...state,
+    pendingUpdate: {
+      version: updateInfo.version.trim(),
+      releaseNotes: normalizeReleaseNotes(updateInfo.releaseNotes)
+    }
+  })
+}
+
+async function selectedLocale(): Promise<'en' | 'zh'> {
+  try {
+    return (await getSelectedLocale?.()) === 'zh' ? 'zh' : 'en'
+  } catch {
+    return app.getLocale().toLowerCase().startsWith('zh') ? 'zh' : 'en'
+  }
 }
 
 async function readLastScheduledCheckAt(): Promise<number | null> {
@@ -475,11 +543,13 @@ async function checkManualUpdate(
 export function initializeGuiUpdater(
   windowGetter: () => BrowserWindow | null,
   channelGetter?: () => GuiUpdateChannel | Promise<GuiUpdateChannel>,
-  beforeInstall?: () => void | Promise<void>
+  beforeInstall?: () => void | Promise<void>,
+  localeGetter?: () => 'en' | 'zh' | Promise<'en' | 'zh'>
 ): void {
   getMainWindow = windowGetter
   getSelectedChannel = channelGetter ?? null
   beforeInstallUpdate = beforeInstall ?? null
+  getSelectedLocale = localeGetter ?? null
   if (initialized) return
   initialized = true
 
@@ -522,6 +592,13 @@ export function initializeGuiUpdater(
     downloaded = true
     const info = toGuiInfo(event, true)
     lastInfo = info
+    pendingVersionStateWrite = recordPendingUpdate(event)
+      .catch((error) => {
+        console.warn('[kun-gui updater] failed to save release notes:', error)
+      })
+      .finally(() => {
+        pendingVersionStateWrite = null
+      })
     emitGuiUpdateState({ status: 'downloaded', info })
   })
 
@@ -537,6 +614,45 @@ export function initializeGuiUpdater(
   })
 
   void scheduleNextBackgroundCheck()
+}
+
+export async function showPostUpdateReleaseNotes(): Promise<void> {
+  const currentVersion = app.getVersion().trim()
+  const state = await readGuiVersionState()
+  if (!state.lastSeenVersion) {
+    await writeGuiVersionState({ ...state, lastSeenVersion: currentVersion })
+    return
+  }
+  if (state.lastSeenVersion === currentVersion) return
+
+  const pendingUpdate =
+    state.pendingUpdate?.version === currentVersion ? state.pendingUpdate : undefined
+  await writeGuiVersionState({ lastSeenVersion: currentVersion })
+
+  const locale = await selectedLocale()
+  const isZh = locale === 'zh'
+  const options: MessageBoxOptions = {
+    type: 'info',
+    title: isZh ? 'Kun 已更新' : 'Kun updated',
+    message: isZh ? `已更新到 Kun ${currentVersion}` : `Kun has been updated to ${currentVersion}`,
+    detail:
+      pendingUpdate?.releaseNotes ??
+      (isZh
+        ? '此版本的完整更新内容可在 Kun 更新日志中查看。'
+        : 'See the Kun changelog for the complete release notes.'),
+    buttons: isZh ? ['查看更新日志', '稍后'] : ['View changelog', 'Later'],
+    defaultId: 0,
+    cancelId: 1,
+    noLink: true
+  }
+  const window = getMainWindow?.()
+  const result =
+    window && !window.isDestroyed()
+      ? await dialog.showMessageBox(window, options)
+      : await dialog.showMessageBox(options)
+  if (result.response === 0) {
+    await shell.openExternal(changelogUrl())
+  }
 }
 
 export function getGuiUpdateState(): GuiUpdateState {
@@ -635,7 +751,7 @@ export async function installGuiUpdate(): Promise<GuiUpdateInstallResult> {
       }
     }
     emitGuiUpdateState({ status: 'installing', info: lastInfo ?? undefined })
-    await runBeforeInstallUpdate()
+    await Promise.all([pendingVersionStateWrite, runBeforeInstallUpdate()])
     autoUpdater.quitAndInstall(false, true)
     return { ok: true }
   } catch (e) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -243,7 +243,8 @@ async function loadGuiUpdaterModule(): Promise<GuiUpdaterModule> {
           module.initializeGuiUpdater(
             () => mainWindow,
             async () => (await store.load()).guiUpdate.channel,
-            stopManagedRuntimesForQuit
+            stopManagedRuntimesForQuit,
+            async () => (await store.load()).locale
           )
           guiUpdaterInitialized = true
         }
@@ -1507,6 +1508,11 @@ app.whenReady().then(async () => {
 
   createWindow({ suppressInitialShow: shouldStartHidden(initial) })
   traceStartup('createWindow:returned')
+  void loadGuiUpdaterModule()
+    .then((module) => module.showPostUpdateReleaseNotes())
+    .catch((error) => {
+      console.warn('[kun-gui updater] failed to show post-update release notes:', error)
+    })
 
   void pruneOnStartup().catch((err) => {
     console.warn('[kun-gui] prune logs:', err)


### PR DESCRIPTION
## Summary / 摘要

- Show release notes once after Kun starts on a newly installed version.
- Kun 更新并重启后，仅提示一次本次版本的更新内容。
- Use release notes from the downloaded update metadata when available, with the official changelog as a fallback.
- 优先展示更新包元数据中的说明；没有内嵌说明时提供官网更新日志入口。

## Changes / 修改

- Persist the last launched GUI version in the existing user data directory.
- Save release notes when an update finishes downloading and wait for that write before installation exits.
- Detect a version change after startup and show a localized Chinese or English message.
- Keep the first install quiet and clear the pending notice after it has been shown.
- Support `KUN_CHANGELOG_URL` and the legacy environment variable for custom distributions.

- 在现有用户数据目录记录上次启动的 GUI 版本。
- 更新下载完成时保存 release notes，并在退出安装前等待写入完成。
- 启动后检测版本变化，按当前界面语言显示中文或英文提示。
- 首次安装不弹窗，版本提示展示后不再重复。
- 支持自定义发行版通过环境变量覆盖更新日志地址。

## Tests / 测试

- `npm.cmd test -- src/main/gui-updater.test.ts --testTimeout=10000` (7 passed)
- `npm.cmd run build`
- `git diff --check`

Full `npm.cmd run typecheck` remains blocked by existing test typing errors in `chat-store-thread-actions.test.ts`, `claw-runtime.test.ts`, and `feishu-streamer.test.ts`, plus the existing duplicate `memory` key in `kun-process.ts`. The production build completes successfully.

完整 `npm.cmd run typecheck` 仍被仓库现有测试类型错误和 `kun-process.ts` 的重复 `memory` 键阻断；本 PR 的生产构建已成功完成。

Fixes #359
