### PR TITLE
style(sdd): align requirement pill and progress colors with dark theme

### DIFF
--- a/src/renderer/src/styles/write-rich-editor.css
+++ b/src/renderer/src/styles/write-rich-editor.css
@@ -272,18 +272,22 @@
 }
 
 [data-theme='dark'] .write-rich-editor .sdd-req-pill-planned {
+  background: color-mix(in srgb, #93c5fd 18%, transparent);
   color: #93c5fd;
 }
 
 [data-theme='dark'] .write-rich-editor .sdd-req-pill-building {
+  background: color-mix(in srgb, #fcd34d 20%, transparent);
   color: #fcd34d;
 }
 
 [data-theme='dark'] .write-rich-editor .sdd-req-pill-done {
+  background: color-mix(in srgb, #86efac 20%, transparent);
   color: #86efac;
 }
 
 [data-theme='dark'] .write-rich-editor .sdd-req-pill-verified {
+  background: color-mix(in srgb, #5eead4 20%, transparent);
   color: #5eead4;
 }
 
@@ -317,6 +321,22 @@
 
 .sdd-req-progress-seg-planned {
   background: #3b82f6;
+}
+
+[data-theme='dark'] .sdd-req-progress-seg-verified {
+  background: #2dd4bf;
+}
+
+[data-theme='dark'] .sdd-req-progress-seg-done {
+  background: #4ade80;
+}
+
+[data-theme='dark'] .sdd-req-progress-seg-building {
+  background: #fbbf24;
+}
+
+[data-theme='dark'] .sdd-req-progress-seg-planned {
+  background: #60a5fa;
 }
 
 /* Inline AI: ghost text suggestion (Phase 3) */


### PR DESCRIPTION
## Summary

The SDD (spec-driven development) requirement status indicators did not fully adapt to the dark theme:

- The status pills (`planned` / `building` / `done` / `verified`) only overrode the **text color** under `[data-theme='dark']`, while keeping the **light-mode background** — a saturated translucent fill tuned for light surfaces. On the dark canvas the pill fill stayed too bright and clashed with the already-adjusted light text color.
- The requirement **progress bar segments** had no dark-theme overrides at all, so the filled segments used the vivid base hues (`#3b82f6`, `#f59e0b`, `#22c55e`, `#14b8a6`), which read as too saturated against the dark background.

## Changes

`src/renderer/src/styles/write-rich-editor.css`:

- Add matching `background` overrides to the four dark-theme pill rules so the pill fill tracks the text color at a soft opacity (`color-mix(... 18-20%, transparent)`), consistent with how the light variants are composed.
- Add `[data-theme='dark']` overrides for the four `.sdd-req-progress-seg-*` segments, switching to the lighter tailwind shades (`#60a5fa`, `#fbbf24`, `#4ade80`, `#2dd4bf`) so the progress bar stays readable on dark surfaces.

Pure CSS change, scoped to SDD requirement visualizations; no markup, theme tokens, or JS touched.

## Tests

- `npm run typecheck` ✅
- `npm run lint` ✅ (only pre-existing `react-hooks/exhaustive-deps` warnings, unrelated to this change)
- `npm run test` ✅ (196 files / 1578 tests passing)
