### PR TITLE
fix(renderer): strip relative time direction labels

### DIFF
--- a/src/renderer/src/lib/format-relative-time.test.ts
+++ b/src/renderer/src/lib/format-relative-time.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { formatRelativeTime } from './format-relative-time'
+
+describe('formatRelativeTime', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('omits the trailing Chinese past suffix for recent relative times', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-19T12:00:00.000Z'))
+
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'zh-CN')).toBe('10分钟')
+    expect(formatRelativeTime('2026-06-19T02:00:00.000Z', 'zh-CN')).toBe('10小时')
+    expect(formatRelativeTime('2026-06-14T12:00:00.000Z', 'zh-CN')).toBe('5天')
+  })
+
+  it('omits past direction words from other locales too', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-19T12:00:00.000Z'))
+
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'en-US')).toBe('10 minutes')
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'ja-JP')).toBe('10 分')
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'ko-KR')).toBe('10분')
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'fr-FR')).toBe('10 minutes')
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'de-DE')).toBe('10 Minuten')
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'es-ES')).toBe('10 minutos')
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'ru-RU')).toBe('10 минут')
+    expect(formatRelativeTime('2026-06-19T11:50:00.000Z', 'ar-SA')).toBe('١٠ دقائق')
+  })
+
+  it('keeps future relative time unchanged', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-19T12:00:00.000Z'))
+
+    expect(formatRelativeTime('2026-06-19T12:10:00.000Z', 'zh-CN')).toBe('10分钟后')
+    expect(formatRelativeTime('2026-06-19T12:10:00.000Z', 'en-US')).toBe('in 10 minutes')
+  })
+})

--- a/src/renderer/src/lib/format-relative-time.ts
+++ b/src/renderer/src/lib/format-relative-time.ts
@@ -10,26 +10,26 @@ export function formatRelativeTime(input: string, locale: string): string {
   const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
 
   if (absSeconds < 60) {
-    return formatter.format(Math.round(diffMs / 1000), 'second')
+    return formatRelativeUnit(formatter, locale, Math.round(diffMs / 1000), 'second')
   }
 
   const absMinutes = absSeconds / 60
   if (absMinutes < 60) {
-    return formatter.format(Math.round(diffMs / (60 * 1000)), 'minute')
+    return formatRelativeUnit(formatter, locale, Math.round(diffMs / (60 * 1000)), 'minute')
   }
 
   const absHours = absMinutes / 60
   if (absHours < 24) {
-    return formatter.format(Math.round(diffMs / (60 * 60 * 1000)), 'hour')
+    return formatRelativeUnit(formatter, locale, Math.round(diffMs / (60 * 60 * 1000)), 'hour')
   }
 
   const absDays = absHours / 24
   if (absDays < 7) {
-    return formatter.format(Math.round(diffMs / (24 * 60 * 60 * 1000)), 'day')
+    return formatRelativeUnit(formatter, locale, Math.round(diffMs / (24 * 60 * 60 * 1000)), 'day')
   }
 
   if (absDays < 30) {
-    return formatter.format(Math.round(diffMs / (7 * 24 * 60 * 60 * 1000)), 'week')
+    return formatRelativeUnit(formatter, locale, Math.round(diffMs / (7 * 24 * 60 * 60 * 1000)), 'week')
   }
 
   const sameYear = date.getFullYear() === now.getFullYear()
@@ -38,4 +38,63 @@ export function formatRelativeTime(input: string, locale: string): string {
     day: 'numeric',
     ...(sameYear ? {} : { year: 'numeric' })
   }).format(date)
+}
+
+type RelativeTimeUnit = Intl.RelativeTimeFormatUnit
+
+function formatRelativeUnit(
+  formatter: Intl.RelativeTimeFormat,
+  locale: string,
+  value: number,
+  unit: RelativeTimeUnit
+): string {
+  const formatted = formatter.format(value, unit)
+  if (value >= 0) {
+    return formatted
+  }
+
+  return stripPastDirectionAffixes(formatter, value, unit) ?? formatted
+}
+
+function stripPastDirectionAffixes(
+  formatter: Intl.RelativeTimeFormat,
+  value: number,
+  unit: RelativeTimeUnit
+): string | null {
+  const pastParts = formatter.formatToParts(value, unit)
+  const futureParts = formatter.formatToParts(Math.abs(value), unit)
+  const pastIntegerIndex = pastParts.findIndex((part) => part.type === 'integer')
+  const futureIntegerIndex = futureParts.findIndex((part) => part.type === 'integer')
+
+  if (pastIntegerIndex < 0 || futureIntegerIndex < 0) {
+    return null
+  }
+
+  const integer = pastParts[pastIntegerIndex]?.value ?? ''
+  const pastBefore = joinPartValues(pastParts.slice(0, pastIntegerIndex))
+  const pastAfter = joinPartValues(pastParts.slice(pastIntegerIndex + 1))
+  const futureBefore = joinPartValues(futureParts.slice(0, futureIntegerIndex))
+  const futureAfter = joinPartValues(futureParts.slice(futureIntegerIndex + 1))
+  const before = pastBefore === futureBefore ? pastBefore : ''
+  const after = commonPrefix(pastAfter, futureAfter)
+  const compact = `${before}${integer}${after}`.trim()
+
+  return compact.length > 0 && compact !== integer ? compact : null
+}
+
+function joinPartValues(parts: Intl.RelativeTimeFormatPart[]): string {
+  return parts.map((part) => part.value).join('')
+}
+
+function commonPrefix(first: string, second: string): string {
+  const firstChars = Array.from(first)
+  const secondChars = Array.from(second)
+  const length = Math.min(firstChars.length, secondChars.length)
+  let index = 0
+
+  while (index < length && firstChars[index] === secondChars[index]) {
+    index += 1
+  }
+
+  return firstChars.slice(0, index).join('')
 }


### PR DESCRIPTION
Summary
- Strip past-direction affixes from renderer relative time labels across locales.
- Keep future relative labels unchanged.
- Add multi-locale regression coverage for Chinese, English, Japanese, Korean, French, German, Spanish, Russian, and Arabic.

Tests
- npm run test -- src/renderer/src/lib/format-relative-time.test.ts
- npx eslint src/renderer/src/lib/format-relative-time.ts src/renderer/src/lib/format-relative-time.test.ts
- npm run typecheck (fails on existing baseline issues: missing @codemirror/merge types and chat-store-thread-actions.test.ts onDeltas typing)