### PR TITLE
feat(tray): add dynamic session menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import kunLogoPng from '../asset/img/kun.png?url'
 import kunMacLogoPng from '../asset/img/kun_mac.png?url'
 import kunTrayPng from '../asset/img/kun_tray.png?url'
 import { createAppIcon, pickTrayIcon, prepareTrayIcon } from './app-icon'
+import { buildTrayMenuTemplate, parseTrayThreads, type TrayThreadSummary } from './tray-session-menu'
 import { configureLinuxWaylandImeSwitches } from './app-command-line'
 import { configureAppIdentity } from './app-identity'
 import { runLegacyKunDataMigration } from './legacy-data-migration'
@@ -36,6 +37,7 @@ import {
 } from '../shared/app-settings'
 import { parseRuntimeErrorBody, runtimeErrorToError, type RuntimeErrorCode } from '../shared/runtime-error'
 import type { GuiUpdateState } from '../shared/gui-update'
+import type { TrayActionPayload } from '../shared/kun-gui-api'
 import { isAllowedDevPreviewUrl } from '../shared/dev-preview-url'
 import { isAuthorizedPrototypeFileUrl } from './services/prototype-embed-registry'
 import { fetchUpstreamModelIds } from './upstream-models'
@@ -203,6 +205,7 @@ let managedRuntimesStopPromise: Promise<void> | null = null
 let appBehavior: AppBehaviorConfigV1 = normalizeAppBehaviorSettings()
 let tray: Tray | null = null
 let trayMenu: Menu | null = null
+let trayMenuOpenPromise: Promise<void> | null = null
 let isQuitting = false
 let closeWindowPromptOpen = false
 
@@ -317,21 +320,6 @@ traceStartup('single instance lock checked', {
   skippedForClawScheduleMcpServer: runningClawScheduleMcpServer
 })
 
