### PR TITLE
Implement event throttling for SSE messages

### DIFF
--- a/src/main/runtime-sse-ipc.ts
+++ b/src/main/runtime-sse-ipc.ts
@@ -203,18 +203,41 @@ export function registerRuntimeSseIpc(options: {
               continue
             }
             reconnectDelayMs = SSE_RECONNECT_BASE_MS
-            const reader = res.body.getReader()
+                        const reader = res.body.getReader()
             const dec = new TextDecoder()
             let buffer = ''
+            
+            // 新增：消息节流队列和定时器
+            let pendingEvents: Record<string, unknown>[] = []
+            let throttleTimer: any = null
+
+            const flushEvents = () => {
+              if (throttleTimer) {
+                clearTimeout(throttleTimer)
+                throttleTimer = null
+              }
+              if (state.stoppedByClient || ac.signal.aborted) {
+                pendingEvents = []
+                return false
+              }
+              if (pendingEvents.length === 0) return true
+              const batch = pendingEvents
+              pendingEvents = []
+              if (!sendSseMessage(wc, 'runtime:sse-event', { streamId: id, events: batch })) {
+                state.stoppedByClient = true
+                ac.abort()
+                return false
+              }
+              return true
+            }
+
             while (true) {
               const { done, value } = await reader.read()
               if (done) break
               buffer += dec.decode(value, { stream: true })
-              // Batch every event parsed from this network chunk into one IPC
-              // message — streaming turns otherwise pay a structured-clone
-              // send per token delta.
-              const batch: Record<string, unknown>[] = []
+              
               let next: { block: string; rest: string } | null
+              let hasNewEvents = false
               while ((next = takeSseBlock(buffer)) !== null) {
                 const block = next.block
                 buffer = next.rest
@@ -224,14 +247,17 @@ export function registerRuntimeSseIpc(options: {
                   if (typeof payload.seq === 'number') {
                     nextSinceSeq = Math.max(nextSinceSeq, payload.seq)
                   }
-                  batch.push(payload)
+                  pendingEvents.push(payload)
+                  hasNewEvents = true
                 }
               }
-              if (batch.length > 0) {
-                if (!sendSseMessage(wc, 'runtime:sse-event', { streamId: id, events: batch })) {
-                  state.stoppedByClient = true
-                  ac.abort()
-                  return
+              if (hasNewEvents) {
+                // 如果当前没有定时器，则开启一个 100ms 的定时器，到期后统一刷入前端
+                if (!throttleTimer) {
+                  throttleTimer = setTimeout(() => {
+                    throttleTimer = null
+                    flushEvents()
+                  }, 100)
                 }
               }
             }
@@ -244,13 +270,11 @@ export function registerRuntimeSseIpc(options: {
                 if (typeof payload.seq === 'number') {
                   nextSinceSeq = Math.max(nextSinceSeq, payload.seq)
                 }
-                if (!sendSseMessage(wc, 'runtime:sse-event', { streamId: id, events: [payload] })) {
-                  state.stoppedByClient = true
-                  ac.abort()
-                  return
-                }
+                pendingEvents.push(payload)
               }
             }
+            // 确保流结束时，将队列里剩余的事件立即刷入前端
+            flushEvents()
           } catch (e) {
             if (state.stoppedByClient || ac.signal.aborted) return
             const msg = e instanceof Error ? e.message : String(e)


### PR DESCRIPTION
Added a message throttling queue and timer to batch events before sending to the frontend.

## Summary / 概要

- 在主进程中为 `runtime:sse-event` 引入了 100ms 消息节流和批处理队列，极大降低了推理模型流式输出时的 IPC 通信频率，避免了渲染进程（前端）卡死。
- Introduced a 100ms message throttling queue and timer in the main process for `runtime:sse-event` to reduce IPC frequency during token streaming, preventing renderer process freezes.

## Why / 背景

- 当使用 DeepSeek V4 系列等推理模型时，后台会以极高频率产生大量的 Reasoning Token（推理/思考过程）。
- 特别地，在网络存在代理（如海外节点中转）、网络抖动或高延迟时，流式数据包在传输过程中极易被 TCP 缓冲积压，导致原本均匀的 Token 以高密度、瞬间爆发的形式（Burst）抵达客户端。
- 主进程在接收到这些 SSE 事件后，原逻辑没有做任何限流，每收到一个数据块就立即向渲染进程发送 IPC 消息。渲染进程（前端）因此被超高频的 React 重载和 Markdown 解析任务占满 CPU 线程，导致界面彻底卡死，直到生成结束后才恢复响应。
- When using reasoning models (like DeepSeek V4 series), a high volume of Reasoning Tokens is streamed rapidly. 
-Furthermore, network proxying, jitter, or high latency can cause streaming chunks to accumulate in TCP buffers, delivering tokens to the client in rapid, high-density bursts.
- The original IPC logic forwarded every SSE chunk immediately to the renderer without throttling, causing the renderer's CPU to peg at 100% on React updates and freeze the UI until streaming completed.

## Changes / 变更

- `src/main/runtime-sse-ipc.ts`: 
  - 在 `registerRuntimeSseIpc` 的数据流读取循环中，引入 `pendingEvents` 缓存队列和 `throttleTimer`。
  - 将原来的即时发送修改为每 100ms 合并打包发送一次（节流），并在数据流结束时立即清空队列以确保响应不丢失。
  - Added `pendingEvents` buffer and `throttleTimer` inside the reader loop of `registerRuntimeSseIpc`.
  - Replaced instant forwarding with a throttled 100ms batch-flush mechanism, ensuring all trailing events are pushed immediately upon stream end.

## Media / 截图或录屏

- (无 UI 样式变更，属于后台逻辑优化 / No visual UI changes, background performance optimization)

## Tests / 测试

- 已在本地环境下对重构打包后的二进制文件（app.asar）进行了测试，卡死问题完全消除，且流式打字输出体验依然保持流畅。
- Verified locally with rebuilt ASAR. The freeze issue is completely resolved while keeping the streaming output smooth.

## Validation / 验证

- [x] I agree that this contribution is submitted under the [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md). / 我同意本贡献遵循 [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md) 提交。
- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run dev` (if runtime or UI behavior changed / 如果运行时或界面行为有变化)
- [ ] UI change: video or GIF attached / 界面变更：已附上视频或 GIF (不适用)
- [ ] Logic change: unit tests added or updated / 逻辑变更：已新增或更新单元测试

## Notes / 备注

- 这是一个纯逻辑层面的 IPC 性能优化，无需修改前端渲染进程代码。
- This is a pure main-process IPC logic optimization, requiring no changes to the React renderer code.
