### PR TITLE
fix(tests): repair typecheck fixtures

### DIFF
--- a/src/main/claw-runtime.test.ts
+++ b/src/main/claw-runtime.test.ts
@@ -15,6 +15,7 @@ import {
   type ModelProviderProfileV1
 } from '../shared/app-settings'
 import { createClawRuntime } from './claw-runtime'
+import type { RuntimeRequestFn } from './claw-runtime-helpers'
 
 function buildSettings(): AppSettingsV1 {
   return {
@@ -3640,8 +3641,8 @@ describe('ClawRuntime handleFeishuMessage streaming', () => {
       .set(channelId, bridge)
   }
 
-  function makeTurnRequest(): ReturnType<typeof vi.fn> {
-    return vi.fn(async (_settings, path) => {
+  function makeTurnRequest(): RuntimeRequestFn {
+    const request: RuntimeRequestFn = async (_settings, path) => {
       if (path === '/v1/threads/thr_1/turns') {
         return {
           ok: true,
@@ -3650,7 +3651,8 @@ describe('ClawRuntime handleFeishuMessage streaming', () => {
         }
       }
       throw new Error(`unexpected path ${path}`)
-    })
+    }
+    return vi.fn(request) as unknown as RuntimeRequestFn
   }
 
   it('routes through runStreamingReply when channel.feishuStream=true', async () => {

--- a/src/main/feishu-streamer.ts
+++ b/src/main/feishu-streamer.ts
@@ -1,6 +1,8 @@
 import type { LarkChannel, MarkdownStreamController, SendOptions } from '@larksuiteoapi/node-sdk'
 import type { SseSubscriber } from './claw-runtime-helpers'
 
+export type { SseSubscriber } from './claw-runtime-helpers'
+
 export type FeishuStreamLogger = (category: string, message: string, detail?: unknown) => void
 
 export type FeishuStreamerOptions = {

--- a/src/renderer/src/store/chat-store-thread-actions.test.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.test.ts
@@ -68,6 +68,11 @@ function buildHarness(): {
   return { actions, state }
 }
 
+function expectSink(sink: ThreadEventSink | null): ThreadEventSink {
+  expect(sink).not.toBeNull()
+  return sink as ThreadEventSink
+}
+
 describe('chat-store-thread-actions queued messages', () => {
   beforeEach(() => {
     rendererRuntimeClient.invalidateSettings()
@@ -291,13 +296,11 @@ describe('chat-store-thread-actions subscribeThreadEventsLive', () => {
     // The chat view switches to the live thread.
     expect(state.activeThreadId).toBe('thr_live')
     // SSE-sourced deltas flow into the chat-store's live state.
-    expect(capturedSink).not.toBeNull()
-    if (capturedSink) {
-      capturedSink.onDeltas([{ kind: 'agent_message', text: 'hello', seq: 1 } as never])
-      expect(state.liveAssistant).toBe('hello')
-      capturedSink.onDeltas([{ kind: 'agent_message', text: ' world', seq: 2 } as never])
-      expect(state.liveAssistant).toBe('hello world')
-    }
+    const sink = expectSink(capturedSink)
+    sink.onDeltas([{ kind: 'agent_message', text: 'hello', seq: 1 }])
+    expect(state.liveAssistant).toBe('hello')
+    sink.onDeltas([{ kind: 'agent_message', text: ' world', seq: 2 }])
+    expect(state.liveAssistant).toBe('hello world')
   })
 
   it('merges fetched history without overwriting live buffers, and takes lastSeq = max(fetched, current)', async () => {
@@ -336,10 +339,9 @@ describe('chat-store-thread-actions subscribeThreadEventsLive', () => {
     expect(state.blocks.length).toBeGreaterThan(0)
     expect(state.blocks[0].id).toBe('b1')
     // SSE deltas that arrived during the fetch are preserved.
-    if (capturedSink) {
-      capturedSink.onDeltas([{ kind: 'agent_message', text: 'live text', seq: 8 } as never])
-      expect(state.liveAssistant).toBe('live text')
-    }
+    const sink = expectSink(capturedSink)
+    sink.onDeltas([{ kind: 'agent_message', text: 'live text', seq: 8 }])
+    expect(state.liveAssistant).toBe('live text')
     // lastSeq is bumped to the max of fetched and current (SSE advanced it).
     expect(state.lastSeq).toBeGreaterThanOrEqual(8)
   })
@@ -368,11 +370,9 @@ describe('chat-store-thread-actions subscribeThreadEventsLive', () => {
     await new Promise((r) => setTimeout(r, 0))
 
     // SSE is still open and deltas still flow.
-    expect(capturedSink).not.toBeNull()
-    if (capturedSink) {
-      capturedSink.onDeltas([{ kind: 'agent_message', text: 'still works', seq: 1 } as never])
-      expect(state.liveAssistant).toBe('still works')
-    }
+    const sink = expectSink(capturedSink)
+    sink.onDeltas([{ kind: 'agent_message', text: 'still works', seq: 1 }])
+    expect(state.liveAssistant).toBe('still works')
     // Error is surfaced.
     expect(state.error).toBeTruthy()
   })


### PR DESCRIPTION
## Summary

Fix TypeScript test fixture errors that prevented `npm run typecheck` from completing.

## Changes

- Restored a typed `ThreadEventSink` assertion helper in `chat-store-thread-actions.test.ts` so `onDeltas` calls stay type-safe.
- Typed the Feishu streaming runtime request mock as `RuntimeRequestFn`.
- Re-exported the `SseSubscriber` type from `feishu-streamer` for tests that exercise the streamer API.

## Tests

- `npm run typecheck`
- `npx vitest run src/renderer/src/store/chat-store-thread-actions.test.ts src/main/feishu-streamer.test.ts src/main/claw-runtime.test.ts`
