### PR TITLE
fix(composer): restore footer picker popovers

### DIFF
--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -2971,7 +2971,7 @@ pre {
 
 .ds-composer-footer {
   flex-wrap: nowrap;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .ds-composer-footer-left {


### PR DESCRIPTION
## Summary

Fixes the footer project and branch picker popovers not appearing from the composer footer.

## Changes

- Allows `.ds-composer-footer` overflow to remain visible so its absolutely positioned picker menus can render above the footer.
- Keeps the existing nowrap footer behavior intact, preserving the previous footer hint layout fix.

## Root Cause

The footer picker components render their menus as absolute children above the footer. The footer had `overflow: hidden`, so the menus were clipped by the footer container and clicks appeared to do nothing.

## Tests

- `git diff --check`
- `npx tsc --noEmit -p tsconfig.web.json`
- `npm run typecheck` still fails on the current develop baseline in workflow node/test fixture types, unrelated to this CSS-only change.
