### PR TITLE
fix(chat): prevent unsafe vision model downgrades

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -512,6 +512,7 @@ export function Workbench(): ReactElement {
   const sddTitleSyncTimerRef = useRef<number | null>(null)
   const lastSyncedSddTitleRef = useRef<Record<string, string>>({})
   const timelineBlocks = blocks
+  const lockVisionToTextModelSwitch = route === 'chat' && timelineBlocks.some((block) => block.kind === 'user')
   const timelineLiveReasoning = liveReasoning
   const timelineLiveAssistant = liveAssistant
   const devPreviewBlocks = useMemo<ChatBlock[]>(() => {
@@ -2593,6 +2594,7 @@ export function Workbench(): ReactElement {
                 composerReasoningEffort={
                   route === 'chat' || route === 'claw' ? composerReasoningEffort : undefined
                 }
+                lockVisionToTextModelSwitch={lockVisionToTextModelSwitch}
                 onComposerModelChange={(modelId, providerId) => {
                   if (route === 'claw' && activeClawChannelId) {
                     void setClawChannelModel(activeClawChannelId, modelId)

--- a/src/renderer/src/components/chat/FloatingComposer.test.ts
+++ b/src/renderer/src/components/chat/FloatingComposer.test.ts
@@ -23,6 +23,7 @@ import {
   composerModelMenuItemSelected,
   composerMenuSupportsModel,
   composerReasoningEffortRequestValue,
+  canSwitchComposerModelFromCurrent,
   filterComposerModelIds,
   normalizeComposerReasoningEffort
 } from './FloatingComposerModelPicker'
@@ -445,6 +446,25 @@ describe('FloatingComposer model controls', () => {
     expect(filterComposerModelIds(modelIds, '')).toEqual(modelIds)
     expect(filterComposerModelIds(modelIds, 'max')).toEqual(['MiniMax-M2'])
     expect(filterComposerModelIds(modelIds, '128K')).toEqual(['moonshot-v1-128k'])
+  })
+
+  it('prevents switching from a vision model to a text-only model', () => {
+    const visionProfile: Parameters<typeof canSwitchComposerModelFromCurrent>[0] = {
+      inputModalities: ['text', 'image'],
+      outputModalities: ['text'],
+      supportsToolCalling: true,
+      messageParts: ['text', 'image_url']
+    }
+    const textProfile: Parameters<typeof canSwitchComposerModelFromCurrent>[1] = {
+      inputModalities: ['text'],
+      outputModalities: ['text'],
+      supportsToolCalling: true,
+      messageParts: ['text']
+    }
+
+    expect(canSwitchComposerModelFromCurrent(visionProfile, textProfile)).toBe(false)
+    expect(canSwitchComposerModelFromCurrent(visionProfile, visionProfile)).toBe(true)
+    expect(canSwitchComposerModelFromCurrent(textProfile, visionProfile)).toBe(true)
   })
 
   it('keeps the reasoning strength visible in the model control', () => {

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -122,6 +122,7 @@ type Props = {
   composerPickList: string[]
   composerModelGroups?: ModelProviderModelGroup[]
   composerReasoningEffort?: string
+  lockVisionToTextModelSwitch?: boolean
   onComposerModelChange: (modelId: string, providerId?: string) => void
   onComposerReasoningEffortChange?: (effort: ComposerReasoningEffort) => void
   onConfigureProviders?: () => void
@@ -441,6 +442,7 @@ export function FloatingComposer({
   composerPickList,
   composerModelGroups = EMPTY_MODEL_GROUPS,
   composerReasoningEffort,
+  lockVisionToTextModelSwitch = false,
   onComposerModelChange,
   onComposerReasoningEffortChange,
   onConfigureProviders,
@@ -2178,6 +2180,7 @@ export function FloatingComposer({
                   composerPickList={composerPickList}
                   composerModelGroups={composerModelGroups}
                   composerReasoningEffort={composerReasoningEffort}
+                  lockVisionToTextModelSwitch={lockVisionToTextModelSwitch}
                   canChangeModel={canChangeModel}
                   stretch={stretchModelPicker}
                   onComposerModelChange={onComposerModelChange}

--- a/src/renderer/src/components/chat/FloatingComposerModelPicker.tsx
+++ b/src/renderer/src/components/chat/FloatingComposerModelPicker.tsx
@@ -41,6 +41,7 @@ type Props = {
   canChangeModel: boolean
   stretch?: boolean
   composerReasoningEffort?: string
+  lockVisionToTextModelSwitch?: boolean
   onComposerModelChange: (modelId: string, providerId?: string) => void
   onComposerReasoningEffortChange?: (effort: ComposerReasoningEffort) => void
   onConfigureProviders?: () => void
@@ -105,6 +106,7 @@ export function FloatingComposerModelPicker({
   canChangeModel,
   stretch = false,
   composerReasoningEffort = 'max',
+  lockVisionToTextModelSwitch = false,
   onComposerModelChange,
   onComposerReasoningEffortChange,
   onConfigureProviders
@@ -411,39 +413,48 @@ export function FloatingComposerModelPicker({
               />
             </label>
             {activeProviderModelIds.length > 0 ? (
-              activeProviderModelIds.map((id) => (
-                <PickerRow
-                  key={`${activeProviderGroup.providerId}:${id}`}
-                  selected={composerModelMenuItemSelected({
-                    groupProviderId: activeProviderGroup.providerId,
-                    selectedProviderId,
-                    currentModel,
-                    modelId: id
-                  })}
-                  title={id}
-                  rightSlot={
-                    modelSupportsImageInput(modelProfileForModel(activeProviderGroup, id))
-                      ? <ModelCapabilityBadge kind="vision" label={t('composerModelVision')} />
-                      : <ModelCapabilityBadge kind="text" label={t('composerModelTextOnly')} />
-                  }
-                  onClick={() => {
-                    const nextReasoning = normalizeComposerReasoningEffort(
-                      composerReasoningEffort,
-                      modelProfileForModel(activeProviderGroup, id)
-                    )
-                    onComposerModelChange(
-                      id,
-                      activeProviderGroup.providerId === UNGROUPED_MODEL_PROVIDER_ID
-                        ? undefined
-                        : activeProviderGroup.providerId
-                    )
-                    if (nextReasoning !== currentReasoning) {
-                      onComposerReasoningEffortChange?.(nextReasoning)
+              activeProviderModelIds.map((id) => {
+                const targetProfile = modelProfileForModel(activeProviderGroup, id)
+                const selected = composerModelMenuItemSelected({
+                  groupProviderId: activeProviderGroup.providerId,
+                  selectedProviderId,
+                  currentModel,
+                  modelId: id
+                })
+                const disabled = lockVisionToTextModelSwitch &&
+                  !selected &&
+                  !canSwitchComposerModelFromCurrent(currentModelProfile, targetProfile)
+                return (
+                  <PickerRow
+                    key={`${activeProviderGroup.providerId}:${id}`}
+                    selected={selected}
+                    disabled={disabled}
+                    title={id}
+                    rightSlot={
+                      modelSupportsImageInput(targetProfile)
+                        ? <ModelCapabilityBadge kind="vision" label={t('composerModelVision')} />
+                        : <ModelCapabilityBadge kind="text" label={t('composerModelTextOnly')} />
                     }
-                    setMenuOpen(false)
-                  }}
-                />
-              ))
+                    onClick={() => {
+                      if (disabled) return
+                      const nextReasoning = normalizeComposerReasoningEffort(
+                        composerReasoningEffort,
+                        targetProfile
+                      )
+                      onComposerModelChange(
+                        id,
+                        activeProviderGroup.providerId === UNGROUPED_MODEL_PROVIDER_ID
+                          ? undefined
+                          : activeProviderGroup.providerId
+                      )
+                      if (nextReasoning !== currentReasoning) {
+                        onComposerReasoningEffortChange?.(nextReasoning)
+                      }
+                      setMenuOpen(false)
+                    }}
+                  />
+                )
+              })
             ) : (
               <div className="px-2.5 py-2 text-[12.5px] font-medium text-ds-faint">
                 {t('composerNoMatchingModels')}
@@ -885,13 +896,22 @@ function MenuSeparator(): ReactElement {
   return <div className="my-2 h-px bg-ds-border-muted" />
 }
 
+export function canSwitchComposerModelFromCurrent(
+  currentProfile: ModelProviderModelProfileV1 | undefined,
+  targetProfile: ModelProviderModelProfileV1 | undefined
+): boolean {
+  return !modelSupportsImageInput(currentProfile) || modelSupportsImageInput(targetProfile)
+}
+
 function PickerRow({
   selected,
+  disabled = false,
   title,
   rightSlot,
   onClick
 }: {
   selected: boolean
+  disabled?: boolean
   title: string
   rightSlot?: ReactElement | null
   onClick: () => void
@@ -902,10 +922,13 @@ function PickerRow({
       role="menuitemradio"
       aria-checked={selected}
       title={title}
+      disabled={disabled}
       onMouseDown={(event) => event.preventDefault()}
       onClick={onClick}
       className={`flex min-h-9 w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition ${
-        selected
+        disabled
+          ? 'cursor-not-allowed text-ds-faint opacity-55'
+          : selected
           ? 'bg-ds-hover text-ds-ink'
           : 'text-ds-muted hover:bg-ds-hover hover:text-ds-ink'
       }`}

--- a/src/renderer/src/store/chat-store-app-actions.test.ts
+++ b/src/renderer/src/store/chat-store-app-actions.test.ts
@@ -256,6 +256,134 @@ describe('chat-store app actions composer model loading', () => {
     expect(state.composerProviderId).toBe('')
   })
 
+  it('blocks switching an active chat with user messages from vision to text-only', () => {
+    const { actions, state } = buildHarness({
+      ok: true,
+      modelIds: ['vision-model', 'text-model'],
+      defaultModelId: 'vision-model',
+      modelGroups: []
+    })
+    state.route = 'chat'
+    state.blocks = [{ kind: 'user', id: 'user-1', text: 'hello' }] as ChatState['blocks']
+    state.activeThreadId = 'thread-a'
+    state.threads = [{
+      id: 'thread-a',
+      title: 'Thread A',
+      workspace: '/tmp/project',
+      model: 'vision-model',
+      status: 'idle',
+      mode: 'agent',
+      updatedAt: '2026-06-01T00:00:00.000Z'
+    }]
+    state.composerModel = 'vision-model'
+    state.composerProviderId = 'test-provider'
+    state.composerModelGroups = [{
+      providerId: 'test-provider',
+      label: 'Test',
+      modelIds: ['vision-model', 'text-model'],
+      modelProfiles: {
+        'vision-model': {
+          inputModalities: ['text', 'image'],
+          outputModalities: ['text'],
+          supportsToolCalling: true,
+          messageParts: ['text', 'image_url']
+        },
+        'text-model': {
+          inputModalities: ['text'],
+          outputModalities: ['text'],
+          supportsToolCalling: true,
+          messageParts: ['text']
+        }
+      }
+    }]
+
+    actions.setComposerModel('text-model', 'test-provider')
+
+    expect(state.composerModel).toBe('vision-model')
+    expect(state.composerProviderId).toBe('test-provider')
+    expect(localStorage.getItem(THREAD_COMPOSER_SELECTION_STORAGE_KEY)).toBeNull()
+    expect(window.kunGui.saveSettingsSilent).not.toHaveBeenCalled()
+  })
+
+  it('allows switching an empty chat from vision to text-only', () => {
+    const { actions, state } = buildHarness({
+      ok: true,
+      modelIds: ['vision-model', 'text-model'],
+      defaultModelId: 'vision-model',
+      modelGroups: []
+    })
+    state.route = 'chat'
+    state.blocks = []
+    state.composerModel = 'vision-model'
+    state.composerProviderId = 'test-provider'
+    state.composerModelGroups = [{
+      providerId: 'test-provider',
+      label: 'Test',
+      modelIds: ['vision-model', 'text-model'],
+      modelProfiles: {
+        'vision-model': {
+          inputModalities: ['text', 'image'],
+          outputModalities: ['text'],
+          supportsToolCalling: true,
+          messageParts: ['text', 'image_url']
+        },
+        'text-model': {
+          inputModalities: ['text'],
+          outputModalities: ['text'],
+          supportsToolCalling: true,
+          messageParts: ['text']
+        }
+      }
+    }]
+
+    actions.setComposerModel('text-model', 'test-provider')
+
+    expect(state.composerModel).toBe('text-model')
+    expect(state.composerProviderId).toBe('test-provider')
+    expect(localStorage.getItem(COMPOSER_MODEL_STORAGE_KEY)).toBe('text-model')
+    expect(window.kunGui.saveSettingsSilent).toHaveBeenCalledWith({
+      agents: { kun: { model: 'text-model' } }
+    })
+  })
+
+  it('allows switching an active chat from text-only to vision', () => {
+    const { actions, state } = buildHarness({
+      ok: true,
+      modelIds: ['vision-model', 'text-model'],
+      defaultModelId: 'text-model',
+      modelGroups: []
+    })
+    state.route = 'chat'
+    state.blocks = [{ kind: 'user', id: 'user-1', text: 'hello' }] as ChatState['blocks']
+    state.composerModel = 'text-model'
+    state.composerProviderId = 'test-provider'
+    state.composerModelGroups = [{
+      providerId: 'test-provider',
+      label: 'Test',
+      modelIds: ['vision-model', 'text-model'],
+      modelProfiles: {
+        'vision-model': {
+          inputModalities: ['text', 'image'],
+          outputModalities: ['text'],
+          supportsToolCalling: true,
+          messageParts: ['text', 'image_url']
+        },
+        'text-model': {
+          inputModalities: ['text'],
+          outputModalities: ['text'],
+          supportsToolCalling: true,
+          messageParts: ['text']
+        }
+      }
+    }]
+
+    actions.setComposerModel('vision-model', 'test-provider')
+
+    expect(state.composerModel).toBe('vision-model')
+    expect(state.composerProviderId).toBe('test-provider')
+    expect(localStorage.getItem(COMPOSER_MODEL_STORAGE_KEY)).toBe('vision-model')
+  })
+
   it('does not overwrite a stored custom model when only fallback models are available', async () => {
     localStorage.setItem(COMPOSER_MODEL_STORAGE_KEY, 'MiniMax-M2')
     const { actions, state } = buildHarness({

--- a/src/renderer/src/store/chat-store-app-actions.ts
+++ b/src/renderer/src/store/chat-store-app-actions.ts
@@ -3,6 +3,7 @@ import type { AppSettingsV1 } from '@shared/app-settings'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 import type { ChatState, ChatStoreGet, ChatStoreSet, InitialSetupMode, PluginHostRoute, SettingsRouteSection } from './chat-store-types'
 import {
+  canSwitchComposerModel,
   composerModelSelectable,
   persistComposerProviderId,
   providerIdForComposerModel,
@@ -72,7 +73,22 @@ export function createAppActions(options: CreateAppActionsOptions): Pick<
 
     setComposerModel: (modelId, providerId) => {
       const nextProviderId = providerId?.trim() || providerIdForComposerModel(get().composerModelGroups, modelId)
-      const activeThreadId = get().activeThreadId
+      const state = get()
+      const lockVisionToTextSwitch =
+        state.route === 'chat' &&
+        Array.isArray(state.blocks) &&
+        state.blocks.some((block) => block.kind === 'user')
+      if (!canSwitchComposerModel(
+        lockVisionToTextSwitch,
+        state.composerModelGroups,
+        state.composerModel,
+        state.composerProviderId,
+        modelId,
+        nextProviderId
+      )) {
+        return
+      }
+      const activeThreadId = state.activeThreadId
       if (activeThreadId) {
         rememberThreadComposerSelection(activeThreadId, modelId, nextProviderId)
       } else {

--- a/src/renderer/src/store/chat-store-helpers.ts
+++ b/src/renderer/src/store/chat-store-helpers.ts
@@ -6,6 +6,7 @@ import {
   CLAW_MODEL_IDS,
   isComposerChatModelId,
   modelProfileSupportsTextChat,
+  modelSupportsImageInput,
   type ClawImAgentProfileV1,
   type ClawImChannelV1,
   type ClawImPlatformCredentialV1,
@@ -119,6 +120,41 @@ export function providerIdForComposerModel(
   return modelGroups.find((group) => modelGroupHasModel(group, model))?.providerId ?? ''
 }
 
+export function canSwitchComposerModel(
+  lockVisionToTextSwitch: boolean,
+  modelGroups: readonly ModelProviderModelGroup[],
+  currentModelId: string,
+  currentProviderId: string,
+  nextModelId: string,
+  nextProviderId: string
+): boolean {
+  if (!lockVisionToTextSwitch) return true
+  const currentProfile = modelProfileForComposerSelection(modelGroups, currentModelId, currentProviderId)
+  if (!modelSupportsImageInput(currentProfile)) return true
+  const nextProfile = modelProfileForComposerSelection(modelGroups, nextModelId, nextProviderId)
+  return modelSupportsImageInput(nextProfile)
+}
+
+function modelProfileForComposerSelection(
+  modelGroups: readonly ModelProviderModelGroup[],
+  modelId: string,
+  providerId: string
+): ReturnType<typeof modelProfileForComposerModel> {
+  const selectedProviderId = providerId.trim()
+  const selectedGroup = selectedProviderId
+    ? modelGroups.find((group) => group.providerId === selectedProviderId)
+    : undefined
+  if (selectedGroup && modelGroupHasModel(selectedGroup, modelId)) {
+    return modelProfileForComposerModel(selectedGroup, modelId)
+  }
+  for (const group of modelGroups) {
+    if (!modelGroupHasModel(group, modelId)) continue
+    const profile = modelProfileForComposerModel(group, modelId)
+    if (profile) return profile
+  }
+  return undefined
+}
+
 function modelGroupHasModel(group: ModelProviderModelGroup, modelId: string): boolean {
   const normalized = normalizeComposerModelId(modelId)
   if (!normalized) return false
@@ -165,7 +201,11 @@ function modelProfileForComposerModel(
   const key = normalizeComposerModelId(model)
   if (!key) return undefined
   const profiles = group.modelProfiles ?? {}
-  return profiles[key] ?? profiles[model]
+  const direct = profiles[key] ?? profiles[model]
+  if (direct) return direct
+  return Object.values(profiles).find((profile) =>
+    profile.aliases?.some((alias) => normalizeComposerModelId(alias) === key)
+  )
 }
 
 function normalizeComposerModelId(modelId: string): string {


### PR DESCRIPTION
## Summary
- Prevent active chat conversations that started with a vision-capable model from switching to a text-only model after user messages exist.
- Keep empty chats free to switch from vision to text-only before sending.
- Keep text-only to vision switching allowed.

## Verification
- npm test -- src/renderer/src/components/chat/FloatingComposer.test.ts src/renderer/src/store/chat-store-app-actions.test.ts
- npm --prefix kun run typecheck

Note: npm run typecheck currently fails on upstream develop test typing in src/renderer/src/store/chat-store-thread-actions.test.ts, unrelated to this change.