### PR TITLE
fix(providers): remove deprecated xiaomi flash model

### DIFF
--- a/docs/model-provider-presets.md
+++ b/docs/model-provider-presets.md
@@ -50,7 +50,7 @@ Xiaomi:
 - base URL: `https://api.xiaomimimo.com/v1`
 - endpoint format: OpenAI Chat Completions
 - initial models: `mimo-v2-omni`, `mimo-v2.5-pro-ultraspeed`,
-  `mimo-v2-pro`, `mimo-v2.5`, `mimo-v2-flash`, `mimo-v2.5-pro`
+  `mimo-v2-pro`, `mimo-v2.5`, `mimo-v2.5-pro`
 
 MiniMax:
 

--- a/src/main/claw-runtime.test.ts
+++ b/src/main/claw-runtime.test.ts
@@ -986,7 +986,7 @@ describe('ClawRuntime', () => {
     settings.claw.im.enabled = true
     settings.claw.im.responseTimeoutMs = 2_000
     settings.agents.kun.providerId = 'xiaomi'
-    settings.agents.kun.model = 'mimo-v2-flash'
+    settings.agents.kun.model = 'mimo-v2.5'
     settings.provider.providers = [
       ...settings.provider.providers,
       buildModelProvider({
@@ -995,15 +995,15 @@ describe('ClawRuntime', () => {
         apiKey: 'sk-xiaomi',
         baseUrl: 'https://api.mimo.example/v1',
         endpointFormat: 'chat_completions',
-        models: ['mimo-v2-flash']
+        models: ['mimo-v2.5']
       })
     ]
     const runtimeRequest = vi.fn(async (requestSettings: AppSettingsV1, path, init) => {
       expect(requestSettings.agents.kun.providerId).toBe('xiaomi')
-      expect(requestSettings.agents.kun.model).toBe('mimo-v2-flash')
+      expect(requestSettings.agents.kun.model).toBe('mimo-v2.5')
       if (path === '/v1/threads/thr_xiaomi/turns' && init?.method === 'POST') {
         const body = JSON.parse(init?.body ?? '{}') as { model?: string }
-        expect(body.model).toBe('mimo-v2-flash')
+        expect(body.model).toBe('mimo-v2.5')
         return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_xiaomi', turnId: 'turn_xiaomi' }) }
       }
       if (path === '/v1/threads/thr_xiaomi' && init?.method === 'GET') {

--- a/src/renderer/src/components/settings-section-agents.test.ts
+++ b/src/renderer/src/components/settings-section-agents.test.ts
@@ -259,6 +259,10 @@ function baseCtx(): Record<string, unknown> {
     activeApiKey: '',
     update: noop,
     updateKun: noop,
+    compactHomePath: (path: string) => path,
+    expandHomePath: (path: string) => path,
+    compactHomePathList: (paths: string[]) => paths,
+    expandHomePathList: (paths: string[]) => paths,
     updateSharedCredential: noop,
     sharedApiKey: '',
     sharedBaseUrl: '',
@@ -405,7 +409,7 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
         id: 'xiaomi',
         baseUrl: 'https://api.xiaomimimo.com/v1',
         endpointFormat: 'chat_completions',
-        models: expect.arrayContaining(['mimo-v2-flash'])
+        models: expect.arrayContaining(['mimo-v2.5'])
       })
     ]))
     expect(patch.agents?.kun).toEqual(expect.objectContaining({

--- a/src/renderer/src/store/chat-store-thread-actions.test.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.test.ts
@@ -165,7 +165,7 @@ describe('chat-store-thread-actions queued messages', () => {
     }
     registryMock.getProvider.mockReturnValue(provider)
     const saveSettingsSilent = vi.fn(async () => ({
-      agents: { kun: { providerId: 'xiaomi-token-plan', model: 'mimo-v2-flash' } },
+      agents: { kun: { providerId: 'xiaomi-token-plan', model: 'mimo-v2.5' } },
       codePromptPrefix: ''
     }))
     const restartRuntime = vi.fn(async () => undefined)
@@ -182,20 +182,20 @@ describe('chat-store-thread-actions queued messages', () => {
     })
     const { actions, state } = buildHarness()
     state.busy = false
-    state.composerModel = 'mimo-v2-flash'
+    state.composerModel = 'mimo-v2.5'
     state.composerProviderId = 'xiaomi-token-plan'
 
     await expect(actions.sendMessage('hello', 'agent')).resolves.toBe(true)
 
     expect(saveSettingsSilent).toHaveBeenCalledWith({
-      agents: { kun: { providerId: 'xiaomi-token-plan', model: 'mimo-v2-flash' } }
+      agents: { kun: { providerId: 'xiaomi-token-plan', model: 'mimo-v2.5' } }
     })
     expect(restartRuntime).toHaveBeenCalledTimes(1)
     expect(provider.connect).toHaveBeenCalledTimes(1)
     expect(provider.sendUserMessage).toHaveBeenCalledWith(
       'thr_existing',
       'hello',
-      expect.objectContaining({ model: 'mimo-v2-flash' })
+      expect.objectContaining({ model: 'mimo-v2.5' })
     )
   })
 

--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -179,7 +179,7 @@ describe('model provider settings', () => {
       name: 'Xiaomi',
       baseUrl: 'https://api.xiaomimimo.com/v1',
       endpointFormat: 'chat_completions',
-      models: expect.arrayContaining(['mimo-v2-flash', 'mimo-v2.5-pro']),
+      models: expect.arrayContaining(['mimo-v2.5-pro']),
       modelProfiles: {
         'mimo-v2.5': expect.objectContaining({
           inputModalities: expect.arrayContaining(['image']),
@@ -715,7 +715,7 @@ describe('model provider settings', () => {
             apiKey: 'tp-key',
             baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
             endpointFormat: 'chat_completions',
-            models: ['mimo-v2-flash', 'mimo-v2-omni', 'mimo-v2.5', 'mimo-v2.5-pro'],
+            models: ['mimo-v2-omni', 'mimo-v2.5', 'mimo-v2.5-pro'],
             modelProfiles: {}
           }
         ]
@@ -724,7 +724,6 @@ describe('model provider settings', () => {
 
     expect(modelSupportsImageInput(resolved.modelProfiles['mimo-v2.5'])).toBe(true)
     expect(modelSupportsImageInput(resolved.modelProfiles['mimo-v2-omni'])).toBe(true)
-    expect(modelSupportsImageInput(resolved.modelProfiles['mimo-v2-flash'])).toBe(false)
     expect(resolved.modelProfiles['mimo-v2.5-pro']).toBeDefined()
   })
 

--- a/src/shared/model-provider-presets.ts
+++ b/src/shared/model-provider-presets.ts
@@ -363,16 +363,14 @@ export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
       'mimo-v2.5-pro',
       'mimo-v2.5',
       'mimo-v2-pro',
-      'mimo-v2-omni',
-      'mimo-v2-flash'
+      'mimo-v2-omni'
     ],
     modelProfiles: {
       'mimo-v2.5-pro-ultraspeed': xiaomiTextChatProfile(1_000_000),
       'mimo-v2.5-pro': xiaomiTextChatProfile(1_000_000),
       'mimo-v2.5': xiaomiVisionChatProfile(1_000_000),
       'mimo-v2-pro': xiaomiTextChatProfile(1_000_000),
-      'mimo-v2-omni': xiaomiVisionChatProfile(256_000),
-      'mimo-v2-flash': xiaomiTextChatProfile(256_000)
+      'mimo-v2-omni': xiaomiVisionChatProfile(256_000)
     },
     speech: {
       protocol: 'mimo-asr',
@@ -397,16 +395,14 @@ export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
         'mimo-v2.5-pro',
         'mimo-v2.5',
         'mimo-v2-pro',
-        'mimo-v2-omni',
-        'mimo-v2-flash'
+        'mimo-v2-omni'
       ],
       modelProfiles: {
         'mimo-v2.5-pro-ultraspeed': xiaomiTextChatProfile(1_000_000),
         'mimo-v2.5-pro': xiaomiTextChatProfile(1_000_000),
         'mimo-v2.5': xiaomiVisionChatProfile(1_000_000),
         'mimo-v2-pro': xiaomiTextChatProfile(1_000_000),
-        'mimo-v2-omni': xiaomiVisionChatProfile(256_000),
-        'mimo-v2-flash': xiaomiTextChatProfile(256_000)
+        'mimo-v2-omni': xiaomiVisionChatProfile(256_000)
       },
       speech: {
         protocol: 'mimo-asr',


### PR DESCRIPTION
## Summary
- Remove `mimo-v2-flash` from the built-in Xiaomi and Xiaomi Token Plan chat model presets.
- Update provider preset documentation and tests to use current Xiaomi model IDs.

## Changes
- Drops the deprecated Flash model from preset model arrays and model profile maps.
- Replaces test fixtures that referenced the removed built-in model with `mimo-v2.5`.
- Adds missing path helper stubs to the agent settings smoke test harness.

## Tests
- `npm run test -- src/shared/app-settings-provider.test.ts src/renderer/src/components/settings-section-agents.test.ts src/main/claw-runtime.test.ts src/renderer/src/store/chat-store-thread-actions.test.ts`
- `git diff --check`
