### PR TITLE
fix(terminal): isolate sessions by workspace

### DIFF
--- a/src/renderer/src/components/WindowsTitleBar.tsx
+++ b/src/renderer/src/components/WindowsTitleBar.tsx
@@ -72,7 +72,7 @@ export function supportsDesktopTitleBar(platform: string): boolean {
 export function buildWindowsTitleBarMenuSections(
   t: TitleBarTranslate,
   actions: WindowsTitleBarActions,
-  shortcuts: Required<KeyboardShortcutBindingsV1> = resolveKeyboardShortcutBindings()
+  shortcuts: Required<KeyboardShortcutBindingsV1> = resolveKeyboardShortcutBindings(undefined, currentPlatform())
 ): WindowsTitleBarMenuSection[] {
   const command = (desktopCommand: DesktopCommand): MenuAction =>
     () => actions.runDesktopCommand(desktopCommand)
@@ -182,8 +182,8 @@ export function WindowsTitleBar({ platform, actions }: Props): ReactElement | nu
   const openSettings = useChatStore((s) => s.openSettings)
   const keyboardShortcuts = useKeyboardShortcutSettings()
   const keyboardShortcutBindings = useMemo(
-    () => resolveKeyboardShortcutBindings(keyboardShortcuts),
-    [keyboardShortcuts]
+    () => resolveKeyboardShortcutBindings(keyboardShortcuts, resolvedPlatform),
+    [keyboardShortcuts, resolvedPlatform]
   )
   const [activeMenuId, setActiveMenuId] = useState<string | null>(null)
   const [isMaximized, setIsMaximized] = useState(false)

--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -493,9 +493,10 @@ export function Workbench(): ReactElement {
   }, [composerModelGroups, writeAssistantModel, writeAssistantProviderId])
   const stageInsetClass = 'ds-stage-inset'
   const keyboardShortcuts = useKeyboardShortcutSettings()
+  const shortcutPlatform = typeof window === 'undefined' ? undefined : window.kunGui?.platform
   const keyboardShortcutBindings = useMemo(
-    () => resolveKeyboardShortcutBindings(keyboardShortcuts),
-    [keyboardShortcuts]
+    () => resolveKeyboardShortcutBindings(keyboardShortcuts, shortcutPlatform),
+    [keyboardShortcuts, shortcutPlatform]
   )
 
   const draftByThread = useRef<Record<string, string>>({})
@@ -703,6 +704,10 @@ export function Workbench(): ReactElement {
         void chooseWorkspace()
         return
       }
+      if (commandId === 'toggle-terminal') {
+        toggleTerminal()
+        return
+      }
       if (commandId === 'settings') {
         openSettings()
         return
@@ -722,6 +727,7 @@ export function Workbench(): ReactElement {
     mode,
     openSettings,
     setMode,
+    toggleTerminal,
     useWorktreePool
   ])
   const showDevPreviewCard =

--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -2655,7 +2655,7 @@ export function Workbench(): ReactElement {
                 />
                 <Suspense fallback={<div className="ds-surface-strong h-full w-full" />}>
                   <TerminalPanel
-                    workspaceRoot={workspaceRoot}
+                    workspaceRoot={fileTreeWorkspaceRoot}
                     height={terminalHeight}
                     className="w-full"
                     onCollapse={toggleTerminal}

--- a/src/renderer/src/components/settings-section-shortcuts.tsx
+++ b/src/renderer/src/components/settings-section-shortcuts.tsx
@@ -16,10 +16,11 @@ export function KeyboardShortcutsSettingsSection({ ctx }: { ctx: Record<string, 
   const [query, setQuery] = useState('')
   const [capturingCommandId, setCapturingCommandId] = useState<KeyboardShortcutCommandId | null>(null)
   const [notice, setNotice] = useState<{ tone: 'error' | 'info'; message: string } | null>(null)
+  const shortcutPlatform = typeof window === 'undefined' ? undefined : window.kunGui?.platform
   const normalized = useMemo(() => normalizeKeyboardShortcuts(form.keyboardShortcuts), [form.keyboardShortcuts])
   const effectiveBindings = useMemo(
-    () => resolveKeyboardShortcutBindings(form.keyboardShortcuts),
-    [form.keyboardShortcuts]
+    () => resolveKeyboardShortcutBindings(form.keyboardShortcuts, shortcutPlatform),
+    [form.keyboardShortcuts, shortcutPlatform]
   )
 
   const commandLabel = useCallback((commandId: KeyboardShortcutCommandId): string => {

--- a/src/renderer/src/components/terminal/TerminalPanel.tsx
+++ b/src/renderer/src/components/terminal/TerminalPanel.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   TerminalSquare,
@@ -19,6 +19,7 @@ import {
   TERMINAL_DEFAULT_COLS,
   TERMINAL_DEFAULT_ROWS
 } from '@shared/terminal'
+import { terminalSessionIdForWorkspace, terminalWorkspaceSessionKey } from './terminal-session'
 
 type Props = {
   className?: string
@@ -40,6 +41,11 @@ type TerminalTabContextMenu = {
   y: number
 }
 
+type TerminalTabState = {
+  tabs: TerminalTab[]
+  activeTabId: string
+}
+
 type RgbaColor = {
   r: number
   g: number
@@ -56,6 +62,13 @@ const TERMINAL_SCROLLBACK = 5000
 const FIT_DEBOUNCE_MS = 80
 const INITIAL_TAB_ID = 'main'
 const MAX_RENDERER_TABS = 8
+
+function initialTerminalTabState(): TerminalTabState {
+  return {
+    tabs: [{ id: INITIAL_TAB_ID, index: 1 }],
+    activeTabId: INITIAL_TAB_ID
+  }
+}
 
 const DARK_THEME = {
   background: '#151d31',
@@ -186,18 +199,45 @@ export function TerminalPanel({ className = '', workspaceRoot, onCollapse, heigh
   const attachTokenRef = useRef(0)
   const [error, setError] = useState<string | null>(null)
   const [exited, setExited] = useState(false)
-  const [tabs, setTabs] = useState<TerminalTab[]>([{ id: INITIAL_TAB_ID, index: 1 }])
-  const [activeTabId, setActiveTabId] = useState(INITIAL_TAB_ID)
+  const [tabs, setTabs] = useState<TerminalTab[]>(() => initialTerminalTabState().tabs)
+  const [activeTabId, setActiveTabId] = useState(() => initialTerminalTabState().activeTabId)
   const [contextMenu, setContextMenu] = useState<TerminalTabContextMenu | null>(null)
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
   const renameInputRef = useRef<HTMLInputElement | null>(null)
   const tabButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({})
+  const workspaceTabStatesRef = useRef<Record<string, TerminalTabState>>({})
+  const workspaceKeyRef = useRef(terminalWorkspaceSessionKey(workspaceRoot))
+  const tabsRef = useRef(tabs)
+  const activeTabIdRef = useRef(activeTabId)
+  const workspaceKey = terminalWorkspaceSessionKey(workspaceRoot)
   const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0]
+
+  tabsRef.current = tabs
+  activeTabIdRef.current = activeTabId
 
   const getTabTitle = useCallback((tab: TerminalTab): string => {
     return tab.title?.trim() || t('terminalTabTitle', { index: tab.index })
   }, [t])
+
+  useLayoutEffect(() => {
+    const previousKey = workspaceKeyRef.current
+    if (previousKey === workspaceKey) return
+    workspaceTabStatesRef.current[previousKey] = {
+      tabs: tabsRef.current,
+      activeTabId: activeTabIdRef.current
+    }
+    const next = workspaceTabStatesRef.current[workspaceKey] ?? initialTerminalTabState()
+    const nextActiveId = next.tabs.some((tab) => tab.id === next.activeTabId)
+      ? next.activeTabId
+      : (next.tabs[0]?.id ?? INITIAL_TAB_ID)
+    workspaceKeyRef.current = workspaceKey
+    setTabs(next.tabs.length > 0 ? next.tabs : initialTerminalTabState().tabs)
+    setActiveTabId(nextActiveId)
+    setContextMenu(null)
+    setRenamingTabId(null)
+    setRenameValue('')
+  }, [workspaceKey])
 
   const disposeRenderer = useCallback(() => {
     const term = termRef.current
@@ -214,7 +254,12 @@ export function TerminalPanel({ className = '', workspaceRoot, onCollapse, heigh
   // On unmount we dispose only the xterm renderer; the underlying PTY stays
   // alive in the main process so toggling the panel preserves shell state
   // and replays recent output from the ring buffer on re-attach.
-  const attachTerminal = useCallback(async (sessionId: string) => {
+  const sessionIdForTab = useCallback((tabId: string): string => {
+    return terminalSessionIdForWorkspace(workspaceRoot, tabId)
+  }, [workspaceRoot])
+
+  const attachTerminal = useCallback(async (tabId: string) => {
+    const sessionId = sessionIdForTab(tabId)
     const attachToken = ++attachTokenRef.current
     const isCurrentAttach = (): boolean => aliveRef.current && attachTokenRef.current === attachToken
     const container = containerRef.current
@@ -334,7 +379,7 @@ export function TerminalPanel({ className = '', workspaceRoot, onCollapse, heigh
       resizeObserver.disconnect()
       if (resizeTimer) clearTimeout(resizeTimer)
     }
-  }, [workspaceRoot])
+  }, [sessionIdForTab, workspaceRoot])
 
   useEffect(() => {
     aliveRef.current = true
@@ -393,7 +438,7 @@ export function TerminalPanel({ className = '', workspaceRoot, onCollapse, heigh
   const handleCloseTab = useCallback((tabId: string) => {
     const closingIndex = tabs.findIndex((tab) => tab.id === tabId)
     if (closingIndex === -1) return
-    void window.kunGui.disposeTerminal(tabId)
+    void window.kunGui.disposeTerminal(sessionIdForTab(tabId))
     setTabs((current) => {
       if (current.length <= 1) return current
       return current.filter((tab) => tab.id !== tabId)
@@ -402,7 +447,7 @@ export function TerminalPanel({ className = '', workspaceRoot, onCollapse, heigh
       const nextTab = tabs[closingIndex + 1] ?? tabs[closingIndex - 1] ?? tabs[0]
       if (nextTab && nextTab.id !== tabId) setActiveTabId(nextTab.id)
     }
-  }, [activeTabId, tabs])
+  }, [activeTabId, sessionIdForTab, tabs])
 
   const openTabContextMenu = useCallback((event: ReactMouseEvent | ReactPointerEvent, tabId: string) => {
     event.preventDefault()
@@ -461,30 +506,31 @@ export function TerminalPanel({ className = '', workspaceRoot, onCollapse, heigh
     const keptTab = tabs.find((tab) => tab.id === tabId)
     if (!keptTab) return
     for (const tab of tabs) {
-      if (tab.id !== tabId) void window.kunGui.disposeTerminal(tab.id)
+      if (tab.id !== tabId) void window.kunGui.disposeTerminal(sessionIdForTab(tab.id))
     }
     setTabs([keptTab])
     setActiveTabId(tabId)
     setContextMenu(null)
     if (renamingTabId && renamingTabId !== tabId) cancelRenameTab()
-  }, [cancelRenameTab, renamingTabId, tabs])
+  }, [cancelRenameTab, renamingTabId, sessionIdForTab, tabs])
 
   const handleCloseAllTabs = useCallback(() => {
     for (const tab of tabs) {
-      void window.kunGui.disposeTerminal(tab.id)
+      void window.kunGui.disposeTerminal(sessionIdForTab(tab.id))
     }
     setContextMenu(null)
     cancelRenameTab()
-    setTabs([{ id: INITIAL_TAB_ID, index: 1 }])
-    setActiveTabId(INITIAL_TAB_ID)
+    const next = initialTerminalTabState()
+    setTabs(next.tabs)
+    setActiveTabId(next.activeTabId)
     onCollapse()
-  }, [cancelRenameTab, onCollapse, tabs])
+  }, [cancelRenameTab, onCollapse, sessionIdForTab, tabs])
 
   const handleRestart = useCallback(async () => {
     if (!activeTab) return
     // Dispose the old shell then re-attach so a fresh one spawns.
     try {
-      await window.kunGui.disposeTerminal(activeTab.id)
+      await window.kunGui.disposeTerminal(sessionIdForTab(activeTab.id))
     } catch {
       /* ignore */
     }
@@ -493,7 +539,7 @@ export function TerminalPanel({ className = '', workspaceRoot, onCollapse, heigh
     disposeRenderer()
     aliveRef.current = true
     void attachTerminal(activeTab.id)
-  }, [activeTab, attachTerminal, disposeRenderer])
+  }, [activeTab, attachTerminal, disposeRenderer, sessionIdForTab])
 
   return (
     <aside

--- a/src/renderer/src/components/terminal/terminal-session.test.ts
+++ b/src/renderer/src/components/terminal/terminal-session.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  terminalSessionIdForWorkspace,
+  terminalWorkspaceSessionKey
+} from './terminal-session'
+
+describe('terminal session ids', () => {
+  it('separates the same tab id across workspaces', () => {
+    const first = terminalSessionIdForWorkspace('/Users/zxy/project-a', 'main')
+    const second = terminalSessionIdForWorkspace('/Users/zxy/project-b', 'main')
+
+    expect(first).not.toBe(second)
+    expect(first).toMatch(/^terminal:[a-z0-9]+:main$/)
+    expect(second).toMatch(/^terminal:[a-z0-9]+:main$/)
+  })
+
+  it('keeps equivalent workspace paths on the same terminal namespace', () => {
+    expect(terminalWorkspaceSessionKey('/Users/zxy/project-a/')).toBe(
+      terminalWorkspaceSessionKey('/users/zxy/project-a')
+    )
+  })
+
+  it('keeps session ids short for very long workspace paths', () => {
+    const longWorkspace = `/Users/zxy/${'nested/'.repeat(80)}project`
+    const sessionId = terminalSessionIdForWorkspace(longWorkspace, 'tab-1')
+
+    expect(sessionId.length).toBeLessThan(80)
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-session.ts
+++ b/src/renderer/src/components/terminal/terminal-session.ts
@@ -1,0 +1,22 @@
+import { workspaceRootIdentityKey } from '../../lib/workspace-path'
+
+const TERMINAL_SESSION_PREFIX = 'terminal'
+
+export function terminalWorkspaceSessionKey(workspaceRoot: string): string {
+  return workspaceRootIdentityKey(workspaceRoot) || 'no-workspace'
+}
+
+function hashString(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+export function terminalSessionIdForWorkspace(workspaceRoot: string, tabId: string): string {
+  const workspaceKey = terminalWorkspaceSessionKey(workspaceRoot)
+  const tabKey = tabId.trim() || 'main'
+  return `${TERMINAL_SESSION_PREFIX}:${hashString(workspaceKey)}:${tabKey}`
+}

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -174,6 +174,8 @@
   "shortcutNewChatDesc": "Start a new chat in the current workspace.",
   "shortcutChooseWorkspace": "Choose workspace",
   "shortcutChooseWorkspaceDesc": "Open the workspace picker.",
+  "shortcutToggleTerminal": "Toggle terminal",
+  "shortcutToggleTerminalDesc": "Open or close the terminal panel.",
   "shortcutSettings": "Settings",
   "shortcutSettingsDesc": "Open settings.",
   "shortcutQuit": "Quit",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -174,6 +174,8 @@
   "shortcutNewChatDesc": "在当前工作区开始新会话。",
   "shortcutChooseWorkspace": "选择工作区",
   "shortcutChooseWorkspaceDesc": "打开工作区选择器。",
+  "shortcutToggleTerminal": "切换终端",
+  "shortcutToggleTerminalDesc": "打开或关闭终端面板。",
   "shortcutSettings": "设置",
   "shortcutSettingsDesc": "打开设置。",
   "shortcutQuit": "退出",

--- a/src/shared/keyboard-shortcuts.test.ts
+++ b/src/shared/keyboard-shortcuts.test.ts
@@ -15,6 +15,7 @@ describe('keyboard shortcuts', () => {
     expect(normalizeKeyboardShortcut('ctrl+=')).toBe('Ctrl++')
     expect(normalizeKeyboardShortcut('ctrl+shift++')).toBe('Ctrl++')
     expect(normalizeKeyboardShortcut('control + shift + i')).toBe('Ctrl+Shift+I')
+    expect(normalizeKeyboardShortcut('command + `')).toBe('Meta+`')
   })
 
   it('converts keyboard events to shortcut strings', () => {
@@ -22,6 +23,7 @@ describe('keyboard shortcuts', () => {
     expect(keyboardEventToShortcut({ key: '+', ctrlKey: true })).toBe('Ctrl++')
     expect(keyboardEventToShortcut({ key: '=', ctrlKey: true })).toBe('Ctrl++')
     expect(keyboardEventToShortcut({ key: '+', ctrlKey: true, shiftKey: true })).toBe('Ctrl++')
+    expect(keyboardEventToShortcut({ key: '`', metaKey: true })).toBe('Meta+`')
     expect(keyboardEventToShortcut({ key: 'Shift', shiftKey: true })).toBeNull()
   })
 
@@ -35,6 +37,11 @@ describe('keyboard shortcuts', () => {
 
     expect(bindings['toggle-plan-mode']).toEqual(['Ctrl+Shift+P'])
     expect(bindings['new-chat']).toEqual(['Ctrl+N'])
+  })
+
+  it('uses platform defaults for the terminal toggle shortcut', () => {
+    expect(resolveKeyboardShortcutBindings(undefined, 'darwin')['toggle-terminal']).toEqual(['Meta+`'])
+    expect(resolveKeyboardShortcutBindings(undefined, 'win32')['toggle-terminal']).toEqual(['Ctrl+`'])
   })
 
   it('ignores unknown commands and detects conflicts', () => {

--- a/src/shared/keyboard-shortcuts.ts
+++ b/src/shared/keyboard-shortcuts.ts
@@ -1,3 +1,12 @@
+type KeyboardShortcutDefaultPlatform = 'darwin' | 'win32' | 'linux'
+type KeyboardShortcutCommandDefinition = {
+  id: string
+  labelKey: string
+  descriptionKey: string
+  defaultBindings: readonly string[]
+  platformDefaultBindings?: Partial<Record<KeyboardShortcutDefaultPlatform, readonly string[]>>
+}
+
 export const KEYBOARD_SHORTCUT_COMMANDS = [
   {
     id: 'toggle-plan-mode',
@@ -16,6 +25,15 @@ export const KEYBOARD_SHORTCUT_COMMANDS = [
     labelKey: 'shortcutChooseWorkspace',
     descriptionKey: 'shortcutChooseWorkspaceDesc',
     defaultBindings: ['Ctrl+O']
+  },
+  {
+    id: 'toggle-terminal',
+    labelKey: 'shortcutToggleTerminal',
+    descriptionKey: 'shortcutToggleTerminalDesc',
+    defaultBindings: ['Ctrl+`'],
+    platformDefaultBindings: {
+      darwin: ['Meta+`']
+    }
   },
   {
     id: 'settings',
@@ -113,7 +131,7 @@ export const KEYBOARD_SHORTCUT_COMMANDS = [
     descriptionKey: 'shortcutToggleMaximizeDesc',
     defaultBindings: []
   }
-] as const
+] as const satisfies readonly KeyboardShortcutCommandDefinition[]
 
 export type KeyboardShortcutCommand = typeof KEYBOARD_SHORTCUT_COMMANDS[number]
 export type KeyboardShortcutCommandId = KeyboardShortcutCommand['id']
@@ -121,6 +139,7 @@ export type KeyboardShortcutBindingsV1 = Partial<Record<KeyboardShortcutCommandI
 export type KeyboardShortcutsConfigV1 = {
   bindings: KeyboardShortcutBindingsV1
 }
+export type KeyboardShortcutPlatform = 'darwin' | 'win32' | 'linux' | string
 
 export type KeyboardShortcutEventLike = {
   key: string
@@ -168,7 +187,8 @@ export function normalizeKeyboardShortcuts(
 }
 
 export function resolveKeyboardShortcutBindings(
-  settings?: Partial<KeyboardShortcutsConfigV1> | null
+  settings?: Partial<KeyboardShortcutsConfigV1> | null,
+  platform?: KeyboardShortcutPlatform | null
 ): Required<KeyboardShortcutBindingsV1> {
   const normalized = normalizeKeyboardShortcuts(settings)
   const bindings: Required<KeyboardShortcutBindingsV1> = {} as Required<KeyboardShortcutBindingsV1>
@@ -176,9 +196,26 @@ export function resolveKeyboardShortcutBindings(
     const configured = normalized.bindings[command.id]
     bindings[command.id] = configured && configured.length > 0
       ? configured
-      : [...command.defaultBindings]
+      : defaultBindingsForCommand(command, platform)
   }
   return bindings
+}
+
+function defaultBindingsForCommand(
+  command: KeyboardShortcutCommand,
+  platform?: KeyboardShortcutPlatform | null
+): string[] {
+  const definition = command as KeyboardShortcutCommandDefinition
+  const platformDefaults = isKeyboardShortcutDefaultPlatform(platform)
+    ? definition.platformDefaultBindings?.[platform]
+    : undefined
+  return [...(platformDefaults ?? command.defaultBindings)]
+}
+
+function isKeyboardShortcutDefaultPlatform(
+  platform?: KeyboardShortcutPlatform | null
+): platform is KeyboardShortcutDefaultPlatform {
+  return platform === 'darwin' || platform === 'win32' || platform === 'linux'
 }
 
 export function normalizeKeyboardShortcut(value: unknown): string | null {

--- a/src/shared/terminal.ts
+++ b/src/shared/terminal.ts
@@ -20,7 +20,7 @@ export const TERMINAL_MAX_ROWS = 200
 export const TERMINAL_MAIN_SESSION_ID = 'main'
 
 export type TerminalCreatePayload = {
-  /** Stable session identifier. The workbench uses a single `main` session. */
+  /** 稳定的 PTY 会话标识,渲染端会按工作区和标签页生成命名空间。 */
   sessionId: string
   /** Working directory for the spawned shell. Defaults to the OS home dir. */
   cwd?: string


### PR DESCRIPTION
## Summary

- Scope built-in terminal PTY session IDs by workspace and tab so switching projects does not reattach to the previous project terminal.
- Pass the active thread workspace into the terminal panel instead of the global default workspace.
- Keep renderer terminal tabs isolated per workspace so project switches do not share tab state.

## Root Cause

The built-in terminal reused fixed renderer tab IDs such as `main` as PTY session IDs. The main process stores PTYs by session ID, so selecting another conversation could reattach to the previous workspace shell and preserve the wrong cwd.

## Validation

- `npm test -- src/renderer/src/components/terminal/terminal-session.test.ts`
- `npx eslint src/renderer/src/components/Workbench.tsx src/renderer/src/components/terminal/TerminalPanel.tsx src/renderer/src/components/terminal/terminal-session.ts src/renderer/src/components/terminal/terminal-session.test.ts src/shared/terminal.ts`

## Notes

- Full `npm run typecheck` is currently blocked by existing develop errors in `src/renderer/src/store/chat-store-thread-actions.test.ts` around `onDeltas` typed as `never`.
- Full `npm run lint` is currently blocked by existing develop `no-control-regex` errors in `kun/src/hooks/builtins/design-quality-hook.ts` and generated `kun/dist/hooks/builtins/design-quality-hook.js`.
