### PR TITLE
fix(providers): repair GLM coding endpoints and compaction history

### DIFF
--- a/kun/src/adapters/model/compat-model-client.endpoint-format.test.ts
+++ b/kun/src/adapters/model/compat-model-client.endpoint-format.test.ts
@@ -120,4 +120,30 @@ describe('CompatModelClient per-model endpointFormat', () => {
     expect(headerCalls[1]['x-api-key']).toBeUndefined()
     expect(headerCalls[1].Authorization).toBe('Bearer sk-test')
   })
+
+  it('uses the exact URL for custom full endpoint chat completions providers', async () => {
+    const calls: CapturedCall[] = []
+    for (const baseUrl of [
+      'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions',
+      'https://api.z.ai/api/coding/paas/v4/chat/completions'
+    ]) {
+      const client = new CompatModelClient({
+        baseUrl,
+        apiKey: 'sk-test',
+        model: 'glm-5.2',
+        endpointFormat: 'custom_endpoint',
+        nonStreaming: true,
+        fetchImpl: fakeFetch(calls),
+        modelCapabilities: modelCapabilities({})
+      })
+
+      await drain(client.stream(request('glm-5.2')))
+    }
+
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions',
+      'https://api.z.ai/api/coding/paas/v4/chat/completions'
+    ])
+    expect(calls.every((call) => call.body.messages)).toBe(true)
+  })
 })

--- a/kun/src/loop/context-compactor.ts
+++ b/kun/src/loop/context-compactor.ts
@@ -182,8 +182,11 @@ export class ContextCompactor {
         replacedTokens: 0
       }
     }
-    const head = keepRecent === 0 ? history : history.slice(0, history.length - keepRecent)
-    const tail = keepRecent === 0 ? [] : history.slice(-keepRecent)
+    const tailStart = keepRecent === 0
+      ? history.length
+      : repairTailStartForToolResults(history, history.length - keepRecent)
+    const head = history.slice(0, tailStart)
+    const tail = history.slice(tailStart)
     const replacedTokens = this.estimator.estimateItems(head)
     const sourceDigest = computeShortHash(compactedItemsDigestSource(head))
     const digestMarker = createToolDigestMarker(sourceDigest)
@@ -233,6 +236,24 @@ export function trimTrailingToolCalls(history: TurnItem[]): TurnItem[] {
     end -= 1
   }
   return end === history.length ? history : history.slice(0, end)