-function trayLabels(locale: AppSettingsV1['locale']): { show: string; quit: string; tooltip: string } {
-  if (locale === 'zh') {
-    return {
-      show: '显示 Kun',
-      quit: '退出',
-      tooltip: 'Kun'
-    }
-  }
-  return {
-    show: 'Show Kun',
-    quit: 'Quit',
-    tooltip: 'Kun'
-  }
-}
-
 function windowCloseLabels(locale: AppSettingsV1['locale']): {
   title: string
   message: string
@@ -400,6 +388,67 @@ function revealMainWindow(): void {
   mainWindow.focus()
 }
 
+function dispatchTrayAction(action: TrayActionPayload): void {
+  revealMainWindow()
+  const window = mainWindow
+  if (!window || window.isDestroyed()) return
+  const send = (): void => {
+    if (!window.isDestroyed()) window.webContents.send('tray:action', action)
+  }
+  if (window.webContents.isLoadingMainFrame()) {
+    window.webContents.once('did-finish-load', send)
+  } else {
+    send()
+  }
+}
+
+function quitFromTray(): void {
+  isQuitting = true
+  app.quit()
+}
+
+function createTrayMenu(settings: AppSettingsV1, threads: TrayThreadSummary[]): Menu {
+  return Menu.buildFromTemplate(buildTrayMenuTemplate({
+    locale: settings.locale,
+    threads,
+    actions: {
+      openThread: (threadId) => dispatchTrayAction({ type: 'open-thread', threadId }),
+      newChat: () => dispatchTrayAction({ type: 'new-chat' }),
+      openApp: revealMainWindow,
+      quit: quitFromTray
+    }
+  }))
+}
+
+async function loadTrayThreads(settings: AppSettingsV1): Promise<TrayThreadSummary[]> {
+  try {
+    const response = await fetch(`${getRuntimeBaseUrlForSettings(settings)}/v1/threads?limit=20`, {
+      headers: runtimeAuthHeaders(settings),
+      signal: AbortSignal.timeout(1_000)
+    })
+    return response.ok ? parseTrayThreads(await response.text()) : []
+  } catch (error) {
+    logWarn('tray', 'Failed to load tray sessions.', {
+      message: error instanceof Error ? error.message : String(error)
+    })
+    return []
+  }
+}
+
+function showTrayMenu(): void {
+  if (!tray || trayMenuOpenPromise) return
+  const currentTray = tray
+  trayMenuOpenPromise = (async () => {
+    const settings = await store.load()
+    const threads = await loadTrayThreads(settings)
+    if (currentTray.isDestroyed()) return
+    trayMenu = createTrayMenu(settings, threads)
+    currentTray.popUpContextMenu(trayMenu)
+  })().finally(() => {
+    trayMenuOpenPromise = null
+  })
+}
+
 function syncTray(settings: AppSettingsV1): void {
   appBehavior = settings.appBehavior
   if (appBehavior.closeAction === 'quit') {
@@ -416,29 +465,14 @@ function syncTray(settings: AppSettingsV1): void {
     // 托盘图加载失败时回退到主应用图,这样不会看到 electron 默认占位。
     const traySource = prepareTrayIcon(pickTrayIcon(trayIcon, appIcon))
     tray = new Tray(traySource.isEmpty() ? nativeImage.createEmpty() : traySource)
-    tray.on('click', revealMainWindow)
+    tray.on('click', showTrayMenu)
     tray.on('double-click', revealMainWindow)
-    if (process.platform === 'darwin') {
-      tray.on('right-click', () => {
-        if (trayMenu) tray?.popUpContextMenu(trayMenu)
-      })
-    }
+    tray.on('right-click', showTrayMenu)
   }
 
-  const labels = trayLabels(settings.locale)
-  tray.setToolTip(labels.tooltip)
-  trayMenu = Menu.buildFromTemplate([
-    { label: labels.show, click: revealMainWindow },
-    { type: 'separator' },
-    {
-      label: labels.quit,
-      click: () => {
-        isQuitting = true
-        app.quit()
-      }
-    }
-  ])
-  tray.setContextMenu(process.platform === 'darwin' ? null : trayMenu)
+  tray.setToolTip('Kun')
+  trayMenu = createTrayMenu(settings, [])
+  tray.setContextMenu(null)
 }
 
 async function saveWindowCloseActionPreference(closeAction: WindowCloseAction): Promise<void> {

--- a/src/main/tray-session-menu.test.ts
+++ b/src/main/tray-session-menu.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildTrayMenuTemplate, parseTrayThreads, type TrayThreadSummary } from './tray-session-menu'
+
+describe('tray session menu', () => {
+  it('parses and sorts active thread summaries', () => {
+    expect(parseTrayThreads(JSON.stringify({ threads: [
+      thread('old', 'idle', '2026-06-01T00:00:00.000Z'),
+      thread('deleted', 'deleted', '2026-06-03T00:00:00.000Z'),
+      thread('new', 'running', '2026-06-02T00:00:00.000Z')
+    ] })).map((item) => item.id)).toEqual(['new', 'old'])
+    expect(parseTrayThreads('not json')).toEqual([])
+  })
+
+  it('groups running and recent threads with project labels', () => {
+    const actions = fakeActions()
+    const menu = buildTrayMenuTemplate({
+      locale: 'en',
+      threads: [
+        thread('run', 'running', '2026-06-02T00:00:00.000Z', 'Fix tests', 'C:\\work\\Kun'),
+        thread('recent', 'idle', '2026-06-01T00:00:00.000Z', 'Review PR', '/work/Docs')
+      ],
+      actions
+    })
+
+    expect(menu.map((item) => item.label).filter(Boolean)).toEqual([
+      'Running', 'Fix tests', 'Recent', 'Review PR', 'New Chat', 'Open Kun', 'Exit'
+    ])
+    expect(menu.find((item) => item.label === 'Fix tests')?.sublabel).toBe('Kun')
+    expect(menu.find((item) => item.label === 'Review PR')?.sublabel).toBe('Docs')
+    menu.find((item) => item.label === 'Fix tests')?.click?.({} as never, undefined, {} as never)
+    expect(actions.openThread).toHaveBeenCalledWith('run')
+  })
+
+  it('moves overflow sessions into More and localizes actions', () => {
+    const actions = fakeActions()
+    const threads = Array.from({ length: 7 }, (_, index) =>
+      thread(`thread-${index}`, 'idle', `2026-06-${String(10 - index).padStart(2, '0')}T00:00:00.000Z`)
+    )
+    const menu = buildTrayMenuTemplate({ locale: 'zh', threads, actions })
+    const more = menu.find((item) => item.label === '更多')
+
+    expect(Array.isArray(more?.submenu) ? more.submenu : []).toHaveLength(2)
+    expect(menu.map((item) => item.label).filter(Boolean)).toEqual([
+      '最近会话',
+      'thread-0',
+      'thread-1',
+      'thread-2',
+      'thread-3',
+      'thread-4',
+      '更多',
+      '新建会话',
+      '打开 Kun',
+      '退出'
+    ])
+  })
+})
+
+function thread(
+  id: string,
+  status: string,
+  updatedAt: string,
+  title = id,
+  workspace = '/work/project'
+): TrayThreadSummary {
+  return { id, title, workspace, status, updatedAt }
+}
+
+function fakeActions() {
+  return {
+    openThread: vi.fn(),
+    newChat: vi.fn(),
+    openApp: vi.fn(),
+    quit: vi.fn()
+  }
+}

--- a/src/main/tray-session-menu.ts
+++ b/src/main/tray-session-menu.ts
@@ -1,0 +1,135 @@
+import { basename } from 'node:path'
+import type { MenuItemConstructorOptions } from 'electron'
+import type { AppSettingsV1 } from '../shared/app-settings'
+
+export type TrayThreadSummary = {
+  id: string
+  title: string
+  workspace?: string
+  status: string
+  updatedAt: string
+}
+
+type TrayMenuActions = {
+  openThread: (threadId: string) => void
+  newChat: () => void
+  openApp: () => void
+  quit: () => void
+}
+
+const PRIMARY_GROUP_LIMIT = 5
+const MORE_GROUP_LIMIT = 10
+
+export function parseTrayThreads(body: string): TrayThreadSummary[] {
+  try {
+    const value = JSON.parse(body) as { threads?: unknown }
+    if (!Array.isArray(value.threads)) return []
+    return value.threads.flatMap((candidate) => {
+      if (!candidate || typeof candidate !== 'object') return []
+      const thread = candidate as Record<string, unknown>
+      if (typeof thread.id !== 'string' || typeof thread.updatedAt !== 'string') return []
+      const status = typeof thread.status === 'string' ? thread.status : 'idle'
+      if (status === 'archived' || status === 'deleted') return []
+      return [{
+        id: thread.id,
+        title: typeof thread.title === 'string' ? thread.title : '',
+        workspace: typeof thread.workspace === 'string' ? thread.workspace : undefined,
+        status,
+        updatedAt: thread.updatedAt
+      }]
+    }).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+  } catch {
+    return []
+  }
+}
+
+export function buildTrayMenuTemplate(input: {
+  locale: AppSettingsV1['locale']
+  threads: TrayThreadSummary[]
+  actions: TrayMenuActions
+}): MenuItemConstructorOptions[] {
+  const labels = traySessionLabels(input.locale)
+  const running = input.threads.filter((thread) => thread.status === 'running')
+  const recent = input.threads.filter((thread) => thread.status !== 'running')
+  const template: MenuItemConstructorOptions[] = []
+
+  appendThreadGroup(template, labels.running, running.slice(0, PRIMARY_GROUP_LIMIT), input.actions)
+  appendThreadGroup(template, labels.recent, recent.slice(0, PRIMARY_GROUP_LIMIT), input.actions)
+
+  const overflow = [...running.slice(PRIMARY_GROUP_LIMIT), ...recent.slice(PRIMARY_GROUP_LIMIT)]
+    .slice(0, MORE_GROUP_LIMIT)
+  if (overflow.length > 0) {
+    template.push({
+      label: labels.more,
+      submenu: overflow.map((thread) => threadMenuItem(thread, input.actions))
+    })
+  }
+  if (template.length > 0) template.push({ type: 'separator' })
+  template.push(
+    { label: labels.newChat, click: input.actions.newChat },
+    { type: 'separator' },
+    { label: labels.openApp, click: input.actions.openApp },
+    { type: 'separator' },
+    { label: labels.quit, click: input.actions.quit }
+  )
+  return template
+}
+
+function appendThreadGroup(
+  template: MenuItemConstructorOptions[],
+  label: string,
+  threads: TrayThreadSummary[],
+  actions: TrayMenuActions
+): void {
+  if (threads.length === 0) return
+  if (template.length > 0) template.push({ type: 'separator' })
+  template.push({ label, enabled: false })
+  template.push(...threads.map((thread) => threadMenuItem(thread, actions)))
+}
+
+function threadMenuItem(
+  thread: TrayThreadSummary,
+  actions: TrayMenuActions
+): MenuItemConstructorOptions {
+  return {
+    label: truncateMenuLabel(thread.title.trim() || 'Untitled'),
+    sublabel: projectLabel(thread.workspace),
+    click: () => actions.openThread(thread.id)
+  }
+}
+
+function projectLabel(workspace: string | undefined): string | undefined {
+  const value = workspace?.trim().replace(/[\\/]+$/, '')
+  return value ? basename(value) : undefined
+}
+
+function truncateMenuLabel(value: string): string {
+  return value.length > 48 ? `${value.slice(0, 47)}…` : value
+}
+
+function traySessionLabels(locale: AppSettingsV1['locale']): {
+  running: string
+  recent: string
+  more: string
+  newChat: string
+  openApp: string
+  quit: string
+} {
+  return locale === 'zh'
+    ? {
+        running: '运行中',
+        recent: '最近会话',
+        more: '更多',
+        newChat: '新建会话',
+        openApp: '打开 Kun',
+        quit: '退出'
+      }
+    : {
+        running: 'Running',
+        recent: 'Recent',
+        more: 'More',
+        newChat: 'New Chat',
+        openApp: 'Open Kun',
+        quit: 'Exit'
+      }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -185,6 +185,14 @@ const api = {
     ipcRenderer.on('claw:channel-activity', wrapped)
     return () => ipcRenderer.removeListener('claw:channel-activity', wrapped)
   },
+  onTrayAction: (handler) => {
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      payload: Parameters<typeof handler>[0]
+    ) => handler(payload)
+    ipcRenderer.on('tray:action', wrapped)
+    return () => ipcRenderer.removeListener('tray:action', wrapped)
+  },
   onRuntimeStatus: (handler) => {
     const wrapped = (
       _: Electron.IpcRendererEvent,

--- a/src/renderer/src/store/chat-store-navigation-actions.test.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.test.ts
@@ -210,6 +210,11 @@ describe('onClawChannelActivity routes through subscribeThreadEventsLive (not se
       return () => {}
     })
     const onRuntimeStatus = vi.fn(() => () => {})
+    let capturedTrayActionCallback: ((payload: { type: 'new-chat' } | { type: 'open-thread'; threadId: string }) => void) | null = null
+    const onTrayAction = vi.fn((cb: typeof capturedTrayActionCallback) => {
+      capturedTrayActionCallback = cb
+      return () => {}
+    })
     const getSettings = vi.fn(async () => ({
       workspaceRoot: '~/.kun/default_workspace',
       write: {
@@ -232,6 +237,7 @@ describe('onClawChannelActivity routes through subscribeThreadEventsLive (not se
       kunGui: {
         getSettings,
         onClawChannelActivity,
+        onTrayAction,
         onRuntimeStatus
       }
     })
@@ -240,6 +246,17 @@ describe('onClawChannelActivity routes through subscribeThreadEventsLive (not se
     await harness.actions.boot()
     expect(typeof capturedClawActivityCallback).toBe('function')
     expect(onClawChannelActivity).toHaveBeenCalledTimes(1)
+    expect(onTrayAction).toHaveBeenCalledTimes(1)
+
+    harness.state.route = 'settings'
+    capturedTrayActionCallback!({ type: 'open-thread', threadId: 'thr_recent' })
+    expect(harness.state.route).toBe('chat')
+    expect(harness.selectThread).toHaveBeenCalledWith('thr_recent')
+
+    harness.state.route = 'settings'
+    capturedTrayActionCallback!({ type: 'new-chat' })
+    expect(harness.state.route).toBe('chat')
+    expect(harness.createThread).toHaveBeenCalledWith({ forceNew: true })
 
     // Set state conditions AFTER boot so they survive the boot's set() calls:
     // route is claw, activeClawChannelId matches incoming channelId,

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -101,6 +101,7 @@ type StoreActionContext = {
 let bootPromise: Promise<void> | null = null
 let clawChannelActivityUnsubscribe: (() => void) | null = null
 let runtimeStatusUnsubscribe: (() => void) | null = null
+let trayActionUnsubscribe: (() => void) | null = null
 
 export function createNavigationActions(
   { set, get, sseAbortRef }: StoreActionContext
@@ -386,6 +387,16 @@ export function createNavigationActions(
                 // On-disk settings were restored by the rollback; refresh the cache.
                 void rendererRuntimeClient.getSettings({ forceRefresh: true }).catch(() => null)
               }
+            }
+          })
+        }
+        if (!trayActionUnsubscribe && typeof window.kunGui.onTrayAction === 'function') {
+          trayActionUnsubscribe = window.kunGui.onTrayAction((action) => {
+            set({ route: 'chat' })
+            if (action.type === 'open-thread') {
+              void get().selectThread(action.threadId)
+            } else {
+              void get().createThread({ forceNew: true })
             }
           })
         }

--- a/src/shared/kun-gui-api.ts
+++ b/src/shared/kun-gui-api.ts
@@ -244,6 +244,9 @@ export type LegacySessionImportResult =
 export type SseEventPayload = { streamId: string; events: unknown[] }
 export type SseEndPayload = { streamId: string }
 export type SseErrorPayload = { streamId: string; status?: number; message?: string }
+export type TrayActionPayload =
+  | { type: 'new-chat' }
+  | { type: 'open-thread'; threadId: string }
 
 export type ComputerUsePermissionKind = 'accessibility' | 'screenRecording'
 export type ComputerUsePermissionState = 'granted' | 'denied' | 'unknown'
@@ -396,6 +399,7 @@ export type KunGuiApi = {
   onSseEnd: (handler: (payload: SseEndPayload) => void) => () => void
   onSseError: (handler: (payload: SseErrorPayload) => void) => () => void
   onClawChannelActivity: (handler: (payload: ClawChannelActivityPayload) => void) => () => void
+  onTrayAction: (handler: (payload: TrayActionPayload) => void) => () => void
   onRuntimeStatus: (handler: (payload: KunRuntimeStatusPayload) => void) => () => void
   mirrorClawChannelMessage: (
     threadId: string,


### PR DESCRIPTION
## Summary
- replace the basic tray menu with a Codex-style dynamic session menu
- show running and recent conversations with project labels and overflow under More
- route tray actions through the existing renderer chat store

## Changes
- fetch the latest Kun thread summaries when the tray menu opens
- add localized Running, Recent, More, New Chat, Open Kun, and Exit entries
- keep an offline-safe action menu when the runtime is unavailable
- expose a typed one-way tray action event through preload
- add focused parsing, grouping, localization, and navigation tests

## Tests
- `npm.cmd run test -- --run src/main/tray-session-menu.test.ts src/main/index.test.ts src/renderer/src/store/chat-store-navigation-actions.test.ts` (24 passed)
- `npm.cmd run build` (passed)
- `npm.cmd run typecheck` (baseline failure only: four existing `onDeltas` errors in `src/renderer/src/store/chat-store-thread-actions.test.ts`)