### PR TITLE
fix(settings): default log retention to 3 days

### DIFF
--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { configureLogger } from './logger'
 import {
   defaultClawSettings,
+  DEFAULT_LOG_RETENTION_DAYS,
   defaultKeyboardShortcuts,
   defaultKunRuntimeSettings,
   defaultModelProviderSettings,
@@ -96,7 +97,7 @@ beforeEach(() => {
 afterEach(async () => {
   const module = await import('./kun-process')
   await module.stopKunChildAndWait()
-  configureLogger({ dir: '', enabled: true, retentionDays: 2 })
+  configureLogger({ dir: '', enabled: true, retentionDays: DEFAULT_LOG_RETENTION_DAYS })
   if (tempRoot) {
     rmSync(tempRoot, { recursive: true, force: true })
     tempRoot = null

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir, readdir, stat, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
+import { DEFAULT_LOG_RETENTION_DAYS } from '../shared/app-settings'
 
 export type LogLevel = 'error' | 'warn' | 'info'
 export type ManagedLogFilePrefix = 'deepseek-gui' | 'kun'
@@ -13,7 +14,7 @@ type LoggerConfig = {
   retentionDays: number
 }
 
-let cfg: LoggerConfig = { dir: '', enabled: true, retentionDays: 2 }
+let cfg: LoggerConfig = { dir: '', enabled: true, retentionDays: DEFAULT_LOG_RETENTION_DAYS }
 const MANAGED_LOG_FILE_PREFIXES: ManagedLogFilePrefix[] = ['deepseek-gui', 'kun']
 
 export function configureLogger(config: Partial<LoggerConfig>): void {

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -6,6 +6,7 @@ import {
   applyKunRuntimePatch,
   kunSettingsEnvelope,
   DEFAULT_GUI_UPDATE_CHANNEL,
+  DEFAULT_LOG_RETENTION_DAYS,
   DEFAULT_WRITE_WORKSPACE_ROOT,
   defaultClawSettings,
   defaultKunRuntimeSettings,
@@ -204,7 +205,7 @@ const defaultSettings = (): AppSettingsV1 => ({
   workspaceRoot: DEFAULT_WORKSPACE_ROOT,
   log: {
     enabled: true,
-    retentionDays: 2
+    retentionDays: DEFAULT_LOG_RETENTION_DAYS
   },
   notifications: {
     turnComplete: true

--- a/src/renderer/src/components/settings-utils.ts
+++ b/src/renderer/src/components/settings-utils.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_LOG_RETENTION_DAYS,
   DEFAULT_GUI_UPDATE_CHANNEL,
   defaultKunRuntimeSettings,
   applyKunRuntimePatch,
@@ -96,7 +97,9 @@ export function coerceRendererSettings(settings: AppSettingsV1): AppSettingsV1 {
     workspaceRoot: typeof raw.workspaceRoot === 'string' ? raw.workspaceRoot : DEFAULT_WORKSPACE_ROOT,
     log: {
       enabled: raw.log?.enabled !== false,
-      retentionDays: typeof raw.log?.retentionDays === 'number' ? raw.log.retentionDays : 2
+      retentionDays: typeof raw.log?.retentionDays === 'number'
+        ? raw.log.retentionDays
+        : DEFAULT_LOG_RETENTION_DAYS
     },
     notifications: {
       turnComplete: raw.notifications?.turnComplete !== false

--- a/src/shared/app-settings-normalize.ts
+++ b/src/shared/app-settings-normalize.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_GUI_UPDATE_CHANNEL,
+  DEFAULT_LOG_RETENTION_DAYS,
   normalizeGuiUpdateChannel,
   type AppBehaviorConfigV1,
   type AppSettingsV1,
@@ -79,7 +80,9 @@ export function normalizeAppSettings(settings: AppSettingsV1): AppSettingsV1 {
     workspaceRoot: typeof maybeSettings.workspaceRoot === 'string' ? maybeSettings.workspaceRoot : '',
     log: {
       enabled: maybeSettings.log?.enabled !== false,
-      retentionDays: typeof maybeSettings.log?.retentionDays === 'number' ? maybeSettings.log.retentionDays : 2
+      retentionDays: typeof maybeSettings.log?.retentionDays === 'number'
+        ? maybeSettings.log.retentionDays
+        : DEFAULT_LOG_RETENTION_DAYS
     },
     notifications: {
       turnComplete: maybeSettings.notifications?.turnComplete !== false

--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -75,6 +75,7 @@ export const DEFAULT_WRITE_INLINE_LONG_COMPLETION_DEBOUNCE_MS = 2_800
 export const DEFAULT_WRITE_INLINE_LONG_COMPLETION_MIN_ACCEPT_SCORE = 0.36
 export const DEFAULT_WRITE_INLINE_LONG_COMPLETION_MAX_TOKENS = 256
 export const DEFAULT_KUN_PORT = 8899
+export const DEFAULT_LOG_RETENTION_DAYS = 3
 export const DEFAULT_WEIXIN_BRIDGE_RPC_URL = 'http://127.0.0.1:18790/api/v1/admin/rpc'
 export const DEFAULT_MODEL_PROVIDER_ID = 'deepseek'
 export const NETWORK_PROXY_PROTOCOLS = ['http', 'https', 'socks', 'socks4', 'socks4a', 'socks5', 'socks5h'] as const

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -5,6 +5,7 @@ import {
   kunSettingsPatch,
   DEFAULT_KUN_DATA_DIR,
   DEFAULT_KUN_MODEL,
+  DEFAULT_LOG_RETENTION_DAYS,
   DEFAULT_APPROVAL_POLICY,
   DEFAULT_SANDBOX_MODE,
   DEFAULT_WEIXIN_BRIDGE_RPC_URL,
@@ -219,6 +220,17 @@ describe('kun defaults', () => {
         }
       }
     })
+  })
+})
+
+describe('log retention settings', () => {
+  it('defaults local error log retention to 3 days', () => {
+    const normalized = normalizeAppSettings({
+      ...settings(),
+      log: undefined
+    } as unknown as AppSettingsV1)
+
+    expect(normalized.log.retentionDays).toBe(DEFAULT_LOG_RETENTION_DAYS)
   })
 })
 


### PR DESCRIPTION
Summary
- Change the local error log retention fallback/default from 2 days to 3 days.
- Share the default through DEFAULT_LOG_RETENTION_DAYS across main, renderer settings normalization, and logger tests.
- Keep the existing IPC validation cap unchanged at 365 days.

Changes
- Updated the main settings store and logger initial config default.
- Updated shared and renderer settings normalization fallbacks.
- Added regression coverage for missing log retention settings.

Tests
- npm run test -- src/shared/app-settings.test.ts src/main/kun-process.test.ts
- git diff --check

Notes
- npm run typecheck currently fails before reaching this change area due to existing src/renderer/src/store/chat-store-thread-actions.test.ts onDeltas type errors.