### PR TITLE
fix(settings): shorten home paths in settings

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,8 +1,10 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
+import { homedir } from 'node:os'
 import type { KunGuiApi } from '../shared/kun-gui-api'
 
 const api = {
   platform: process.platform,
+  homeDir: homedir(),
   getSettings: () => ipcRenderer.invoke('settings:get'),
   setSettings: (partial) =>
     ipcRenderer.invoke('settings:set', partial),

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -28,6 +28,13 @@ import { applyCursorSpotlight, applyTheme, applyUiFontScale, applyWriteTypograph
 import { formatWorkspacePickerError } from '../lib/format-workspace-picker-error'
 import type { SkillRootListItem } from '@shared/kun-gui-api'
 import { normalizeWorkspaceRoot } from '../lib/workspace-path'
+import {
+  compactHomePathForSettingsDisplay,
+  compactHomePathListForSettingsDisplay,
+  expandHomePathForSettingsUse,
+  expandHomePathListForSettingsUse,
+  expandSettingsHomePathsForUse
+} from '../lib/settings-home-paths'
 import { useChatStore, type SettingsRouteSection } from '../store/chat-store'
 import { SettingsSidebar } from './SettingsSidebar'
 import { WriteDebugLogModal } from './settings-debug-log'
@@ -137,6 +144,16 @@ export function SettingsView(): ReactElement {
   const formPort = formKun?.port
   const formGuiUpdateChannel = form?.guiUpdate?.channel
   const formCursorSpotlight = form?.cursorSpotlight
+  const settingsPlatform = typeof window !== 'undefined' ? window.kunGui?.platform ?? '' : ''
+  const settingsHomeDir = typeof window !== 'undefined' ? window.kunGui?.homeDir ?? '' : ''
+  const compactHomePath = useCallback((value: string): string =>
+    compactHomePathForSettingsDisplay(value, settingsHomeDir, settingsPlatform), [settingsHomeDir, settingsPlatform])
+  const expandHomePath = useCallback((value: string): string =>
+    expandHomePathForSettingsUse(value, settingsHomeDir, settingsPlatform), [settingsHomeDir, settingsPlatform])
+  const compactHomePathList = useCallback((values: readonly string[]): string =>
+    compactHomePathListForSettingsDisplay(values, settingsHomeDir, settingsPlatform), [settingsHomeDir, settingsPlatform])
+  const expandHomePathList = useCallback((values: readonly string[]): string[] =>
+    expandHomePathListForSettingsUse(values, settingsHomeDir, settingsPlatform), [settingsHomeDir, settingsPlatform])
   const {
     checkingGuiUpdate,
     checkGuiUpdate,
@@ -358,7 +375,7 @@ export function SettingsView(): ReactElement {
     if (typeof window.kunGui?.listSkillRoots !== 'function') return
     setSkillRootsLoading(true)
     try {
-      const workspaceRoot = normalizeWorkspaceRoot(formWorkspaceRoot)
+      const workspaceRoot = normalizeWorkspaceRoot(expandHomePath(formWorkspaceRoot ?? ''))
       const result = await window.kunGui.listSkillRoots(workspaceRoot || undefined)
       if (result.ok) setSkillRoots(result.roots)
     } catch {
@@ -366,7 +383,7 @@ export function SettingsView(): ReactElement {
     } finally {
       setSkillRootsLoading(false)
     }
-  }, [formWorkspaceRoot])
+  }, [expandHomePath, formWorkspaceRoot])
 
   useEffect(() => {
     if (category !== 'agents') return
@@ -437,7 +454,7 @@ export function SettingsView(): ReactElement {
       setMcpConfigExists(true)
       setMcpNotice({
         tone: 'success',
-        message: t('mcpSaved', { path: result.path })
+        message: t('mcpSaved', { path: compactHomePath(result.path) })
       })
     } catch (e) {
       setMcpNotice({
@@ -463,7 +480,7 @@ export function SettingsView(): ReactElement {
     setRuntimeDiagnosticsNotice(null)
     try {
       const loaded = await loadKunDiagnostics(provider, {
-        workspace: normalizeWorkspaceRoot(formWorkspaceRoot)
+        workspace: normalizeWorkspaceRoot(expandHomePath(formWorkspaceRoot ?? ''))
       })
       if (loaded.runtimeInfo !== undefined) setRuntimeInfo(loaded.runtimeInfo)
       if (loaded.toolDiagnostics !== undefined) setToolDiagnostics(loaded.toolDiagnostics)
@@ -482,7 +499,7 @@ export function SettingsView(): ReactElement {
     } finally {
       setRuntimeDiagnosticsBusy(false)
     }
-  }, [formWorkspaceRoot])
+  }, [expandHomePath, formWorkspaceRoot])
 
   useEffect(() => {
     if (category !== 'agents' && category !== 'permissions' && category !== 'memory') return
@@ -589,7 +606,11 @@ export function SettingsView(): ReactElement {
     setSaveError(null)
 
     try {
-      const next = coerceRendererSettings(await rendererRuntimeClient.setSettings(snapshot))
+      const next = coerceRendererSettings(
+        await rendererRuntimeClient.setSettings(
+          expandSettingsHomePathsForUse(snapshot, settingsHomeDir, settingsPlatform)
+        )
+      )
       if (version !== draftVersion.current) return
 
       setForm(next)
@@ -746,7 +767,7 @@ export function SettingsView(): ReactElement {
       if (typeof window.kunGui?.pickWorkspaceDirectory !== 'function') {
         throw new Error('workspace:pick-directory unavailable')
       }
-      const picked = await window.kunGui.pickWorkspaceDirectory(form.workspaceRoot || undefined)
+      const picked = await window.kunGui.pickWorkspaceDirectory(expandHomePath(form.workspaceRoot) || undefined)
       if (!picked.canceled && picked.path) {
         update({ workspaceRoot: picked.path })
       }
@@ -757,7 +778,7 @@ export function SettingsView(): ReactElement {
 
   const resetWorkspaceToDefault = (): void => {
     setWorkspacePickerError(null)
-    update({ workspaceRoot: DEFAULT_WORKSPACE_ROOT })
+    update({ workspaceRoot: expandHomePath(DEFAULT_WORKSPACE_ROOT) })
   }
 
   const pickWriteWorkspace = async (): Promise<void> => {
@@ -767,7 +788,7 @@ export function SettingsView(): ReactElement {
         throw new Error('workspace:pick-directory unavailable')
       }
       const picked = await window.kunGui.pickWorkspaceDirectory(
-        form.write.defaultWorkspaceRoot || DEFAULT_WRITE_WORKSPACE_ROOT
+        expandHomePath(form.write.defaultWorkspaceRoot || DEFAULT_WRITE_WORKSPACE_ROOT)
       )
       if (!picked.canceled && picked.path) {
         const workspaces = [
@@ -790,11 +811,12 @@ export function SettingsView(): ReactElement {
 
   const resetWriteWorkspaceToDefault = (): void => {
     setWriteWorkspacePickerError(null)
+    const workspaceRoot = expandHomePath(DEFAULT_WRITE_WORKSPACE_ROOT)
     update({
       write: {
-        defaultWorkspaceRoot: DEFAULT_WRITE_WORKSPACE_ROOT,
-        activeWorkspaceRoot: DEFAULT_WRITE_WORKSPACE_ROOT,
-        workspaces: [DEFAULT_WRITE_WORKSPACE_ROOT, ...form.write.workspaces]
+        defaultWorkspaceRoot: workspaceRoot,
+        activeWorkspaceRoot: workspaceRoot,
+        workspaces: [workspaceRoot, ...form.write.workspaces]
       }
     })
   }
@@ -806,7 +828,7 @@ export function SettingsView(): ReactElement {
         throw new Error('workspace:pick-directory unavailable')
       }
       const picked = await window.kunGui.pickWorkspaceDirectory(
-        form.claw.im.workspaceRoot || form.workspaceRoot || undefined
+        expandHomePath(form.claw.im.workspaceRoot || form.workspaceRoot) || undefined
       )
       if (!picked.canceled && picked.path) {
         update({ claw: { im: { workspaceRoot: picked.path } } })
@@ -875,6 +897,10 @@ export function SettingsView(): ReactElement {
     logPath,
     logDirOpenError,
     setLogDirOpenError,
+    compactHomePath,
+    expandHomePath,
+    compactHomePathList,
+    expandHomePathList,
     pickWriteWorkspace,
     resetWriteWorkspaceToDefault,
     writeWorkspacePickerError,

--- a/src/renderer/src/components/schedule/ScheduleDefaultsDialog.tsx
+++ b/src/renderer/src/components/schedule/ScheduleDefaultsDialog.tsx
@@ -7,6 +7,13 @@ import {
   mergeScheduleSettings,
   type ScheduleSettingsV1
 } from '@shared/app-settings'
+import {
+  compactHomePathForSettingsDisplay,
+  compactHomePathTextForSettingsDisplay,
+  expandHomePathForSettingsUse,
+  expandHomePathListForSettingsUse,
+  expandHomePathTextForSettingsUse
+} from '../../lib/settings-home-paths'
 
 type ScheduleModelProviderOption = {
   providerId: string
@@ -89,14 +96,14 @@ export function ScheduleDefaultsDialog({
     const selection = resolveDefaultsModelSelection(modelProviders, draft.providerId, draft.model)
     await onSave({
       enabled: draft.enabled,
-      defaultWorkspaceRoot: draft.defaultWorkspaceRoot,
+      defaultWorkspaceRoot: expandHomePathForSettingsUse(draft.defaultWorkspaceRoot),
       providerId: selection.providerId,
       model: selection.model,
       mode: 'agent',
       promptPrefix: draft.promptPrefix,
       skills: {
         defaultNames: splitLooseList(draft.defaultNames),
-        extraDirs: splitLooseList(draft.extraDirs)
+        extraDirs: expandHomePathListForSettingsUse(splitLooseList(draft.extraDirs))
       }
     })
   }
@@ -190,8 +197,9 @@ export function ScheduleDefaultsDialog({
         <label className="mt-4 flex flex-col gap-2 text-[13px] font-medium text-ds-ink">
           {t('scheduleDefaultWorkspace')}
           <input
-            value={draft.defaultWorkspaceRoot}
-            onChange={(event) => update({ defaultWorkspaceRoot: event.target.value })}
+            value={compactHomePathForSettingsDisplay(draft.defaultWorkspaceRoot)}
+            onChange={(event) =>
+              update({ defaultWorkspaceRoot: expandHomePathForSettingsUse(event.target.value) })}
             placeholder={t('scheduleWorkspacePlaceholder')}
             className="w-full rounded-xl border border-ds-border bg-ds-main/60 px-3 py-2 text-[14px] text-ds-ink outline-none focus:border-accent/40 focus:ring-1 focus:ring-accent/25"
           />
@@ -220,8 +228,9 @@ export function ScheduleDefaultsDialog({
           <label className="flex flex-col gap-2 text-[13px] font-medium text-ds-ink">
             {t('scheduleExtraSkillDirs')}
             <textarea
-              value={draft.extraDirs}
-              onChange={(event) => update({ extraDirs: event.target.value })}
+              value={compactHomePathTextForSettingsDisplay(draft.extraDirs)}
+              onChange={(event) =>
+                update({ extraDirs: expandHomePathTextForSettingsUse(event.target.value) })}
               placeholder={t('scheduleExtraSkillDirsPlaceholder')}
               className="min-h-[92px] w-full resize-y rounded-xl border border-ds-border bg-ds-main/60 px-3 py-3 text-[14px] leading-6 text-ds-ink outline-none focus:border-accent/40 focus:ring-1 focus:ring-accent/25"
             />

--- a/src/renderer/src/components/schedule/ScheduleTasksView.tsx
+++ b/src/renderer/src/components/schedule/ScheduleTasksView.tsx
@@ -43,6 +43,10 @@ import {
 import { rendererRuntimeClient } from '../../agent/runtime-client'
 import { confirmDialog } from '../../lib/confirm-dialog'
 import { formatWorkspacePickerError } from '../../lib/format-workspace-picker-error'
+import {
+  compactHomePathForSettingsDisplay,
+  expandHomePathForSettingsUse
+} from '../../lib/settings-home-paths'
 import { SidebarTitlebarToggleButton } from '../sidebar/SidebarPrimitives'
 import { ScheduleDefaultsDialog } from './ScheduleDefaultsDialog'
 
@@ -483,7 +487,9 @@ export function ScheduleTasksView({
       if (typeof window.kunGui?.pickWorkspaceDirectory !== 'function') {
         throw new Error(t('workspacePickerUnavailable'))
       }
-      const picked = await window.kunGui.pickWorkspaceDirectory(resolveDialogWorkspaceRoot(dialog.draft.workspaceRoot) || undefined)
+      const picked = await window.kunGui.pickWorkspaceDirectory(
+        expandHomePathForSettingsUse(resolveDialogWorkspaceRoot(dialog.draft.workspaceRoot)) || undefined
+      )
       if (picked.canceled || !picked.path) return
       onDraftChangeInDialog({ workspaceRoot: picked.path })
       setDialogError(null)
@@ -504,7 +510,7 @@ export function ScheduleTasksView({
       return
     }
     const now = nowIso()
-    const workspaceRoot = resolveDialogWorkspaceRoot(dialog.draft.workspaceRoot)
+    const workspaceRoot = expandHomePathForSettingsUse(resolveDialogWorkspaceRoot(dialog.draft.workspaceRoot))
     const draftClawChannelId = dialog.draft.clawChannelId.trim()
     const selection = resolveScheduleModelSelection(
       modelProviders,
@@ -1194,8 +1200,9 @@ function ScheduleTaskDialog({
                   <FieldLabel>{t('scheduleWorkspace')}</FieldLabel>
                   <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_138px]">
                     <input
-                      value={draft.workspaceRoot}
-                      onChange={(event) => updateDraft({ workspaceRoot: event.target.value })}
+                      value={compactHomePathForSettingsDisplay(draft.workspaceRoot)}
+                      onChange={(event) =>
+                        updateDraft({ workspaceRoot: expandHomePathForSettingsUse(event.target.value) })}
                       placeholder={t('scheduleWorkspacePlaceholder')}
                       className="h-10 w-full rounded-xl border border-ds-border bg-ds-main/55 px-3 text-[14px] text-ds-ink outline-none transition placeholder:text-ds-faint focus:border-accent/45 focus:ring-2 focus:ring-accent/15"
                     />

--- a/src/renderer/src/components/settings-section-agents.tsx
+++ b/src/renderer/src/components/settings-section-agents.tsx
@@ -175,6 +175,10 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
     logPath,
     logDirOpenError,
     setLogDirOpenError,
+    compactHomePath,
+    expandHomePath,
+    compactHomePathList,
+    expandHomePathList,
     pickWriteWorkspace,
     resetWriteWorkspaceToDefault,
     writeWorkspacePickerError,
@@ -518,8 +522,8 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                       <input
                         className="w-full min-w-0 rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[14px] text-ds-ink shadow-sm focus:border-accent/40 focus:outline-none focus:ring-1 focus:ring-accent/30 md:max-w-md"
                         placeholder={t('kunBinaryPlaceholder')}
-                        value={kun.binaryPath}
-                        onChange={(e) => updateKun({ binaryPath: e.target.value })}
+                        value={compactHomePath(kun.binaryPath)}
+                        onChange={(e) => updateKun({ binaryPath: expandHomePath(e.target.value) })}
                       />
                     }
                   />
@@ -530,8 +534,8 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                       <input
                         className="w-full min-w-0 rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[14px] text-ds-ink shadow-sm focus:border-accent/40 focus:outline-none focus:ring-1 focus:ring-accent/30 md:max-w-md"
                         placeholder={DEFAULT_KUN_DATA_DIR}
-                        value={kun.dataDir}
-                        onChange={(e) => updateKun({ dataDir: e.target.value })}
+                        value={compactHomePath(kun.dataDir)}
+                        onChange={(e) => updateKun({ dataDir: expandHomePath(e.target.value) })}
                       />
                     }
                   />
@@ -762,7 +766,7 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                                   )}
                                 </div>
                                 <code className="mt-1 block break-all font-mono text-[12px] text-ds-muted">
-                                  {root.path}
+                                  {compactHomePath(root.path)}
                                 </code>
                               </div>
                               <div className="flex shrink-0 items-center gap-1.5 pt-0.5">
@@ -789,12 +793,12 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                     wideControl
                     control={
                       <textarea
-                        value={listSettingsText(form.claw.skills.extraDirs)}
+                        value={compactHomePathList(form.claw.skills.extraDirs)}
                         onChange={(event) =>
                           update({
                             claw: {
                               skills: {
-                                extraDirs: splitSettingsList(event.target.value)
+                                extraDirs: expandHomePathList(splitSettingsList(event.target.value))
                               }
                             }
                           })
@@ -941,7 +945,7 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                     control={
                       <div className="w-full min-w-0 rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[13px] text-ds-muted shadow-sm">
                         <code className="block break-all rounded-lg bg-ds-main/70 px-2 py-1 font-mono text-[12px] text-ds-ink">
-                          {mcpConfigPath}
+                          {compactHomePath(mcpConfigPath)}
                         </code>
                       </div>
                     }
@@ -1201,10 +1205,10 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                     control={
                       <input
                         className="w-full min-w-0 rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[14px] text-ds-ink shadow-sm focus:border-accent/40 focus:outline-none focus:ring-1 focus:ring-accent/30 md:max-w-md"
-                        value={storage.sqlitePath}
+                        value={compactHomePath(storage.sqlitePath)}
                         disabled={storage.backend !== 'hybrid'}
                         placeholder={t('kunStorageSqlitePathPlaceholder')}
-                        onChange={(e) => updateStorage({ sqlitePath: e.target.value })}
+                        onChange={(e) => updateStorage({ sqlitePath: expandHomePath(e.target.value) })}
                       />
                     }
                   />

--- a/src/renderer/src/components/settings-section-claw.test.ts
+++ b/src/renderer/src/components/settings-section-claw.test.ts
@@ -112,6 +112,8 @@ describe('ClawSettingsSection', () => {
           form: buildSettings(),
           update: vi.fn(),
           selectControlClass: 'select-control',
+          compactHomePath: (path: string) => path,
+          expandHomePath: (path: string) => path,
           pickClawWorkspace: async () => undefined,
           resetClawWorkspaceToDefault: () => undefined,
           clawWorkspacePickerError: null

--- a/src/renderer/src/components/settings-section-claw.tsx
+++ b/src/renderer/src/components/settings-section-claw.tsx
@@ -14,6 +14,8 @@ type ClawSettingsContext = {
   form: AppSettingsV1
   update: (partial: AppSettingsPatch) => void
   selectControlClass: string
+  compactHomePath: (path: string) => string
+  expandHomePath: (path: string) => string
   pickClawWorkspace: () => Promise<void>
   resetClawWorkspaceToDefault: () => void
   clawWorkspacePickerError: string | null
@@ -84,6 +86,8 @@ export function ClawSettingsSection({ ctx }: { ctx: ClawSettingsContext }): Reac
     form,
     update,
     selectControlClass,
+    compactHomePath,
+    expandHomePath,
     pickClawWorkspace,
     resetClawWorkspaceToDefault,
     clawWorkspacePickerError
@@ -110,17 +114,17 @@ export function ClawSettingsSection({ ctx }: { ctx: ClawSettingsContext }): Reac
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                 <input
                   className={textInputClass()}
-                  value={form.claw.im.workspaceRoot}
+                  value={compactHomePath(form.claw.im.workspaceRoot)}
                   onChange={(e) =>
                     update({
                       claw: {
                         im: {
-                          workspaceRoot: e.target.value
+                          workspaceRoot: expandHomePath(e.target.value)
                         }
                       }
                     })
                   }
-                  placeholder={t('clawDefaultWorkspacePlaceholder', { path: form.workspaceRoot })}
+                  placeholder={t('clawDefaultWorkspacePlaceholder', { path: compactHomePath(form.workspaceRoot) })}
                 />
                 <button
                   type="button"
@@ -165,6 +169,8 @@ export function ClawSettingsSection({ ctx }: { ctx: ClawSettingsContext }): Reac
                         provider: 'Feishu / Lark',
                         model: channel.model,
                         workspace: channelEffectiveWorkspace(form, channel)
+                          ? compactHomePath(channelEffectiveWorkspace(form, channel))
+                          : ''
                       })}
                     </div>
                   </div>
@@ -231,10 +237,11 @@ export function ClawSettingsSection({ ctx }: { ctx: ClawSettingsContext }): Reac
                     </span>
                     <input
                       className={textInputClass()}
-                      value={channel.workspaceRoot}
-                      onChange={(e) => updateChannel(form, update, channel.id, { workspaceRoot: e.target.value })}
+                      value={compactHomePath(channel.workspaceRoot)}
+                      onChange={(e) =>
+                        updateChannel(form, update, channel.id, { workspaceRoot: expandHomePath(e.target.value) })}
                       placeholder={t('clawWorkspaceInherit', {
-                        path: form.claw.im.workspaceRoot.trim() || form.workspaceRoot
+                        path: compactHomePath(form.claw.im.workspaceRoot.trim() || form.workspaceRoot)
                       })}
                     />
                   </label>

--- a/src/renderer/src/components/settings-section-general-legacy-import.tsx
+++ b/src/renderer/src/components/settings-section-general-legacy-import.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type ReactElement } from 'react'
 import { ArchiveRestore, FolderOpen, Loader2 } from 'lucide-react'
 import type { LegacySessionDetectResult } from '@shared/kun-gui-api'
+import { compactHomePathForSettingsDisplay } from '../lib/settings-home-paths'
 import { InlineNoticeView, SettingsCard, SettingRow, type InlineNotice } from './settings-controls'
 
 type TranslateFn = (key: string, options?: Record<string, unknown>) => string
@@ -138,7 +139,7 @@ export function LegacySessionImportCard({
                         total: source.threadCount
                       })}
                     </span>
-                    <code className="break-all font-mono">{source.path}</code>
+                    <code className="break-all font-mono">{compactHomePathForSettingsDisplay(source.path)}</code>
                   </li>
                 ))}
               </ul>

--- a/src/renderer/src/components/settings-section-general.tsx
+++ b/src/renderer/src/components/settings-section-general.tsx
@@ -39,6 +39,8 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
     logPath,
     logDirOpenError,
     setLogDirOpenError,
+    compactHomePath,
+    expandHomePath,
     pickWriteWorkspace,
     resetWriteWorkspaceToDefault,
     writeWorkspacePickerError,
@@ -161,8 +163,8 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                       <div className="flex items-center gap-2">
                         <input
                           className="w-full rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[14px] text-ds-ink shadow-sm focus:border-accent/40 focus:outline-none focus:ring-1 focus:ring-accent/30"
-                          value={form.workspaceRoot}
-                          onChange={(e) => update({ workspaceRoot: e.target.value })}
+                          value={compactHomePath(form.workspaceRoot)}
+                          onChange={(e) => update({ workspaceRoot: expandHomePath(e.target.value) })}
                           placeholder={t('workspaceRootPlaceholder')}
                         />
                         <button
@@ -323,7 +325,7 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                     <div className="flex w-full min-w-0 flex-col items-start gap-2">
                       {logPath ? (
                         <code className="block w-full max-w-full break-all rounded-xl bg-ds-main/70 px-3 py-2 font-mono text-[12px] text-ds-muted shadow-sm">
-                          {logPath}
+                          {compactHomePath(logPath)}
                         </code>
                       ) : (
                         <span className="text-[13px] text-ds-faint">…</span>

--- a/src/renderer/src/components/settings-section-worktree.tsx
+++ b/src/renderer/src/components/settings-section-worktree.tsx
@@ -7,7 +7,7 @@ import { useWorktreeStore } from '../stores/worktree-store'
 import { SettingsCard, SettingRow } from './settings-controls'
 
 export function WorktreeSettingsSection({ ctx }: { ctx: Record<string, any> }): ReactElement {
-  const { t } = ctx
+  const { t, compactHomePath, expandHomePath } = ctx
   const { poolStatus, loading, error, lastMergeResult, lastSyncResult, setPoolStatus, setLoading, setError, setLastMergeResult, setLastSyncResult } =
     useWorktreeStore()
   const [busyPool, setBusyPool] = useState<number | null>(null)
@@ -17,7 +17,7 @@ export function WorktreeSettingsSection({ ctx }: { ctx: Record<string, any> }): 
   const worktreeRoot: string | undefined = ctx.form?.worktreeRootPath || undefined
 
   const refresh = useCallback(async () => {
-    const path = ctx.form?.workspaceRoot || ctx.kun?.workspaceRoot || ''
+    const path = expandHomePath(ctx.form?.workspaceRoot || ctx.kun?.workspaceRoot || '')
     if (!path) return
     setProjectPath(path)
     setLoading(true)
@@ -199,8 +199,11 @@ export function WorktreeSettingsSection({ ctx }: { ctx: Record<string, any> }): 
               </div>
               <div className="rounded-xl border border-ds-border-muted bg-ds-main/40 px-3 py-2">
                 <div className="text-ds-faint">{t('worktreePoolDir')}</div>
-                <div className="mt-0.5 truncate font-mono text-[11px] text-ds-muted" title={poolStatus?.poolDir}>
-                  {poolStatus?.poolDir ?? '—'}
+                <div
+                  className="mt-0.5 truncate font-mono text-[11px] text-ds-muted"
+                  title={poolStatus?.poolDir ? compactHomePath(poolStatus.poolDir) : undefined}
+                >
+                  {poolStatus?.poolDir ? compactHomePath(poolStatus.poolDir) : '—'}
                 </div>
               </div>
               <div className="flex items-end justify-end">
@@ -263,8 +266,11 @@ export function WorktreeSettingsSection({ ctx }: { ctx: Record<string, any> }): 
                               </span>
                             )}
                           </div>
-                          <div className="mt-0.5 truncate text-[11px] text-ds-faint" title={wt?.path}>
-                            {wt ? wt.path : t('worktreeNotCreated')}
+                          <div
+                            className="mt-0.5 truncate text-[11px] text-ds-faint"
+                            title={wt?.path ? compactHomePath(wt.path) : undefined}
+                          >
+                            {wt ? compactHomePath(wt.path) : t('worktreeNotCreated')}
                             {wt && wt.changesCount > 0 ? (
                               <span className="ml-2 text-amber-600 dark:text-amber-400">
                                 · {wt.changesCount} {t('worktreeUncommitted')}

--- a/src/renderer/src/components/settings-section-write.tsx
+++ b/src/renderer/src/components/settings-section-write.tsx
@@ -67,6 +67,8 @@ export function WriteSettingsSection({ ctx }: { ctx: Record<string, any> }): Rea
     kun,
     update,
     selectControlClass,
+    compactHomePath,
+    expandHomePath,
     pickWriteWorkspace,
     resetWriteWorkspaceToDefault,
     writeWorkspacePickerError,
@@ -112,16 +114,17 @@ export function WriteSettingsSection({ ctx }: { ctx: Record<string, any> }): Rea
                       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                         <input
                           className="w-full rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[14px] text-ds-ink shadow-sm focus:border-accent/40 focus:outline-none focus:ring-1 focus:ring-accent/30"
-                          value={form.write.defaultWorkspaceRoot}
-                          onChange={(e) =>
+                          value={compactHomePath(form.write.defaultWorkspaceRoot)}
+                          onChange={(e) => {
+                            const workspaceRoot = expandHomePath(e.target.value)
                             update({
                               write: {
-                                defaultWorkspaceRoot: e.target.value,
-                                activeWorkspaceRoot: e.target.value,
-                                workspaces: [e.target.value, ...form.write.workspaces]
+                                defaultWorkspaceRoot: workspaceRoot,
+                                activeWorkspaceRoot: workspaceRoot,
+                                workspaces: [workspaceRoot, ...form.write.workspaces]
                               }
                             })
-                          }
+                          }}
                           placeholder={t('writeWorkspaceRootPlaceholder')}
                         />
                         <button

--- a/src/renderer/src/lib/settings-home-paths.test.ts
+++ b/src/renderer/src/lib/settings-home-paths.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultClawSettings,
+  defaultKeyboardShortcuts,
+  defaultKunRuntimeSettings,
+  defaultModelProviderSettings,
+  defaultScheduleSettings,
+  defaultWriteSettings,
+  type AppSettingsV1,
+  type ClawImChannelV1,
+  type ScheduledTaskV1
+} from '@shared/app-settings'
+import {
+  compactHomePathForSettingsDisplay,
+  compactHomePathTextForSettingsDisplay,
+  expandHomePathForSettingsUse,
+  expandHomePathTextForSettingsUse,
+  expandSettingsHomePathsForUse
+} from './settings-home-paths'
+
+function channel(workspaceRoot: string): ClawImChannelV1 {
+  const now = '2026-06-19T00:00:00.000Z'
+  return {
+    id: 'channel-1',
+    provider: 'feishu',
+    label: 'Feishu Agent',
+    enabled: true,
+    providerId: '',
+    model: 'auto',
+    threadId: '',
+    workspaceRoot,
+    agentProfile: {
+      name: 'Feishu Agent',
+      description: '',
+      identity: '',
+      personality: '',
+      userContext: '',
+      replyRules: ''
+    },
+    conversations: [
+      {
+        id: 'conversation-1',
+        chatId: 'chat-1',
+        remoteThreadId: '',
+        latestMessageId: '',
+        senderId: '',
+        senderName: '',
+        localThreadId: '',
+        workspaceRoot: '~/claw/channel-1/conversations/chat-1',
+        createdAt: now,
+        updatedAt: now
+      }
+    ],
+    createdAt: now,
+    updatedAt: now
+  }
+}
+
+function scheduledTask(workspaceRoot: string): ScheduledTaskV1 {
+  const now = '2026-06-19T00:00:00.000Z'
+  return {
+    id: 'task-1',
+    title: 'Task',
+    enabled: true,
+    prompt: 'run',
+    workspaceRoot,
+    clawChannelId: '',
+    providerId: '',
+    model: 'deepseek-v4-flash',
+    reasoningEffort: 'medium',
+    mode: 'agent',
+    schedule: {
+      kind: 'manual',
+      everyMinutes: 60,
+      timeOfDay: '',
+      atTime: ''
+    },
+    createdAt: now,
+    updatedAt: now,
+    lastRunAt: '',
+    nextRunAt: '',
+    lastStatus: 'idle',
+    lastMessage: '',
+    lastThreadId: ''
+  }
+}
+
+function settings(): AppSettingsV1 {
+  return {
+    version: 1,
+    locale: 'en',
+    theme: 'system',
+    uiFontScale: 'small',
+    cursorSpotlight: true,
+    provider: defaultModelProviderSettings(),
+    agents: {
+      kun: {
+        ...defaultKunRuntimeSettings(),
+        binaryPath: '~/bin/kun',
+        dataDir: '~/.kun/data',
+        storage: {
+          ...defaultKunRuntimeSettings().storage,
+          sqlitePath: '~/Library/Application Support/Kun/kun.sqlite3'
+        }
+      }
+    },
+    workspaceRoot: '~/.kun/default_workspace',
+    log: { enabled: true, retentionDays: 2 },
+    notifications: { turnComplete: true },
+    appBehavior: { openAtLogin: false, startMinimized: false, closeToTray: false },
+    keyboardShortcuts: defaultKeyboardShortcuts(),
+    write: {
+      ...defaultWriteSettings(),
+      defaultWorkspaceRoot: '~/.kun/write_workspace',
+      activeWorkspaceRoot: '~/drafts',
+      workspaces: ['~/.kun/write_workspace', '~/drafts']
+    },
+    claw: {
+      ...defaultClawSettings(),
+      skills: {
+        ...defaultClawSettings().skills,
+        extraDirs: ['~/skills']
+      },
+      im: {
+        ...defaultClawSettings().im,
+        workspaceRoot: '~/claw'
+      },
+      channels: [channel('~/claw/channel-1')]
+    },
+    schedule: {
+      ...defaultScheduleSettings(),
+      defaultWorkspaceRoot: '~/schedule',
+      skills: {
+        ...defaultScheduleSettings().skills,
+        extraDirs: ['~/schedule-skills']
+      },
+      tasks: [scheduledTask('~/schedule/task-1')]
+    },
+    guiUpdate: { channel: 'stable' },
+    codePromptPrefix: '',
+    disabledSkillIds: []
+  }
+}
+
+describe('settings home paths', () => {
+  it('compacts absolute home paths on macOS and Linux', () => {
+    expect(compactHomePathForSettingsDisplay('/Users/mothra/.kun/default_workspace', '/Users/mothra', 'darwin'))
+      .toBe('~/.kun/default_workspace')
+    expect(compactHomePathForSettingsDisplay('/home/mothra/.kun/default_workspace', '/home/mothra', 'linux'))
+      .toBe('~/.kun/default_workspace')
+    expect(compactHomePathForSettingsDisplay('/Users/mothra/work/', '/Users/mothra', 'darwin'))
+      .toBe('~/work/')
+    expect(compactHomePathForSettingsDisplay('/Users/mothra/', '/Users/mothra', 'darwin'))
+      .toBe('~/')
+  })
+
+  it('does not compact home paths on Windows', () => {
+    expect(compactHomePathForSettingsDisplay('C:\\Users\\mothra\\.kun', 'C:\\Users\\mothra', 'win32'))
+      .toBe('C:\\Users\\mothra\\.kun')
+  })
+
+  it('expands tilde input on macOS and Linux only', () => {
+    expect(expandHomePathForSettingsUse('~/.kun/data', '/Users/mothra', 'darwin'))
+      .toBe('/Users/mothra/.kun/data')
+    expect(expandHomePathForSettingsUse('~/.kun/data', '/home/mothra', 'linux'))
+      .toBe('/home/mothra/.kun/data')
+    expect(expandHomePathForSettingsUse('~\\.kun\\data', '/Users/mothra', 'win32'))
+      .toBe('~\\.kun\\data')
+  })
+
+  it('keeps multiline path text shape while compacting and expanding', () => {
+    const text = '/Users/mothra/skills\n\n/Users/mothra/more-skills'
+    expect(compactHomePathTextForSettingsDisplay(text, '/Users/mothra', 'darwin'))
+      .toBe('~/skills\n\n~/more-skills')
+    expect(expandHomePathTextForSettingsUse('~/skills\n\n~/more-skills', '/Users/mothra', 'darwin'))
+      .toBe('/Users/mothra/skills\n\n/Users/mothra/more-skills')
+  })
+
+  it('expands nested settings paths before saving', () => {
+    const expanded = expandSettingsHomePathsForUse(settings(), '/Users/mothra', 'darwin')
+
+    expect(expanded.workspaceRoot).toBe('/Users/mothra/.kun/default_workspace')
+    expect(expanded.agents.kun.binaryPath).toBe('/Users/mothra/bin/kun')
+    expect(expanded.agents.kun.dataDir).toBe('/Users/mothra/.kun/data')
+    expect(expanded.agents.kun.storage.sqlitePath).toBe('/Users/mothra/Library/Application Support/Kun/kun.sqlite3')
+    expect(expanded.write.defaultWorkspaceRoot).toBe('/Users/mothra/.kun/write_workspace')
+    expect(expanded.write.activeWorkspaceRoot).toBe('/Users/mothra/drafts')
+    expect(expanded.claw.im.workspaceRoot).toBe('/Users/mothra/claw')
+    expect(expanded.claw.skills.extraDirs).toEqual(['/Users/mothra/skills'])
+    expect(expanded.claw.channels[0].workspaceRoot).toBe('/Users/mothra/claw/channel-1')
+    expect(expanded.claw.channels[0].conversations[0].workspaceRoot)
+      .toBe('/Users/mothra/claw/channel-1/conversations/chat-1')
+    expect(expanded.schedule.defaultWorkspaceRoot).toBe('/Users/mothra/schedule')
+    expect(expanded.schedule.skills.extraDirs).toEqual(['/Users/mothra/schedule-skills'])
+    expect(expanded.schedule.tasks[0].workspaceRoot).toBe('/Users/mothra/schedule/task-1')
+  })
+})

--- a/src/renderer/src/lib/settings-home-paths.ts
+++ b/src/renderer/src/lib/settings-home-paths.ts
@@ -1,0 +1,156 @@
+import type { AppSettingsV1 } from '@shared/app-settings'
+
+function supportsHomeAlias(platform: string | undefined): boolean {
+  return platform === 'darwin' || platform === 'linux'
+}
+
+function normalizedHomeDir(homeDir: string | undefined): string {
+  return (homeDir ?? '').replace(/\\/g, '/').replace(/\/+$/g, '')
+}
+
+function currentPlatform(): string {
+  return typeof window !== 'undefined' ? window.kunGui?.platform ?? '' : ''
+}
+
+function currentHomeDir(): string {
+  return typeof window !== 'undefined' ? window.kunGui?.homeDir ?? '' : ''
+}
+
+export function compactHomePathForSettingsDisplay(
+  value: string,
+  homeDir = currentHomeDir(),
+  platform = currentPlatform()
+): string {
+  const home = normalizedHomeDir(homeDir)
+  if (!supportsHomeAlias(platform) || !home || !value) return value
+  const normalizedValue = value.replace(/\\/g, '/')
+  const withoutTrailingSlash = normalizedValue.replace(/\/+$/g, '')
+  if (normalizedValue === home) return '~'
+  if (withoutTrailingSlash === home) return '~/'
+  if (normalizedValue.startsWith(`${home}/`)) {
+    return `~/${normalizedValue.slice(home.length + 1)}`
+  }
+  return value
+}
+
+export function expandHomePathForSettingsUse(
+  value: string,
+  homeDir = currentHomeDir(),
+  platform = currentPlatform()
+): string {
+  const home = normalizedHomeDir(homeDir)
+  if (!supportsHomeAlias(platform) || !home) return value
+  const trimmed = value.trim()
+  if (trimmed === '~') return home
+  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
+    return `${home}/${trimmed.slice(2).replace(/\\/g, '/')}`
+  }
+  return value
+}
+
+export function compactHomePathListForSettingsDisplay(
+  values: readonly string[],
+  homeDir = currentHomeDir(),
+  platform = currentPlatform()
+): string {
+  return values
+    .map((value) => compactHomePathForSettingsDisplay(value, homeDir, platform))
+    .join('\n')
+}
+
+export function expandHomePathListForSettingsUse(
+  values: readonly string[],
+  homeDir = currentHomeDir(),
+  platform = currentPlatform()
+): string[] {
+  return values.map((value) => expandHomePathForSettingsUse(value, homeDir, platform))
+}
+
+export function compactHomePathTextForSettingsDisplay(
+  value: string,
+  homeDir = currentHomeDir(),
+  platform = currentPlatform()
+): string {
+  return value
+    .split('\n')
+    .map((line) => compactHomePathForSettingsDisplay(line, homeDir, platform))
+    .join('\n')
+}
+
+export function expandHomePathTextForSettingsUse(
+  value: string,
+  homeDir = currentHomeDir(),
+  platform = currentPlatform()
+): string {
+  return value
+    .split('\n')
+    .map((line) => expandHomePathForSettingsUse(line, homeDir, platform))
+    .join('\n')
+}
+
+export function expandSettingsHomePathsForUse(
+  settings: AppSettingsV1,
+  homeDir = currentHomeDir(),
+  platform = currentPlatform()
+): AppSettingsV1 {
+  const expand = (value: string): string => expandHomePathForSettingsUse(value, homeDir, platform)
+  const expandList = (values: readonly string[]): string[] => expandHomePathListForSettingsUse(values, homeDir, platform)
+  const kun = settings.agents.kun
+  return {
+    ...settings,
+    workspaceRoot: expand(settings.workspaceRoot),
+    agents: {
+      ...settings.agents,
+      kun: {
+        ...kun,
+        binaryPath: expand(kun.binaryPath),
+        dataDir: expand(kun.dataDir),
+        storage: {
+          ...kun.storage,
+          sqlitePath: expand(kun.storage.sqlitePath)
+        }
+      }
+    },
+    write: {
+      ...settings.write,
+      defaultWorkspaceRoot: expand(settings.write.defaultWorkspaceRoot),
+      activeWorkspaceRoot: expand(settings.write.activeWorkspaceRoot),
+      workspaces: expandList(settings.write.workspaces)
+    },
+    claw: {
+      ...settings.claw,
+      skills: {
+        ...settings.claw.skills,
+        extraDirs: expandList(settings.claw.skills.extraDirs)
+      },
+      im: {
+        ...settings.claw.im,
+        workspaceRoot: expand(settings.claw.im.workspaceRoot)
+      },
+      channels: settings.claw.channels.map((channel) => ({
+        ...channel,
+        workspaceRoot: expand(channel.workspaceRoot),
+        conversations: channel.conversations.map((conversation) => ({
+          ...conversation,
+          workspaceRoot: expand(conversation.workspaceRoot)
+        }))
+      })),
+      tasks: settings.claw.tasks.map((task) => ({
+        ...task,
+        workspaceRoot: expand(task.workspaceRoot)
+      }))
+    },
+    schedule: {
+      ...settings.schedule,
+      defaultWorkspaceRoot: expand(settings.schedule.defaultWorkspaceRoot),
+      skills: {
+        ...settings.schedule.skills,
+        extraDirs: expandList(settings.schedule.skills.extraDirs)
+      },
+      tasks: settings.schedule.tasks.map((task) => ({
+        ...task,
+        workspaceRoot: expand(task.workspaceRoot)
+      }))
+    }
+  }
+}

--- a/src/shared/kun-gui-api.ts
+++ b/src/shared/kun-gui-api.ts
@@ -259,6 +259,7 @@ export type ComputerUsePermissions = {
 
 export type KunGuiApi = {
   platform: string
+  homeDir: string
   getSettings: () => Promise<AppSettingsV1>
   setSettings: (partial: AppSettingsPatch) => Promise<AppSettingsV1>
   saveSettingsSilent: (partial: AppSettingsPatch) => Promise<AppSettingsV1>


### PR DESCRIPTION
Summary
- Show macOS/Linux home-directory paths as `~` across settings UI path fields.
- Expand `~` back to absolute home paths before saving or passing settings paths to runtime/pickers.
- Add focused renderer coverage for path compaction, expansion, multiline path text, and nested settings paths.

Changes
- Exposes `homeDir` through preload so renderer path display uses the real user home directory.
- Adds shared settings path helpers and wires General, Agents, Write, Claw, Schedule, Worktree, legacy import, log, MCP, and storage path displays through them.

Tests
- `npm run test -- settings-home-paths.test.ts settings-section-claw.test.ts`
- `git diff --check`
- `npm run typecheck` currently still fails on existing `src/renderer/src/store/chat-store-thread-actions.test.ts` `onDeltas` type errors unrelated to this PR.