### PR TITLE
fix: refine context capacity and write selection handling

### DIFF
--- a/kun/src/loop/context-compactor.ts
+++ b/kun/src/loop/context-compactor.ts
@@ -19,6 +19,17 @@ import {
 
 export type CompactionMode = 'normal' | 'aggressive' | 'force'
 
+/**
+ * Provider `prompt_tokens` is trusted only while it stays within this multiple
+ * of our local estimate of the sent request. Beyond it the count is treated as
+ * a provider accounting artifact (e.g. MiniMax-M3 summing cumulative cache
+ * reads into prompt_tokens) and ignored in favour of the estimate. The factor
+ * is wide enough to absorb legitimate under-counting (image tool results,
+ * formatting/role tokens) while still catching the order-of-magnitude inflation
+ * that strands a thread at "100%".
+ */
+export const PROMPT_TOKEN_TRUST_FACTOR = 6
+
 export type CompactionPlan = {
   mode: CompactionMode
   keepRecent: number
@@ -94,7 +105,16 @@ export class ContextCompactor {
     // `promptTokens` still wins via the Math.max below when present.
     const overheadTokens = Math.max(0, Math.floor(options?.overheadTokens ?? 0))
     const estimatedTokens = this.estimate(compactableItems) + overheadTokens
-    const promptTokens = typeof options?.promptTokens === 'number' ? options.promptTokens : undefined
+    const reportedPromptTokens = typeof options?.promptTokens === 'number' ? options.promptTokens : undefined
+    // Some providers over-report prompt_tokens by folding cumulative cache
+    // reads into the per-request count. MiniMax-M3 was observed reporting up to
+    // ~25x the real prompt size (prompt_cache_hit_tokens alone exceeded the
+    // entire stored conversation, which is physically impossible). Trusting that
+    // number pins the gauge at 100% and makes compaction fire pointlessly on a
+    // context that is actually tiny. A request cannot really exceed our own
+    // estimate of what we sent by a wide margin, so when the reported count
+    // blows past it we distrust the provider and fall back to the estimate.
+    const promptTokens = trustworthyPromptTokens(reportedPromptTokens, estimatedTokens, options?.model)
     const tokens = Math.max(estimatedTokens, promptTokens ?? 0)
     if (tokens < thresholds.softThreshold) return null
     const aggressiveThreshold = aggressiveCompactionThreshold(thresholds)
@@ -217,6 +237,40 @@ export function trimTrailingToolCalls(history: TurnItem[]): TurnItem[] {
 function aggressiveCompactionThreshold(thresholds: ModelContextThresholds): number {
   const span = Math.max(0, thresholds.hardThreshold - thresholds.softThreshold)
   return thresholds.softThreshold + Math.floor(span * 0.6)
+}
+
+const inflationWarnedAt = new Map<string, number>()
+const INFLATION_WARN_INTERVAL_MS = 60_000
+
+/**
+ * Returns the provider `prompt_tokens` when it is consistent with our local
+ * estimate, or `undefined` when it exceeds it by more than
+ * `PROMPT_TOKEN_TRUST_FACTOR` (treated as a provider accounting artifact and
+ * dropped so the estimate drives the decision instead).
+ */
+function trustworthyPromptTokens(
+  reported: number | undefined,
+  estimate: number,
+  model?: string
+): number | undefined {
+  if (reported === undefined) return undefined
+  if (estimate > 0 && reported > estimate * PROMPT_TOKEN_TRUST_FACTOR) {
+    warnInflatedPromptTokens(reported, estimate, model)
+    return undefined
+  }
+  return reported
+}
+
+function warnInflatedPromptTokens(reported: number, estimate: number, model?: string): void {
+  const key = model || 'unknown'
+  const now = Date.now()
+  if (now - (inflationWarnedAt.get(key) ?? 0) < INFLATION_WARN_INTERVAL_MS) return
+  inflationWarnedAt.set(key, now)
+  console.warn(
+    `[kun] ignoring inflated prompt_tokens for model "${key}": reported ${reported} vs local estimate ${estimate} ` +
+      `(>${PROMPT_TOKEN_TRUST_FACTOR}x). Falling back to the estimate for context/compaction; the provider is likely ` +
+      `summing cumulative cache reads into prompt_tokens.`
+  )
 }
 
 function normalizeFrozenMessageCount(value: number | undefined, historyLength: number): number {

--- a/kun/tests/loop.test.ts
+++ b/kun/tests/loop.test.ts
@@ -1931,7 +1931,29 @@ describe('AgentLoop', () => {
     ]
 
     expect(compactor.shouldCompact(tinyHistory)).toBe(false)
-    expect(compactor.shouldCompact(tinyHistory, { promptTokens: 120 })).toBe(true)
+    // A reported count within PROMPT_TOKEN_TRUST_FACTOR of the estimate (here
+    // the per-request system/tool overhead) is honoured and drives compaction.
+    expect(compactor.shouldCompact(tinyHistory, { promptTokens: 120, overheadTokens: 40 })).toBe(true)
+  })
+
+  it('ignores prompt tokens inflated far beyond the local estimate', () => {
+    // Regression: MiniMax-M3 folds cumulative cache reads into prompt_tokens and
+    // reported ~1.2M for a thread whose real content was ~33k, stranding it at
+    // "100%" and firing compaction that folded almost nothing. An implausibly
+    // large reported count must be ignored in favour of the local estimate.
+    const compactor = new ContextCompactor({ softThreshold: 100, hardThreshold: 200 })
+    const history = [
+      makeUserItem({ id: 'h', turnId: 'turn_1', threadId: 'thr_1', text: 'x'.repeat(360) })
+    ]
+
+    // ~90 estimated tokens of real content, below the soft threshold.
+    expect(compactor.shouldCompact(history)).toBe(false)
+    // A plausible provider count (within the trust factor) still triggers.
+    expect(compactor.shouldCompact(history, { promptTokens: 300 })).toBe(true)
+    // An order-of-magnitude-inflated count is dropped; the estimate wins, so a
+    // genuinely small thread is not pinned at the threshold compacting nothing.
+    expect(compactor.shouldCompact(history, { promptTokens: 1_000_000 })).toBe(false)
+    expect(compactor.planCompaction(history, { promptTokens: 1_000_000 })).toBeNull()
   })
 
   it('adds per-request overhead to the estimate-only compaction trigger', () => {
@@ -1966,15 +1988,17 @@ describe('AgentLoop', () => {
       })
     ]
 
-    expect(compactor.planCompaction(tinyHistory, { promptTokens: 120 })).toMatchObject({
+    // overheadTokens keeps the reported counts within the trust factor of the
+    // estimate (mirroring the real per-request system/tool floor).
+    expect(compactor.planCompaction(tinyHistory, { promptTokens: 120, overheadTokens: 40 })).toMatchObject({
       mode: 'normal',
       keepRecent: 4
     })
-    expect(compactor.planCompaction(tinyHistory, { promptTokens: 160 })).toMatchObject({
+    expect(compactor.planCompaction(tinyHistory, { promptTokens: 160, overheadTokens: 40 })).toMatchObject({
       mode: 'aggressive',
       keepRecent: 2
     })
-    expect(compactor.planCompaction(tinyHistory, { promptTokens: 220 })).toMatchObject({
+    expect(compactor.planCompaction(tinyHistory, { promptTokens: 220, overheadTokens: 40 })).toMatchObject({
       mode: 'force',
       keepRecent: 1
     })

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -636,12 +636,15 @@ export function FloatingComposer({
   const measuredTotalRef = useRef<number | null>(null)
   if (!busy) measuredTotalRef.current = liveMeasuredTotal
   const measuredContextTotal = busy ? measuredTotalRef.current : liveMeasuredTotal
-  // The message estimate only feeds the per-category split (popover) or the
-  // no-measured-total fallback. Never subscribe to `blocks` while streaming with
-  // the popover closed — blocks churn on every delta and re-render the whole
-  // composer. Freeze the last estimate in a ref instead.
+  // The message estimate feeds the per-category split (popover), the
+  // no-measured-total fallback, AND the sanity check that rejects an inflated
+  // measured total (some providers over-report prompt_tokens — see
+  // buildContextCapacity). We therefore need it whenever the gauge is idle, not
+  // just when the popover is open. Never subscribe to `blocks` while streaming
+  // with the popover closed — blocks churn on every delta and re-render the
+  // whole composer; the frozen ref is good enough for that transient window.
   const needMessageEstimate =
-    canShowContextCapacity && (contextCapacityOpen || measuredContextTotal == null)
+    canShowContextCapacity && (contextCapacityOpen || measuredContextTotal == null || !busy)
   const subscribeContextBlocks = needMessageEstimate && (contextCapacityOpen || !busy)
   const contextBlocks = useChatStore((s) => (subscribeContextBlocks ? s.blocks : EMPTY_CONTEXT_BLOCKS))
   const conversationTokensRef = useRef(0)

--- a/src/renderer/src/components/write/WriteInlineAgent.tsx
+++ b/src/renderer/src/components/write/WriteInlineAgent.tsx
@@ -82,6 +82,11 @@ type Props = {
   /** A raster image is selected instead of text: only image-aware actions
    * apply, everything text-oriented is hidden. */
   imageMode?: boolean
+  /** Called when the AI-edit textarea gains focus so the parent can freeze the
+   * selection state and keep the toolbar visible while the user types. */
+  onTextareaFocus?: () => void
+  /** Called when the AI-edit textarea loses focus so the parent can unfreeze. */
+  onTextareaBlur?: () => void
 }
 
 /**
@@ -185,7 +190,9 @@ export function WriteInlineAgent({
   onGenerateDesignDraft,
   prototypeEnabled = false,
   onGeneratePrototype,
-  imageMode = false
+  imageMode = false,
+  onTextareaFocus,
+  onTextareaBlur
 }: Props): ReactElement {
   const { t } = useTranslation('common')
   const menuRef = useRef<HTMLDivElement | null>(null)
@@ -508,6 +515,8 @@ export function WriteInlineAgent({
             disabled={inFlight}
             onChange={(event) => onValueChange(event.target.value)}
             onKeyDown={handleKeyDown}
+            onFocus={onTextareaFocus}
+            onBlur={onTextareaBlur}
           />
           {!askOnly ? (
             <button

--- a/src/renderer/src/components/write/WriteWorkspaceView.tsx
+++ b/src/renderer/src/components/write/WriteWorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import {
   Columns2,
@@ -44,7 +44,7 @@ import { WriteWorkspaceToolbar } from './WriteWorkspaceToolbar'
 import { WriteInlineAgent } from './WriteInlineAgent'
 import { WriteWorkspaceDocumentPane } from './WriteWorkspaceDocumentPane'
 import { resolveWriteAgentPreset } from '../../write/agent-presets'
-import type { WriteMarkdownEditorHandle } from './WriteMarkdownEditor'
+import type { WriteEditorSelectionState, WriteMarkdownEditorHandle } from './WriteMarkdownEditor'
 import {
   INLINE_EDIT_RECENT_CONTEXT_CHARS,
   WRITE_AUTOSAVE_MS,
@@ -185,6 +185,8 @@ export function WriteWorkspaceView({
   const markdownHandleRef = useRef<WriteMarkdownEditorHandle | null>(null)
   const [inlineAgentValue, setInlineAgentValue] = useState('')
   const [pointerSelecting, setPointerSelecting] = useState(false)
+  const [inlineAgentFocused, setInlineAgentFocused] = useState(false)
+  const selectionBeforeFocusRef = useRef<WriteEditorSelectionState | null>(null)
   const resolvedAgentPresets = agentPresets.map((preset) => resolveWriteAgentPreset(preset))
   const [inlineEditInFlight, setInlineEditInFlight] = useState(false)
   const [modeMenuOpen, setModeMenuOpen] = useState(false)
@@ -207,10 +209,16 @@ export function WriteWorkspaceView({
     ? t('writeImagePreview')
     : activeFileIsPdf ? t('writePdfPreview')
     : renderSafety.readOnly ? t('writeReadOnly') : formatSaveLabel(saveStatus, t)
+  // When the inline agent textarea is focused the editor loses focus and may
+  // report an empty selection (TipTap fires onSelectionUpdate on blur). Use
+  // the selection captured at focus-time so the toolbar stays visible while
+  // the user types their prompt.
+  const effectiveSelection =
+    inlineAgentFocused && selectionBeforeFocusRef.current ? selectionBeforeFocusRef.current : selection
   // Only surface the toolbar once the selection gesture settles: while the
   // pointer is down (dragging to select) it stays hidden to avoid flicker.
   const selectionAction =
-    selection.charCount > 0 && !pointerSelecting ? inlineAgentPosition(selection, { compact: activeFileIsPdf }) : null
+    effectiveSelection.charCount > 0 && !pointerSelecting ? inlineAgentPosition(effectiveSelection, { compact: activeFileIsPdf }) : null
   const activeFileLabel = activeFilePath
     ? writeRelativeToWorkspace(workspaceRoot, activeFilePath)
     : t('writeNoFileOpen')
@@ -256,6 +264,16 @@ export function WriteWorkspaceView({
     setAssistantOpen(true)
     setInput(input.trim() ? `${input.trim()}\n\n${prompt}` : prompt)
   }
+
+  const handleInlineAgentFocus = useCallback((): void => {
+    selectionBeforeFocusRef.current = selection
+    setInlineAgentFocused(true)
+  }, [selection])
+
+  const handleInlineAgentBlur = useCallback((): void => {
+    setInlineAgentFocused(false)
+    selectionBeforeFocusRef.current = null
+  }, [])
 
   const submitInlineAgent = (prompt: string): void => {
     const trimmed = prompt.trim()
@@ -1050,7 +1068,7 @@ export function WriteWorkspaceView({
           preferAbove={activeFileIsPdf}
           formattingEnabled={activeFileIsText && isMarkdown && !renderSafety.readOnly}
           onApplyFormat={applyInlineFormat}
-          blockType={selection.blockType}
+          blockType={effectiveSelection.blockType}
           onSetBlockType={applyBlockType}
           quickActions={inlineQuickActions}
           onQuickAction={runQuickAction}
@@ -1061,6 +1079,8 @@ export function WriteWorkspaceView({
           onOpenAgentSettings={onOpenAgentSettings}
           infographicEnabled={activeFileIsText && imageGenReady && isMarkdown && !renderSafety.readOnly}
           onGenerateInfographic={generateInfographic}
+          onTextareaFocus={handleInlineAgentFocus}
+          onTextareaBlur={handleInlineAgentBlur}
         />
       ) : null}
 

--- a/src/renderer/src/lib/context-capacity.test.ts
+++ b/src/renderer/src/lib/context-capacity.test.ts
@@ -132,6 +132,22 @@ describe('estimateBlockTokens', () => {
     ).toBeGreaterThan(0)
   })
 
+  it('counts the compaction summary (re-sent to the model), not just the pinned constraints', () => {
+    // Regression: a compaction block's `detail` is only the short
+    // pinned-constraints line (~a handful of tokens), but the runtime re-sends
+    // the much larger `summary` as a system message. The gauge must count the
+    // summary, else "消息" collapses to ~7 after compaction.
+    const summary = 'Conversation and work summary:\n' + 'point. '.repeat(400)
+    const tokens = estimateBlockTokens({
+      kind: 'compaction',
+      id: 'c1',
+      status: 'success',
+      summary,
+      detail: 'user: preserve recent turns'
+    } as unknown as ChatBlock)
+    expect(tokens).toBeGreaterThan(300)
+  })
+
   it('discounts base64 screenshot payloads instead of counting them as text', () => {
     // A computer_use screenshot tool result: detail is JSON.stringify(output)
     // carrying a huge base64 image. Counting it as text would read as ~100k+

--- a/src/renderer/src/lib/context-capacity.test.ts
+++ b/src/renderer/src/lib/context-capacity.test.ts
@@ -46,14 +46,46 @@ describe('buildContextCapacity', () => {
   it('clamps a measured total that exceeds the window', () => {
     const cap = buildContextCapacity({
       windowTokens: 100_000,
+      // A conversation that genuinely fills the window; the measured total is a
+      // little over it (overhead/formatting) and must clamp. messageTokens keeps
+      // the measured total within the trust factor so it is not mistaken for
+      // provider inflation.
       lastTurnInputTokens: 150_000,
-      messageTokens: 0,
+      messageTokens: 90_000,
       toolCount: 10,
       skillCount: 0
     })
+    expect(cap.hasMeasuredTotal).toBe(true)
     expect(cap.usedTokens).toBe(100_000)
     expect(cap.freeTokens).toBe(0)
     expect(cap.usedRatio).toBe(1)
+  })
+
+  it('rejects a measured total that dwarfs the local estimate (provider inflation)', () => {
+    // Regression: MiniMax-M3 reported ~1.2M prompt tokens for a thread whose real
+    // content was ~33k, pinning the gauge at 100%. The measured total must be
+    // ignored in favour of the estimate so the gauge shows the true ~3%.
+    const cap = buildContextCapacity({
+      windowTokens: 1_000_000,
+      lastTurnInputTokens: 1_246_505,
+      messageTokens: 33_000,
+      toolCount: 20,
+      skillCount: 2
+    })
+    expect(cap.hasMeasuredTotal).toBe(false)
+    // Falls back to the estimate (conversation + prefix), nowhere near 100%.
+    expect(cap.usedTokens).toBeLessThan(120_000)
+    expect(cap.usedRatio).toBeLessThan(0.15)
+    // A plausible measured total (within the trust factor) is still honoured.
+    const trusted = buildContextCapacity({
+      windowTokens: 1_000_000,
+      lastTurnInputTokens: 120_000,
+      messageTokens: 33_000,
+      toolCount: 20,
+      skillCount: 2
+    })
+    expect(trusted.hasMeasuredTotal).toBe(true)
+    expect(trusted.usedTokens).toBe(120_000)
   })
 
   it('falls back to a pure estimate when there is no measured turn', () => {

--- a/src/renderer/src/lib/context-capacity.ts
+++ b/src/renderer/src/lib/context-capacity.ts
@@ -148,8 +148,14 @@ export function estimateBlockTokens(block: ChatBlock): number {
     case 'system':
       return estimateTokensFromText(block.text ?? '') + estimateDetailTokens(block.detail ?? '')
     case 'tool':
-    case 'compaction':
       return estimateDetailTokens(block.detail ?? '')
+    case 'compaction':
+      // After compaction the runtime drops the folded history and re-sends the
+      // `summary` as a system message — that summary IS the post-compaction
+      // conversation, so it is what occupies the window. `detail` is only the
+      // short pinned-constraints line; counting it alone collapses the whole
+      // conversation to a handful of tokens (the "消息: 7" surprise).
+      return estimateDetailTokens(block.summary ?? '')
     default:
       return 0
   }

--- a/src/renderer/src/lib/context-capacity.ts
+++ b/src/renderer/src/lib/context-capacity.ts
@@ -64,6 +64,16 @@ export const TOKENS_PER_SKILL = 45
 export const SYSTEM_PROMPT_BASE_TOKENS = 1600
 export const OTHER_BASE_TOKENS = 220
 
+// Guard against providers that over-report prompt_tokens by folding cumulative
+// cache reads into the per-request count. MiniMax-M3 was observed reporting
+// ~1.2M prompt tokens for a thread whose real content was ~33k (its reported
+// cache-hit tokens alone exceeded the entire conversation, which is impossible),
+// pinning this gauge at 100%. When the measured total dwarfs our own estimate of
+// the whole prompt by more than this factor, treat it as unreliable and fall
+// back to the estimate. Wide enough to absorb honest under-counting (images,
+// formatting) while still catching order-of-magnitude inflation.
+export const PROMPT_TOKEN_TRUST_FACTOR = 6
+
 const CJK_TOKENS_PER_CHAR = 0.9
 const ASCII_CHARS_PER_TOKEN = 4
 
@@ -159,8 +169,18 @@ export function buildContextCapacity(input: ContextCapacityInput): ContextCapaci
   const otherEstimate = OTHER_BASE_TOKENS
   const prefixEstimate = toolsEstimate + skillsEstimate + systemEstimate + otherEstimate
 
-  const hasMeasuredTotal =
+  // The measured prompt-token total is the source of truth only while it stays
+  // within a sane multiple of what we estimate the whole prompt to be. Beyond
+  // that it is a provider accounting artifact (see PROMPT_TOKEN_TRUST_FACTOR);
+  // fall back to the estimate so the gauge reflects the real, much smaller
+  // context rather than being stranded at 100%.
+  const localEstimate = messageEstimate + prefixEstimate
+  const measuredTotal =
     typeof input.lastTurnInputTokens === 'number' && input.lastTurnInputTokens > 0
+      ? input.lastTurnInputTokens
+      : 0
+  const hasMeasuredTotal =
+    measuredTotal > 0 && measuredTotal <= localEstimate * PROMPT_TOKEN_TRUST_FACTOR
 
   let tools: number
   let system: number
@@ -172,7 +192,7 @@ export function buildContextCapacity(input: ContextCapacityInput): ContextCapaci
   if (hasMeasuredTotal) {
     // Real total; estimate the breakdown but scale the prefix so the parts add
     // up to the measured occupancy exactly.
-    usedTokens = clamp(Math.round(input.lastTurnInputTokens as number), 0, windowTokens)
+    usedTokens = clamp(Math.round(measuredTotal), 0, windowTokens)
     messages = clamp(messageEstimate, 0, usedTokens)
     const prefixActual = Math.max(0, usedTokens - messages)
     const scale = prefixEstimate > 0 ? prefixActual / prefixEstimate : 0


### PR DESCRIPTION
## Summary

- Account for provider-inflated prompt usage when estimating remaining context and deciding compaction behavior.
- Count compaction summary tokens in renderer context-capacity calculations.
- Preserve the Write AI-edit selection when the edit textarea has focus.

## Changes

- Added Kun loop coverage for prompt-token trust factor behavior and compaction thresholds.
- Updated renderer context-capacity helpers and tests for adjusted prompt usage and summary token accounting.
- Updated Write workspace selection handling so AI edit flows keep the intended selection while editing.

## Tests

- `npm run test -- src/renderer/src/lib/context-capacity.test.ts` - passed
- `npm --prefix kun run test -- tests/loop.test.ts` - passed
- `npm run build:kun` - passed
- `npm run typecheck` - fails on existing errors in `src/renderer/src/store/chat-store-thread-actions.test.ts` where `onDeltas` is inferred on `never`; that file is not part of this PR diff.
