### PR TITLE
fix(memory): isolate project-scoped records

### DIFF
--- a/kun/src/adapters/tool/memory-tool-provider.ts
+++ b/kun/src/adapters/tool/memory-tool-provider.ts
@@ -18,7 +18,6 @@ export function buildMemoryToolProviders(store: MemoryStore | undefined): Capabi
           properties: {
             content: { type: 'string' },
             scope: { type: 'string', enum: ['user', 'workspace', 'project'] },
-            workspace: { type: 'string' },
             tags: { type: 'array', items: { type: 'string' } }
           },
           required: ['content'],
@@ -33,7 +32,8 @@ export function buildMemoryToolProviders(store: MemoryStore | undefined): Capabi
               memory: await store.create({
                 content,
                 scope: args.scope === 'user' || args.scope === 'project' ? args.scope : 'workspace',
-                workspace: typeof args.workspace === 'string' ? args.workspace : context.workspace,
+                workspace: context.workspace,
+                ...(args.scope === 'project' ? { project: context.workspace } : {}),
                 sourceThreadId: context.threadId,
                 sourceTurnId: context.turnId,
                 tags: Array.isArray(args.tags) ? args.tags.filter((tag): tag is string => typeof tag === 'string') : []
@@ -56,14 +56,14 @@ export function buildMemoryToolProviders(store: MemoryStore | undefined): Capabi
           additionalProperties: false
         },
         policy: 'on-request',
-        execute: async (args) => {
+        execute: async (args, context) => {
           if (typeof args.id !== 'string') return { output: { error: 'id is required' }, isError: true }
           return {
             output: {
               memory: await store.update(args.id, {
                 ...(typeof args.content === 'string' ? { content: args.content } : {}),
                 ...(typeof args.disabled === 'boolean' ? { disabled: args.disabled } : {})
-              })
+              }, { workspace: context.workspace })
             }
           }
         }
@@ -78,9 +78,9 @@ export function buildMemoryToolProviders(store: MemoryStore | undefined): Capabi
           additionalProperties: false
         },
         policy: 'on-request',
-        execute: async (args) => {
+        execute: async (args, context) => {
           if (typeof args.id !== 'string') return { output: { error: 'id is required' }, isError: true }
-          return { output: { memory: await store.delete(args.id) } }
+          return { output: { memory: await store.delete(args.id, { workspace: context.workspace }) } }
         }
       })
     ]

