### PR TITLE
fix(settings): move permissions tab after agents

### DIFF
--- a/src/renderer/src/components/SettingsSidebar.tsx
+++ b/src/renderer/src/components/SettingsSidebar.tsx
@@ -75,13 +75,13 @@ export function SettingsSidebar({
           <Bot className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} />
           {t('agents')}
         </button>
-        <button type="button" className={catCls('archives')} onClick={() => setCategory('archives')}>
-          <Archive className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} />
-          {t('archives')}
-        </button>
         <button type="button" className={catCls('permissions')} onClick={() => setCategory('permissions')}>
           <ShieldCheck className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} />
           {t('permissions')}
+        </button>
+        <button type="button" className={catCls('archives')} onClick={() => setCategory('archives')}>
+          <Archive className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} />
+          {t('archives')}
         </button>
         <button type="button" className={catCls('worktree')} onClick={() => setCategory('worktree')}>
           <GitBranch className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} />

--- a/src/renderer/src/components/settings-section-archives.test.ts
+++ b/src/renderer/src/components/settings-section-archives.test.ts
@@ -99,7 +99,7 @@ describe('ArchivedThreadsSettingsSection', () => {
     expect(html).toContain('Delete archived chat')
   })
 
-  it('places archived chats directly after the AI assistant settings tab', () => {
+  it('places permissions directly after the AI assistant settings tab', () => {
     const html = renderToStaticMarkup(createElement(SettingsSidebar, {
       category: 'archives',
       goBack: () => undefined,
@@ -111,7 +111,7 @@ describe('ArchivedThreadsSettingsSection', () => {
     const archivesIndex = html.indexOf('Archived chats')
     const permissionsIndex = html.indexOf('permissions')
     expect(agentsIndex).toBeGreaterThanOrEqual(0)
-    expect(archivesIndex).toBeGreaterThan(agentsIndex)
-    expect(permissionsIndex).toBeGreaterThan(archivesIndex)
+    expect(permissionsIndex).toBeGreaterThan(agentsIndex)
+    expect(archivesIndex).toBeGreaterThan(permissionsIndex)
   })
 })


### PR DESCRIPTION
## Summary

Move the Permissions settings sidebar item directly after AI assistant.

## Changes

- Reordered the settings sidebar so Permissions appears before Archived chats.
- Updated the sidebar order regression test to assert the new order.

## Tests

- `npm run test -- src/renderer/src/components/settings-section-archives.test.ts`
- `git diff --check -- src/renderer/src/components/SettingsSidebar.tsx src/renderer/src/components/settings-section-archives.test.ts`

Known baseline issue:

- `npm run typecheck` currently fails in `src/renderer/src/store/chat-store-thread-actions.test.ts` with existing `onDeltas` type errors unrelated to this change.
