### PR TITLE
fix(image): preserve attachment reference paths

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, relative, resolve } from 'node:path'
 import type { ModelClient, ModelRequest, ModelToolSpec } from '../ports/model-client.js'
 import type {
   ToolHost,
@@ -1182,6 +1183,12 @@ export class AgentLoop {
       ...((this.emptyPostToolRecoveryStepsByTurn.get(turnId) ?? 0) > 0
         ? [emptyPostToolRecoveryInstruction()]
         : []),
+      ...imageGenerationReferenceInstructions({
+        imageAttachments: attachments.imageAttachments,
+        textFallbacks: attachments.textFallbacks,
+        workspace: thread?.workspace ?? '',
+        tools: effectiveToolSpecs
+      }),
       ...memoryInstructions(memories),
       ...skillResolution.instructions,
       ...(userInputDisabled ? [userInputUnavailableInstruction()] : []),
@@ -2544,7 +2551,8 @@ export class AgentLoop {
           mimeType: attachment.mimeType,
           dataBase64: attachment.data.toString('base64'),
           ...(attachment.width ? { width: attachment.width } : {}),
-          ...(attachment.height ? { height: attachment.height } : {})
+          ...(attachment.height ? { height: attachment.height } : {}),
+          ...(attachment.localFilePath ? { localFilePath: attachment.localFilePath } : {})
         })
         continue
       }
@@ -2651,6 +2659,45 @@ function attachmentRequestPipelineDetails(input: {
     ),
     textFallbackMimeTypes: [...new Set(input.textFallbacks.map((attachment) => attachment.mimeType))]
   }
