### PR TITLE
fix(skills): preserve disable preferences / 修复 Skill 禁用设置

### DIFF
--- a/src/main/ipc/app-ipc-schemas.test.ts
+++ b/src/main/ipc/app-ipc-schemas.test.ts
@@ -310,7 +310,7 @@ describe('app-ipc-schemas', () => {
     expect(fromText.modelHint).toBe('deepseek-v4-pro')
   })
 
-  it('strips legacy settings keys before validating settings patches', () => {
+  it('strips legacy settings keys while preserving current skill settings', () => {
     const payload = settingsPatchSchema.parse({
       locale: 'zh',
       disabledSkillIds: ['legacy-skill'],
@@ -340,7 +340,7 @@ describe('app-ipc-schemas', () => {
     expect(payload.provider?.providers?.[0]?.imageRecognition).toEqual({ enabled: true })
     expect(payload.agents?.kun?.port).toBe(9001)
     expect(payload.agents?.kun?.imageRecognition).toEqual({ enabled: true })
-    expect('disabledSkillIds' in payload).toBe(false)
+    expect(payload.disabledSkillIds).toEqual(['legacy-skill'])
     expect('reasonix' in payload).toBe(false)
     expect('quickChat' in payload).toBe(false)
     expect('reasonix' in (payload.agents ?? {})).toBe(false)

--- a/src/main/ipc/app-ipc-schemas.ts
+++ b/src/main/ipc/app-ipc-schemas.ts
@@ -696,7 +696,6 @@ function stripLegacySettingsPatchKeys(payload: unknown): unknown {
 
   delete next.agentProvider
   delete next.deepseek
-  delete next.disabledSkillIds
   delete next.reasonix
   delete next.quickChat
 

--- a/src/main/services/skill-service.test.ts
+++ b/src/main/services/skill-service.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   defaultClawSettings,
   defaultKeyboardShortcuts,
@@ -13,14 +13,24 @@ import {
 } from '../../shared/app-settings'
 import { guiSkillRootsForRuntime, listGuiSkillRoots, listGuiSkills } from './skill-service'
 
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return {
+    ...actual,
+    homedir: () => process.env.KUN_SKILL_TEST_HOME || actual.homedir()
+  }
+})
+
 describe('skill-service', () => {
   let tempRoot = ''
 
   beforeEach(async () => {
     tempRoot = await mkdtemp(join(tmpdir(), 'gui-skills-'))
+    process.env.KUN_SKILL_TEST_HOME = tempRoot
   })
 
   afterEach(async () => {
+    delete process.env.KUN_SKILL_TEST_HOME
     await rm(tempRoot, { recursive: true, force: true })
   })
 
@@ -181,6 +191,21 @@ describe('skill-service', () => {
     if (!list.ok) return
     const claude = list.roots.find((root) => root.labelKey === 'pluginSkillRootWorkspaceClaude')
     expect(claude?.enabled).toBe(false)
+  })
+
+  it('omits discovered Codex plugin roots disabled by path', async () => {
+    const workspaceRoot = join(tempRoot, 'ws-plugin-toggle')
+    const pluginRoot = join(tempRoot, '.codex', 'plugins', 'cache', 'github', '1.0', 'skills')
+    await mkdir(join(pluginRoot, 'review'), { recursive: true })
+    await writeFile(join(pluginRoot, 'review', 'SKILL.md'), ['---', 'name: review', '---'].join('\n'), 'utf8')
+
+    const settings = createSettings(workspaceRoot)
+    expect((await guiSkillRootsForRuntime(settings, workspaceRoot)).map((root) => comparable(root.path)))
+      .toContain(comparable(pluginRoot))
+
+    settings.claw.skills.disabledDirs = [pluginRoot]
+    expect((await guiSkillRootsForRuntime(settings, workspaceRoot)).map((root) => comparable(root.path)))
+      .not.toContain(comparable(pluginRoot))
   })
 
   function comparable(path: string): string {

--- a/src/main/services/skill-service.ts
+++ b/src/main/services/skill-service.ts
@@ -64,8 +64,8 @@ type SkillRootCandidate = {
 /**
  * Enabled, on-disk skill roots passed to the Kun runtime. Builds the common
  * directory conventions (.agents/.claude/.codex/skills + global equivalents)
- * plus configured extra dirs, drops any the user toggled off, and appends the
- * always-on Codex plugin caches. Precedence (earlier wins on duplicate skill
+ * plus configured extra dirs, drops any the user toggled off, and appends
+ * enabled Codex plugin caches. Precedence (earlier wins on duplicate skill
  * id): project commons → global commons → plugin caches → extra dirs.
  */
 export async function guiSkillRootsForRuntime(
@@ -86,6 +86,7 @@ export async function guiSkillRootsForRuntime(
   const extra = candidates.filter((c) => c.source === 'extra')
   const pluginRoots = (await discoverCodexPluginSkillRoots())
     .filter((root) => existsSync(root))
+    .filter((root) => !disabled.has(comparablePath(root)))
     .map((path) => ({ path, scope: 'global' as const }))
 
   return uniqueSkillRoots([


### PR DESCRIPTION
## Summary / 摘要

Fix both skill-disable paths reported in #392: per-skill disable choices are now persisted, and auto-discovered Codex plugin skill roots respect the existing disabled-directory configuration.

修复 #392 中的两条 skill 禁用路径：单个 skill 的禁用选择现在可以持久化，自动发现的 Codex 插件 skill 根也会遵守现有的目录禁用配置。

## Root cause / 原因

- `stripLegacySettingsPatchKeys` removed `disabledSkillIds` even though it is a current settings field accepted by the schema and used by the plugin UI.
- Codex plugin roots were appended after normal root filtering, so `disabledDirs` could not exclude them.

- `stripLegacySettingsPatchKeys` 把仍在使用的 `disabledSkillIds` 当作旧字段删除，导致插件页面保存后立即丢失。
- Codex 插件根在普通目录过滤之后直接追加，因此绕过了 `disabledDirs`。

## Changes / 改动

- Preserve `disabledSkillIds` during settings patch validation.
- Filter discovered `~/.codex/plugins/cache` skill roots against configured disabled paths.
- Update the schema regression test and add a real temporary-directory discovery test.

- 在设置 patch 校验中保留 `disabledSkillIds`。
- 用已配置的禁用路径过滤 `~/.codex/plugins/cache` 下发现的 skill 根。
- 更新 schema 回归测试，并增加真实临时目录扫描测试。

Fixes #392

## Tests / 测试

- `npm.cmd exec vitest -- run src/main/ipc/app-ipc-schemas.test.ts src/main/services/skill-service.test.ts` (37 passed, 1 skipped)
- `npm.cmd exec eslint -- ...` (0 errors)
- `npm.cmd run build`
- `git diff --check`
- `npm.cmd run typecheck` still reports 4 pre-existing errors in `chat-store-thread-actions.test.ts`; none are in the changed files.