### PR TITLE
fix(sidebar): move worktree badge before thread title

### DIFF
--- a/src/renderer/src/components/chat/SidebarProjectsSection.test.ts
+++ b/src/renderer/src/components/chat/SidebarProjectsSection.test.ts
@@ -10,8 +10,17 @@ import {
   filterSddDraftHistoryItems,
   mergeSidebarWorkspaceGroupsWithDraftHistory,
   SddDraftHistoryRows,
+  ThreadRow,
   ThreadRenameDialog
 } from './SidebarProjectsSection'
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      key === 'sidebarThreadWorktree' ? `Worktree ${String(opts?.branch)}` : key
+  })
+}))
 
 function thread(overrides: Partial<NormalizedThread> & Pick<NormalizedThread, 'id' | 'workspace'>): NormalizedThread {
   return {
@@ -285,6 +294,52 @@ describe('ThreadRenameDialog', () => {
     expect(html).toContain('sidebarThreadRename')
     expect(html).toContain('value="Build rename dialog"')
     expect(html).toContain('type="submit" disabled=""')
+  })
+})
+
+describe('ThreadRow', () => {
+  it('renders the worktree badge before the truncated title and outside the action buttons', () => {
+    const html = renderToStaticMarkup(
+      createElement(ThreadRow, {
+        thread: thread({
+          id: 'thr_worktree',
+          title: 'Very long archived worktree thread title',
+          workspace: '/Users/zxy/project-a',
+          archived: true
+        }),
+        worktreeRecord: {
+          projectPath: '/Users/zxy/project-a',
+          worktreePath: '/Users/zxy/.kun/worktrees/abcd/project-a',
+          branch: 'feature/layout-fix'
+        },
+        active: false,
+        deleting: false,
+        locale: 'zh-CN',
+        showRunning: false,
+        showUnread: false,
+        onSelect: vi.fn(),
+        onContextMenu: vi.fn(),
+        onRename: vi.fn(),
+        onArchive: vi.fn(),
+        onDelete: vi.fn(),
+        onRestore: vi.fn()
+      })
+    )
+
+    const rowButtonStart = html.indexOf('<button')
+    const rowButtonEnd = html.indexOf('</button>', rowButtonStart)
+    const rowButtonHtml = html.slice(rowButtonStart, rowButtonEnd)
+    const actionsHtml = html.slice(rowButtonEnd)
+
+    expect(rowButtonHtml.indexOf('aria-label="Worktree feature/layout-fix"')).toBeGreaterThan(-1)
+    expect(rowButtonHtml.lastIndexOf('Very long archived worktree thread title')).toBeGreaterThan(-1)
+    expect(rowButtonHtml.indexOf('aria-label="Worktree feature/layout-fix"')).toBeLessThan(
+      rowButtonHtml.lastIndexOf('Very long archived worktree thread title')
+    )
+    expect(rowButtonHtml).toContain('min-w-[3.75rem]')
+    expect(actionsHtml).toContain('sidebarThreadRestore')
+    expect(actionsHtml).toContain('sidebarThreadDelete')
+    expect(actionsHtml).not.toContain('Worktree feature/layout-fix')
   })
 })
 

--- a/src/renderer/src/components/chat/SidebarProjectsSection.tsx
+++ b/src/renderer/src/components/chat/SidebarProjectsSection.tsx
@@ -1004,7 +1004,7 @@ export function SddDraftHistoryRows({
   )
 }
 
-function ThreadRow({
+export function ThreadRow({
   thread,
   worktreeRecord,
   active,
@@ -1078,13 +1078,6 @@ function ThreadRow({
       onContextMenu={onContextMenu}
     >
       <span className="flex min-w-0 flex-1 items-center gap-1.5">
-        <span
-          className={`min-w-0 flex-1 truncate text-[13.5px] leading-5 ${
-            showUnreadDot && !active ? 'font-semibold text-ds-ink' : 'text-ds-ink'
-          }`}
-        >
-          {thread.title}
-        </span>
         {worktreeRecord ? (
           <span
             className="inline-grid h-5 w-5 shrink-0 place-items-center rounded-full border border-ds-border-muted bg-ds-card/80 text-ds-muted"
@@ -1094,7 +1087,14 @@ function ThreadRow({
             <GitBranch className="h-3 w-3" strokeWidth={1.8} />
           </span>
         ) : null}
-        <span className={`ml-auto flex shrink-0 items-center gap-1.5 transition ${
+        <span
+          className={`min-w-0 flex-1 truncate text-[13.5px] leading-5 ${
+            showUnreadDot && !active ? 'font-semibold text-ds-ink' : 'text-ds-ink'
+          }`}
+        >
+          {thread.title}
+        </span>
+        <span className={`ml-auto flex min-w-[3.75rem] shrink-0 items-center justify-end gap-1.5 transition ${
           deleting ? 'opacity-0' : 'group-hover:opacity-0 group-focus-within:opacity-0'
         }`}>
           <span className="shrink-0 text-right text-[12px] leading-4 text-ds-faint tabular-nums">


### PR DESCRIPTION
Summary
- Move the per-thread worktree badge before the sidebar thread title so it no longer overlaps archived-thread actions.
- Keep the thread title truncating before the fixed right-side status/action area.
- Add a SidebarProjectsSection regression test for the worktree badge/action layout.

Tests
- npm run test -- SidebarProjectsSection
- npm run typecheck
- git diff --check