### PR TITLE
fix: harden macOS update startup recovery

### DIFF
--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -223,6 +223,16 @@ function appRoot(): string {
     : app.getAppPath()
 }
 
+function resolveNodeScriptCommand(command: string): string {
+  if (command !== process.execPath) return command
+  if (process.platform !== 'darwin') return command
+  return resolveClawScheduleMcpCommand({
+    appPath: app.getAppPath(),
+    execPath: command,
+    isPackaged: app.isPackaged
+  })
+}
+
 export function resolveKunDataDir(runtime: { dataDir: string }): string {
   const trimmed = runtime.dataDir?.trim()
   if (trimmed) return expandHomePath(trimmed)
@@ -304,6 +314,7 @@ async function startKunChildOnce(
   // kun/src/cli/serve-entry.ts). The extra Chromium overhead is only paid
   // when the user actually opted into host control.
   const runAsElectron = process.platform === 'darwin' && runtime.computerUse?.enabled === true
+  const command = runAsElectron ? resolution.command : resolveNodeScriptCommand(resolution.command)
   const childEnv: NodeJS.ProcessEnv = {
     ...process.env,
     KUN_RUNTIME_TOKEN: runtime.runtimeToken,
@@ -311,7 +322,7 @@ async function startKunChildOnce(
   }
   if (!runAsElectron) childEnv.ELECTRON_RUN_AS_NODE = '1'
   else delete childEnv.ELECTRON_RUN_AS_NODE
-  child = spawn(resolution.command, args, {
+  child = spawn(command, args, {
     env: childEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false

--- a/src/main/runtime-sse-ipc.ts
+++ b/src/main/runtime-sse-ipc.ts
@@ -1,4 +1,4 @@
-import type { IpcMain } from 'electron'
+import type { IpcMain, WebContents } from 'electron'
 import { randomUUID } from 'node:crypto'
 import { URL } from 'node:url'
 import type { AppSettingsV1 } from '../shared/app-settings'
@@ -18,6 +18,16 @@ const SSE_START_TIMEOUT_MS = 15_000
 
 
 const sseControllers = new Map<string, SseControllerState>()
+
+function sendSseMessage(wc: WebContents, channel: string, payload: unknown): boolean {
+  if (wc.isDestroyed()) return false
+  try {
+    wc.send(channel, payload)
+    return true
+  } catch {
+    return false
+  }
+}
 
 async function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
   if (signal.aborted || ms <= 0) return
@@ -177,7 +187,11 @@ export function registerRuntimeSseIpc(options: {
             const res = await fetchSseWithStartTimeout(url, requestHeaders, ac.signal, SSE_START_TIMEOUT_MS)
             if (!res.ok || !res.body) {
               if (isFatalSseStatus(res.status)) {
-                wc.send('runtime:sse-error', { streamId: id, status: res.status })
+                if (!sendSseMessage(wc, 'runtime:sse-error', { streamId: id, status: res.status })) {
+                  state.stoppedByClient = true
+                  ac.abort()
+                  return
+                }
                 logError('sse', `SSE connection failed for thread ${request.threadId}`, {
                   status: res.status,
                   streamId: id
@@ -214,7 +228,11 @@ export function registerRuntimeSseIpc(options: {
                 }
               }
               if (batch.length > 0) {
-                wc.send('runtime:sse-event', { streamId: id, events: batch })
+                if (!sendSseMessage(wc, 'runtime:sse-event', { streamId: id, events: batch })) {
+                  state.stoppedByClient = true
+                  ac.abort()
+                  return
+                }
               }
             }
             buffer += dec.decode()
@@ -226,7 +244,11 @@ export function registerRuntimeSseIpc(options: {
                 if (typeof payload.seq === 'number') {
                   nextSinceSeq = Math.max(nextSinceSeq, payload.seq)
                 }
-                wc.send('runtime:sse-event', { streamId: id, events: [payload] })
+                if (!sendSseMessage(wc, 'runtime:sse-event', { streamId: id, events: [payload] })) {
+                  state.stoppedByClient = true
+                  ac.abort()
+                  return
+                }
               }
             }
           } catch (e) {
@@ -237,18 +259,28 @@ export function registerRuntimeSseIpc(options: {
               reconnectDelayMs = Math.min(reconnectDelayMs * 2, SSE_RECONNECT_MAX_MS)
               continue
             }
-            wc.send('runtime:sse-error', { streamId: id, message: msg })
+            if (!sendSseMessage(wc, 'runtime:sse-error', { streamId: id, message: msg })) {
+              state.stoppedByClient = true
+              ac.abort()
+              return
+            }
             logError('sse', `SSE stream error for thread ${request.threadId}`, { message: msg, streamId: id })
             return
           }
         }
       } finally {
         if (!state.stoppedByClient && !ac.signal.aborted) {
-          wc.send('runtime:sse-end', { streamId: id })
+          sendSseMessage(wc, 'runtime:sse-end', { streamId: id })
         }
         sseControllers.delete(id)
       }
-    })()
+    })().catch((error) => {
+      sseControllers.delete(id)
+      logError('sse', `SSE worker crashed for thread ${request.threadId}`, {
+        message: error instanceof Error ? error.message : String(error),
+        streamId: id
+      })
+    })
 
     return { streamId: id }
   })

--- a/src/main/settings-store.test.ts
+++ b/src/main/settings-store.test.ts
@@ -308,6 +308,47 @@ describe('JsonSettingsStore', () => {
     expect(() => JSON.parse(replaced)).not.toThrow()
   })
 
+  it('backs up non-object settings JSON and replaces it with defaults', async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), 'ds-gui-settings-'))
+    const settingsPath = join(userDataDir, 'kun-settings.json')
+    await writeFile(settingsPath, 'null', 'utf8')
+
+    const store = new JsonSettingsStore(userDataDir)
+    const loaded = await store.load()
+    const files = await readdir(userDataDir)
+    const backupName = files.find((file) => file.startsWith('kun-settings.invalid-'))
+
+    expect(loaded.workspaceRoot.length).toBeGreaterThan(0)
+    expect(backupName).toBeTruthy()
+    expect(await readFile(join(userDataDir, backupName ?? ''), 'utf8')).toBe('null')
+    const replaced = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<string, unknown>
+    expect(replaced.version).toBe(1)
+  })
+
+  it('ignores null entries in persisted Claw channels and schedule tasks', async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), 'ds-gui-settings-'))
+
+    await writeFile(
+      join(userDataDir, 'kun-settings.json'),
+      JSON.stringify({
+        version: 1,
+        claw: {
+          channels: [null]
+        },
+        schedule: {
+          tasks: [null]
+        }
+      }),
+      'utf8'
+    )
+
+    const store = new JsonSettingsStore(userDataDir)
+    const loaded = await store.load()
+
+    expect(loaded.claw.channels).toEqual([])
+    expect(loaded.schedule.tasks).toEqual([])
+  })
+
   it('loads the legacy file name inside the current userData dir and re-saves it under the new name', async () => {
     // userData 整目录迁移后的常见形态:目录已经叫 Kun,里面还是旧文件名。
     const userDataDir = await mkdtemp(join(tmpdir(), 'ds-gui-settings-'))

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -256,6 +256,10 @@ function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
   return typeof error === 'object' && error !== null
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 async function loadDefaultSettings(): Promise<AppSettingsV1> {
   const defaults = normalizeStoredSettings(defaultSettings())
   await ensureWorkspaceRootExists(defaults.workspaceRoot)
@@ -276,6 +280,27 @@ async function writeInvalidSettingsBackup(path: string, raw: string): Promise<st
   } catch {
     return null
   }
+}
+
+async function replaceInvalidSettingsWithDefaults(
+  store: JsonSettingsStore,
+  sourcePath: string,
+  raw: string,
+  reason: string
+): Promise<AppSettingsV1> {
+  const backupPath = await writeInvalidSettingsBackup(sourcePath, raw)
+  const defaults = await loadDefaultSettings()
+  await store.save(defaults)
+  if (backupPath) {
+    console.warn(
+      `[kun-gui] Invalid settings were replaced with defaults (${reason}). Backup: ${backupPath}`
+    )
+  } else {
+    console.warn(
+      `[kun-gui] Invalid settings were replaced with defaults (${reason}). Backup could not be written for ${sourcePath}.`
+    )
+  }
+  return defaults
 }
 
 function compatibleSettingsPaths(currentPath: string): string[] {
@@ -346,30 +371,22 @@ export class JsonSettingsStore {
       throw new Error(`Failed to read settings file ${sourcePath}: ${message}`, { cause: error })
     }
 
-    let parsed: Partial<AppSettingsV1>
+    let parsed: unknown
     try {
-      parsed = JSON.parse(raw) as Partial<AppSettingsV1>
+      parsed = JSON.parse(raw)
     } catch (error) {
       if (error instanceof SyntaxError) {
-        const backupPath = await writeInvalidSettingsBackup(sourcePath, raw)
-        const defaults = await loadDefaultSettings()
-        await this.save(defaults)
-        if (backupPath) {
-          console.warn(
-            `[kun-gui] Invalid settings JSON was replaced with defaults. Backup: ${backupPath}`
-          )
-        } else {
-          console.warn(
-            `[kun-gui] Invalid settings JSON was replaced with defaults. Backup could not be written for ${sourcePath}.`
-          )
-        }
-        return defaults
+        return replaceInvalidSettingsWithDefaults(this, sourcePath, raw, 'invalid JSON')
       }
       const message = error instanceof Error ? error.message : String(error)
       throw new Error(`Failed to parse settings file ${sourcePath}: ${message}`, { cause: error })
     }
 
-    const normalized = normalizeStoredSettings(buildMergedSettings(parsed))
+    if (!isRecord(parsed)) {
+      return replaceInvalidSettingsWithDefaults(this, sourcePath, raw, 'top-level value is not an object')
+    }
+
+    const normalized = normalizeStoredSettings(buildMergedSettings(parsed as Partial<AppSettingsV1>))
     await ensureWorkspaceRootExists(normalized.workspaceRoot)
     await ensureWriteWorkspaceRootsExist(normalized)
     await ensureClawChannelWorkspaceRootsExist(normalized)

--- a/src/shared/app-settings-claw.ts
+++ b/src/shared/app-settings-claw.ts
@@ -31,6 +31,10 @@ type LegacyClawImSettingsPatch = Partial<ClawImSettingsV1> & {
   openClawGatewayUrl?: unknown
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 function defaultClawChannelLabel(provider: ClawImProvider): string {
   return provider === 'weixin' ? 'weixin agent' : 'feishu agent'
 }
@@ -82,14 +86,15 @@ export function defaultClawSettings(): ClawSettingsV1 {
 
 export function normalizeClawSettings(input: ClawSettingsPatchV1 | undefined): ClawSettingsV1 {
   const defaults = defaultClawSettings()
-  const source = input ?? {}
-  const skills = source.skills ?? defaults.skills
-  const im = (source.im ?? defaults.im) as LegacyClawImSettingsPatch
+  const source = isRecord(input) ? input as ClawSettingsPatchV1 : {}
+  const skills = isRecord(source.skills) ? source.skills : defaults.skills
+  const im = (isRecord(source.im) ? source.im : defaults.im) as LegacyClawImSettingsPatch
   const weixinBridgeUrl = typeof im.weixinBridgeUrl === 'string' ? im.weixinBridgeUrl.trim() : ''
   const legacyOpenClawGatewayUrl =
     typeof im.openClawGatewayUrl === 'string' ? im.openClawGatewayUrl.trim() : ''
   const rawChannels = Array.isArray(source.channels)
     ? source.channels.filter((channel) => {
+        if (!isRecord(channel)) return false
         const raw = channel as Partial<ClawImChannelV1>
         return (
           raw.provider === undefined ||

--- a/src/shared/app-settings-schedule.ts
+++ b/src/shared/app-settings-schedule.ts
@@ -17,6 +17,10 @@ import {
   normalizeTimeOfDay
 } from './app-settings-normalizers'
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 export function normalizeScheduledTask(
   task: Partial<ScheduledTaskV1>,
   index: number,
@@ -77,9 +81,9 @@ export function normalizeScheduleSettings(
   input: ScheduleSettingsPatchV1 | undefined
 ): ScheduleSettingsV1 {
   const defaults = defaultScheduleSettings()
-  const source = input ?? {}
-  const skills = source.skills ?? defaults.skills
-  const internal = source.internal ?? defaults.internal
+  const source = isRecord(input) ? input as ScheduleSettingsPatchV1 : {}
+  const skills = isRecord(source.skills) ? source.skills : defaults.skills
+  const internal = isRecord(source.internal) ? source.internal : defaults.internal
   const now = new Date().toISOString()
   return {
     enabled: normalizeBoolean(source.enabled, defaults.enabled),
@@ -100,7 +104,9 @@ export function normalizeScheduleSettings(
       secret: typeof internal.secret === 'string' ? internal.secret.trim() : ''
     },
     tasks: Array.isArray(source.tasks)
-      ? source.tasks.map((task, index) => normalizeScheduledTask(task as Partial<ScheduledTaskV1>, index, now))
+      ? source.tasks
+        .filter(isRecord)
+        .map((task, index) => normalizeScheduledTask(task as Partial<ScheduledTaskV1>, index, now))
       : []
   }
 }


### PR DESCRIPTION
## Summary

- recover from malformed persisted settings instead of quitting during startup
- ignore invalid `null` entries in Claw channels and schedule tasks loaded from disk
- stop SSE worker sends when the renderer webContents is destroyed
- use the macOS Electron Helper command for managed Kun Node child processes, while preserving the real Electron path when computer-use requires `runAsElectron`

## Root Cause

Issue #368 reports an Intel macOS user on 0.2.12 who could enter a key successfully, then clicked update and hit repeated app exits. The online 0.2.13 x64 update artifact verifies as signed, notarized, x86_64, and able to start the bundled Kun runtime, so the highest-risk app-side path is startup state recovery after update. The app previously parsed syntactically valid but structurally invalid settings and some nested arrays without object guards, allowing startup-time exceptions before the main window is created.

This supersedes closed PR #382 after rebasing onto `develop` and preserving the new computer-use `runAsElectron` spawn behavior.

## Validation

- `npm test -- src/main/settings-store.test.ts src/main/kun-process.test.ts src/main/claw-schedule-mcp-config.test.ts`

Full-suite notes from current `develop` baseline, unrelated to this PR's changed files:

- `npm run typecheck` currently fails in `src/renderer/src/store/chat-store-thread-actions.test.ts` around `onDeltas`
- `npm run lint` currently fails in `kun/src/hooks/builtins/design-quality-hook.ts` and generated `kun/dist/hooks/builtins/design-quality-hook.js` due `no-control-regex`
- `npm test` currently fails in `src/main/packaging-config.test.ts` because Windows icon expectation differs from config
