### PR TITLE
修复 macOS 顶部栏与侧栏折叠布局对齐

### DIFF
--- a/src/renderer/src/components/PluginMarketplaceView.tsx
+++ b/src/renderer/src/components/PluginMarketplaceView.tsx
@@ -33,12 +33,18 @@ import {
   type McpMarketplaceOverlay,
   type McpMarketplaceOverlayStatus
 } from './plugin-marketplace-runtime'
+import { SidebarTitlebarToggleButton } from './sidebar/SidebarPrimitives'
 
 type PluginKind = 'mcp' | 'skill'
 type PluginFilter = 'all' | 'recommended' | 'installed'
 type NoticeTone = 'success' | 'error' | 'info'
 
 type Notice = MarketplaceNotice
+
+type Props = {
+  leftSidebarCollapsed: boolean
+  onToggleLeftSidebar: () => void
+}
 
 type MarketplaceItem = {
   id: string
@@ -579,7 +585,7 @@ export function recommendedMarketplaceItemIds(): string[] {
   return RECOMMENDED_ITEMS.map((item) => item.id)
 }
 
-export function PluginMarketplaceView(): ReactElement {
+export function PluginMarketplaceView({ leftSidebarCollapsed, onToggleLeftSidebar }: Props): ReactElement {
   const { t } = useTranslation('common')
   const workspaceRoot = normalizeWorkspaceRoot(useChatStore((s) => s.workspaceRoot))
   const [activeKind, setActiveKind] = useState<PluginKind>('mcp')
@@ -1004,8 +1010,28 @@ export function PluginMarketplaceView(): ReactElement {
   }
 
   return (
-    <div className="ds-no-drag h-full min-h-0 overflow-y-auto px-6 py-7 md:px-10 lg:px-14">
-      <div className="mx-auto max-w-6xl">
+    <div className="ds-drag flex h-full min-h-0 flex-col bg-ds-main">
+      <div className="ds-stage-inset shrink-0">
+        <header className="ds-topbar-surface relative z-10 mt-3 flex min-h-[46px] w-full items-stretch overflow-visible rounded-[24px]">
+          <div className="grid w-full min-w-0 items-center gap-2.5 px-3 py-2 sm:px-4 md:pl-5 md:pr-2">
+            <div
+              className={`flex min-w-0 items-center gap-2.5 ${
+                leftSidebarCollapsed ? 'ds-window-controls-collapsed-titlebar-inset' : ''
+              }`}
+            >
+              <SidebarTitlebarToggleButton
+                onClick={onToggleLeftSidebar}
+                title={leftSidebarCollapsed ? t('sidebarExpand') : t('sidebarCollapse')}
+                ariaLabel={leftSidebarCollapsed ? t('sidebarExpand') : t('sidebarCollapse')}
+              />
+              <h1 className="sr-only">{t('plugins')}</h1>
+            </div>
+          </div>
+        </header>
+      </div>
+
+      <main className="ds-no-drag min-h-0 flex-1 overflow-y-auto px-6 pb-8 pt-7 md:px-10 lg:px-14">
+        <div className="mx-auto max-w-6xl">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="inline-flex rounded-xl bg-ds-subtle p-1">
             <TabButton active={activeKind === 'mcp'} onClick={() => setActiveKind('mcp')}>
@@ -1203,7 +1229,8 @@ export function PluginMarketplaceView(): ReactElement {
             <span>{t('pluginMcpRestartHint')}</span>
           </div>
         ) : null}
-      </div>
+        </div>
+      </main>
     </div>
   )
 }

--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -2484,18 +2484,12 @@ export function Workbench(): ReactElement {
         }`}
       >
         {route === 'plugins' ? (
-          <>
-            <div className="ds-no-drag shrink-0 px-4 pt-4">
-              <SidebarTitlebarToggleButton
-                onClick={toggleLeftSidebar}
-                title={leftSidebarCollapsed ? t('sidebarExpand') : t('sidebarCollapse')}
-                ariaLabel={leftSidebarCollapsed ? t('sidebarExpand') : t('sidebarCollapse')}
-              />
-            </div>
-            <Suspense fallback={<div className="h-full bg-ds-main" />}>
-              <PluginMarketplaceView />
-            </Suspense>
-          </>
+          <Suspense fallback={<div className="h-full bg-ds-main" />}>
+            <PluginMarketplaceView
+              leftSidebarCollapsed={leftSidebarCollapsed}
+              onToggleLeftSidebar={toggleLeftSidebar}
+            />
+          </Suspense>
         ) : route === 'schedule' ? (
           <Suspense fallback={<div className="h-full bg-ds-main" />}>
             <ScheduleTasksView
@@ -2550,11 +2544,11 @@ export function Workbench(): ReactElement {
           ) : (
             <section className="ds-chat-stage ds-drag flex min-h-0 min-w-0 flex-1 flex-col">
             <div className={`${stageInsetClass} flex min-h-0 min-w-0 flex-1 flex-col`}>
-            <header className="chat-topbar ds-topbar-surface relative z-10 mt-3 flex min-h-[46px] w-full shrink-0 items-stretch overflow-visible rounded-[24px]">
-              <div className="chat-topbar-grid grid w-full min-w-0 items-start gap-2.5 px-3 py-2 sm:px-4 md:pl-5 md:pr-2">
+            <header className="chat-topbar ds-topbar-surface relative z-10 flex w-full shrink-0 items-stretch overflow-visible">
+              <div className="chat-topbar-grid grid w-full min-w-0 items-center gap-2.5 px-3 py-2 sm:px-4 md:pl-5 md:pr-2">
                 <div
                   className={`chat-topbar-session flex min-w-0 items-center gap-2.5 ${
-                    leftSidebarCollapsed ? 'ds-window-controls-safe-inset' : ''
+                    leftSidebarCollapsed ? 'ds-window-controls-collapsed-titlebar-inset' : ''
                   }`}
                 >
                   <SidebarTitlebarToggleButton
@@ -2564,7 +2558,7 @@ export function Workbench(): ReactElement {
                   />
                   <SessionHeader compact className="min-w-0 flex-1" />
                 </div>
-                <div className="chat-topbar-actions flex min-w-0 flex-wrap items-center justify-end gap-2 self-start">
+                <div className="chat-topbar-actions flex min-w-0 flex-wrap items-center justify-end gap-2 self-center">
                   {busy ? (
                     <span className="inline-flex shrink-0 rounded-full bg-amber-500/16 px-2.5 py-1 text-[11.5px] font-semibold text-amber-950 dark:text-amber-100">
                       {t('running')}

--- a/src/renderer/src/components/chat/ConnectPhoneView.tsx
+++ b/src/renderer/src/components/chat/ConnectPhoneView.tsx
@@ -443,7 +443,7 @@ export function ConnectPhoneView({
   return (
     <section className="ds-no-drag relative flex min-h-0 flex-1 overflow-hidden bg-transparent">
       {leftSidebarCollapsed ? (
-        <div className="absolute left-4 top-4 z-20">
+        <div className="ds-window-controls-collapsed-titlebar-anchor absolute top-4 z-20">
           <SidebarTitlebarToggleButton
             onClick={onToggleSidebar}
             title={t('sidebarExpand')}

--- a/src/renderer/src/components/chat/WorkbenchTopBar.tsx
+++ b/src/renderer/src/components/chat/WorkbenchTopBar.tsx
@@ -48,6 +48,17 @@ type Props = {
   onOpenSideChat?: () => void
 }
 
+const TOPBAR_ICON_CLASS = 'h-[17px] w-[17px]'
+const TOPBAR_BUTTON_BASE =
+  'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border p-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]'
+const TOPBAR_BUTTON_ACTIVE = 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
+const TOPBAR_BUTTON_IDLE =
+  'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
+
+function topbarIconButtonClass(active: boolean): string {
+  return `${TOPBAR_BUTTON_BASE} ${active ? TOPBAR_BUTTON_ACTIVE : TOPBAR_BUTTON_IDLE}`
+}
+
 export function WorkbenchTopBar({
   rightPanelMode,
   onToggleRightPanelMode,
@@ -250,18 +261,18 @@ export function WorkbenchTopBar({
 
   const renderGuiUpdateIcon = (): ReactElement => {
     if (guiUpdateState.status === 'downloading' || guiUpdateState.status === 'installing' || applyingGuiUpdate) {
-      return <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={2} />
+      return <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2} />
     }
     if (guiUpdateAction?.downloaded || guiUpdateState.status === 'downloaded') {
-      return <RefreshCw className="h-3.5 w-3.5" strokeWidth={1.85} />
+      return <RefreshCw className="h-4 w-4" strokeWidth={1.85} />
     }
     if (guiUpdateAction?.manualOnly) {
-      return <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.85} />
+      return <ExternalLink className="h-4 w-4" strokeWidth={1.85} />
     }
     if (guiUpdateAction) {
-      return <ArrowUpCircle className="h-3.5 w-3.5" strokeWidth={1.85} />
+      return <ArrowUpCircle className="h-4 w-4" strokeWidth={1.85} />
     }
-    return <Download className="h-3.5 w-3.5" strokeWidth={1.85} />
+    return <Download className="h-4 w-4" strokeWidth={1.85} />
   }
 
   return (
@@ -284,7 +295,7 @@ export function WorkbenchTopBar({
         <button
           type="button"
           onClick={() => setEditorMenuOpen((value) => !value)}
-          className="inline-flex items-center gap-1 rounded-full border border-transparent bg-white/38 px-2.5 py-1.5 text-ds-faint opacity-90 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:bg-white/8"
+          className="inline-flex h-7 items-center gap-1 rounded-full border border-transparent bg-white/38 px-2.5 text-ds-faint opacity-90 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:bg-white/8"
           aria-label={t('editorPickerTitle')}
           aria-expanded={editorMenuOpen}
           title={
@@ -293,8 +304,8 @@ export function WorkbenchTopBar({
               : t('editorPickerTitle')
           }
         >
-          {renderEditorIcon(selectedEditor, 'h-4 w-4')}
-          <ChevronDown className="h-3 w-3 opacity-60" strokeWidth={1.9} />
+          {renderEditorIcon(selectedEditor, TOPBAR_ICON_CLASS)}
+          <ChevronDown className="h-3.5 w-3.5 opacity-60" strokeWidth={1.9} />
         </button>
 
         {editorMenuOpen ? (
@@ -335,16 +346,12 @@ export function WorkbenchTopBar({
           type="button"
           onClick={onOpenSideChat}
           disabled={!sideChatEnabled}
-          className={`relative rounded-full border px-2.5 py-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition disabled:cursor-not-allowed disabled:opacity-45 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
-            sideChatOpen
-              ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
-              : 'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
-          }`}
+          className={`relative ${topbarIconButtonClass(sideChatOpen)} disabled:cursor-not-allowed disabled:opacity-45`}
           aria-label={t('sidePanelOpen')}
           aria-pressed={sideChatOpen}
           title={t('sidePanelOpen')}
         >
-          <MessageCircleMore className="h-4 w-4" strokeWidth={1.75} />
+          <MessageCircleMore className={TOPBAR_ICON_CLASS} strokeWidth={1.75} />
           {sideChatCount > 0 ? (
             <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold leading-none text-white">
               {Math.min(sideChatCount, 9)}
@@ -365,31 +372,23 @@ export function WorkbenchTopBar({
             <button
               type="button"
               onClick={() => onToggleRightPanelMode(item.mode)}
-              className={`rounded-full border px-2.5 py-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
-                active
-                  ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
-                  : 'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
-              }`}
+              className={topbarIconButtonClass(active)}
               aria-label={item.label}
               aria-pressed={active}
               title={item.label}
             >
-              <Icon className="h-4 w-4" strokeWidth={1.75} />
+              <Icon className={TOPBAR_ICON_CLASS} strokeWidth={1.75} />
             </button>
             {isChanges && onToggleTerminal ? (
               <button
                 type="button"
                 onClick={onToggleTerminal}
-                className={`rounded-full border px-2.5 py-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
-                  terminalOpen
-                    ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
-                    : 'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
-                }`}
+                className={topbarIconButtonClass(terminalOpen)}
                 aria-label={t('rightPanelTerminal')}
                 aria-pressed={terminalOpen}
                 title={t('rightPanelTerminal')}
               >
-                <Terminal className="h-4 w-4" strokeWidth={1.75} />
+                <Terminal className={TOPBAR_ICON_CLASS} strokeWidth={1.75} />
               </button>
             ) : null}
           </Fragment>
@@ -401,16 +400,12 @@ export function WorkbenchTopBar({
           type="button"
           onClick={onToggleFileTree}
           disabled={!fileTreeEnabled}
-          className={`rounded-full border px-2.5 py-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition disabled:cursor-not-allowed disabled:opacity-45 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
-            fileTreeOpen
-              ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
-              : 'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
-          }`}
+          className={`${topbarIconButtonClass(fileTreeOpen)} disabled:cursor-not-allowed disabled:opacity-45`}
           aria-label={t('rightPanelFiles')}
           aria-pressed={fileTreeOpen}
           title={t('rightPanelFiles')}
         >
-          <Files className="h-4 w-4" strokeWidth={1.75} />
+          <Files className={TOPBAR_ICON_CLASS} strokeWidth={1.75} />
         </button>
       ) : null}
     </div>

--- a/src/renderer/src/components/schedule/ScheduleTasksView.tsx
+++ b/src/renderer/src/components/schedule/ScheduleTasksView.tsx
@@ -608,7 +608,7 @@ export function ScheduleTasksView({
           <div className="grid w-full min-w-0 items-center gap-2.5 px-3 py-2 sm:px-4 md:pl-5 md:pr-2">
             <div
               className={`flex min-w-0 items-center gap-2.5 ${
-                leftSidebarCollapsed ? 'ds-window-controls-safe-inset' : ''
+                leftSidebarCollapsed ? 'ds-window-controls-collapsed-titlebar-inset' : ''
               }`}
             >
               <SidebarTitlebarToggleButton

--- a/src/renderer/src/components/sdd/SddAssistantPanel.tsx
+++ b/src/renderer/src/components/sdd/SddAssistantPanel.tsx
@@ -152,7 +152,7 @@ export function SddAssistantPanel({
             title={t('rightPanelCollapse')}
             className="shrink-0"
           >
-            <PanelRightClose className="h-[13px] w-[13px]" strokeWidth={1.55} />
+            <PanelRightClose className="h-4 w-4" strokeWidth={1.75} />
           </SidebarTitlebarToggleButton>
           <div className="sdd-assistant-title-pill flex min-w-0 flex-1 items-center gap-2 rounded-[12px] bg-ds-surface-subtle px-3 py-1.5 dark:bg-white/8">
             <Sparkles className="sdd-assistant-sparkle h-4 w-4 shrink-0 text-accent" strokeWidth={1.8} />

--- a/src/renderer/src/components/sdd/SddDraftEditorView.tsx
+++ b/src/renderer/src/components/sdd/SddDraftEditorView.tsx
@@ -1064,7 +1064,7 @@ export function SddDraftEditorView({
           <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 sm:px-4 md:pl-5 md:pr-2">
             <div
               className={`flex min-w-0 items-center gap-2.5 ${
-                leftSidebarCollapsed ? 'ds-window-controls-safe-inset' : ''
+                leftSidebarCollapsed ? 'ds-window-controls-collapsed-titlebar-inset' : ''
               }`}
             >
               {leftSidebarCollapsed ? (

--- a/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
+++ b/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
@@ -36,7 +36,7 @@ export function SidebarTitlebarToggleButton({
       aria-label={ariaLabel ?? title}
       className={cx('ds-titlebar-sidebar-toggle ds-no-drag', className)}
     >
-      {children ?? <PanelLeft className="h-[13px] w-[13px]" strokeWidth={1.55} />}
+      {children ?? <PanelLeft className="h-4 w-4" strokeWidth={1.75} />}
     </button>
   )
 }

--- a/src/renderer/src/components/workflow/WorkflowEditorView.test.ts
+++ b/src/renderer/src/components/workflow/WorkflowEditorView.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  WORKFLOW_EDITOR_BACK_BUTTON_CLASS,
+  WORKFLOW_EDITOR_HEADER_CLASS,
+  WORKFLOW_EDITOR_HEADER_SIDEBAR_COLLAPSED_CLASS,
+  WORKFLOW_EDITOR_SIDEBAR_CLASS
+} from './WorkflowEditorView'
+
+describe('WorkflowEditorView', () => {
+  it('keeps back navigation in the sidebar and reserves titlebar space only when collapsed', async () => {
+    const nodeFs = 'node:fs/promises'
+    const { readFile } = await import(/* @vite-ignore */ nodeFs)
+    const css = await readFile(new URL('../../styles/workflow-canvas.css', import.meta.url), 'utf8')
+    const source = await readFile(new URL('./WorkflowEditorView.tsx', import.meta.url), 'utf8')
+
+    expect(WORKFLOW_EDITOR_HEADER_CLASS).toContain('workflow-editor-header')
+    expect(WORKFLOW_EDITOR_HEADER_CLASS).toContain('ds-drag')
+    expect(WORKFLOW_EDITOR_HEADER_CLASS).not.toContain('py-')
+    expect(WORKFLOW_EDITOR_SIDEBAR_CLASS).toContain('workflow-editor-sidebar')
+    expect(WORKFLOW_EDITOR_SIDEBAR_CLASS).toContain('ds-drag')
+    expect(WORKFLOW_EDITOR_BACK_BUTTON_CLASS).toContain('ds-no-drag')
+    expect(css).toContain('.workflow-editor-header')
+    expect(css).toContain('height: 4rem')
+    expect(css).toContain(":root[data-platform='darwin'] .workflow-editor-header")
+    expect(css).toContain('padding-top: 1rem')
+    expect(css).toContain('padding-bottom: 0.5rem')
+    expect(css).toContain(`:root[data-platform='darwin'] .${WORKFLOW_EDITOR_HEADER_SIDEBAR_COLLAPSED_CLASS}`)
+    expect(css).toContain('var(--ds-collapsed-sidebar-titlebar-extra-inset)')
+    expect(source).toContain('className={WORKFLOW_EDITOR_SIDEBAR_CLASS}')
+    expect(source).toContain('className={WORKFLOW_EDITOR_BACK_BUTTON_CLASS}')
+    expect(source.indexOf('className={WORKFLOW_EDITOR_SIDEBAR_CLASS}')).toBeLessThan(
+      source.indexOf('className={`${WORKFLOW_EDITOR_HEADER_CLASS}')
+    )
+  })
+})