--- a/kun/src/memory/memory-store.ts
+++ b/kun/src/memory/memory-store.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, readdir } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import type { MemoryCapabilityConfig } from '../contracts/capabilities.js'
 import { atomicWriteFile } from '../adapters/file/atomic-write.js'
 import {
@@ -11,13 +11,15 @@ import {
 
 export interface MemoryStore {
   create(input: MemoryCreateRequest): Promise<MemoryRecord>
-  update(id: string, patch: MemoryUpdateRequest): Promise<MemoryRecord>
-  delete(id: string): Promise<MemoryRecord>
+  update(id: string, patch: MemoryUpdateRequest, access?: MemoryAccess): Promise<MemoryRecord>
+  delete(id: string, access?: MemoryAccess): Promise<MemoryRecord>
   list(filter?: { workspace?: string; includeDeleted?: boolean }): Promise<MemoryRecord[]>
   retrieve(input: { query: string; workspace?: string; limit: number }): Promise<MemoryRecord[]>
   diagnostics(): Promise<MemoryDiagnostics>
   setLastInjected(ids: string[]): void
 }
+
+export type MemoryAccess = { workspace?: string }
 
 export class FileMemoryStore implements MemoryStore {
   private lastInjectedIds: string[] = []
@@ -34,12 +36,15 @@ export class FileMemoryStore implements MemoryStore {
   async create(input: MemoryCreateRequest): Promise<MemoryRecord> {
     await mkdir(this.options.rootDir, { recursive: true })
     const now = this.now()
+    const scope = input.scope ?? 'workspace'
+    const workspace = normalizeScopePath(input.workspace)
+    const project = normalizeScopePath(input.project ?? (scope === 'project' ? input.workspace : undefined))
     const parsed = MemoryRecord.parse({
       id: this.options.idGenerator?.() ?? `mem_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
       content: input.content,
-      scope: input.scope ?? 'workspace',
-      workspace: input.workspace,
-      project: input.project,
+      scope,
+      ...(scope !== 'user' && workspace ? { workspace } : {}),
+      ...(scope === 'project' && project ? { project } : {}),
       sourceThreadId: input.sourceThreadId,
       sourceTurnId: input.sourceTurnId,
       tags: input.tags ?? [],
@@ -51,8 +56,8 @@ export class FileMemoryStore implements MemoryStore {
     return parsed
   }
 
-  async update(id: string, patch: MemoryUpdateRequest): Promise<MemoryRecord> {
-    const current = await this.mustGet(id)
+  async update(id: string, patch: MemoryUpdateRequest, access?: MemoryAccess): Promise<MemoryRecord> {
+    const current = await this.mustGet(id, access)
     const now = this.now()
     const next = MemoryRecord.parse({
       ...current,
@@ -67,8 +72,8 @@ export class FileMemoryStore implements MemoryStore {
     return next
   }
 
-  async delete(id: string): Promise<MemoryRecord> {
-    const current = await this.mustGet(id)
+  async delete(id: string, access?: MemoryAccess): Promise<MemoryRecord> {
+    const current = await this.mustGet(id, access)
     const now = this.now()
     const next = MemoryRecord.parse({
       ...current,
@@ -122,9 +127,11 @@ export class FileMemoryStore implements MemoryStore {
     this.lastInjectedIds = [...ids]
   }
 
-  private async mustGet(id: string): Promise<MemoryRecord> {
+  private async mustGet(id: string, access?: MemoryAccess): Promise<MemoryRecord> {
     const record = (await this.readAll()).find((candidate) => candidate.id === id)
-    if (!record) throw new Error(`memory not found: ${id}`)
+    if (!record || (access && !inScope(record, access.workspace))) {
+      throw new Error(`memory not found: ${id}`)
+    }
     return record
   }
 
@@ -153,14 +160,20 @@ export class FileMemoryStore implements MemoryStore {
 
 function inScope(record: MemoryRecord, workspace: string | undefined): boolean {
   if (record.scope === 'user') return true
+  const currentWorkspace = normalizeScopePath(workspace)
+  if (!currentWorkspace) return false
   if (record.scope === 'workspace') {
-    // Records created via the GUI may not carry a workspace (e.g. manually
-    // added before any thread ran). Treat a missing workspace as in-scope so
-    // they are still retrievable; otherwise require an exact match.
-    if (!record.workspace) return true
-    return Boolean(workspace && record.workspace === workspace)
+    return normalizeScopePath(record.workspace) === currentWorkspace
   }
-  return true
+  const project = normalizeScopePath(record.project ?? record.workspace)
+  return Boolean(project && project === currentWorkspace)
+}
+
+function normalizeScopePath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) return undefined
+  const normalized = resolve(trimmed)
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
 }
 
 function scoreMemory(record: MemoryRecord, query: string): number {

--- a/kun/src/server/routes/index.ts
+++ b/kun/src/server/routes/index.ts
@@ -126,7 +126,7 @@ export function buildRouter(runtime: ServerRuntime): Router {
   })
   router.add('DELETE', '/v1/memory/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
-    return deleteMemory(runtime.memoryStore, ctx.params.id)
+    return deleteMemory(runtime.memoryStore, ctx.params.id, request)
   })
   router.add('GET', '/v1/workspace/status', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()

--- a/kun/src/server/routes/memory.ts
+++ b/kun/src/server/routes/memory.ts
@@ -31,16 +31,18 @@ export async function updateMemory(store: MemoryStore | undefined, id: string, r
   const parsed = MemoryUpdateRequest.safeParse(body.value)
   if (!parsed.success) return ERRORS.validation('invalid memory update body', parsed.error.issues)
   try {
-    return jsonResponse({ memory: await store.update(id, parsed.data) })
+    const workspace = new URL(request.url).searchParams.get('workspace') ?? undefined
+    return jsonResponse({ memory: await store.update(id, parsed.data, { workspace }) })
   } catch (error) {
     return ERRORS.notFound(errorMessage(error))
   }
 }
 
-export async function deleteMemory(store: MemoryStore | undefined, id: string): Promise<JsonResponse> {
+export async function deleteMemory(store: MemoryStore | undefined, id: string, request: Request): Promise<JsonResponse> {
   if (!store) return ERRORS.unavailable('memory store is unavailable')
   try {
-    return jsonResponse({ memory: await store.delete(id) })
+    const workspace = new URL(request.url).searchParams.get('workspace') ?? undefined
+    return jsonResponse({ memory: await store.delete(id, { workspace }) })
   } catch (error) {
     return ERRORS.notFound(errorMessage(error))
   }

--- a/kun/tests/memory-store.test.ts
+++ b/kun/tests/memory-store.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { CapabilityRegistry } from '../src/adapters/tool/capability-registry.js'
 import { LocalToolHost } from '../src/adapters/tool/local-tool-host.js'
@@ -80,7 +80,7 @@ describe('Memory store and recall', () => {
 
     const disabled = await dispatchRequest(
       h.router,
-      new Request(`http://localhost/v1/memory/${body.memory.id}`, {
+      new Request(`http://localhost/v1/memory/${body.memory.id}?workspace=/tmp/ws`, {
         method: 'PATCH',
         headers: { authorization: 'Bearer tok-1', 'content-type': 'application/json' },
         body: JSON.stringify({ disabled: true })
@@ -89,7 +89,7 @@ describe('Memory store and recall', () => {
     expect(disabled.status).toBe(200)
     const deleted = await dispatchRequest(
       h.router,
-      new Request(`http://localhost/v1/memory/${body.memory.id}`, {
+      new Request(`http://localhost/v1/memory/${body.memory.id}?workspace=/tmp/ws`, {
         method: 'DELETE',
         headers: { authorization: 'Bearer tok-1' }
       })
@@ -113,7 +113,7 @@ describe('Memory store and recall', () => {
     const result = await host.execute({
       callId: 'call_1',
       toolName: 'memory_create',
-      arguments: { content: 'Use pnpm', workspace: '/tmp/ws' }
+      arguments: { content: 'Use pnpm', workspace: '/tmp/forged' }
     }, {
       threadId: 'thr_1',
       turnId: 'turn_1',
@@ -129,6 +129,7 @@ describe('Memory store and recall', () => {
     expect(approvals).toBe(1)
     expect(result.item).toMatchObject({ kind: 'tool_result', isError: false })
     expect(await store.list({ workspace: '/tmp/ws' })).toHaveLength(1)
+    expect(await store.list({ workspace: '/tmp/forged' })).toEqual([])
   })
 
   it('injects relevant memories into AgentLoop metadata and stops after deletion', async () => {
@@ -165,6 +166,40 @@ describe('Memory store and recall', () => {
     expect(finalInstructions).toContain('<shell_environment>')
   })
 
+  it('injects project memory into new threads only inside the same project', async () => {
+    const store = createStore()
+    const memory = await store.create({
+      content: 'Project Alpha release command is pnpm ship',
+      scope: 'project',
+      workspace: '/tmp/project-alpha'
+    })
+    const seenRequests: ModelRequest[] = []
+    const model: ModelClient = {
+      provider: 'fake',
+      model: 'fake',
+      async *stream(request) {
+        seenRequests.push(request)
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    }
+
+    const sameProject = makeHarness(model, { memoryStore: store })
+    await bootstrapThread(sameProject, {
+      workspace: '/tmp/project-alpha',
+      request: { prompt: 'What is the pnpm release command?' }
+    })
+    await sameProject.loop.runTurn(sameProject.threadId, sameProject.turnId)
+    expect(seenRequests.at(-1)?.contextInstructions?.join('\n')).toContain(memory.id)
+
+    const otherProject = makeHarness(model, { memoryStore: store })
+    await bootstrapThread(otherProject, {
+      workspace: '/tmp/project-beta',
+      request: { prompt: 'What is the pnpm release command?' }
+    })
+    await otherProject.loop.runTurn(otherProject.threadId, otherProject.turnId)
+    expect(seenRequests.at(-1)?.contextInstructions?.join('\n')).not.toContain(memory.id)
+  })
+
   it('retrieves memories for CJK queries (regression: token-split-on-[^a-z0-9_])', async () => {
     const store = createStore()
     // Use workspace scope so this exercises the scored n-gram path. (user scope
@@ -187,17 +222,49 @@ describe('Memory store and recall', () => {
     expect(misses).toEqual([])
   })
 
-  it('retrieves workspace-scope memories that have no workspace field (GUI-created)', async () => {
+  it('quarantines legacy workspace memories that have no workspace field', async () => {
     const store = createStore()
-    // GUI-created workspace memories may omit the workspace field. They should
-    // still be retrievable instead of being silently filtered out by inScope.
+    // Older GUI versions created unbound workspace memories. Treating them as
+    // global leaks their contents into every project, so they must stay out of
+    // retrieval until the user recreates them with an explicit workspace.
     const memory = await store.create({
       content: 'Workspace prefers tabs over spaces',
       scope: 'workspace'
     })
     expect(memory.workspace).toBeUndefined()
     const hits = await store.retrieve({ query: 'tabs spaces indentation', workspace: '/tmp/ws', limit: 3 })
-    expect(hits.map((item) => item.id)).toEqual([memory.id])
+    expect(hits).toEqual([])
+  })
+
+  it('isolates project memories and scope-protects mutations', async () => {
+    const store = createStore()
+    const memory = await store.create({
+      content: 'Project Alpha deploys with pnpm',
+      scope: 'project',
+      workspace: '/tmp/project-alpha'
+    })
+
+    const expectedProject = resolve('/tmp/project-alpha')
+    expect(memory.project).toBe(process.platform === 'win32' ? expectedProject.toLowerCase() : expectedProject)
+    expect(await store.retrieve({
+      query: 'pnpm deploy',
+      workspace: '/tmp/project-alpha/.',
+      limit: 3
+    })).toHaveLength(1)
+    expect(await store.retrieve({
+      query: 'pnpm deploy',
+      workspace: '/tmp/project-beta',
+      limit: 3
+    })).toEqual([])
+    await expect(store.update(memory.id, { content: 'leaked' }, {
+      workspace: '/tmp/project-beta'
+    })).rejects.toThrow(`memory not found: ${memory.id}`)
+    await expect(store.delete(memory.id, {
+      workspace: '/tmp/project-beta'
+    })).rejects.toThrow(`memory not found: ${memory.id}`)
+    await expect(store.update(memory.id, { content: 'Project Alpha uses npm' }, {
+      workspace: '/tmp/project-alpha'
+    })).resolves.toMatchObject({ content: 'Project Alpha uses npm' })
   })
 
   it('injects user-scope memories on semantic queries with zero keyword overlap', async () => {

--- a/src/renderer/src/agent/kun-runtime.test.ts
+++ b/src/renderer/src/agent/kun-runtime.test.ts
@@ -575,7 +575,7 @@ describe('KunRuntimeProvider', () => {
           })
         }
       }
-      if (path === '/v1/memory/mem_1' && method === 'PATCH') {
+      if (path === '/v1/memory/mem_1?workspace=%2Ftmp%2Fworkspace' && method === 'PATCH') {
         expect(body).toBe(JSON.stringify({ disabled: true }))
         return {
           ok: true,
@@ -592,7 +592,7 @@ describe('KunRuntimeProvider', () => {
           })
         }
       }
-      if (path === '/v1/memory/mem_1' && method === 'DELETE') {
+      if (path === '/v1/memory/mem_1?workspace=%2Ftmp%2Fworkspace' && method === 'DELETE') {
         return {
           ok: true,
           status: 200,
@@ -614,11 +614,11 @@ describe('KunRuntimeProvider', () => {
     const provider = new KunRuntimeProvider()
 
     await expect(provider.listMemories({ workspace: '/tmp/workspace', includeDeleted: false })).resolves.toHaveLength(1)
-    await expect(provider.updateMemory('mem_1', { disabled: true })).resolves.toMatchObject({
+    await expect(provider.updateMemory('mem_1', { disabled: true }, { workspace: '/tmp/workspace' })).resolves.toMatchObject({
       id: 'mem_1',
       disabledAt: 't1'
     })
-    await expect(provider.deleteMemory('mem_1')).resolves.toMatchObject({
+    await expect(provider.deleteMemory('mem_1', { workspace: '/tmp/workspace' })).resolves.toMatchObject({
       id: 'mem_1',
       deletedAt: 't2'
     })

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -687,10 +687,12 @@ export class KunRuntimeProvider implements AgentProvider {
 
   async updateMemory(
     memoryId: string,
-    patch: { content?: string; tags?: string[]; confidence?: number; disabled?: boolean }
+    patch: { content?: string; tags?: string[]; confidence?: number; disabled?: boolean },
+    options: { workspace?: string } = {}
   ): Promise<CoreMemoryRecordJson> {
+    const query = buildQuery({ workspace: options.workspace })
     const response = await rendererRuntimeClient.runtimeRequest(
-      kunMemoryRecordPath(memoryId),
+      `${kunMemoryRecordPath(memoryId)}${query}`,
       'PATCH',
       JSON.stringify(patch)
     )
@@ -703,8 +705,9 @@ export class KunRuntimeProvider implements AgentProvider {
     ).memory
   }
 
-  async deleteMemory(memoryId: string): Promise<CoreMemoryRecordJson> {
-    const response = await rendererRuntimeClient.runtimeRequest(kunMemoryRecordPath(memoryId), 'DELETE')
+  async deleteMemory(memoryId: string, options: { workspace?: string } = {}): Promise<CoreMemoryRecordJson> {
+    const query = buildQuery({ workspace: options.workspace })
+    const response = await rendererRuntimeClient.runtimeRequest(`${kunMemoryRecordPath(memoryId)}${query}`, 'DELETE')
     if (!response.ok) {
       throw runtimeErrorToError(readRuntimeError(response.body, 'failed to delete memory'))
     }

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -484,9 +484,10 @@ export interface AgentProvider {
   }): Promise<CoreMemoryRecordJson>
   updateMemory?(
     memoryId: string,
-    patch: { content?: string; tags?: string[]; confidence?: number; disabled?: boolean }
+    patch: { content?: string; tags?: string[]; confidence?: number; disabled?: boolean },
+    options?: { workspace?: string }
   ): Promise<CoreMemoryRecordJson>
-  deleteMemory?(memoryId: string): Promise<CoreMemoryRecordJson>
+  deleteMemory?(memoryId: string, options?: { workspace?: string }): Promise<CoreMemoryRecordJson>
   getMemoryDiagnostics?(): Promise<CoreMemoryDiagnosticsJson>
   steerUserMessage?(threadId: string, turnId: string, text: string): Promise<void>
   interruptTurn(threadId: string, turnId: string, options?: { discard?: boolean }): Promise<void>

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -514,7 +514,12 @@ export function SettingsView(): ReactElement {
     const provider = getProvider()
     if (typeof provider.createMemory !== 'function') return false
     try {
-      const memory = await provider.createMemory(input)
+      const workspace = normalizeWorkspaceRoot(formWorkspaceRoot)
+      const memory = await provider.createMemory({
+        ...input,
+        ...(input.scope === 'user' ? {} : { workspace }),
+        ...(input.scope === 'project' ? { project: workspace } : {})
+      })
       setMemoryRecords((records) => [memory, ...records])
       return true
     } catch (error) {
@@ -533,7 +538,9 @@ export function SettingsView(): ReactElement {
     const provider = getProvider()
     if (typeof provider.updateMemory !== 'function') return false
     try {
-      const memory = await provider.updateMemory(memoryId, patch)
+      const memory = await provider.updateMemory(memoryId, patch, {
+        workspace: normalizeWorkspaceRoot(formWorkspaceRoot)
+      })
       setMemoryRecords((records) => records.map((record) => (record.id === memoryId ? memory : record)))
       return true
     } catch (error) {
@@ -549,7 +556,9 @@ export function SettingsView(): ReactElement {
     const provider = getProvider()
     if (typeof provider.updateMemory !== 'function') return
     try {
-      const memory = await provider.updateMemory(memoryId, { disabled: true })
+      const memory = await provider.updateMemory(memoryId, { disabled: true }, {
+        workspace: normalizeWorkspaceRoot(formWorkspaceRoot)
+      })
       setMemoryRecords((records) => records.map((record) => record.id === memoryId ? memory : record))
     } catch (error) {
       setRuntimeDiagnosticsNotice({
@@ -563,7 +572,9 @@ export function SettingsView(): ReactElement {
     const provider = getProvider()
     if (typeof provider.deleteMemory !== 'function') return
     try {
-      await provider.deleteMemory(memoryId)
+      await provider.deleteMemory(memoryId, {
+        workspace: normalizeWorkspaceRoot(formWorkspaceRoot)
+      })
       setMemoryRecords((records) => records.filter((record) => record.id !== memoryId))
     } catch (error) {
       setRuntimeDiagnosticsNotice({


### PR DESCRIPTION
## Summary

- Isolate workspace and project memories to the active workspace instead of treating project records and unbound legacy records as global.
- Bind GUI-created and model-created memories to the real current workspace.
- Scope-protect memory update/delete paths so another project cannot mutate a record by ID.

## Root cause

`inScope()` returned `true` for every project memory, while GUI-created records omitted workspace/project identifiers. The memory tool also accepted a model-provided workspace, and update/delete operations did not carry the active workspace.

## Changes

- Canonicalize workspace/project paths before persistence and comparison.
- Quarantine legacy workspace/project records that have no scope identity.
- Remove model control over `memory_create.workspace`; use `ToolHostContext.workspace`.
- Pass the active workspace through renderer PATCH/DELETE requests and enforce it in the store.
- Preserve global behavior only for explicit user-scope memories.

## Tests

- `npm.cmd --prefix kun test -- tests/memory-store.test.ts` (10 passed)
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd test -- src/renderer/src/agent/kun-runtime.test.ts src/renderer/src/lib/load-kun-diagnostics.test.ts` (22 passed)
- `npm.cmd run build`
- `git diff --check`

## Notes

- `npm.cmd run typecheck` remains blocked by four existing `onDeltas` errors in `src/renderer/src/store/chat-store-thread-actions.test.ts` on `develop`; Kun typecheck and the production build pass.

Fixes #404