### PR TITLE
fix(composer): align context capacity with selected model

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -27,7 +27,11 @@ import type { CoreRuntimeInfoJson, CoreRuntimeSkillJson } from '../agent/kun-con
 import { getProvider } from '../agent/registry'
 import { rendererRuntimeClient } from '../agent/runtime-client'
 import { useChatStore } from '../store/chat-store'
-import { isClawThread, providerIdForComposerModel } from '../store/chat-store-helpers'
+import {
+  isClawThread,
+  providerIdForComposerModel,
+  resolveComposerContextWindowTokens
+} from '../store/chat-store-helpers'
 import { threadHasPendingRuntimeWork } from '../store/chat-store-runtime-helpers'
 import {
   extractLatestTurnAutoOpenDevPreviewUrls,
@@ -973,6 +977,13 @@ export function Workbench(): ReactElement {
     }
     return false
   }, [composerModelGroups, runtimeInfo, selectedComposerModel, selectedComposerProviderId])
+  const selectedContextWindowTokens = useMemo(() => {
+    return resolveComposerContextWindowTokens(
+      composerModelGroups,
+      selectedComposerModel,
+      selectedComposerProviderId
+    )
+  }, [composerModelGroups, selectedComposerModel, selectedComposerProviderId])
 
   const attachmentUploadEnabled = isChatAttachmentUploadEnabled({
     runtimeConnection,
@@ -2614,7 +2625,7 @@ export function Workbench(): ReactElement {
                 busy={busy}
                 runtimeReady={runtimeConnection === 'ready'}
                 hasActiveThread={Boolean(activeThreadId)}
-                contextWindowTokens={runtimeInfo?.capabilities.model.contextWindowTokens}
+                contextWindowTokens={selectedContextWindowTokens}
                 runtimeToolCount={
                   runtimeInfo
                     ? runtimeInfo.capabilities.mcp.search?.active

--- a/src/renderer/src/store/chat-store-helpers.test.ts
+++ b/src/renderer/src/store/chat-store-helpers.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClawImChannelV1 } from '@shared/app-settings'
+import type { ModelProviderModelGroup } from '@shared/kun-gui-api'
 import { CLAW_MANAGED_INSTRUCTIONS_HEADING } from '@shared/app-settings'
 import {
   MAX_TURN_MODEL_LABELS,
   MAX_THREAD_COMPOSER_SELECTIONS,
   MAX_CODE_WORKSPACE_ROOTS,
+  DEFAULT_COMPOSER_CONTEXT_WINDOW_TOKENS,
   clawThreadIdsFromChannels,
   clawThreadTitleLooksManaged,
   compactCodeWorkspaceRoots,
@@ -18,7 +20,8 @@ import {
   readThreadComposerSelection,
   reconcileCodeWorkspaceRoots,
   rememberThreadComposerSelection,
-  rememberTurnModel
+  rememberTurnModel,
+  resolveComposerContextWindowTokens
 } from './chat-store-helpers'
 
 const TURN_MODEL_STORAGE_KEY = 'kun.turnModelLabel'
@@ -207,6 +210,67 @@ describe('chat-store Claw helpers', () => {
     expect(fallbackComposerModel(pick, 'missing-model')).toBe('deepseek-v4-pro')
     expect(fallbackComposerModel(['a-model'], '')).toBe('a-model')
     expect(fallbackComposerModel([], '')).toBe('')
+  })
+
+  it('resolves context windows from the selected provider model profile', () => {
+    const modelGroups: ModelProviderModelGroup[] = [
+      {
+        providerId: 'other',
+        label: 'Other',
+        modelIds: ['glm-4.5'],
+        modelProfiles: {
+          'glm-4.5': {
+            contextWindowTokens: 256_000,
+            inputModalities: ['text'],
+            outputModalities: ['text'],
+            supportsToolCalling: true,
+            messageParts: ['text']
+          }
+        }
+      },
+      {
+        providerId: 'zhipu',
+        label: 'Zhipu',
+        modelIds: ['glm-4.5'],
+        modelProfiles: {
+          'glm-4.5': {
+            contextWindowTokens: 200_000,
+            inputModalities: ['text'],
+            outputModalities: ['text'],
+            supportsToolCalling: true,
+            messageParts: ['text']
+          }
+        }
+      }
+    ]
+
+    expect(resolveComposerContextWindowTokens(modelGroups, 'glm-4.5', 'zhipu')).toBe(200_000)
+  })
+
+  it('falls back to 128k when the selected model lacks a configured window', () => {
+    const modelGroups: ModelProviderModelGroup[] = [
+      {
+        providerId: 'custom',
+        label: 'Custom',
+        modelIds: ['custom-model'],
+        modelProfiles: {
+          'custom-model': {
+            inputModalities: ['text'],
+            outputModalities: ['text'],
+            supportsToolCalling: true,
+            messageParts: ['text']
+          }
+        }
+      }
+    ]
+
+    expect(resolveComposerContextWindowTokens(modelGroups, 'custom-model', 'custom')).toBe(
+      DEFAULT_COMPOSER_CONTEXT_WINDOW_TOKENS
+    )
+    expect(resolveComposerContextWindowTokens(modelGroups, 'missing-model', 'custom')).toBe(
+      DEFAULT_COMPOSER_CONTEXT_WINDOW_TOKENS
+    )
+    expect(resolveComposerContextWindowTokens(modelGroups, '', 'custom')).toBeUndefined()
   })
 
   it('normalizes and caps persisted turn model labels', () => {

--- a/src/renderer/src/store/chat-store-helpers.ts
+++ b/src/renderer/src/store/chat-store-helpers.ts
@@ -30,6 +30,7 @@ const CODE_WORKSPACE_ROOTS_STORAGE_KEY = 'kun.codeWorkspaceRoots.v1'
 export const MAX_CODE_WORKSPACE_ROOTS = 30
 export const MAX_THREAD_COMPOSER_SELECTIONS = 500
 export const MAX_TURN_MODEL_LABELS = 500
+export const DEFAULT_COMPOSER_CONTEXT_WINDOW_TOKENS = 128_000
 
 export type ThreadComposerSelection = {
   model: string
@@ -118,6 +119,19 @@ export function providerIdForComposerModel(
   const model = modelId.trim()
   if (!model) return ''
   return modelGroups.find((group) => modelGroupHasModel(group, model))?.providerId ?? ''
+}
+
+export function resolveComposerContextWindowTokens(
+  modelGroups: readonly ModelProviderModelGroup[],
+  modelId: string,
+  providerId: string
+): number | undefined {
+  if (!modelId.trim()) return undefined
+  const profile = modelProfileForComposerSelection(modelGroups, modelId, providerId)
+  if (typeof profile?.contextWindowTokens === 'number' && profile.contextWindowTokens > 0) {
+    return profile.contextWindowTokens
+  }
+  return DEFAULT_COMPOSER_CONTEXT_WINDOW_TOKENS
 }
 
 export function canSwitchComposerModel(


### PR DESCRIPTION
Summary
- Make the composer context-capacity popover use the selected model profile context window first.
- Fall back to 128K when the selected model has no configured context window.

Changes
- Added a shared composer helper for resolving contextWindowTokens from provider/model selection.
- Wired Workbench to pass the resolved selected-model window into FloatingComposer instead of the runtime manifest window.
- Added coverage for same-model IDs across providers, including a 200K model profile overriding a 256K profile from another provider, plus the 128K missing-context fallback.

Tests
- npm run test -- src/renderer/src/store/chat-store-helpers.test.ts
- npx tsc --noEmit -p tsconfig.web.json
- git diff --check

Note
- npm run typecheck still fails on existing node/main workflow and IPC test type errors unrelated to this renderer change.