--- a/src/renderer/src/components/workflow/WorkflowEditorView.tsx
+++ b/src/renderer/src/components/workflow/WorkflowEditorView.tsx
@@ -82,6 +82,15 @@ const DND_MIME = 'application/x-workflow-node'
 const PRESET_DND_MIME = 'application/x-workflow-preset'
 const MODULE_DND_MIME = 'application/x-workflow-module'
 
+export const WORKFLOW_EDITOR_HEADER_CLASS =
+  'workflow-editor-header ds-drag flex shrink-0 items-center gap-3 border-b border-ds-border px-4'
+export const WORKFLOW_EDITOR_HEADER_SIDEBAR_COLLAPSED_CLASS =
+  'workflow-editor-header-sidebar-collapsed'
+export const WORKFLOW_EDITOR_SIDEBAR_CLASS =
+  'workflow-editor-sidebar ds-drag flex w-[184px] shrink-0 flex-col border-r border-ds-border bg-ds-card/40'
+export const WORKFLOW_EDITOR_BACK_BUTTON_CLASS =
+  'ds-no-drag flex h-9 items-center gap-2 rounded-xl px-2 text-[13px] font-medium text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink'
+
 type WorkflowConnectionsArg = ReturnType<typeof flowToWorkflowGraph>['connections']
 
 type Props = {
@@ -428,392 +437,402 @@ function WorkflowEditorInner({
   )
 
   return (
-    <div className="ds-no-drag fixed inset-0 z-[60] flex flex-col bg-ds-main">
-      <header
-        className="ds-drag flex shrink-0 items-center gap-3 border-b border-ds-border py-2.5 pr-4"
-        style={{ paddingLeft: 'calc(var(--ds-window-controls-safe-inset) + 2.5rem)' }}
-      >
-        <button
-          type="button"
-          onClick={onBack}
-          className="inline-flex h-9 items-center gap-1.5 rounded-xl border border-ds-border bg-ds-card px-3 text-[13px] text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
-        >
-          <ArrowLeft className="h-4 w-4" strokeWidth={1.8} />
-          {t('workflowBack')}
-        </button>
-        <input
-          className="min-w-0 flex-1 rounded-xl border border-transparent bg-transparent px-2 py-1.5 text-[15px] font-medium text-ds-ink outline-none focus:border-ds-border focus:bg-ds-card"
-          value={name}
-          placeholder={t('workflowNamePlaceholder')}
-          onChange={(event) => {
-            setName(event.target.value)
-            setDirty(true)
-          }}
-        />
-        <label className="flex shrink-0 items-center gap-2 text-[13px] font-medium text-ds-muted">
-          {t('workflowEnabled')}
-          <input
-            type="checkbox"
-            checked={enabled}
-            onChange={(event) => {
-              setEnabled(event.target.checked)
-              setDirty(true)
-            }}
-          />
-        </label>
-        <button
-          type="button"
-          onClick={() => setShowHistory(true)}
-          title={t('workflowRunHistory')}
-          aria-label={t('workflowRunHistory')}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-ds-border bg-ds-card text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
-        >
-          <History className="h-4 w-4" strokeWidth={1.8} />
-        </button>
-        <button
-          type="button"
-          onClick={() => setShowEnv(true)}
-          title={t('workflowEnvVars')}
-          aria-label={t('workflowEnvVars')}
-          className="relative inline-flex h-9 items-center gap-1.5 rounded-xl border border-ds-border bg-ds-card px-3 text-[13px] font-medium text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
-        >
-          <Variable className="h-4 w-4" strokeWidth={1.8} />
-          {t('workflowEnvVars')}
-          {env.length > 0 ? (
-            <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-accent/15 px-1 text-[10px] font-semibold text-accent">
-              {env.length}
-            </span>
-          ) : null}
-        </button>
-        <button
-          type="button"
-          onClick={() => void handleSave()}
-          disabled={saving}
-          className="inline-flex h-9 items-center gap-1.5 rounded-xl border border-ds-border bg-ds-card px-3 text-[13px] font-medium text-ds-ink transition hover:bg-ds-hover disabled:opacity-60"
-        >
-          <Save className="h-4 w-4" strokeWidth={1.8} />
-          {dirty ? t('workflowSave') : t('workflowSaved')}
-        </button>
-        {running ? (
-          <button
-            type="button"
-            onClick={() => void onStop()}
-            className="inline-flex h-9 items-center gap-1.5 rounded-xl bg-red-500/90 px-4 text-[13px] font-semibold text-white shadow-sm transition hover:bg-red-500"
-          >
-            <Square className="h-3.5 w-3.5" strokeWidth={2} />
-            {t('workflowStop')}
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={() => void handleRun()}
-            className="inline-flex h-9 items-center gap-1.5 rounded-xl bg-ds-userbubble px-4 text-[13px] font-semibold text-ds-userbubbleFg shadow-sm transition hover:opacity-90"
-          >
-            <Play className="h-4 w-4" strokeWidth={2} />
-            {t('workflowRunNow')}
-          </button>
-        )}
-      </header>
-
-      <div className="flex min-h-0 flex-1">
-        {!leftPanelCollapsed ? (
-        <aside className="flex w-[184px] shrink-0 flex-col gap-1 overflow-y-auto border-r border-ds-border bg-ds-card/40 px-2 py-3">
-          <span className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-ds-faint">
-            {t('workflowPalette')}
-          </span>
-          {WORKFLOW_PALETTE_GROUPS.map((group) => {
-            const collapsed = collapsedGroups.has(group.id)
-            return (
-              <div key={group.id} className="flex flex-col">
-                <button
-                  type="button"
-                  onClick={() => toggleGroup(group.id)}
-                  className="flex items-center gap-1 px-2 py-1 text-[10.5px] font-semibold uppercase tracking-wide text-ds-faint transition hover:text-ds-muted"
-                >
-                  <ChevronRight
-                    className={`h-3 w-3 shrink-0 transition-transform ${collapsed ? '' : 'rotate-90'}`}
-                    strokeWidth={2}
-                  />
-                  <span className="min-w-0 flex-1 truncate text-left">{t(`workflowGroup_${group.id}`)}</span>
-                </button>
-                {!collapsed
-                  ? group.kinds.map((kind) => {
-                      const Icon = NODE_ICONS[kind]
-                      return (
-                        <button
-                          key={kind}
-                          type="button"
-                          draggable
-                          onDragStart={(event) => onPaletteDragStart(event, kind)}
-                          onClick={() => addNode(kind)}
-                          className="flex cursor-grab items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 text-left text-[12.5px] text-ds-ink transition hover:border-ds-border hover:bg-ds-hover active:cursor-grabbing"
-                        >
-                          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
-                            <Icon className="h-3.5 w-3.5" strokeWidth={1.9} />
-                          </span>
-                          <span className="min-w-0 flex-1 truncate">{t(`workflowNode_${kind}`)}</span>
-                          <Plus className="h-3.5 w-3.5 shrink-0 text-ds-faint" strokeWidth={1.8} />
-                        </button>
-                      )
-                    })
-                  : null}
-              </div>
-            )
-          })}
-
-          <div className="flex flex-col">
-            <div className="flex items-center gap-1 pr-1">
-              <button
-                type="button"
-                onClick={() => toggleGroup('custom')}
-                className="flex min-w-0 flex-1 items-center gap-1 px-2 py-1 text-[10.5px] font-semibold uppercase tracking-wide text-ds-faint transition hover:text-ds-muted"
-              >
-                <ChevronRight
-                  className={`h-3 w-3 shrink-0 transition-transform ${collapsedGroups.has('custom') ? '' : 'rotate-90'}`}
-                  strokeWidth={2}
-                />
-                <span className="min-w-0 flex-1 truncate text-left">{t('workflowGroup_custom')}</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowModules(true)}
-                title={t('workflowModulesManage')}
-                aria-label={t('workflowModulesManage')}
-                className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-ds-faint transition hover:bg-ds-hover hover:text-ds-ink"
-              >
-                <Settings2 className="h-3.5 w-3.5" strokeWidth={1.8} />
-              </button>
-            </div>
-            {!collapsedGroups.has('custom') ? (
-              <>
-                {modules.map((module) => {
-                  const Icon = NODE_ICONS.custom
-                  return (
-                    <button
-                      key={module.id}
-                      type="button"
-                      draggable
-                      onDragStart={(event) => onModuleDragStart(event, module.id)}
-                      onClick={() => addModuleNode(module)}
-                      title={module.description || module.name}
-                      className="flex cursor-grab items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 text-left text-[12.5px] text-ds-ink transition hover:border-ds-border hover:bg-ds-hover active:cursor-grabbing"
-                    >
-                      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
-                        <Icon className="h-3.5 w-3.5" strokeWidth={1.9} />
-                      </span>
-                      <span className="min-w-0 flex-1 truncate">{module.name}</span>
-                      <Plus className="h-3.5 w-3.5 shrink-0 text-ds-faint" strokeWidth={1.8} />
-                    </button>
-                  )
-                })}
-                {presets.map((preset) => {
-                  const Icon = NODE_ICONS[preset.nodeType]
-                  return (
-                    <div key={preset.id} className="group/preset relative flex items-center">
-                      <button
-                        type="button"
-                        draggable
-                        onDragStart={(event) => onPresetDragStart(event, preset.id)}
-                        onClick={() => addPresetNode(preset)}
-                        className="flex min-w-0 flex-1 cursor-grab items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 pr-7 text-left text-[12.5px] text-ds-ink transition hover:border-ds-border hover:bg-ds-hover active:cursor-grabbing"
-                      >
-                        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
-                          <Icon className="h-3.5 w-3.5" strokeWidth={1.9} />
-                        </span>
-                        <span className="min-w-0 flex-1 truncate">{preset.label}</span>
-                      </button>
-                      <button
-                        type="button"
-                        title={t('workflowPresetDelete')}
-                        aria-label={t('workflowPresetDelete')}
-                        onClick={() => void onDeletePreset(preset.id)}
-                        className="absolute right-1 flex h-5 w-5 items-center justify-center rounded text-ds-faint opacity-0 transition hover:bg-red-500/10 hover:text-red-600 group-hover/preset:opacity-100"
-                      >
-                        <X className="h-3 w-3" strokeWidth={2} />
-                      </button>
-                    </div>
-                  )
-                })}
-                {modules.length === 0 && presets.length === 0 ? (
-                  <p className="px-2 py-1 text-[11px] leading-4 text-ds-faint">{t('workflowPresetEmpty')}</p>
-                ) : null}
-              </>
-            ) : null}
+    <div className="ds-no-drag fixed inset-0 z-[60] flex bg-ds-main">
+      {!leftPanelCollapsed ? (
+        <aside className={WORKFLOW_EDITOR_SIDEBAR_CLASS}>
+          <div className="shrink-0 px-2 pb-2 pt-3">
+            <div aria-hidden className="ds-titlebar-safe-block" />
+            <button type="button" onClick={onBack} className={WORKFLOW_EDITOR_BACK_BUTTON_CLASS}>
+              <ArrowLeft className="h-4 w-4" strokeWidth={1.8} />
+              {t('workflowBack')}
+            </button>
           </div>
-        </aside>
-        ) : null}
-
-        <div className="relative min-w-0 flex-1" onDrop={onCanvasDrop} onDragOver={onCanvasDragOver}>
-          <WorkflowRunStatusContext.Provider value={runStatus}>
-            <WorkflowNodeActionsContext.Provider value={nodeActions}>
-              <ReactFlow
-                className="ds-workflow-canvas"
-                nodes={rfNodes}
-                edges={styledEdges}
-                nodeTypes={workflowNodeTypes}
-                onNodesChange={onNodesChange}
-                onEdgesChange={onEdgesChange}
-                onConnect={onConnect}
-                onConnectStart={onConnectStart}
-                onConnectEnd={onConnectEnd}
-                onNodeClick={(_, node) => setSelectedNodeId(node.id)}
-                onPaneClick={() => setSelectedNodeId(null)}
-                fitView
-                fitViewOptions={{ maxZoom: 1, padding: 0.2 }}
-                minZoom={0.2}
-                proOptions={{ hideAttribution: true }}
-              >
-                <Background variant={BackgroundVariant.Dots} gap={18} size={1} />
-                <Controls showInteractive={false} />
-                <MiniMap
-                  pannable
-                  zoomable
-                  className="ds-workflow-minimap"
-                  style={{ width: 150, height: 96 }}
-                  nodeColor="var(--ds-accent)"
-                  nodeStrokeColor="transparent"
-                  nodeBorderRadius={3}
-                  maskColor="rgb(15 23 42 / 0.08)"
-                />
-              </ReactFlow>
-            </WorkflowNodeActionsContext.Provider>
-          </WorkflowRunStatusContext.Provider>
-          {rfNodes.length === 0 ? (
-            <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 text-center">
-              <MousePointerClick className="h-8 w-8 text-ds-faint" strokeWidth={1.4} />
-              <p className="text-[13px] text-ds-faint">{t('workflowEmptyCanvas')}</p>
-            </div>
-          ) : null}
-          {connectMenu ? (
-            <>
-              <div className="fixed inset-0 z-[70]" onClick={() => setConnectMenu(null)} />
-              <div
-                className="fixed z-[71] max-h-[60vh] w-44 overflow-y-auto rounded-lg border border-ds-border bg-ds-card p-1 shadow-lg"
-                style={{ left: connectMenu.x, top: connectMenu.y }}
-              >
-                {WORKFLOW_PALETTE_GROUPS.map((group) => {
-                  const kinds = group.kinds.filter((kind) => !TRIGGER_KINDS.has(kind))
-                  if (kinds.length === 0) return null
-                  return (
-                    <div key={group.id}>
-                      <div className="px-2 pb-0.5 pt-1.5 text-[9.5px] font-semibold uppercase tracking-wide text-ds-faint">
-                        {t(`workflowGroup_${group.id}`)}
-                      </div>
-                      {kinds.map((kind) => {
+          <div className="ds-no-drag flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto px-2 pb-3">
+            <span className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-ds-faint">
+              {t('workflowPalette')}
+            </span>
+            {WORKFLOW_PALETTE_GROUPS.map((group) => {
+              const collapsed = collapsedGroups.has(group.id)
+              return (
+                <div key={group.id} className="flex flex-col">
+                  <button
+                    type="button"
+                    onClick={() => toggleGroup(group.id)}
+                    className="flex items-center gap-1 px-2 py-1 text-[10.5px] font-semibold uppercase tracking-wide text-ds-faint transition hover:text-ds-muted"
+                  >
+                    <ChevronRight
+                      className={`h-3 w-3 shrink-0 transition-transform ${collapsed ? '' : 'rotate-90'}`}
+                      strokeWidth={2}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-left">{t(`workflowGroup_${group.id}`)}</span>
+                  </button>
+                  {!collapsed
+                    ? group.kinds.map((kind) => {
                         const Icon = NODE_ICONS[kind]
                         return (
                           <button
                             key={kind}
                             type="button"
-                            onClick={() => addConnectedNode(kind)}
-                            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] text-ds-ink transition hover:bg-ds-hover"
+                            draggable
+                            onDragStart={(event) => onPaletteDragStart(event, kind)}
+                            onClick={() => addNode(kind)}
+                            className="flex cursor-grab items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 text-left text-[12.5px] text-ds-ink transition hover:border-ds-border hover:bg-ds-hover active:cursor-grabbing"
                           >
-                            <Icon className="h-3.5 w-3.5 text-accent" strokeWidth={1.9} />
-                            {t(`workflowNode_${kind}`)}
+                            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
+                              <Icon className="h-3.5 w-3.5" strokeWidth={1.9} />
+                            </span>
+                            <span className="min-w-0 flex-1 truncate">{t(`workflowNode_${kind}`)}</span>
+                            <Plus className="h-3.5 w-3.5 shrink-0 text-ds-faint" strokeWidth={1.8} />
                           </button>
                         )
-                      })}
-                    </div>
-                  )
-                })}
+                      })
+                    : null}
+                </div>
+              )
+            })}
+
+            <div className="flex flex-col">
+              <div className="flex items-center gap-1 pr-1">
+                <button
+                  type="button"
+                  onClick={() => toggleGroup('custom')}
+                  className="flex min-w-0 flex-1 items-center gap-1 px-2 py-1 text-[10.5px] font-semibold uppercase tracking-wide text-ds-faint transition hover:text-ds-muted"
+                >
+                  <ChevronRight
+                    className={`h-3 w-3 shrink-0 transition-transform ${collapsedGroups.has('custom') ? '' : 'rotate-90'}`}
+                    strokeWidth={2}
+                  />
+                  <span className="min-w-0 flex-1 truncate text-left">{t('workflowGroup_custom')}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowModules(true)}
+                  title={t('workflowModulesManage')}
+                  aria-label={t('workflowModulesManage')}
+                  className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-ds-faint transition hover:bg-ds-hover hover:text-ds-ink"
+                >
+                  <Settings2 className="h-3.5 w-3.5" strokeWidth={1.8} />
+                </button>
               </div>
-            </>
-          ) : null}
-
-          <button
-            type="button"
-            onClick={() => setLeftPanelCollapsed((value) => !value)}
-            title={leftPanelCollapsed ? t('workflowExpandPanel') : t('workflowCollapsePanel')}
-            aria-label={leftPanelCollapsed ? t('workflowExpandPanel') : t('workflowCollapsePanel')}
-            className="absolute left-0 top-1/2 z-10 flex h-12 w-5 -translate-y-1/2 items-center justify-center rounded-r-lg border border-l-0 border-ds-border bg-ds-card text-ds-faint shadow-sm transition hover:text-ds-ink"
-          >
-            {leftPanelCollapsed ? (
-              <ChevronRight className="h-4 w-4" strokeWidth={2} />
-            ) : (
-              <ChevronLeft className="h-4 w-4" strokeWidth={2} />
-            )}
-          </button>
-          <button
-            type="button"
-            onClick={() => setRightPanelCollapsed((value) => !value)}
-            title={rightPanelCollapsed ? t('workflowExpandPanel') : t('workflowCollapsePanel')}
-            aria-label={rightPanelCollapsed ? t('workflowExpandPanel') : t('workflowCollapsePanel')}
-            className="absolute right-0 top-1/2 z-10 flex h-12 w-5 -translate-y-1/2 items-center justify-center rounded-l-lg border border-r-0 border-ds-border bg-ds-card text-ds-faint shadow-sm transition hover:text-ds-ink"
-          >
-            {rightPanelCollapsed ? (
-              <ChevronLeft className="h-4 w-4" strokeWidth={2} />
-            ) : (
-              <ChevronRight className="h-4 w-4" strokeWidth={2} />
-            )}
-          </button>
-        </div>
-
-        {!rightPanelCollapsed ? (
-        <aside className="flex w-[320px] shrink-0 flex-col overflow-hidden border-l border-ds-border bg-ds-card/40">
-          <div className="flex shrink-0 items-center gap-1 border-b border-ds-border px-2 pt-2">
-            {(['config', 'log'] as const).map((tab) => (
-              <button
-                key={tab}
-                type="button"
-                onClick={() => setRightTab(tab)}
-                className={`relative flex items-center gap-1.5 px-3 py-2 text-[12.5px] font-medium transition ${
-                  rightTab === tab ? 'text-ds-ink' : 'text-ds-faint hover:text-ds-muted'
-                }`}
-              >
-                {tab === 'config' ? t('workflowTabConfig') : t('workflowTabRunLog')}
-                {tab === 'log' && running ? (
-                  <span className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
-                ) : null}
-                {rightTab === tab ? (
-                  <span className="absolute inset-x-2 -bottom-px h-0.5 rounded-full bg-accent" />
-                ) : null}
-              </button>
-            ))}
-          </div>
-          <div className="flex min-h-0 flex-1 flex-col">
-            {rightTab === 'config' ? (
-              <NodeConfigPanel
-                node={selectedNode}
-                settings={settings}
-                lastResult={selectedNodeId ? logResults[selectedNodeId] ?? lastResults[selectedNodeId] ?? null : null}
-                onChange={handleNodeChange}
-                onDelete={handleDeleteNode}
-                onSavePreset={handleSavePreset}
-                workflowName={name}
-                upstreamNodes={upstreamNodes}
-                workflowId={workflow.id}
-                onBeforeTest={handleSave}
-              />
-            ) : (
-              <WorkflowRunLogPanel nodes={workflow.nodes} results={logResults} running={running} />
-            )}
+              {!collapsedGroups.has('custom') ? (
+                <>
+                  {modules.map((module) => {
+                    const Icon = NODE_ICONS.custom
+                    return (
+                      <button
+                        key={module.id}
+                        type="button"
+                        draggable
+                        onDragStart={(event) => onModuleDragStart(event, module.id)}
+                        onClick={() => addModuleNode(module)}
+                        title={module.description || module.name}
+                        className="flex cursor-grab items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 text-left text-[12.5px] text-ds-ink transition hover:border-ds-border hover:bg-ds-hover active:cursor-grabbing"
+                      >
+                        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
+                          <Icon className="h-3.5 w-3.5" strokeWidth={1.9} />
+                        </span>
+                        <span className="min-w-0 flex-1 truncate">{module.name}</span>
+                        <Plus className="h-3.5 w-3.5 shrink-0 text-ds-faint" strokeWidth={1.8} />
+                      </button>
+                    )
+                  })}
+                  {presets.map((preset) => {
+                    const Icon = NODE_ICONS[preset.nodeType]
+                    return (
+                      <div key={preset.id} className="group/preset relative flex items-center">
+                        <button
+                          type="button"
+                          draggable
+                          onDragStart={(event) => onPresetDragStart(event, preset.id)}
+                          onClick={() => addPresetNode(preset)}
+                          className="flex min-w-0 flex-1 cursor-grab items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 pr-7 text-left text-[12.5px] text-ds-ink transition hover:border-ds-border hover:bg-ds-hover active:cursor-grabbing"
+                        >
+                          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
+                            <Icon className="h-3.5 w-3.5" strokeWidth={1.9} />
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">{preset.label}</span>
+                        </button>
+                        <button
+                          type="button"
+                          title={t('workflowPresetDelete')}
+                          aria-label={t('workflowPresetDelete')}
+                          onClick={() => void onDeletePreset(preset.id)}
+                          className="absolute right-1 flex h-5 w-5 items-center justify-center rounded text-ds-faint opacity-0 transition hover:bg-red-500/10 hover:text-red-600 group-hover/preset:opacity-100"
+                        >
+                          <X className="h-3 w-3" strokeWidth={2} />
+                        </button>
+                      </div>
+                    )
+                  })}
+                  {modules.length === 0 && presets.length === 0 ? (
+                    <p className="px-2 py-1 text-[11px] leading-4 text-ds-faint">{t('workflowPresetEmpty')}</p>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
           </div>
         </aside>
+      ) : null}
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header
+          className={`${WORKFLOW_EDITOR_HEADER_CLASS}${leftPanelCollapsed ? ` ${WORKFLOW_EDITOR_HEADER_SIDEBAR_COLLAPSED_CLASS}` : ''}`}
+        >
+          {leftPanelCollapsed ? (
+            <button type="button" onClick={onBack} className={`${WORKFLOW_EDITOR_BACK_BUTTON_CLASS} shrink-0`}>
+              <ArrowLeft className="h-4 w-4" strokeWidth={1.8} />
+              {t('workflowBack')}
+            </button>
+          ) : null}
+          <input
+            className="min-w-0 flex-1 rounded-xl border border-transparent bg-transparent px-2 py-1.5 text-[15px] font-medium text-ds-ink outline-none focus:border-ds-border focus:bg-ds-card"
+            value={name}
+            placeholder={t('workflowNamePlaceholder')}
+            onChange={(event) => {
+              setName(event.target.value)
+              setDirty(true)
+            }}
+          />
+          <label className="flex shrink-0 items-center gap-2 text-[13px] font-medium text-ds-muted">
+            {t('workflowEnabled')}
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(event) => {
+                setEnabled(event.target.checked)
+                setDirty(true)
+              }}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => setShowHistory(true)}
+            title={t('workflowRunHistory')}
+            aria-label={t('workflowRunHistory')}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-ds-border bg-ds-card text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
+          >
+            <History className="h-4 w-4" strokeWidth={1.8} />
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowEnv(true)}
+            title={t('workflowEnvVars')}
+            aria-label={t('workflowEnvVars')}
+            className="relative inline-flex h-9 items-center gap-1.5 rounded-xl border border-ds-border bg-ds-card px-3 text-[13px] font-medium text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
+          >
+            <Variable className="h-4 w-4" strokeWidth={1.8} />
+            {t('workflowEnvVars')}
+            {env.length > 0 ? (
+              <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-accent/15 px-1 text-[10px] font-semibold text-accent">
+                {env.length}
+              </span>
+            ) : null}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={saving}
+            className="inline-flex h-9 items-center gap-1.5 rounded-xl border border-ds-border bg-ds-card px-3 text-[13px] font-medium text-ds-ink transition hover:bg-ds-hover disabled:opacity-60"
+          >
+            <Save className="h-4 w-4" strokeWidth={1.8} />
+            {dirty ? t('workflowSave') : t('workflowSaved')}
+          </button>
+          {running ? (
+            <button
+              type="button"
+              onClick={() => void onStop()}
+              className="inline-flex h-9 items-center gap-1.5 rounded-xl bg-red-500/90 px-4 text-[13px] font-semibold text-white shadow-sm transition hover:bg-red-500"
+            >
+              <Square className="h-3.5 w-3.5" strokeWidth={2} />
+              {t('workflowStop')}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void handleRun()}
+              className="inline-flex h-9 items-center gap-1.5 rounded-xl bg-ds-userbubble px-4 text-[13px] font-semibold text-ds-userbubbleFg shadow-sm transition hover:opacity-90"
+            >
+              <Play className="h-4 w-4" strokeWidth={2} />
+              {t('workflowRunNow')}
+            </button>
+          )}
+        </header>
+
+        <div className="flex min-h-0 flex-1">
+          <div className="relative min-w-0 flex-1" onDrop={onCanvasDrop} onDragOver={onCanvasDragOver}>
+            <WorkflowRunStatusContext.Provider value={runStatus}>
+              <WorkflowNodeActionsContext.Provider value={nodeActions}>
+                <ReactFlow
+                  className="ds-workflow-canvas"
+                  nodes={rfNodes}
+                  edges={styledEdges}
+                  nodeTypes={workflowNodeTypes}
+                  onNodesChange={onNodesChange}
+                  onEdgesChange={onEdgesChange}
+                  onConnect={onConnect}
+                  onConnectStart={onConnectStart}
+                  onConnectEnd={onConnectEnd}
+                  onNodeClick={(_, node) => setSelectedNodeId(node.id)}
+                  onPaneClick={() => setSelectedNodeId(null)}
+                  fitView
+                  fitViewOptions={{ maxZoom: 1, padding: 0.2 }}
+                  minZoom={0.2}
+                  proOptions={{ hideAttribution: true }}
+                >
+                  <Background variant={BackgroundVariant.Dots} gap={18} size={1} />
+                  <Controls showInteractive={false} />
+                  <MiniMap
+                    pannable
+                    zoomable
+                    className="ds-workflow-minimap"
+                    style={{ width: 150, height: 96 }}
+                    nodeColor="var(--ds-accent)"
+                    nodeStrokeColor="transparent"
+                    nodeBorderRadius={3}
+                    maskColor="rgb(15 23 42 / 0.08)"
+                  />
+                </ReactFlow>
+              </WorkflowNodeActionsContext.Provider>
+            </WorkflowRunStatusContext.Provider>
+            {rfNodes.length === 0 ? (
+              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 text-center">
+                <MousePointerClick className="h-8 w-8 text-ds-faint" strokeWidth={1.4} />
+                <p className="text-[13px] text-ds-faint">{t('workflowEmptyCanvas')}</p>
+              </div>
+            ) : null}
+            {connectMenu ? (
+              <>
+                <div className="fixed inset-0 z-[70]" onClick={() => setConnectMenu(null)} />
+                <div
+                  className="fixed z-[71] max-h-[60vh] w-44 overflow-y-auto rounded-lg border border-ds-border bg-ds-card p-1 shadow-lg"
+                  style={{ left: connectMenu.x, top: connectMenu.y }}
+                >
+                  {WORKFLOW_PALETTE_GROUPS.map((group) => {
+                    const kinds = group.kinds.filter((kind) => !TRIGGER_KINDS.has(kind))
+                    if (kinds.length === 0) return null
+                    return (
+                      <div key={group.id}>
+                        <div className="px-2 pb-0.5 pt-1.5 text-[9.5px] font-semibold uppercase tracking-wide text-ds-faint">
+                          {t(`workflowGroup_${group.id}`)}
+                        </div>
+                        {kinds.map((kind) => {
+                          const Icon = NODE_ICONS[kind]
+                          return (
+                            <button
+                              key={kind}
+                              type="button"
+                              onClick={() => addConnectedNode(kind)}
+                              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] text-ds-ink transition hover:bg-ds-hover"
+                            >
+                              <Icon className="h-3.5 w-3.5 text-accent" strokeWidth={1.9} />
+                              {t(`workflowNode_${kind}`)}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    )
+                  })}
+                </div>
+              </>
+            ) : null}
+
+            <button
+              type="button"
+              onClick={() => setLeftPanelCollapsed((value) => !value)}
+              title={leftPanelCollapsed ? t('workflowExpandPanel') : t('workflowCollapsePanel')}
+              aria-label={leftPanelCollapsed ? t('workflowExpandPanel') : t('workflowCollapsePanel')}
+              className="absolute left-0 top-1/2 z-10 flex h-12 w-5 -translate-y-1/2 items-center justify-center rounded-r-lg border border-l-0 border-ds-border bg-ds-card text-ds-faint shadow-sm transition hover:text-ds-ink"
+            >
+              {leftPanelCollapsed ? (
+                <ChevronRight className="h-4 w-4" strokeWidth={2} />
+              ) : (
+                <ChevronLeft className="h-4 w-4" strokeWidth={2} />
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => setRightPanelCollapsed((value) => !value)}
+              title={rightPanelCollapsed ? t('workflowExpandPanel') : t('workflowCollapsePanel')}
+              aria-label={rightPanelCollapsed ? t('workflowExpandPanel') : t('workflowCollapsePanel')}
+              className="absolute right-0 top-1/2 z-10 flex h-12 w-5 -translate-y-1/2 items-center justify-center rounded-l-lg border border-r-0 border-ds-border bg-ds-card text-ds-faint shadow-sm transition hover:text-ds-ink"
+            >
+              {rightPanelCollapsed ? (
+                <ChevronLeft className="h-4 w-4" strokeWidth={2} />
+              ) : (
+                <ChevronRight className="h-4 w-4" strokeWidth={2} />
+              )}
+            </button>
+          </div>
+
+          {!rightPanelCollapsed ? (
+            <aside className="flex w-[320px] shrink-0 flex-col overflow-hidden border-l border-ds-border bg-ds-card/40">
+              <div className="flex shrink-0 items-center gap-1 border-b border-ds-border px-2 pt-2">
+                {(['config', 'log'] as const).map((tab) => (
+                  <button
+                    key={tab}
+                    type="button"
+                    onClick={() => setRightTab(tab)}
+                    className={`relative flex items-center gap-1.5 px-3 py-2 text-[12.5px] font-medium transition ${
+                      rightTab === tab ? 'text-ds-ink' : 'text-ds-faint hover:text-ds-muted'
+                    }`}
+                  >
+                    {tab === 'config' ? t('workflowTabConfig') : t('workflowTabRunLog')}
+                    {tab === 'log' && running ? (
+                      <span className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+                    ) : null}
+                    {rightTab === tab ? (
+                      <span className="absolute inset-x-2 -bottom-px h-0.5 rounded-full bg-accent" />
+                    ) : null}
+                  </button>
+                ))}
+              </div>
+              <div className="flex min-h-0 flex-1 flex-col">
+                {rightTab === 'config' ? (
+                  <NodeConfigPanel
+                    node={selectedNode}
+                    settings={settings}
+                    lastResult={
+                      selectedNodeId ? logResults[selectedNodeId] ?? lastResults[selectedNodeId] ?? null : null
+                    }
+                    onChange={handleNodeChange}
+                    onDelete={handleDeleteNode}
+                    onSavePreset={handleSavePreset}
+                    workflowName={name}
+                    upstreamNodes={upstreamNodes}
+                    workflowId={workflow.id}
+                    onBeforeTest={handleSave}
+                  />
+                ) : (
+                  <WorkflowRunLogPanel nodes={workflow.nodes} results={logResults} running={running} />
+                )}
+              </div>
+            </aside>
+          ) : null}
+        </div>
+
+        {showModules ? (
+          <ModuleManager
+            modules={modules}
+            onChange={(next) => void onSaveModules(next)}
+            onClose={() => setShowModules(false)}
+          />
+        ) : null}
+
+        {showEnv ? (
+          <EnvVarsModal
+            env={env}
+            onChange={(next) => {
+              setEnv(next)
+              setDirty(true)
+            }}
+            onClose={() => setShowEnv(false)}
+          />
+        ) : null}
+
+        {showHistory ? (
+          <WorkflowRunHistory runs={workflow.runs} nodes={workflow.nodes} onClose={() => setShowHistory(false)} />
         ) : null}
       </div>
-
-      {showModules ? (
-        <ModuleManager
-          modules={modules}
-          onChange={(next) => void onSaveModules(next)}
-          onClose={() => setShowModules(false)}
-        />
-      ) : null}
-
-      {showEnv ? (
-        <EnvVarsModal
-          env={env}
-          onChange={(next) => {
-            setEnv(next)
-            setDirty(true)
-          }}
-          onClose={() => setShowEnv(false)}
-        />
-      ) : null}
-
-      {showHistory ? (
-        <WorkflowRunHistory runs={workflow.runs} nodes={workflow.nodes} onClose={() => setShowHistory(false)} />
-      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/components/workflow/WorkflowView.tsx
+++ b/src/renderer/src/components/workflow/WorkflowView.tsx
@@ -375,7 +375,7 @@ export function WorkflowView({ leftSidebarCollapsed, onToggleLeftSidebar }: Prop
           <div className="grid w-full min-w-0 items-center gap-2.5 px-3 py-2 sm:px-4 md:pl-5 md:pr-2">
             <div
               className={`flex min-w-0 items-center gap-2.5 ${
-                leftSidebarCollapsed ? 'ds-window-controls-safe-inset' : ''
+                leftSidebarCollapsed ? 'ds-window-controls-collapsed-titlebar-inset' : ''
               }`}
             >
               <SidebarTitlebarToggleButton

--- a/src/renderer/src/components/write/WriteWorkspaceToolbar.tsx
+++ b/src/renderer/src/components/write/WriteWorkspaceToolbar.tsx
@@ -96,7 +96,7 @@ export function WriteWorkspaceToolbar({
           <div className="write-pdf-topbar-grid grid w-full min-w-0 items-center gap-2 px-3 py-2 sm:px-4 md:pl-5 md:pr-3">
             <div
               className={`flex min-w-0 items-center gap-2.5 ${
-                leftSidebarCollapsed ? 'ds-window-controls-safe-inset' : ''
+                leftSidebarCollapsed ? 'ds-window-controls-collapsed-titlebar-inset' : ''
               }`}
             >
               <SidebarTitlebarToggleButton
@@ -147,7 +147,7 @@ export function WriteWorkspaceToolbar({
         <div className="write-workspace-toolbar-grid grid w-full min-w-0 items-center gap-2 px-3 py-2 sm:px-4 md:pl-5 md:pr-2 lg:gap-4">
           <div
             className={`flex min-w-0 items-center gap-2.5 ${
-              leftSidebarCollapsed ? 'ds-window-controls-safe-inset' : ''
+              leftSidebarCollapsed ? 'ds-window-controls-collapsed-titlebar-inset' : ''
             }`}
           >
             <SidebarTitlebarToggleButton

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -1,6 +1,7 @@
 :root {
   --ds-window-controls-safe-block: 0px;
   --ds-window-controls-safe-inset: 0px;
+  --ds-collapsed-sidebar-titlebar-extra-inset: 0px;
   --ds-write-titlebar-extra-inset: 0px;
   --ds-ui-scale: 1;
   /* Kun 吉祥物配色:鲸蓝 #6ca2dd / 小鸟浅蓝 #85c1f1 / 奶油 #fff2db / 珊瑚 #f47464 / 藏青描边 #0e2f66 / 淡紫天光 #f9f8ff */
@@ -99,6 +100,7 @@
 :root[data-platform='darwin'] {
   --ds-window-controls-safe-block: 42px;
   --ds-window-controls-safe-inset: 56px;
+  --ds-collapsed-sidebar-titlebar-extra-inset: 3.5rem;
   --ds-write-titlebar-extra-inset: 20px;
 }
 
@@ -2796,9 +2798,9 @@ pre {
 }
 
 .chat-topbar {
-  margin-top: 0.35rem;
-  min-height: 40px;
-  border-radius: 18px;
+  margin-top: 1rem;
+  min-height: 46px;
+  border-radius: 22px;
 }
 
 .ds-message-timeline-content {
@@ -2809,14 +2811,14 @@ pre {
 
 .chat-topbar-grid {
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
+  align-items: center;
   gap: 0.5rem;
-  padding-block: 0.35rem;
+  padding-block: 0.45rem;
 }
 
 .chat-topbar-session {
   min-width: 0;
-  align-self: start;
+  align-self: center;
 }
 
 .chat-topbar-actions {
@@ -2824,9 +2826,14 @@ pre {
   flex-wrap: nowrap;
   overflow-x: visible;
   overflow-y: visible;
-  align-self: start;
+  align-self: center;
   justify-self: end;
   scrollbar-width: none;
+  transform: translateY(-3px);
+}
+
+.chat-topbar .ds-titlebar-sidebar-toggle {
+  transform: translateY(-3px);
 }
 
 .chat-topbar-actions::-webkit-scrollbar {
@@ -2854,12 +2861,12 @@ pre {
 
 @container (max-width: 760px) {
   .chat-topbar {
-    margin-top: 0.2rem;
-    min-height: 36px;
+    margin-top: 0.875rem;
+    min-height: 42px;
   }
 
   .chat-topbar-grid {
-    padding-block: 0.25rem;
+    padding-block: 0.35rem;
   }
 
   .session-meta-usage,
@@ -2889,12 +2896,12 @@ pre {
   }
 
   .chat-topbar {
-    margin-top: 0.2rem;
-    min-height: 36px;
+    margin-top: 0.875rem;
+    min-height: 42px;
   }
 
   .chat-topbar-grid {
-    padding-block: 0.25rem;
+    padding-block: 0.35rem;
   }
 
   .ds-chat-stage .ds-floating-composer {

--- a/src/renderer/src/styles/surfaces-write.css
+++ b/src/renderer/src/styles/surfaces-write.css
@@ -412,13 +412,13 @@
 
 .ds-titlebar-sidebar-toggle {
   display: inline-flex;
-  height: 16px;
-  width: 16px;
+  height: 24px;
+  width: 24px;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   border: 0;
-  border-radius: 4px;
+  border-radius: 7px;
   background: transparent;
   color: #9b9b9b;
   box-shadow: none;

--- a/src/renderer/src/styles/workflow-canvas.css
+++ b/src/renderer/src/styles/workflow-canvas.css
@@ -1,4 +1,19 @@
 /* Re-theme React Flow (@xyflow/react) to the app's --ds-* design tokens. */
+.workflow-editor-header {
+  height: 4rem;
+}
+
+:root[data-platform='darwin'] .workflow-editor-header {
+  padding-top: 1rem;
+  padding-bottom: 0.5rem;
+}
+
+:root[data-platform='darwin'] .workflow-editor-header-sidebar-collapsed {
+  padding-left: calc(
+    var(--ds-window-controls-safe-inset) + var(--ds-collapsed-sidebar-titlebar-extra-inset)
+  );
+}
+
 .ds-workflow-canvas {
   --xy-background-color: var(--ds-bg-main);
   --xy-background-pattern-color: var(--ds-border-muted, var(--ds-border));

--- a/src/renderer/src/styles/write-editor.css
+++ b/src/renderer/src/styles/write-editor.css
@@ -47,6 +47,16 @@
   padding-left: var(--ds-window-controls-safe-inset);
 }
 
+.ds-window-controls-collapsed-titlebar-inset {
+  padding-left: calc(
+    var(--ds-window-controls-safe-inset) + var(--ds-collapsed-sidebar-titlebar-extra-inset)
+  );
+}
+
+.ds-window-controls-collapsed-titlebar-anchor {
+  left: calc(1rem + var(--ds-window-controls-safe-inset) + var(--ds-collapsed-sidebar-titlebar-extra-inset));
+}
+
 .ds-write-titlebar-safe-inset {
   padding-left: calc(var(--ds-window-controls-safe-inset) + var(--ds-write-titlebar-extra-inset));
 }


### PR DESCRIPTION
## 概要

修复 macOS 下 Kun 多个页面顶部栏与系统红黄绿窗口按钮不对齐的问题，并补上 workflow 编辑器左侧栏折叠后的返回入口，避免用户无法直接退出编辑器。

## 修改内容

- 将创建 loop 编辑器的返回按钮保留到折叠态 header 中，满足 review 中“侧栏折叠后仍可退出编辑器”的要求。
- 统一聊天页顶部工具按钮尺寸与垂直对齐，避免折叠按钮、标题和右侧工具按钮各自使用不同尺寸/位置规则。
- 为插件页改用和定时任务、创建 loop 相同的顶部栏结构，不再由 Workbench 单独塞一个裸按钮。
- 统一左侧栏折叠时的 macOS 安全区缩进，覆盖聊天、写作、插件、定时任务、创建 loop、SDD、连接手机等入口。
- 保留并更新 workflow 标题栏安全区相关测试。

## 验证

- `git diff --check`
- `npm run test -- src/renderer/src/components/PluginMarketplaceView.test.ts src/renderer/src/components/workflow/WorkflowEditorView.test.ts`
- `npm run typecheck`
- 本地 Electron 开发版截图检查：聊天页、插件页、定时任务、创建 loop 顶部按钮位置一致。
