### PR TITLE
feat(ui): add cursor spotlight preference / 增加鼠标跟随高光开关

### DIFF
--- a/src/main/ipc/app-ipc-schemas.test.ts
+++ b/src/main/ipc/app-ipc-schemas.test.ts
@@ -184,6 +184,10 @@ describe('app-ipc-schemas', () => {
     expect(payload.disabledSkillIds).toEqual(['test-skill-08'])
   })
 
+  it('accepts the cursor spotlight preference', () => {
+    expect(settingsPatchSchema.parse({ cursorSpotlight: false }).cursorSpotlight).toBe(false)
+  })
+
   it('accepts media generation settings and provider capability patches', () => {
     const payload = settingsPatchSchema.parse({
       provider: {

--- a/src/main/ipc/app-ipc-schemas.ts
+++ b/src/main/ipc/app-ipc-schemas.ts
@@ -716,6 +716,7 @@ const settingsPatchObjectSchema = z.object({
   locale: localeSchema.optional(),
   theme: themeSchema.optional(),
   uiFontScale: uiFontScaleSchema.optional(),
+  cursorSpotlight: z.boolean().optional(),
   provider: modelProviderPatchSchema.optional(),
   agents: z.object({
     kun: kunRuntimePatchSchema.optional()

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -196,6 +196,7 @@ const defaultSettings = (): AppSettingsV1 => ({
   locale: 'en',
   theme: 'system',
   uiFontScale: 'small',
+  cursorSpotlight: true,
   provider: defaultModelProviderSettings(),
   agents: {
     kun: defaultKunRuntimeSettings()

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -24,7 +24,7 @@ import type {
   CoreRuntimeToolDiagnosticsJson
 } from '../agent/kun-contract'
 import type { WriteInlineCompletionDebugEntry } from '@shared/write-inline-completion'
-import { applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
+import { applyCursorSpotlight, applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
 import { formatWorkspacePickerError } from '../lib/format-workspace-picker-error'
 import type { SkillRootListItem } from '@shared/kun-gui-api'
 import { normalizeWorkspaceRoot } from '../lib/workspace-path'
@@ -136,6 +136,7 @@ export function SettingsView(): ReactElement {
   const formKun = form ? getKunRuntimeSettings(form) : null
   const formPort = formKun?.port
   const formGuiUpdateChannel = form?.guiUpdate?.channel
+  const formCursorSpotlight = form?.cursorSpotlight
   const {
     checkingGuiUpdate,
     checkGuiUpdate,
@@ -179,6 +180,12 @@ export function SettingsView(): ReactElement {
     applyTheme(formTheme)
     applyUiFontScale(formUiFontScale)
   }, [formTheme, formUiFontScale])
+
+  useEffect(() => {
+    if (typeof formCursorSpotlight === 'boolean') {
+      applyCursorSpotlight(formCursorSpotlight)
+    }
+  }, [formCursorSpotlight])
 
   // Live-preview the Write editor typography as the form changes, mirroring the
   // theme/scale preview above. Keyed on the scalar fields so it only re-applies

--- a/src/renderer/src/components/WindowsTitleBar.tsx
+++ b/src/renderer/src/components/WindowsTitleBar.tsx
@@ -287,6 +287,7 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
               <div key={menu.id} className="ds-windows-menu-slot">
                 <button
                   type="button"
+                  data-cursor-spotlight-target
                   className={`ds-windows-menu-button ${open ? 'is-open' : ''}`}
                   aria-haspopup="menu"
                   aria-expanded={open}
@@ -307,6 +308,7 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
                         <button
                           key={item.id}
                           type="button"
+                          data-cursor-spotlight-target
                           role="menuitem"
                           className="ds-windows-menu-item"
                           onClick={() => runMenuAction(item)}

--- a/src/renderer/src/components/chat/Sidebar.tsx
+++ b/src/renderer/src/components/chat/Sidebar.tsx
@@ -302,6 +302,7 @@ function FocusModeToggle({
   return (
     <button
       type="button"
+      data-cursor-spotlight-target
       role="switch"
       aria-checked={enabled}
       aria-label={ariaLabel}

--- a/src/renderer/src/components/chat/WorkspaceModeTabs.tsx
+++ b/src/renderer/src/components/chat/WorkspaceModeTabs.tsx
@@ -37,6 +37,7 @@ export function WorkspaceModeTabs({
     >
       <button
         type="button"
+        data-cursor-spotlight-target
         role="tab"
         aria-selected={activeView === 'chat'}
         onClick={onCodeOpen}
@@ -47,6 +48,7 @@ export function WorkspaceModeTabs({
       </button>
       <button
         type="button"
+        data-cursor-spotlight-target
         role="tab"
         aria-selected={activeView === 'write'}
         onClick={onWriteOpen}

--- a/src/renderer/src/components/settings-section-general.tsx
+++ b/src/renderer/src/components/settings-section-general.tsx
@@ -188,6 +188,16 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                     </div>
                   }
                 />
+                <SettingRow
+                  title={t('cursorSpotlight')}
+                  description={t('cursorSpotlightDesc')}
+                  control={
+                    <Toggle
+                      checked={form.cursorSpotlight !== false}
+                      onChange={(enabled) => update({ cursorSpotlight: enabled })}
+                    />
+                  }
+                />
               </SettingsCard>
 
               <SettingsCard title={t('desktopBehavior')} className="mt-6">

--- a/src/renderer/src/components/settings-utils.ts
+++ b/src/renderer/src/components/settings-utils.ts
@@ -90,6 +90,7 @@ export function coerceRendererSettings(settings: AppSettingsV1): AppSettingsV1 {
     locale: raw.locale === 'zh' ? 'zh' : 'en',
     theme,
     uiFontScale,
+    cursorSpotlight: raw.cursorSpotlight !== false,
     provider: normalizeModelProviderSettings(raw.provider),
     agents: kunSettingsEnvelope(mergeKunRuntimeSettings(defaultKunRuntimeSettings(), getKunRuntimeSettings(settings))),
     workspaceRoot: typeof raw.workspaceRoot === 'string' ? raw.workspaceRoot : DEFAULT_WORKSPACE_ROOT,

--- a/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
+++ b/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
@@ -110,6 +110,7 @@ export function SidebarCommandRow({
   return (
     <button
       type="button"
+      data-cursor-spotlight-target
       disabled={disabled}
       title={disabled ? disabledHint : undefined}
       onClick={onClick}
@@ -204,6 +205,7 @@ export function SidebarIconButton({
   return (
     <button
       type="button"
+      data-cursor-spotlight-target
       disabled={disabled}
       onPointerDown={(event) => {
         if (stopPropagation) event.stopPropagation()
@@ -320,6 +322,7 @@ export function SidebarTreeRow({
 
   return (
     <div
+      data-cursor-spotlight-target
       className={cx(
         'group relative flex w-full items-center overflow-hidden rounded-[8px] text-[13px] font-normal transition',
         outlined

--- a/src/renderer/src/lib/apply-theme.test.ts
+++ b/src/renderer/src/lib/apply-theme.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { applyDocumentLocale } from './apply-theme'
+import { applyCursorSpotlight, applyDocumentLocale } from './apply-theme'
 
 describe('applyDocumentLocale', () => {
   afterEach(() => {
@@ -37,5 +37,18 @@ describe('applyDocumentLocale', () => {
 
     applyDocumentLocale('en')
     expect(writes).toBe(0)
+  })
+})
+
+describe('applyCursorSpotlight', () => {
+  it('reflects the saved preference on the document root', () => {
+    const dataset: Record<string, string> = {}
+    vi.stubGlobal('document', { documentElement: { dataset } })
+
+    applyCursorSpotlight(true)
+    expect(dataset.cursorSpotlight).toBe('on')
+
+    applyCursorSpotlight(false)
+    expect(dataset.cursorSpotlight).toBe('off')
   })
 })

--- a/src/renderer/src/lib/apply-theme.ts
+++ b/src/renderer/src/lib/apply-theme.ts
@@ -49,6 +49,10 @@ export function applyUiFontScale(scale: UiFontScale): void {
   root.style.setProperty('--ds-ui-scale', factor)
 }
 
+export function applyCursorSpotlight(enabled: boolean): void {
+  document.documentElement.dataset.cursorSpotlight = enabled ? 'on' : 'off'
+}
+
 /**
  * Pushes the Write editor typography onto CSS variables consumed by the rich
  * editor, the CodeMirror live appearance, and the markdown preview. Setting the

--- a/src/renderer/src/lib/cursor-spotlight.ts
+++ b/src/renderer/src/lib/cursor-spotlight.ts
@@ -1,0 +1,29 @@
+let installed = false
+
+export function installCursorSpotlightTracking(): void {
+  if (installed || typeof document === 'undefined') return
+  installed = true
+
+  let frame = 0
+  let target: HTMLElement | null = null
+  let clientX = 0
+  let clientY = 0
+
+  document.addEventListener('pointermove', (event) => {
+    if (document.documentElement.dataset.cursorSpotlight !== 'on') return
+    target = event.target instanceof Element
+      ? event.target.closest<HTMLElement>('[data-cursor-spotlight-target]')
+      : null
+    if (!target) return
+    clientX = event.clientX
+    clientY = event.clientY
+    if (frame) return
+    frame = requestAnimationFrame(() => {
+      frame = 0
+      if (!target) return
+      const rect = target.getBoundingClientRect()
+      target.style.setProperty('--spotlight-x', `${clientX - rect.left}px`)
+      target.style.setProperty('--spotlight-y', `${clientY - rect.top}px`)
+    })
+  }, { passive: true })
+}

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -142,6 +142,8 @@
   "fontScaleMedium": "Medium",
   "fontScaleLarge": "Large",
   "fontScaleCurrent": "Current: {{value}}",
+  "cursorSpotlight": "Interactive effects",
+  "cursorSpotlightDesc": "Show a soft cursor-follow spotlight on the title bar and sidebar.",
   "turnCompleteNotification": "Reply completion notifications",
   "turnCompleteNotificationDesc": "Show a native Windows/macOS notification when the AI assistant finishes replying.",
   "desktopBehavior": "Desktop behavior",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -142,6 +142,8 @@
   "fontScaleMedium": "中",
   "fontScaleLarge": "大",
   "fontScaleCurrent": "当前：{{value}}",
+  "cursorSpotlight": "交互特效",
+  "cursorSpotlightDesc": "在置顶栏和侧边栏显示跟随鼠标的柔和高光。",
   "turnCompleteNotification": "回复完成通知",
   "turnCompleteNotificationDesc": "AI 助手回复完成时，显示 Windows/macOS 系统通知。",
   "desktopBehavior": "桌面行为",

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -11,8 +11,12 @@ import './styles/write-editor.css'
 import './styles/write-rich-editor.css'
 import App from './App'
 import './i18n'
+import { applyCursorSpotlight } from './lib/apply-theme'
+import { installCursorSpotlightTracking } from './lib/cursor-spotlight'
 
 document.documentElement.dataset.platform = window.kunGui?.platform ?? 'unknown'
+applyCursorSpotlight(true)
+installCursorSpotlightTracking()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/renderer/src/store/chat-store-app-actions.test.ts
+++ b/src/renderer/src/store/chat-store-app-actions.test.ts
@@ -77,6 +77,7 @@ function buildHarness(fetchModelsResult: FetchModelsResult): {
       },
       applyTheme: () => undefined,
       applyUiFontScale: () => undefined,
+      applyCursorSpotlight: () => undefined,
       applyWriteTypography: () => undefined,
       applyDocumentLocale: () => undefined,
       workspaceLabelFromPath: (workspaceRoot) => workspaceRoot,

--- a/src/renderer/src/store/chat-store-app-actions.ts
+++ b/src/renderer/src/store/chat-store-app-actions.ts
@@ -24,6 +24,7 @@ type CreateAppActionsOptions = {
   setComposerModelLoadPromise: (promise: Promise<void> | null) => void
   applyTheme: (theme: AppSettingsV1['theme']) => void
   applyUiFontScale: (scale: AppSettingsV1['uiFontScale']) => void
+  applyCursorSpotlight: (enabled: boolean) => void
   applyWriteTypography: (typography: AppSettingsV1['write']['typography']) => void
   applyDocumentLocale: (locale: AppSettingsV1['locale']) => void
   workspaceLabelFromPath: (workspaceRoot: string) => string
@@ -59,6 +60,7 @@ export function createAppActions(options: CreateAppActionsOptions): Pick<
     setComposerModelLoadPromise,
     applyTheme,
     applyUiFontScale,
+    applyCursorSpotlight,
     applyWriteTypography,
     applyDocumentLocale,
     workspaceLabelFromPath,
@@ -188,6 +190,7 @@ export function createAppActions(options: CreateAppActionsOptions): Pick<
       const workspaceRoot = normalizeWorkspaceRoot(settings.workspaceRoot)
       applyTheme(settings.theme)
       applyUiFontScale(settings.uiFontScale)
+      applyCursorSpotlight(settings.cursorSpotlight !== false)
       if (settings.write?.typography) applyWriteTypography(settings.write.typography)
       set({
         workspaceRoot,

--- a/src/renderer/src/store/chat-store-navigation-actions.test.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.test.ts
@@ -12,6 +12,7 @@ vi.mock('../agent/registry', () => ({
 }))
 
 const applyThemeLibMock = vi.hoisted(() => ({
+  applyCursorSpotlight: vi.fn(),
   applyTheme: vi.fn(),
   applyUiFontScale: vi.fn(),
   applyDocumentLocale: vi.fn()

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -2,7 +2,7 @@ import type { NormalizedThread } from '../agent/types'
 import { getProvider } from '../agent/registry'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 import i18n from '../i18n'
-import { applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
+import { applyCursorSpotlight, applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
 import { formatWorkspacePickerError } from '../lib/format-workspace-picker-error'
 import { formatRuntimeError, getRuntimeErrorCode } from '../lib/format-runtime-error'
 import {
@@ -367,6 +367,7 @@ export function createNavigationActions(
         const needsInitialSetup = !getActiveAgentApiKey(settings).trim()
         applyTheme(settings.theme)
         applyUiFontScale(settings.uiFontScale)
+        applyCursorSpotlight(settings.cursorSpotlight !== false)
         if (settings.write?.typography) applyWriteTypography(settings.write.typography)
         await get().applyI18nFromSettings(settings.locale)
         if (!runtimeStatusUnsubscribe && typeof window.kunGui.onRuntimeStatus === 'function') {

--- a/src/renderer/src/store/chat-store.ts
+++ b/src/renderer/src/store/chat-store.ts
@@ -3,7 +3,13 @@ import type { NormalizedThread } from '../agent/types'
 import { getProvider } from '../agent/registry'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 import i18n from '../i18n'
-import { applyDocumentLocale, applyTheme, applyUiFontScale, applyWriteTypography } from '../lib/apply-theme'
+import {
+  applyCursorSpotlight,
+  applyDocumentLocale,
+  applyTheme,
+  applyUiFontScale,
+  applyWriteTypography
+} from '../lib/apply-theme'
 import { formatWorkspacePickerError } from '../lib/format-workspace-picker-error'
 import { formatRuntimeError, getRuntimeErrorCode } from '../lib/format-runtime-error'
 import {
@@ -194,6 +200,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     },
     applyTheme,
     applyUiFontScale,
+    applyCursorSpotlight,
     applyWriteTypography,
     applyDocumentLocale,
     workspaceLabelFromPath,

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -89,6 +89,8 @@
   --ds-scrollbar-thumb: rgba(84, 103, 140, 0.24);
   --ds-scrollbar-thumb-hover: rgba(84, 103, 140, 0.34);
   --ds-selection: rgba(59, 130, 216, 0.2);
+  --ds-cursor-spotlight: rgba(133, 193, 241, 0.28);
+  --ds-cursor-spotlight-edge: rgba(108, 162, 221, 0.1);
   --ds-shadow-card-soft: 0 10px 28px rgba(20, 47, 95, 0.06);
   --ds-shadow-card-strong: 0 14px 36px rgba(20, 47, 95, 0.09);
   --ds-shadow-chip: inset 0 1px 0 rgba(255, 255, 255, 0.78);
@@ -198,6 +200,8 @@
   --ds-scrollbar-thumb: rgba(151, 178, 215, 0.28);
   --ds-scrollbar-thumb-hover: rgba(171, 198, 233, 0.38);
   --ds-selection: rgba(111, 176, 232, 0.26);
+  --ds-cursor-spotlight: rgba(111, 176, 232, 0.2);
+  --ds-cursor-spotlight-edge: rgba(151, 192, 235, 0.08);
   --ds-shadow-card-soft: 0 16px 42px rgba(2, 6, 16, 0.22);
   --ds-shadow-card-strong: 0 22px 56px rgba(2, 6, 16, 0.3);
   --ds-shadow-chip: inset 0 1px 0 rgba(151, 192, 235, 0.06);
@@ -595,6 +599,26 @@ html {
 .ds-window-control-btn--close:hover {
   background: #c42b1c;
   color: #ffffff;
+}
+
+[data-cursor-spotlight-target] {
+  --spotlight-x: 50%;
+  --spotlight-y: 50%;
+}
+
+[data-cursor-spotlight='on'] [data-cursor-spotlight-target]:is(:hover, :focus-visible, :focus-within),
+[data-cursor-spotlight='on'] .ds-windows-menu-button.is-open {
+  background-image: radial-gradient(
+    150px circle at var(--spotlight-x) var(--spotlight-y),
+    var(--ds-cursor-spotlight),
+    var(--ds-cursor-spotlight-edge) 38%,
+    transparent 72%
+  );
+  background-repeat: no-repeat;
+}
+
+[data-cursor-spotlight='off'] [data-cursor-spotlight-target] {
+  background-image: none;
 }
 
 [data-theme='dark'] .ds-windows-titlebar {

--- a/src/shared/app-settings-normalize.ts
+++ b/src/shared/app-settings-normalize.ts
@@ -69,6 +69,7 @@ export function normalizeAppSettings(settings: AppSettingsV1): AppSettingsV1 {
       maybeSettings.uiFontScale === 'large'
         ? maybeSettings.uiFontScale
         : 'small',
+    cursorSpotlight: maybeSettings.cursorSpotlight !== false,
     provider: providerSettings,
     agents: kunSettingsEnvelope(mergeKunRuntimeSettings(defaultKunRuntimeSettings(), {
       ...runtime,

--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -846,6 +846,7 @@ export type AppSettingsV1 = {
   locale: 'en' | 'zh'
   theme: 'system' | 'light' | 'dark'
   uiFontScale: UiFontScale
+  cursorSpotlight?: boolean
   provider: ModelProviderSettingsV1
   agents: KunSettingsEnvelopeV1
   workspaceRoot: string

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -267,6 +267,19 @@ describe('app behavior settings', () => {
   })
 })
 
+describe('cursor spotlight settings', () => {
+  it('defaults the interaction effect on and preserves an explicit opt-out', () => {
+    expect(normalizeAppSettings({
+      ...settings(),
+      cursorSpotlight: undefined
+    }).cursorSpotlight).toBe(true)
+    expect(normalizeAppSettings({
+      ...settings(),
+      cursorSpotlight: false
+    }).cursorSpotlight).toBe(false)
+  })
+})
+
 describe('keyboard shortcut settings', () => {
   it('defaults shortcut overrides to empty', () => {
     const raw = {


### PR DESCRIPTION
## Summary / 摘要

Add an optional cursor-follow spotlight to Kun's desktop navigation surfaces. The effect is enabled by default and can be disabled from **Settings > General > Basics** for lower-powered devices.

为 Kun 的桌面导航区域增加可选的鼠标跟随高光。该效果默认开启，低性能设备可在 **设置 > 通用 > 基础设置** 中关闭。

## Changes / 改动

- Add a persisted `cursorSpotlight` preference with migration-safe defaults.
- Apply the spotlight to Windows title-bar controls, Code/Write tabs, sidebar commands, tree rows, and focus controls.
- Track pointer position with one passive listener and `requestAnimationFrame`, updating CSS variables without React re-renders.
- Add light/dark theme colors and English/Chinese settings copy.
- Rebase the implementation on the latest `develop` after the earlier #352 branch was closed.

- 新增持久化的 `cursorSpotlight` 设置，并兼容旧配置，默认开启。
- 将高光应用到 Windows 标题栏、Code/Write 标签、侧边栏命令、树节点和专注模式控件。
- 使用单一 passive 监听和 `requestAnimationFrame` 更新 CSS 变量，不触发 React 重渲染。
- 补充明暗主题颜色及中英文设置文案。
- 在旧的 #352 关闭后，基于最新 `develop` 重新整理实现。

## Tests / 测试

- `npm.cmd run build`
- 5 focused Vitest files: 99 tests passed
- IPC schema focused test: 1 passed
- Changed TypeScript/TSX lint: 0 errors (1 pre-existing hook warning)
- Locale JSON parse and `git diff --check`