### PR TITLE
fix(sidebar): tighten workspace mode tab spacing

### DIFF
--- a/src/renderer/src/components/chat/WorkspaceModeTabs.tsx
+++ b/src/renderer/src/components/chat/WorkspaceModeTabs.tsx
@@ -16,7 +16,7 @@ export function WorkspaceModeTabs({
   const { t } = useTranslation('common')
 
   const tabClass = (active: boolean): string =>
-    `group inline-flex min-h-[30px] flex-1 min-w-0 items-center justify-center gap-1.5 rounded-[7px] px-2.5 py-1 text-[13px] outline-none transition-[background-color,color,box-shadow] duration-150 focus-visible:ring-2 focus-visible:ring-black/10 dark:focus-visible:ring-white/20 ${
+    `group inline-flex min-h-[28px] flex-1 min-w-0 items-center justify-center gap-1.5 rounded-[6px] px-2 py-0.5 text-[13px] outline-none transition-[background-color,color,box-shadow] duration-150 focus-visible:ring-2 focus-visible:ring-black/10 dark:focus-visible:ring-white/20 ${
       active
         ? 'bg-white font-medium text-[#1f2733] shadow-[0_1px_2px_rgba(20,47,95,0.12),0_2px_5px_rgba(20,47,95,0.06)] dark:bg-white/[0.12] dark:text-white dark:shadow-[0_1px_2px_rgba(0,0,0,0.35)]'
         : 'font-normal text-[#646e7c] hover:text-[#1f2733] dark:text-white/55 dark:hover:text-white/90'
@@ -33,7 +33,7 @@ export function WorkspaceModeTabs({
     <div
       role="tablist"
       aria-label={`${t('code')} / ${t('write')}`}
-      className="mb-2 flex flex-row gap-1 rounded-[9px] bg-[color-mix(in_srgb,var(--ds-sidebar-field-bg)_72%,transparent)] p-[3px] shadow-[inset_0_0_0_1px_var(--ds-sidebar-row-ring)] dark:bg-white/[0.045] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.05)]"
+      className="mb-1.5 flex flex-row gap-1 rounded-[8px] bg-[color-mix(in_srgb,var(--ds-sidebar-field-bg)_72%,transparent)] p-0.5 shadow-[inset_0_0_0_1px_var(--ds-sidebar-row-ring)] dark:bg-white/[0.045] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.05)]"
     >
       <button
         type="button"

--- a/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
+++ b/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
@@ -55,7 +55,7 @@ export function SidebarFrame({
         className
       )}
     >
-      <div className="ds-sidebar-titlebar-spacer shrink-0 pb-5 pt-3">
+      <div className="ds-sidebar-titlebar-spacer shrink-0 pb-2 pt-2">
         <div className="ds-sidebar-titlebar-row flex min-h-[34px] items-start justify-between">
           <div aria-hidden className="ds-titlebar-safe-block min-w-[86px]" />
           {onCollapse ? (


### PR DESCRIPTION
## Summary

- Tighten the sidebar Code/写作 mode switch so the control sits closer to the macOS titlebar area.
- Reduce the switch container and active tab padding to remove excess empty space inside the border.

## Changes

- Reduced the shared sidebar titlebar spacer padding.
- Lowered the workspace mode tab min height, padding, and radius.

## Tests

- npm run build
- npm run dist:mac:arm64
- Unzipped dist/Kun-0.1.0-mac-arm64.zip and launched dist/Kun-0.1.0-mac-arm64-unzipped/Kun.app
- Verified packaged runtime health: http://127.0.0.1:8899/health returned {"status":"ok","service":"kun","mode":"serve"}
- Captured packaged-app UI screenshot at /tmp/kun-packaged-sidebar.png

## Notes

- npm run typecheck is blocked by existing test typing errors in src/renderer/src/store/chat-store-thread-actions.test.ts around onDeltas on type never.
