### PR TITLE
fix(installer): stop bundled processes before windows upgrade

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,36 @@
+!macro customCheckAppRunning
+  Var /GLOBAL KunInstallerCurrentPid
+  Var /GLOBAL KunInstallerStopAttempt
+  Var /GLOBAL KunInstallerStopResult
+
+  ${if} $INSTDIR == ""
+    Return
+  ${endif}
+
+  System::Call 'kernel32::GetCurrentProcessId() i .r0'
+  StrCpy $KunInstallerCurrentPid $0
+  System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_APP_ROOT", "$INSTDIR").r0'
+  System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_SELF_PID", "$KunInstallerCurrentPid").r0'
+
+  StrCpy $KunInstallerStopAttempt 0
+
+  KunStopProcessesFromInstallDir:
+    IntOp $KunInstallerStopAttempt $KunInstallerStopAttempt + 1
+    DetailPrint "Checking for running ${PRODUCT_NAME} processes under $INSTDIR."
+    nsExec::Exec `"$PowerShellPath" -NoProfile -ExecutionPolicy Bypass -Command "$$ErrorActionPreference='SilentlyContinue'; $$root=[System.IO.Path]::GetFullPath($$env:KUN_INSTALLER_APP_ROOT).TrimEnd('\'); $$self=[int]$$env:KUN_INSTALLER_SELF_PID; $$procs=@(Get-CimInstance -ClassName Win32_Process | Where-Object { $$_.ProcessId -ne $$self -and $$_.Path -and [System.IO.Path]::GetFullPath($$_.Path).StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); if ($$procs.Count -gt 0) { $$procs | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }; exit 0 } else { exit 1 }"`
+    Pop $KunInstallerStopResult
+
+    ${if} $KunInstallerStopResult != 0
+      Goto KunInstallDirProcessesStopped
+    ${endif}
+
+    Sleep 1200
+    ${if} $KunInstallerStopAttempt <= 5
+      Goto KunStopProcessesFromInstallDir
+    ${endif}
+
+    MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY KunStopProcessesFromInstallDir
+    Quit
+
+  KunInstallDirProcessesStopped:
+!macroend

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -175,6 +175,7 @@ module.exports = {
     perMachine: false,
     allowElevation: true,
     selectPerMachineByDefault: false,
+    include: 'build/installer.nsh',
     // 明确创建快捷方式；always 在覆盖安装时也会重建（即使用户曾删掉桌面图标）
     createDesktopShortcut: 'always',
     createStartMenuShortcut: true,


### PR DESCRIPTION
Summary
- Fix Windows NSIS upgrades hanging when an existing Kun install still has bundled child processes running under the install directory.
- Add a packaged Windows 0.2.15 installer build for validation and handoff.

Changes
- Wire a custom NSIS include through electron-builder.
- Override the installer app-running check to enumerate processes under $INSTDIR and stop them before uninstalling/replacing the old install, excluding the installer process itself.

Tests
- npm run typecheck
- git diff --check
- Built Windows NSIS installer: dist/Kun-0.2.15-win-x64.exe
- Verified Windows x64 PE outputs for Kun.exe, better_sqlite3.node, and node-pty pty.node
- SHA256: fe5f67d45e28e952869a3d2cf9f9c88e8e8887279450b5cda4e851fbbba0d3fd

Fixes #451
