### PR TITLE
fix(composer): render context capacity as circular gauge

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -107,6 +107,17 @@ import type { ComposerChangedFile } from '../../lib/composer-change-summary'
 export type { ComposerFileReference } from '../../lib/composer-file-references'
 export type { ComposerExecutionSettings } from './FloatingComposerExecutionPicker'
 
+const CONTEXT_CAPACITY_RING_SIZE = 18
+const CONTEXT_CAPACITY_RING_STROKE = 2.25
+const CONTEXT_CAPACITY_RING_RADIUS = (CONTEXT_CAPACITY_RING_SIZE - CONTEXT_CAPACITY_RING_STROKE) / 2
+const CONTEXT_CAPACITY_RING_CIRCUMFERENCE = 2 * Math.PI * CONTEXT_CAPACITY_RING_RADIUS
+
+function contextCapacityColor(usedRatio: number): string {
+  if (usedRatio >= 0.9) return '#d9544e'
+  if (usedRatio >= 0.75) return '#d9920f'
+  return 'var(--ds-accent)'
+}
+
 type Props = {
   variant?: 'default' | 'compact'
   workspaceRootOverride?: string
@@ -2141,23 +2152,34 @@ export function FloatingComposer({
                     aria-expanded={contextCapacityOpen}
                     title={t('contextCapacityTitle')}
                   >
-                    <span
-                      className="relative flex h-1.5 w-6 overflow-hidden rounded-full"
-                      style={{ background: 'var(--ds-surface-subtle)' }}
+                    <svg
+                      className="h-[18px] w-[18px] -rotate-90 shrink-0"
+                      viewBox={`0 0 ${CONTEXT_CAPACITY_RING_SIZE} ${CONTEXT_CAPACITY_RING_SIZE}`}
                       aria-hidden="true"
                     >
-                      <span
-                        style={{
-                          width: `${Math.min(100, contextCapacity.usedRatio * 100)}%`,
-                          background:
-                            contextCapacity.usedRatio >= 0.9
-                              ? '#d9544e'
-                              : contextCapacity.usedRatio >= 0.75
-                                ? '#d9920f'
-                                : 'var(--ds-accent)'
-                        }}
+                      <circle
+                        cx={CONTEXT_CAPACITY_RING_SIZE / 2}
+                        cy={CONTEXT_CAPACITY_RING_SIZE / 2}
+                        r={CONTEXT_CAPACITY_RING_RADIUS}
+                        fill="none"
+                        stroke="var(--ds-surface-subtle)"
+                        strokeWidth={CONTEXT_CAPACITY_RING_STROKE}
                       />
-                    </span>
+                      <circle
+                        cx={CONTEXT_CAPACITY_RING_SIZE / 2}
+                        cy={CONTEXT_CAPACITY_RING_SIZE / 2}
+                        r={CONTEXT_CAPACITY_RING_RADIUS}
+                        fill="none"
+                        stroke={contextCapacityColor(contextCapacity.usedRatio)}
+                        strokeWidth={CONTEXT_CAPACITY_RING_STROKE}
+                        strokeLinecap="round"
+                        strokeDasharray={CONTEXT_CAPACITY_RING_CIRCUMFERENCE}
+                        strokeDashoffset={
+                          CONTEXT_CAPACITY_RING_CIRCUMFERENCE *
+                          (1 - Math.min(1, Math.max(0, contextCapacity.usedRatio)))
+                        }
+                      />
+                    </svg>
                     <span className="shrink-0 tabular-nums">
                       {formatPercent(contextCapacity.usedRatio)}
                     </span>


### PR DESCRIPTION
## Summary

- Replace the composer context capacity chip progress bar with a circular percentage ring.
- Preserve the existing percentage text, popover behavior, accessibility label, and threshold colors.

## Changes

- Adds shared ring sizing/circumference constants for the composer context capacity indicator.
- Uses SVG circles with `strokeDashoffset` to render the used-context percentage.

## Tests

- `npm run test -- src/renderer/src/components/chat/FloatingComposer.test.ts`
- `npm run build`
- `npx eslint src/renderer/src/components/chat/FloatingComposer.tsx`
- `git diff --check`
- `npm run typecheck` currently fails on existing `src/renderer/src/store/chat-store-thread-actions.test.ts` `onDeltas` type errors, unrelated to this change.
