### PR TITLE
fix(shortcuts): use ctrl terminal toggle on macOS

### DIFF
--- a/src/shared/keyboard-shortcuts.test.ts
+++ b/src/shared/keyboard-shortcuts.test.ts
@@ -39,9 +39,10 @@ describe('keyboard shortcuts', () => {
     expect(bindings['new-chat']).toEqual(['Ctrl+N'])
   })
 
-  it('uses platform defaults for the terminal toggle shortcut', () => {
-    expect(resolveKeyboardShortcutBindings(undefined, 'darwin')['toggle-terminal']).toEqual(['Meta+`'])
+  it('uses Ctrl+` for the terminal toggle shortcut on every platform', () => {
+    expect(resolveKeyboardShortcutBindings(undefined, 'darwin')['toggle-terminal']).toEqual(['Ctrl+`'])
     expect(resolveKeyboardShortcutBindings(undefined, 'win32')['toggle-terminal']).toEqual(['Ctrl+`'])
+    expect(resolveKeyboardShortcutBindings(undefined, 'linux')['toggle-terminal']).toEqual(['Ctrl+`'])
   })
 
   it('ignores unknown commands and detects conflicts', () => {

--- a/src/shared/keyboard-shortcuts.ts
+++ b/src/shared/keyboard-shortcuts.ts
@@ -30,10 +30,7 @@ export const KEYBOARD_SHORTCUT_COMMANDS = [
     id: 'toggle-terminal',
     labelKey: 'shortcutToggleTerminal',
     descriptionKey: 'shortcutToggleTerminalDesc',
-    defaultBindings: ['Ctrl+`'],
-    platformDefaultBindings: {
-      darwin: ['Meta+`']
-    }
+    defaultBindings: ['Ctrl+`']
   },
   {
     id: 'settings',


### PR DESCRIPTION
## Summary
- Remove the macOS-specific terminal shortcut override that changed the default from Ctrl+` to Meta+`.
- Keep the terminal toggle default on Ctrl+` for macOS, Windows, and Linux.
- Update shortcut coverage so platform resolution asserts Ctrl+` everywhere.

## Root Cause
The shared shortcut definition for `toggle-terminal` had a Darwin-specific `platformDefaultBindings` entry that replaced the cross-platform Ctrl+` default with Meta+`. Settings display and runtime key handling both resolve through that shared map, so macOS showed and listened for the wrong default shortcut.

## Tests
- `npm run test -- src/shared/keyboard-shortcuts.test.ts`
- `git diff --check`
- `npm run typecheck` fails on current develop baseline in existing workflow typing/test files, including `src/main/workflow-runtime.run.test.ts`, `src/main/workflow-runtime.test.ts`, and two existing `src/main/ipc/app-ipc-schemas.ts` zod helper call sites; no failures are from the touched shortcut files.