+}
+
+function repairTailStartForToolResults(history: TurnItem[], start: number): number {
+  const tailStart = Math.max(0, Math.min(history.length, start))
+  const tail = history.slice(tailStart)
+  if (!hasOrphanToolResult(tail)) return tailStart
+  for (let index = tailStart - 1; index >= 0; index -= 1) {
+    if (history[index].kind === 'user_message') return index > 0 ? index : tailStart
+  }
+  return tailStart
+}
+
+function hasOrphanToolResult(items: TurnItem[]): boolean {
+  const callIds = new Set<string>()
+  for (const item of items) {
+    if (item.kind === 'tool_call') callIds.add(item.callId)
+  }
+  return items.some((item) => item.kind === 'tool_result' && !callIds.has(item.callId))
 }
 
 function aggressiveCompactionThreshold(thresholds: ModelContextThresholds): number {

--- a/kun/tests/loop.test.ts
+++ b/kun/tests/loop.test.ts
@@ -14,6 +14,7 @@ import { effectiveHistoryAfterLatestCompaction } from '../src/loop/compaction-hi
 import { resolveModelContextProfile } from '../src/loop/model-context-profile.js'
 import {
   makeApprovalItem,
+  makeAssistantReasoningItem,
   makeAssistantTextItem,
   makeToolCallItem,
   makeToolResultItem,
@@ -2138,6 +2139,62 @@ describe('AgentLoop', () => {
     expect(result.next.some((item) => item.kind === 'tool_call')).toBe(false)
     expect(result.summaryItem.kind === 'compaction' ? result.summaryItem.summary : '')
       .toContain('Active Skill: documents (documents)')
+  })
+
+  it('keeps the latest user turn when force compaction would orphan a tool result', () => {
+    const compactor = new ContextCompactor({ softThreshold: 1, hardThreshold: 2 })
+    const prefix = createImmutablePrefix({ systemPrompt: 'system' })
+    const result = compactor.compact({
+      threadId: 'thr_1',
+      turnId: 'turn_2',
+      prefix,
+      keepRecent: 1,
+      history: [
+        makeUserItem({ id: 'u1', turnId: 'turn_1', threadId: 'thr_1', text: 'fold this old request' }),
+        makeAssistantTextItem({
+          id: 'a1',
+          turnId: 'turn_1',
+          threadId: 'thr_1',
+          text: 'old answer',
+          status: 'completed'
+        }),
+        makeUserItem({ id: 'u2', turnId: 'turn_2', threadId: 'thr_1', text: 'keep this current request' }),
+        makeAssistantReasoningItem({
+          id: 'r2',
+          turnId: 'turn_2',
+          threadId: 'thr_1',
+          text: 'need read before answering',
+          status: 'completed'
+        }),
+        makeToolCallItem({
+          id: 'call_2',
+          turnId: 'turn_2',
+          threadId: 'thr_1',
+          callId: 'call_2',
+          toolName: 'read',
+          arguments: { path: 'current.ts' },
+          status: 'completed'
+        }),
+        makeToolResultItem({
+          id: 'result_2',
+          turnId: 'turn_2',
+          threadId: 'thr_1',
+          callId: 'call_2',
+          toolName: 'read',
+          output: 'current file content'
+        })
+      ]
+    })
+
+    expect(result.next.map((item) => item.id)).toEqual([
+      result.summaryItem.id,
+      'u2',
+      'r2',
+      'call_2',
+      'result_2'
+    ])
+    expect(result.summaryItem.kind === 'compaction' ? result.summaryItem.sourceItemIds : [])
+      .toEqual(['u1', 'a1'])
   })
 
   it('embeds a digest marker and skips frozen messages when compacting history', () => {

--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -965,8 +965,8 @@ describe('provider presets', () => {
     expect(zhipu && modelProviderPresetProfile(zhipu)).toMatchObject({
       id: 'zhipu-coding-plan',
       name: 'Zhipu Coding Plan',
-      baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
-      endpointFormat: 'chat_completions',
+      baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions',
+      endpointFormat: 'custom_endpoint',
       models: ['glm-5.2', 'glm-5.1', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
       modelProfiles: {
         'glm-5.2': expect.objectContaining({
@@ -990,10 +990,15 @@ describe('provider presets', () => {
     expect(zai && modelProviderPresetProfile(zai)).toMatchObject({
       id: 'zai-coding-plan',
       name: 'Z.ai Coding Plan',
-      baseUrl: 'https://api.z.ai/api/coding/paas/v4',
-      endpointFormat: 'chat_completions',
-      models: ['glm-5.1', 'glm-5', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
+      baseUrl: 'https://api.z.ai/api/coding/paas/v4/chat/completions',
+      endpointFormat: 'custom_endpoint',
+      models: ['glm-5.2', 'glm-5.1', 'glm-5', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
       modelProfiles: {
+        'glm-5.2': expect.objectContaining({
+          contextWindowTokens: 1_000_000,
+          supportsToolCalling: true,
+          inputModalities: ['text']
+        }),
         'glm-5': expect.objectContaining({
           contextWindowTokens: 200_000,
           supportsToolCalling: true,
@@ -1001,7 +1006,7 @@ describe('provider presets', () => {
         })
       }
     })
-    expect(zai && modelProviderPresetProfile(zai).modelProfiles['glm-5'].reasoning)
+    expect(zai && modelProviderPresetProfile(zai).modelProfiles['glm-5.2'].reasoning)
       .toEqual({
         supportedEfforts: ['off', 'high', 'max'],
         defaultEffort: 'max',
@@ -1057,14 +1062,14 @@ describe('provider presets', () => {
 
   it('resolves new OpenAI-compatible presets through the selected provider', () => {
     const cases = [
-      ['zhipu-coding-plan', 'https://open.bigmodel.cn/api/coding/paas/v4', 'glm-5.2'],
-      ['zai-coding-plan', 'https://api.z.ai/api/coding/paas/v4', 'glm-5.1'],
+      ['zhipu-coding-plan', 'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions', 'glm-5.2', 'custom_endpoint'],
+      ['zai-coding-plan', 'https://api.z.ai/api/coding/paas/v4/chat/completions', 'glm-5.1', 'custom_endpoint'],
       ['kimi-code', 'https://api.kimi.com/coding/v1', 'kimi-for-coding'],
       ['moonshot-cn', 'https://api.moonshot.cn/v1', 'kimi-k2.7-code'],
       ['moonshot-global', 'https://api.moonshot.ai/v1', 'kimi-k2.7-code']
     ] as const
 
-    for (const [presetId, baseUrl, model] of cases) {
+    for (const [presetId, baseUrl, model, endpointFormat = 'chat_completions'] of cases) {
       const preset = getModelProviderPreset(presetId)
       expect(preset).not.toBeNull()
       const profile = modelProviderPresetProfile(preset!, `sk-${presetId}`)
@@ -1089,7 +1094,7 @@ describe('provider presets', () => {
       expect(resolved).toEqual(expect.objectContaining({
         apiKey: `sk-${presetId}`,
         baseUrl,
-        endpointFormat: 'chat_completions',
+        endpointFormat,
         model
       }))
       expect(resolved.modelProfiles[model]).toEqual(expect.objectContaining({

--- a/src/shared/model-provider-presets.ts
+++ b/src/shared/model-provider-presets.ts
@@ -178,6 +178,7 @@ const ZHIPU_CODING_PLAN_MODELS = [
 ]
 
 const ZAI_CODING_PLAN_MODELS = [
+  'glm-5.2',
   'glm-5.1',
   'glm-5',
   'glm-5-turbo',
@@ -208,8 +209,8 @@ export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
     id: 'zhipu-coding-plan',
     name: 'Zhipu Coding Plan',
     category: 'subscription',
-    baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
-    endpointFormat: 'chat_completions',
+    baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions',
+    endpointFormat: 'custom_endpoint',
     models: [...ZHIPU_CODING_PLAN_MODELS],
     modelProfiles: {
       'glm-5.2': textChatProfile(1_000_000, GLM_REASONING),
@@ -225,10 +226,11 @@ export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
     id: 'zai-coding-plan',
     name: 'Z.ai Coding Plan',
     category: 'subscription',
-    baseUrl: 'https://api.z.ai/api/coding/paas/v4',
-    endpointFormat: 'chat_completions',
+    baseUrl: 'https://api.z.ai/api/coding/paas/v4/chat/completions',
+    endpointFormat: 'custom_endpoint',
     models: [...ZAI_CODING_PLAN_MODELS],
     modelProfiles: {
+      'glm-5.2': textChatProfile(1_000_000, GLM_REASONING),
       'glm-5.1': textChatProfile(200_000, GLM_REASONING),
       'glm-5': textChatProfile(200_000, GLM_REASONING),
       'glm-5-turbo': textChatProfile(200_000, GLM_REASONING),


### PR DESCRIPTION
## Summary

- Fixes Zhipu and Z.ai Coding Plan presets so they use the provider full chat completions endpoint as a custom endpoint.
- Adds `glm-5.2` to the Z.ai Coding Plan preset.
- Keeps the latest user turn intact during forced compaction when trimming before it would orphan a tool result.

## Changes

- Change Zhipu and Z.ai Coding Plan base URLs to `/api/coding/paas/v4/chat/completions` and mark them as `custom_endpoint`.
- Add preset coverage for exact custom endpoint URL usage so `/v1` is not appended.
- Adjust compaction tail selection to back up to the nearest user turn when the retained tail would begin with orphaned tool results.

## Tests

- `npm run test -- --run src/shared/app-settings-provider.test.ts`
- `npm --prefix kun run test -- --run src/adapters/model/compat-model-client.endpoint-format.test.ts`
- `npm --prefix kun run test -- --run tests/loop.test.ts`
- `npm --prefix kun run typecheck`
- `npx tsc --noEmit -p tsconfig.web.json`
- `git diff --check`
- Live Zhipu custom endpoint smoke test with `glm-5.2`: request URL stayed `https://open.bigmodel.cn/api/coding/paas/v4/chat/completions` and returned `ok`.

Note: full `npm run typecheck` still hits existing workflow/IPC test type errors outside this change; targeted Kun and web typechecks pass.

Fixes KunAgent/Kun#437