+}
+
+function imageGenerationReferenceInstructions(input: {
+  imageAttachments: readonly ModelInputAttachment[]
+  textFallbacks: readonly ModelTextAttachmentFallback[]
+  workspace: string
+  tools: readonly Pick<ModelToolSpec, 'name'>[]
+}): string[] {
+  if (!input.tools.some((tool) => tool.name === 'generate_image')) return []
+
+  const references = [...input.imageAttachments, ...input.textFallbacks]
+    .filter((attachment) => attachment.mimeType.startsWith('image/'))
+    .map((attachment) => ({
+      name: attachment.name,
+      path: workspaceRelativeAttachmentPath(attachment.localFilePath, input.workspace)
+    }))
+    .filter((attachment): attachment is { name: string; path: string } => Boolean(attachment.path))
+
+  if (references.length === 0) return []
+  return [[
+    'Image-to-image reference images are available for this turn:',
+    ...references.map((reference) => `- ${reference.name}: ${reference.path}`),
+    'For image edits, restyles, redraws, or transformations, call `generate_image` with the matching workspace-relative path(s) in `reference_image_paths`.'
+  ].join('\n')]
+}
+
+function workspaceRelativeAttachmentPath(
+  localFilePath: string | undefined,
+  workspace: string
+): string | null {
+  const workspaceRoot = workspace.trim()
+  const rawPath = localFilePath?.trim()
+  if (!workspaceRoot || !rawPath) return null
+
+  const workspaceAbsolute = resolve(workspaceRoot)
+  const fileAbsolute = isAbsolute(rawPath) ? resolve(rawPath) : resolve(workspaceAbsolute, rawPath)
+  const relativePath = relative(workspaceAbsolute, fileAbsolute)
+  if (!relativePath || relativePath.startsWith('..') || isAbsolute(relativePath)) return null
+  return relativePath.replace(/\\/g, '/')
 }
 
 function normalizeApprovalPolicy(

--- a/kun/src/ports/model-client.ts
+++ b/kun/src/ports/model-client.ts
@@ -71,6 +71,7 @@ export type ModelInputAttachment = {
   dataBase64: string
   width?: number
   height?: number
+  localFilePath?: string
 }
 
 export type ModelTextAttachmentFallback = {

--- a/kun/tests/attachment-store.test.ts
+++ b/kun/tests/attachment-store.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/contracts/capabilities.js'
 import { modelCapabilitiesForModel } from '../src/loop/model-context-profile.js'
 import type { ModelClient, ModelRequest } from '../src/ports/model-client.js'
+import type { LocalTool } from '../src/adapters/tool/local-tool-host.js'
 import { dispatchRequest } from '../src/server/http-server.js'
 import { bootstrapThread, makeHarness } from './loop-test-harness.js'
 import { buildHarness, readJson } from './http-server-test-harness.js'
@@ -173,12 +174,14 @@ describe('Attachment store and multimodal input', () => {
 
   it('resolves image attachments for vision models and text fallbacks for text-only models', async () => {
     const store = createStore()
+    const workspace = join(dir, 'workspace')
+    const localFilePath = join(workspace, 'assets', 'shot.png')
     const attachment = await store.create({
       name: 'shot.png',
       data: png(1, 1),
-      localFilePath: '/tmp/picked/shot.png',
+      localFilePath,
       threadId: 'thr_1',
-      workspace: '/tmp/ws'
+      workspace
     })
     const seenRequests: ModelRequest[] = []
     const model: ModelClient = {
@@ -191,10 +194,11 @@ describe('Attachment store and multimodal input', () => {
     }
     const h = makeHarness(model, {
       attachmentStore: store,
-      modelCapabilities: () => visionCapabilities()
+      modelCapabilities: () => visionCapabilities(),
+      tools: [generateImageTool()]
     })
     await bootstrapThread(h, {
-      workspace: '/tmp/ws',
+      workspace,
       request: { prompt: 'look', attachmentIds: [attachment.id], model: 'vision-model' }
     })
 
@@ -203,15 +207,18 @@ describe('Attachment store and multimodal input', () => {
     expect(seenRequests.at(-1)?.attachments?.[0]).toMatchObject({
       id: attachment.id,
       mimeType: 'image/png',
-      dataBase64: expect.any(String)
+      dataBase64: expect.any(String),
+      localFilePath
     })
+    expect(seenRequests.at(-1)?.contextInstructions?.join('\n')).toContain('reference_image_paths')
+    expect(seenRequests.at(-1)?.contextInstructions?.join('\n')).toContain('assets/shot.png')
 
     const textOnly = makeHarness(model, {
       attachmentStore: store,
       modelCapabilities: () => ({ ...visionCapabilities(), inputModalities: ['text'] })
     })
     await bootstrapThread(textOnly, {
-      workspace: '/tmp/ws',
+      workspace,
       request: { prompt: 'look', attachmentIds: [attachment.id], model: 'text-only' }
     })
     expect(await textOnly.loop.runTurn(textOnly.threadId, textOnly.turnId)).toBe('completed')
@@ -220,9 +227,46 @@ describe('Attachment store and multimodal input', () => {
       id: attachment.id,
       mimeType: 'image/png',
       dataBase64: expect.any(String),
-      localFilePath: '/tmp/picked/shot.png',
+      localFilePath,
       wasCompressed: false
     })
+    expect(seenRequests.at(-1)?.contextInstructions?.join('\n') ?? '').not.toContain('reference_image_paths')
+  })
+
+  it('does not expose image reference paths outside the active workspace', async () => {
+    const store = createStore()
+    const workspace = join(dir, 'workspace')
+    const localFilePath = join(dir, 'outside', 'secret.png')
+    const attachment = await store.create({
+      name: 'secret.png',
+      data: png(1, 1),
+      localFilePath,
+      threadId: 'thr_1',
+      workspace
+    })
+    const seenRequests: ModelRequest[] = []
+    const model: ModelClient = {
+      provider: 'fake',
+      model: 'fake',
+      async *stream(request) {
+        seenRequests.push(request)
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    }
+    const h = makeHarness(model, {
+      attachmentStore: store,
+      modelCapabilities: () => visionCapabilities(),
+      tools: [generateImageTool()]
+    })
+    await bootstrapThread(h, {
+      workspace,
+      request: { prompt: 'look', attachmentIds: [attachment.id], model: 'vision-model' }
+    })
+
+    expect(await h.loop.runTurn(h.threadId, h.turnId)).toBe('completed')
+    const instructions = seenRequests.at(-1)?.contextInstructions?.join('\n') ?? ''
+    expect(instructions).not.toContain('reference_image_paths')
+    expect(instructions).not.toContain(localFilePath)
   })
 
   it('routes built-in DeepSeek v4 image attachments as text fallbacks', async () => {
@@ -463,5 +507,18 @@ function visionCapabilities(): ModelCapabilityMetadata {
     supportsToolCalling: true,
     contextWindowTokens: 128_000,
     messageParts: ['text', 'image_url']
+  }
+}
+
+function generateImageTool(): LocalTool {
+  return {
+    name: 'generate_image',
+    description: 'Generate or edit an image.',
+    inputSchema: { type: 'object' },
+    toolKind: 'tool_call',
+    policy: 'auto',
+    async execute() {
+      return { output: { ok: true } }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- preserve `localFilePath` when vision attachments become `ModelInputAttachment` values
- guide `generate_image` to use workspace-relative reference paths for image edits
- keep paths outside the active workspace out of model instructions

## Changes
- carry the real attachment path through the vision-capable model request path
- inject per-turn image-to-image guidance only when `generate_image` is available
- normalize reference paths to workspace-relative forward-slash paths
- cover the real `FileAttachmentStore -> AgentLoop -> ModelRequest` path
- verify external paths and no-tool requests do not leak reference instructions

## Tests
- `npm.cmd --prefix kun test -- --run tests/attachment-store.test.ts tests/image-gen-tool-provider.test.ts` (28 passed)
- `npm.cmd --prefix kun run typecheck` (passed)
- `npm.cmd run build` (passed)

Replaces closed PR #385.
Fixes #339