### PR TITLE
fix(preload): avoid node builtin in sandbox preload

### DIFF
--- a/src/main/packaging-config.test.ts
+++ b/src/main/packaging-config.test.ts
@@ -1,5 +1,5 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { createRequire } from 'node:module'
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { builtinModules, createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -20,6 +20,28 @@ function tempRoot(): string {
 function touch(path: string): void {
   mkdirSync(join(path, '..'), { recursive: true })
   writeFileSync(path, '{}\n', 'utf8')
+}
+
+function preloadSourceFiles(dir = join(process.cwd(), 'src/preload')): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) return preloadSourceFiles(path)
+    return path.endsWith('.ts') && !path.endsWith('.d.ts') ? [path] : []
+  })
+}
+
+function forbiddenPreloadImports(source: string): string[] {
+  const builtins = new Set(builtinModules.map((moduleName) => moduleName.replace(/^node:/, '')))
+  const imports = source.matchAll(/(?:from\s+|import\s*\(|require\s*\()\s*['"]([^'"]+)['"]/g)
+  return [...imports]
+    .map((match) => match[1])
+    .filter((specifier) => {
+      const moduleName = specifier.replace(/^node:/, '')
+      return specifier.startsWith('node:') ||
+        builtins.has(moduleName) ||
+        builtins.has(moduleName.split('/')[0] ?? moduleName)
+    })
 }
 
 function loadBuilderConfigWithEnv(env: Record<string, string | undefined>): typeof builderConfig {
@@ -137,6 +159,12 @@ describe('electron-builder Kun packaging', () => {
     // instead of downscaling a single 1024px PNG (#222). The .ico still carries
     // the rounded Kun artwork — it is derived from kun_mac.png.
     expect(builderConfig.win.icon).toBe('./build/icon.ico')
+  })
+
+  it('keeps sandboxed preload free of Node builtin imports', () => {
+    for (const sourcePath of preloadSourceFiles()) {
+      expect(forbiddenPreloadImports(readFileSync(sourcePath, 'utf8'))).toEqual([])
+    }
   })
 
   it('requires Apple secure timestamps when Developer ID signing is enabled', () => {


### PR DESCRIPTION
## Summary

- Remove the Node `node:os` import from the sandboxed preload script so packaged builds can load `window.kunGui`.
- Add a packaging regression test that rejects Node builtin imports from preload sources.
- Update the Windows icon packaging assertion to match the current `.ico` asset configuration.

## Root Cause

Commit `5626ce85` added `homedir()` from `node:os` to the preload bridge for settings path compaction. The main window runs with `sandbox: true`, so the packaged preload cannot resolve Node builtin modules and fails before exposing `window.kunGui`.

## Tests

- `npm run test -- src/main/packaging-config.test.ts src/renderer/src/lib/settings-home-paths.test.ts`
- `npm run typecheck`
