### PR TITLE
fix(settings): merge media generation menus

### DIFF
--- a/src/renderer/src/components/SettingsSidebar.tsx
+++ b/src/renderer/src/components/SettingsSidebar.tsx
@@ -1,7 +1,7 @@
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
-import { Archive, AudioLines, Bot, BrainCircuit, GitBranch, Bug, ChevronLeft, Globe, ImageIcon, Keyboard, Mic, PencilLine, RefreshCw, ServerCog, Settings, ShieldCheck, Smartphone, Sparkles } from 'lucide-react'
+import { Archive, AudioLines, Bot, BrainCircuit, GitBranch, Bug, ChevronLeft, Globe, Keyboard, Mic, PencilLine, RefreshCw, ServerCog, Settings, ShieldCheck, Smartphone, Sparkles } from 'lucide-react'
 
-type SettingsCategory = 'general' | 'providers' | 'write' | 'imageGeneration' | 'mediaGeneration' | 'speechToText' | 'agents' | 'archives' | 'permissions' | 'worktree' | 'memory' | 'shortcuts' | 'easterEgg' | 'claw' | 'updates' | 'debug'
+type SettingsCategory = 'general' | 'providers' | 'write' | 'mediaGeneration' | 'speechToText' | 'agents' | 'archives' | 'permissions' | 'worktree' | 'memory' | 'shortcuts' | 'easterEgg' | 'claw' | 'updates' | 'debug'
 
 export function SettingsSidebar({
   category,
@@ -46,14 +46,6 @@ export function SettingsSidebar({
         <button type="button" className={catCls('write')} onClick={() => setCategory('write')}>
           <PencilLine className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} />
           {t('write')}
-        </button>
-        <button
-          type="button"
-          className={catCls('imageGeneration')}
-          onClick={() => setCategory('imageGeneration')}
-        >
-          <ImageIcon className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} />
-          {t('imageGen')}
         </button>
         <button
           type="button"

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -48,7 +48,6 @@ import {
   ClawSettingsSection,
   EasterEggSettingsSection,
   GeneralSettingsSection,
-  ImageGenerationSettingsSection,
   KeyboardShortcutsSettingsSection,
   LlmDebugSettingsSection,
   WorktreeSettingsSection,
@@ -60,7 +59,7 @@ import {
   WriteSettingsSection
 } from './settings-sections'
 
-type SettingsCategory = 'general' | 'providers' | 'write' | 'imageGeneration' | 'mediaGeneration' | 'speechToText' | 'agents' | 'archives' | 'permissions' | 'worktree' | 'memory' | 'shortcuts' | 'easterEgg' | 'claw' | 'updates' | 'debug'
+type SettingsCategory = 'general' | 'providers' | 'write' | 'mediaGeneration' | 'speechToText' | 'agents' | 'archives' | 'permissions' | 'worktree' | 'memory' | 'shortcuts' | 'easterEgg' | 'claw' | 'updates' | 'debug'
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 type SettingsPatch = AppSettingsPatch
 type InlineNotice = {
@@ -260,7 +259,7 @@ export function SettingsView(): ReactElement {
       return
     }
     if (settingsSection === 'imageGeneration') {
-      setCategory('imageGeneration')
+      setCategory('mediaGeneration')
       return
     }
     if (settingsSection === 'mediaGeneration') {
@@ -989,7 +988,6 @@ export function SettingsView(): ReactElement {
           {category === 'general' ? <GeneralSettingsSection ctx={settingsSectionContext} /> : null}
           {category === 'providers' ? <ProvidersSettingsSection ctx={settingsSectionContext} /> : null}
           {category === 'write' ? <WriteSettingsSection ctx={settingsSectionContext} /> : null}
-          {category === 'imageGeneration' ? <ImageGenerationSettingsSection ctx={settingsSectionContext} /> : null}
           {category === 'mediaGeneration' ? <MediaGenerationSettingsSection ctx={settingsSectionContext} /> : null}
           {category === 'speechToText' ? <SpeechToTextSettingsSection ctx={settingsSectionContext} /> : null}
           {category === 'agents' || category === 'permissions' ? <AgentsSettingsSection ctx={settingsSectionContext} /> : null}

--- a/src/renderer/src/components/settings-section-image-generation.test.ts
+++ b/src/renderer/src/components/settings-section-image-generation.test.ts
@@ -10,6 +10,7 @@ const labels: Record<string, string> = {
   general: 'General',
   write: 'Write',
   agents: 'AI assistant',
+  mediaGeneration: 'Media generation',
   keyboardShortcuts: 'Keyboard shortcuts',
   claw: 'Connect phone',
   settingsFooter: 'Settings',
@@ -67,19 +68,21 @@ describe('ImageGenerationSettingsSection', () => {
     expect(html).toContain('value="240000"')
   })
 
-  it('places the image generation tab between Write and AI assistant', () => {
+  it('uses the media generation tab for image generation settings', () => {
     const html = renderToStaticMarkup(createElement(SettingsSidebar, {
-      category: 'imageGeneration',
+      category: 'mediaGeneration',
       goBack: () => undefined,
       setCategory: () => undefined,
       t
     }))
 
     const writeIndex = html.indexOf('Write')
+    const mediaIndex = html.indexOf('Media generation')
     const imageIndex = html.indexOf('Image generation')
     const agentsIndex = html.indexOf('AI assistant')
     expect(writeIndex).toBeGreaterThanOrEqual(0)
-    expect(imageIndex).toBeGreaterThan(writeIndex)
-    expect(agentsIndex).toBeGreaterThan(imageIndex)
+    expect(mediaIndex).toBeGreaterThan(writeIndex)
+    expect(imageIndex).toBe(-1)
+    expect(agentsIndex).toBeGreaterThan(mediaIndex)
   })
 })

--- a/src/renderer/src/components/settings-section-media-generation.test.ts
+++ b/src/renderer/src/components/settings-section-media-generation.test.ts
@@ -6,6 +6,9 @@ import { MediaGenerationSettingsSection } from './settings-section-media-generat
 const labels: Record<string, string> = {
   mediaGeneration: 'Media generation',
   mediaGenerationDesc: 'Expose media tools',
+  imageGen: 'Image generation',
+  imageGenEnabled: 'Enable image generation',
+  imageGenEnabledDesc: 'Enable generate_image',
   textToSpeech: 'Speech generation',
   textToSpeechEnabled: 'Enable speech generation',
   textToSpeechEnabledDesc: 'Enable generate_speech',
@@ -128,6 +131,8 @@ describe('MediaGenerationSettingsSection', () => {
     }))
 
     expect(html).toContain('Media generation')
+    expect(html).toContain('Image generation')
+    expect(html).toContain('Enable generate_image')
     expect(html).toContain('Speech generation')
     expect(html).toContain('speech-2.8-hd')
     expect(html).toContain('Music generation')

--- a/src/renderer/src/components/settings-section-media-generation.tsx
+++ b/src/renderer/src/components/settings-section-media-generation.tsx
@@ -11,6 +11,7 @@ import {
   VIDEO_GENERATION_PROTOCOLS
 } from '@shared/app-settings'
 import { ModelSelect, SecretInput, SettingsCard, SettingRow, Toggle } from './settings-controls'
+import { ImageGenerationSettingsSection } from './settings-section-image-generation'
 
 const AUDIO_FORMATS = ['mp3', 'wav', 'flac'] as const
 const VIDEO_RESOLUTIONS = ['768P', '1080P'] as const
@@ -149,6 +150,8 @@ export function MediaGenerationSettingsSection({ ctx }: { ctx: Record<string, an
           {t('mediaGenerationDesc')}
         </div>
       </SettingsCard>
+
+      <ImageGenerationSettingsSection ctx={ctx} />
 
       <SettingsCard title={t('textToSpeech')}>
         <SettingRow

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -529,7 +529,7 @@
   "imageGenTimeout": "Timeout (ms)",
   "imageGenTimeoutDesc": "Per-request timeout for the image API. Image models can take minutes at high resolutions.",
   "mediaGeneration": "Media generation",
-  "mediaGenerationDesc": "Expose speech, music, and video generation as agent tools. When enabled, Kun registers generate_speech, generate_music, and generate_video.",
+  "mediaGenerationDesc": "Expose image, speech, music, and video generation as agent tools. When enabled, Kun registers generate_image, generate_speech, generate_music, and generate_video according to configuration.",
   "textToSpeech": "Speech generation",
   "textToSpeechEnabled": "Enable speech generation",
   "textToSpeechEnabledDesc": "Enables the generate_speech tool in agent chats to synthesize text into audio files.",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -529,7 +529,7 @@
   "imageGenTimeout": "超时（毫秒）",
   "imageGenTimeoutDesc": "单次图片请求的超时时间。高分辨率出图可能需要数分钟。",
   "mediaGeneration": "媒体生成",
-  "mediaGenerationDesc": "把语音、音乐和视频生成配置成 Agent 可调用工具。启用后会分别注册 generate_speech、generate_music 和 generate_video。",
+  "mediaGenerationDesc": "把图片、语音、音乐和视频生成配置成 Agent 可调用工具。启用后会按配置注册 generate_image、generate_speech、generate_music 和 generate_video。",
   "textToSpeech": "语音生成",
   "textToSpeechEnabled": "启用语音生成",
   "textToSpeechEnabledDesc": "启用 Agent 对话里的 generate_speech 工具，把文本生成语音文件。",


### PR DESCRIPTION
## Summary
- Merge the separate image generation settings menu into Media generation.
- Render image generation settings inside the Media generation page before speech, music, and video controls.
- Keep legacy imageGeneration route navigation working by redirecting it to the merged Media generation page.

## Changes
- Removed the standalone Image generation sidebar item.
- Updated Media generation copy in English and Chinese to include image generation.
- Updated focused renderer tests for the merged menu behavior.

## Tests
- npm ci
- npm run test -- settings-section-image-generation.test.ts settings-section-media-generation.test.ts
- git diff --check

Note: npm run typecheck still fails on the existing src/renderer/src/store/chat-store-thread-actions.test.ts onDeltas type errors, unrelated to this settings menu change.