### PR TITLE
fix(memory): isolate project and workspace recall

### DIFF
--- a/kun/src/adapters/tool/memory-tool-provider.ts
+++ b/kun/src/adapters/tool/memory-tool-provider.ts
@@ -19,6 +19,7 @@ export function buildMemoryToolProviders(store: MemoryStore | undefined): Capabi
             content: { type: 'string' },
             scope: { type: 'string', enum: ['user', 'workspace', 'project'] },
             workspace: { type: 'string' },
+            project: { type: 'string' },
             tags: { type: 'array', items: { type: 'string' } }
           },
           required: ['content'],
@@ -28,12 +29,20 @@ export function buildMemoryToolProviders(store: MemoryStore | undefined): Capabi
         execute: async (args, context) => {
           const content = typeof args.content === 'string' ? args.content.trim() : ''
           if (!content) return { output: { error: 'content is required' }, isError: true }
+          const scope = args.scope === 'user' || args.scope === 'project' ? args.scope : 'workspace'
+          const workspace = context.workspace.trim()
+          if (scope !== 'user' && !workspace) {
+            return { output: { error: 'workspace is required for workspace/project memory' }, isError: true }
+          }
           return {
             output: {
               memory: await store.create({
                 content,
-                scope: args.scope === 'user' || args.scope === 'project' ? args.scope : 'workspace',
-                workspace: typeof args.workspace === 'string' ? args.workspace : context.workspace,
+                scope,
+                ...(scope === 'user' ? {} : { workspace }),
+                ...(scope === 'project'
+                  ? { project: workspace }
+                  : {}),
                 sourceThreadId: context.threadId,
                 sourceTurnId: context.turnId,
                 tags: Array.isArray(args.tags) ? args.tags.filter((tag): tag is string => typeof tag === 'string') : []

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -862,7 +862,8 @@ export class AgentLoop {
     }
     const memories = await this.retrieveMemories({
       prompt: turn?.prompt ?? '',
-      workspace: thread?.workspace ?? ''
+      workspace: thread?.workspace ?? '',
+      project: thread?.workspace ?? ''
     })
     const planTurnActive = effectiveMode === 'plan' || Boolean(activePlanContext)
     const activeGoalInstruction = planTurnActive
@@ -2355,11 +2356,13 @@ export class AgentLoop {
   private async retrieveMemories(input: {
     prompt: string
     workspace: string
+    project?: string
   }) {
     if (!this.opts.memoryStore) return []
     const memories = await this.opts.memoryStore.retrieve({
       query: input.prompt,
       workspace: input.workspace,
+      project: input.project,
       limit: 8
     })
     this.opts.memoryStore.setLastInjected(memories.map((memory) => memory.id))

--- a/kun/src/memory/memory-store.ts
+++ b/kun/src/memory/memory-store.ts
@@ -13,8 +13,8 @@ export interface MemoryStore {
   create(input: MemoryCreateRequest): Promise<MemoryRecord>
   update(id: string, patch: MemoryUpdateRequest): Promise<MemoryRecord>
   delete(id: string): Promise<MemoryRecord>
-  list(filter?: { workspace?: string; includeDeleted?: boolean }): Promise<MemoryRecord[]>
-  retrieve(input: { query: string; workspace?: string; limit: number }): Promise<MemoryRecord[]>
+  list(filter?: { workspace?: string; project?: string; includeDeleted?: boolean }): Promise<MemoryRecord[]>
+  retrieve(input: { query: string; workspace?: string; project?: string; limit: number }): Promise<MemoryRecord[]>
   diagnostics(): Promise<MemoryDiagnostics>
   setLastInjected(ids: string[]): void
 }
@@ -79,17 +79,19 @@ export class FileMemoryStore implements MemoryStore {
     return next
   }
 
-  async list(filter: { workspace?: string; includeDeleted?: boolean } = {}): Promise<MemoryRecord[]> {
+  async list(filter: { workspace?: string; project?: string; includeDeleted?: boolean } = {}): Promise<MemoryRecord[]> {
     const records = await this.readAll()
     return records
       .filter((record) => filter.includeDeleted || !record.deletedAt)
-      .filter((record) => inScope(record, filter.workspace))
+      .filter((record) => inScope(record, filter, { includeAllWhenUnfiltered: true }))
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
   }
 
-  async retrieve(input: { query: string; workspace?: string; limit: number }): Promise<MemoryRecord[]> {
+  async retrieve(input: { query: string; workspace?: string; project?: string; limit: number }): Promise<MemoryRecord[]> {
     if (!this.options.config.enabled) return []
-    const active = (await this.list({ workspace: input.workspace }))
+    const active = (await this.readAll())
+      .filter((record) => !record.deletedAt)
+      .filter((record) => inScope(record, input, { includeAllWhenUnfiltered: false }))
       .filter((record) => !record.disabledAt)
     // User-scope memories are persistent identity facts (name, preferences,
     // account) — small in number, high in value, and frequently queried by
@@ -151,16 +153,30 @@ export class FileMemoryStore implements MemoryStore {
   }
 }
 
-function inScope(record: MemoryRecord, workspace: string | undefined): boolean {
+function inScope(
+  record: MemoryRecord,
+  filter: { workspace?: string; project?: string },
+  options: { includeAllWhenUnfiltered: boolean }
+): boolean {
   if (record.scope === 'user') return true
+  const workspace = normalizeScopeKey(filter.workspace)
+  const project = normalizeScopeKey(filter.project) || workspace
+  if (!workspace && !project) return options.includeAllWhenUnfiltered
   if (record.scope === 'workspace') {
-    // Records created via the GUI may not carry a workspace (e.g. manually
-    // added before any thread ran). Treat a missing workspace as in-scope so
-    // they are still retrievable; otherwise require an exact match.
-    if (!record.workspace) return true
-    return Boolean(workspace && record.workspace === workspace)
+    return Boolean(workspace && normalizeScopeKey(record.workspace) === workspace)
   }
-  return true
+  if (record.scope === 'project') {
+    const recordProject = normalizeScopeKey(record.project) || normalizeScopeKey(record.workspace)
+    return Boolean(project && recordProject === project)
+  }
+  return false
+}
+
+function normalizeScopeKey(value: string | undefined): string {
+  const trimmed = value?.trim() ?? ''
+  if (!trimmed) return ''
+  if (trimmed === '/') return trimmed
+  return trimmed.replace(/\/+$/, '')
 }
 
 function scoreMemory(record: MemoryRecord, query: string): number {

--- a/kun/src/server/routes/memory.ts
+++ b/kun/src/server/routes/memory.ts
@@ -10,6 +10,7 @@ export async function listMemories(store: MemoryStore | undefined, request: Requ
   return jsonResponse({
     memories: await store.list({
       workspace: url.searchParams.get('workspace') ?? undefined,
+      project: url.searchParams.get('project') ?? undefined,
       includeDeleted: url.searchParams.get('include_deleted') === 'true'
     })
   })

--- a/kun/tests/memory-store.test.ts
+++ b/kun/tests/memory-store.test.ts
@@ -39,8 +39,26 @@ describe('Memory store and recall', () => {
       scope: 'workspace',
       workspace: '/tmp/other'
     })
+    const projectMemory = await store.create({
+      content: 'Project uses Vitest for regression coverage',
+      scope: 'project',
+      workspace: '/tmp/ws',
+      project: '/tmp/ws'
+    })
 
     expect((await store.retrieve({ query: 'frontend pnpm preference', workspace: '/tmp/ws', limit: 3 })).map((item) => item.id)).toEqual([memory.id])
+    expect((await store.retrieve({
+      query: 'Vitest regression coverage',
+      workspace: '/tmp/ws/',
+      project: '/tmp/ws/',
+      limit: 3
+    })).map((item) => item.id)).toEqual([projectMemory.id])
+    expect(await store.retrieve({
+      query: 'Vitest regression coverage',
+      workspace: '/tmp/other',
+      project: '/tmp/other',
+      limit: 3
+    })).toEqual([])
     expect(await createStore({ enabled: false }).retrieve({ query: 'pnpm', workspace: '/tmp/ws', limit: 3 })).toEqual([])
 
     await store.update(memory.id, { disabled: true })
@@ -50,6 +68,30 @@ describe('Memory store and recall', () => {
     await store.delete(memory.id)
     expect(await store.retrieve({ query: 'pnpm', workspace: '/tmp/ws', limit: 3 })).toEqual([])
     expect((await store.list({ workspace: '/tmp/ws', includeDeleted: true })).find((item) => item.id === memory.id)?.deletedAt).toBeTruthy()
+  })
+
+  it('does not recall workspace/project memories when no workspace is active', async () => {
+    const store = createStore()
+    await store.create({
+      content: 'Workspace prefers pnpm',
+      scope: 'workspace',
+      workspace: '/tmp/ws'
+    })
+    await store.create({
+      content: 'Project uses Vitest',
+      scope: 'project',
+      workspace: '/tmp/ws',
+      project: '/tmp/ws'
+    })
+    await store.create({
+      content: 'Global user preference should remain available everywhere',
+      scope: 'user'
+    })
+
+    expect((await store.retrieve({
+      query: 'pnpm Vitest Global user preference',
+      limit: 5
+    })).map((item) => item.scope)).toEqual(['user'])
   })
 
   it('exposes memory API routes with diagnostics', async () => {
@@ -131,6 +173,66 @@ describe('Memory store and recall', () => {
     expect(await store.list({ workspace: '/tmp/ws' })).toHaveLength(1)
   })
 
+  it('binds project-scope memory tool writes to the current project', async () => {
+    const store = createStore()
+    const host = new LocalToolHost({
+      registry: new CapabilityRegistry(buildMemoryToolProviders(store))
+    })
+    const result = await host.execute({
+      callId: 'call_1',
+      toolName: 'memory_create',
+      arguments: {
+        content: 'Use Vitest in this project',
+        scope: 'project',
+        workspace: '/tmp/project-b',
+        project: '/tmp/project-b'
+      }
+    }, {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      workspace: '/tmp/project-a',
+      approvalPolicy: 'on-request',
+      abortSignal: new AbortController().signal,
+      awaitApproval: async () => 'allow'
+    })
+
+    expect(result.item).toMatchObject({ kind: 'tool_result', isError: false })
+    expect(await store.retrieve({
+      query: 'Vitest project',
+      workspace: '/tmp/project-a',
+      project: '/tmp/project-a',
+      limit: 3
+    })).toHaveLength(1)
+    expect(await store.retrieve({
+      query: 'Vitest project',
+      workspace: '/tmp/project-b',
+      project: '/tmp/project-b',
+      limit: 3
+    })).toEqual([])
+  })
+
+  it('rejects workspace/project memory tool writes when no workspace is active', async () => {
+    const store = createStore()
+    const host = new LocalToolHost({
+      registry: new CapabilityRegistry(buildMemoryToolProviders(store))
+    })
+    const result = await host.execute({
+      callId: 'call_1',
+      toolName: 'memory_create',
+      arguments: { content: 'Use Vitest in this project', scope: 'project' }
+    }, {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      workspace: '',
+      approvalPolicy: 'on-request',
+      abortSignal: new AbortController().signal,
+      awaitApproval: async () => 'allow'
+    })
+
+    expect(result.item).toMatchObject({ kind: 'tool_result', isError: true })
+    expect(await store.list()).toEqual([])
+  })
+
   it('injects relevant memories into AgentLoop metadata and stops after deletion', async () => {
     const store = createStore()
     const memory = await store.create({
@@ -187,17 +289,16 @@ describe('Memory store and recall', () => {
     expect(misses).toEqual([])
   })
 
-  it('retrieves workspace-scope memories that have no workspace field (GUI-created)', async () => {
+  it('does not inject workspace-scope memories without a workspace into arbitrary workspaces', async () => {
     const store = createStore()
-    // GUI-created workspace memories may omit the workspace field. They should
-    // still be retrievable instead of being silently filtered out by inScope.
     const memory = await store.create({
       content: 'Workspace prefers tabs over spaces',
       scope: 'workspace'
     })
     expect(memory.workspace).toBeUndefined()
     const hits = await store.retrieve({ query: 'tabs spaces indentation', workspace: '/tmp/ws', limit: 3 })
-    expect(hits.map((item) => item.id)).toEqual([memory.id])
+    expect(hits).toEqual([])
+    expect((await store.list()).map((item) => item.id)).toEqual([memory.id])
   })
 
   it('injects user-scope memories on semantic queries with zero keyword overlap', async () => {

--- a/src/renderer/src/agent/kun-runtime.test.ts
+++ b/src/renderer/src/agent/kun-runtime.test.ts
@@ -506,7 +506,7 @@ describe('KunRuntimeProvider', () => {
 
   it('lists, disables, and deletes memory records through Kun endpoints', async () => {
     const runtimeRequest = vi.fn(async (path: string, method?: string, body?: string) => {
-      if (path === '/v1/memory?workspace=%2Ftmp%2Fworkspace&include_deleted=false') {
+      if (path === '/v1/memory?workspace=%2Ftmp%2Fworkspace&project=%2Ftmp%2Fworkspace&include_deleted=false') {
         return {
           ok: true,
           status: 200,
@@ -562,7 +562,11 @@ describe('KunRuntimeProvider', () => {
     installDsGui({ runtimeRequest })
     const provider = new KunRuntimeProvider()
 
-    await expect(provider.listMemories({ workspace: '/tmp/workspace', includeDeleted: false })).resolves.toHaveLength(1)
+    await expect(provider.listMemories({
+      workspace: '/tmp/workspace',
+      project: '/tmp/workspace',
+      includeDeleted: false
+    })).resolves.toHaveLength(1)
     await expect(provider.updateMemory('mem_1', { disabled: true })).resolves.toMatchObject({
       id: 'mem_1',
       disabledAt: 't1'

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -631,9 +631,10 @@ export class KunRuntimeProvider implements AgentProvider {
     )
   }
 
-  async listMemories(options: { workspace?: string; includeDeleted?: boolean } = {}): Promise<CoreMemoryRecordJson[]> {
+  async listMemories(options: { workspace?: string; project?: string; includeDeleted?: boolean } = {}): Promise<CoreMemoryRecordJson[]> {
     const query = buildQuery({
       workspace: options.workspace,
+      project: options.project,
       include_deleted: options.includeDeleted
     })
     const response = await rendererRuntimeClient.runtimeRequest(`${KUN_MEMORY_PATH}${query}`, 'GET')

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -464,7 +464,7 @@ export interface AgentProvider {
     attachmentId: string,
     options?: { threadId?: string; workspace?: string }
   ): Promise<CoreAttachmentContentResponseJson>
-  listMemories?(options?: { workspace?: string; includeDeleted?: boolean }): Promise<CoreMemoryRecordJson[]>
+  listMemories?(options?: { workspace?: string; project?: string; includeDeleted?: boolean }): Promise<CoreMemoryRecordJson[]>
   createMemory?(input: {
     content: string
     scope?: 'user' | 'workspace' | 'project'

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -456,7 +456,8 @@ export function SettingsView(): ReactElement {
     setRuntimeDiagnosticsNotice(null)
     try {
       const loaded = await loadKunDiagnostics(provider, {
-        workspace: normalizeWorkspaceRoot(formWorkspaceRoot)
+        workspace: normalizeWorkspaceRoot(formWorkspaceRoot),
+        project: normalizeWorkspaceRoot(formWorkspaceRoot)
       })
       if (loaded.runtimeInfo !== undefined) setRuntimeInfo(loaded.runtimeInfo)
       if (loaded.toolDiagnostics !== undefined) setToolDiagnostics(loaded.toolDiagnostics)
@@ -501,13 +502,20 @@ export function SettingsView(): ReactElement {
   const createMemoryRecord = async (input: {
     content: string
     scope?: 'user' | 'workspace' | 'project'
+    workspace?: string
+    project?: string
     tags?: string[]
     confidence?: number
   }): Promise<boolean> => {
     const provider = getProvider()
     if (typeof provider.createMemory !== 'function') return false
     try {
-      const memory = await provider.createMemory(input)
+      const workspace = normalizeWorkspaceRoot(formWorkspaceRoot)
+      const memory = await provider.createMemory({
+        ...input,
+        ...(input.scope === 'workspace' && workspace ? { workspace } : {}),
+        ...(input.scope === 'project' && workspace ? { workspace, project: workspace } : {})
+      })
       setMemoryRecords((records) => [memory, ...records])
       return true
     } catch (error) {

--- a/src/renderer/src/lib/load-kun-diagnostics.ts
+++ b/src/renderer/src/lib/load-kun-diagnostics.ts
@@ -17,13 +17,13 @@ export type LoadedKunDiagnostics = {
 
 export async function loadKunDiagnostics(
   provider: DiagnosticsProvider,
-  options: { workspace?: string } = {}
+  options: { workspace?: string; project?: string } = {}
 ): Promise<LoadedKunDiagnostics> {
   const [runtimeInfo, toolDiagnostics, memoryRecords] = await Promise.allSettled([
     provider.getRuntimeInfo ? provider.getRuntimeInfo() : Promise.resolve(null),
     provider.getToolDiagnostics ? provider.getToolDiagnostics() : Promise.resolve(null),
     provider.listMemories
-      ? provider.listMemories({ workspace: options.workspace, includeDeleted: false })
+      ? provider.listMemories({ workspace: options.workspace, project: options.project, includeDeleted: false })
       : Promise.resolve([])
   ])
 


### PR DESCRIPTION
Summary
- Fix memory recall so workspace/project scoped records cannot leak across projects.
- Keep user-scope memories globally shared.

Changes
- Bind project memory creation to the active workspace/project and reject non-user scoped tool writes without an active workspace.
- Separate management listing from runtime recall so unscoped runtime turns only inject user memories.
- Add regression coverage for project isolation, no-workspace recall, forged tool scopes, and project query propagation.

Tests
- npm --prefix kun run test -- tests/memory-store.test.ts
- npm run test -- src/renderer/src/lib/load-kun-diagnostics.test.ts
- npx vitest run src/renderer/src/agent/kun-runtime.test.ts
- npm run typecheck
- npm run build:kun