### PR TITLE
fix(settings): keep sidebar footer visible

### DIFF
--- a/src/renderer/src/components/SettingsSidebar.tsx
+++ b/src/renderer/src/components/SettingsSidebar.tsx
@@ -22,8 +22,8 @@ export function SettingsSidebar({
     }`
 
   return (
-    <aside className="ds-drag flex w-[248px] shrink-0 flex-col border-r border-ds-border bg-ds-sidebar backdrop-blur-md">
-      <div className="px-3 pb-3 pt-3">
+    <aside className="ds-drag flex h-full min-h-0 w-[248px] shrink-0 flex-col border-r border-ds-border bg-ds-sidebar backdrop-blur-md">
+      <div className="shrink-0 px-3 pb-3 pt-3">
         <div aria-hidden className="ds-titlebar-safe-block" />
         <button
           type="button"
@@ -34,7 +34,7 @@ export function SettingsSidebar({
           {t('back')}
         </button>
       </div>
-      <nav className="ds-no-drag flex flex-col gap-0.5 px-2">
+      <nav className="ds-no-drag flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain px-2 pb-2">
         <button type="button" className={catCls('general')} onClick={() => setCategory('general')}>
           <Globe className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} />
           {t('general')}
@@ -112,7 +112,7 @@ export function SettingsSidebar({
           {t('debug')}
         </button>
       </nav>
-      <div className="ds-no-drag mt-auto border-t border-ds-border p-3">
+      <div className="ds-no-drag shrink-0 border-t border-ds-border p-3">
         <div className="flex items-center gap-2 rounded-xl px-2 py-2">
           <div className="flex h-8 w-8 items-center justify-center rounded-full bg-ds-subtle text-ds-muted">
             <Settings className="h-4 w-4" strokeWidth={1.75} />

--- a/src/renderer/src/components/settings-section-archives.test.ts
+++ b/src/renderer/src/components/settings-section-archives.test.ts
@@ -114,4 +114,19 @@ describe('ArchivedThreadsSettingsSection', () => {
     expect(archivesIndex).toBeGreaterThan(agentsIndex)
     expect(permissionsIndex).toBeGreaterThan(archivesIndex)
   })
+
+  it('keeps settings tabs scrollable without pushing the footer away', () => {
+    const html = renderToStaticMarkup(createElement(SettingsSidebar, {
+      category: 'shortcuts',
+      goBack: () => undefined,
+      setCategory: () => undefined,
+      t
+    }))
+
+    expect(html).toContain('flex h-full min-h-0 w-[248px]')
+    expect(html).toContain('flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain')
+    expect(html).toContain('ds-no-drag shrink-0 border-t border-ds-border p-3')
+    expect(html).toContain('Kun')
+    expect(html).toContain('Settings')
+  })
 })


### PR DESCRIPTION
## Summary
- Make the Settings sidebar own the full available height so the footer stays visible.
- Let the Settings tab list scroll independently in short windows.
- Add a renderer markup regression test for the scrollable tab list and fixed footer structure.

## Changes
- Add `h-full min-h-0` to the Settings sidebar shell.
- Make the tab list `flex-1 overflow-y-auto`.
- Change the Kun footer from `mt-auto` to a non-shrinking footer region.

## Tests
- `npm run test -- src/renderer/src/components/settings-section-archives.test.ts`
- `npx eslint src/renderer/src/components/SettingsSidebar.tsx src/renderer/src/components/settings-section-archives.test.ts`
- `npm run build`
- `npm run dist:mac:arm64`
- Unzipped `dist/Kun-0.1.0-mac-arm64.zip`, launched `dist/Kun-0.1.0-mac-arm64-unzipped/Kun.app`, and verified `http://127.0.0.1:8899/health` returned `{"status":"ok","service":"kun","mode":"serve"}`.

## Notes
- `npm run typecheck` currently fails in `src/renderer/src/store/chat-store-thread-actions.test.ts` because `onDeltas` is inferred as `never`; this is outside this settings sidebar change.
