### PR TITLE
feat(theme): add Retroma parchment light palette as built-in mode

### DIFF
--- a/src/renderer/src/components/settings-section-easter-egg.test.ts
+++ b/src/renderer/src/components/settings-section-easter-egg.test.ts
@@ -43,6 +43,8 @@ const labels: Record<string, string> = {
   uiModeWorkshopDesc: 'Pick the workspace mascot pack. iKun is a pre-installed plugin example.',
   uiModeDefaultTitle: 'Default Kun',
   uiModeDefaultSubtitle: 'The little blue bird',
+  uiPaletteRetromaOn: 'Retroma palette on — click to use default palette',
+  uiPaletteRetromaOff: 'Switch to Retroma parchment palette',
   uiPluginInstall: 'Install plugin folder…',
   uiPluginActivate: 'Use',
   uiPluginActive: 'Active',
@@ -83,6 +85,9 @@ describe('EasterEggSettingsSection (mode workshop)', () => {
     // 默认模式应处于使用中状态;iKun 不再硬编码,而是预装插件,SSR 下列表为空
     expect(html).toContain('Active')
     expect(html).not.toContain('iKun mode')
+    // 默认 Kun 卡片右上角带 Retroma 配色切换按钮(SSR 下 uiMode=default,按钮为关闭态)
+    expect(html).toContain('Switch to Retroma parchment palette')
+    expect(html).toContain('aria-pressed="false"')
   })
 
   it('adds the workshop tab to the settings sidebar', () => {

--- a/src/renderer/src/components/settings-section-easter-egg.tsx
+++ b/src/renderer/src/components/settings-section-easter-egg.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import { useEffect, useState } from 'react'
-import { FolderPlus, Trash2 } from 'lucide-react'
-import { UI_MODE_DEFAULT } from '../lib/ui-mode'
+import { FolderPlus, Palette, Trash2 } from 'lucide-react'
+import { UI_MODE_DEFAULT, UI_MODE_RETROMA } from '../lib/ui-mode'
 import { useUiPluginStore } from '../store/ui-plugin-store'
 import kunBirdFigure from '../../../asset/img/kun_bird.png'
 import { SettingsCard, SettingRow } from './settings-controls'
@@ -20,18 +20,28 @@ function ModeCardButton({
   busy,
   onActivate,
   onRemove,
+  onTogglePalette,
+  paletteOn,
   activeLabel,
   activateLabel,
-  removeLabel
+  removeLabel,
+  paletteOnLabel,
+  paletteOffLabel
 }: {
   card: ModeCard
   active: boolean
   busy: boolean
   onActivate: () => void
   onRemove?: () => void
+  /** 切换 Retroma 羊皮纸配色(仅默认 Kun 卡片提供) */
+  onTogglePalette?: () => void
+  /** Retroma 配色当前是否开启 */
+  paletteOn?: boolean
   activeLabel: string
   activateLabel: string
   removeLabel: string
+  paletteOnLabel: string
+  paletteOffLabel: string
 }): ReactElement {
   return (
     <div
@@ -70,6 +80,23 @@ function ModeCardButton({
       >
         {active ? activeLabel : activateLabel}
       </button>
+      {onTogglePalette ? (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onTogglePalette}
+          title={paletteOn ? paletteOnLabel : paletteOffLabel}
+          aria-label={paletteOn ? paletteOnLabel : paletteOffLabel}
+          aria-pressed={paletteOn ? 'true' : 'false'}
+          className={`absolute right-2 top-2 rounded-md p-1 transition disabled:opacity-50 ${
+            paletteOn
+              ? 'bg-accent/15 text-accent hover:bg-accent/20'
+              : 'text-ds-faint hover:bg-accent/12 hover:text-accent'
+          }`}
+        >
+          <Palette className="h-3.5 w-3.5" strokeWidth={1.8} />
+        </button>
+      ) : null}
       {card.removable && onRemove ? (
         <button
           type="button"
@@ -138,21 +165,36 @@ export function EasterEggSettingsSection({ ctx }: { ctx: Record<string, any> }):
         control={
           <div className="flex w-full flex-col gap-3">
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-              {[...builtinCards, ...pluginCards].map((card) => (
+              {[...builtinCards, ...pluginCards].map((card) => {
+                const isBuiltin = card.mode === UI_MODE_DEFAULT
+                // 默认 Kun 卡承载 Retroma 配色:default 或 retroma 均视为该卡激活
+                const cardActive =
+                  isBuiltin ? uiMode === UI_MODE_DEFAULT || uiMode === UI_MODE_RETROMA : uiMode === card.mode
+                const retromaOn = uiMode === UI_MODE_RETROMA
+                return (
                 <ModeCardButton
                   key={card.mode}
                   card={card}
-                  active={uiMode === card.mode}
+                  active={cardActive}
                   busy={busy}
                   onActivate={() => void activateUiMode(card.mode)}
                   onRemove={
                     card.removable ? () => void removeUiPluginById(card.mode) : undefined
                   }
+                  onTogglePalette={
+                    isBuiltin
+                      ? () => void activateUiMode(retromaOn ? UI_MODE_DEFAULT : UI_MODE_RETROMA)
+                      : undefined
+                  }
+                  paletteOn={isBuiltin ? retromaOn : undefined}
                   activeLabel={t('uiPluginActive')}
                   activateLabel={t('uiPluginActivate')}
                   removeLabel={t('uiPluginRemove')}
+                  paletteOnLabel={t('uiPaletteRetromaOn')}
+                  paletteOffLabel={t('uiPaletteRetromaOff')}
                 />
-              ))}
+                )
+              })}
             </div>
             {pluginCards.length === 0 ? (
               <p className="text-[12.5px] leading-5 text-ds-faint">{t('uiPluginEmpty')}</p>

--- a/src/renderer/src/lib/ui-mode.ts
+++ b/src/renderer/src/lib/ui-mode.ts
@@ -2,13 +2,15 @@ import { readBrowserStorageItem, writeBrowserStorageItem } from './browser-stora
 import { IKUN_MODE_STORAGE_KEY } from './ikun-mode'
 
 /**
- * 形象模式偏好:'default' | 'ikun' | <UI 插件 id>。
+ * 形象模式偏好:'default' | 'ikun' | 'retroma' | <UI 插件 id>。
  * 取代旧的布尔型 kun.ikunMode(读取时自动迁移)。
  */
 export const UI_MODE_STORAGE_KEY = 'kun.uiMode'
 
 export const UI_MODE_DEFAULT = 'default'
 export const UI_MODE_IKUN = 'ikun'
+/** Retroma 羊皮纸浅色配色模式:纯配色(无吉祥物),仅浅色生效 */
+export const UI_MODE_RETROMA = 'retroma'
 
 const UI_MODE_PATTERN = /^[a-z0-9][a-z0-9-]{1,39}$/
 

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -1014,6 +1014,8 @@
   "uiModeWorkshopDesc": "Pick the workspace mascot pack. The built-in iKun mode is itself a pre-installed UI plugin example — build and install your own packs with the developer guide (declarative image packs, no executable code).",
   "uiModeDefaultTitle": "Default Kun",
   "uiModeDefaultSubtitle": "The little blue bird",
+  "uiPaletteRetromaOn": "Retroma palette on — click to use default palette",
+  "uiPaletteRetromaOff": "Switch to Retroma parchment palette",
   "uiPluginInstall": "Install plugin folder…",
   "uiPluginActivate": "Use",
   "uiPluginActive": "Active",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -1014,6 +1014,8 @@
   "uiModeWorkshopDesc": "选择工作台吉祥物形象。iKun 模式本身就是一个预装的 UI 插件示例,你也可以按开发指南制作并安装自己的形象包(纯声明式图片包,不含可执行代码)。",
   "uiModeDefaultTitle": "默认 Kun",
   "uiModeDefaultSubtitle": "小Kun",
+  "uiPaletteRetromaOn": "已开启 Retroma 羊皮纸配色 — 点击切回默认配色",
+  "uiPaletteRetromaOff": "切换到 Retroma 羊皮纸配色",
   "uiPluginInstall": "安装插件文件夹…",
   "uiPluginActivate": "启用",
   "uiPluginActive": "使用中",

--- a/src/renderer/src/store/ui-plugin-store.ts
+++ b/src/renderer/src/store/ui-plugin-store.ts
@@ -11,6 +11,7 @@ import {
 import {
   UI_MODE_DEFAULT,
   UI_MODE_IKUN,
+  UI_MODE_RETROMA,
   readUiModePreference,
   writeUiModePreference
 } from '../lib/ui-mode'
@@ -50,6 +51,9 @@ function applyUiModeDom(mode: string, runtime: UiPluginRuntime | null): void {
   if (typeof document === 'undefined') return
   const root = document.documentElement
   root.setAttribute('data-ikun-mode', mode === UI_MODE_IKUN ? 'on' : 'off')
+  // Retroma 是纯配色模式:仅点亮 data-retroma-mode(浅色守卫在 CSS 侧),
+  // 不走插件运行时,不注入插件 token。
+  root.setAttribute('data-retroma-mode', mode === UI_MODE_RETROMA ? 'on' : 'off')
   if (runtime && mode === runtime.manifest.id) {
     root.setAttribute('data-ui-plugin', runtime.manifest.id)
   } else {
@@ -82,7 +86,7 @@ export const useUiPluginStore = create<UiPluginState>((set, get) => ({
     if (get().initialized) return
     set({ initialized: true })
     const mode = readUiModePreference()
-    if (mode === UI_MODE_DEFAULT) {
+    if (mode === UI_MODE_DEFAULT || mode === UI_MODE_RETROMA) {
       set({ uiMode: mode })
       applyUiModeDom(mode, null)
       void get().refreshUiPlugins()
@@ -108,6 +112,14 @@ export const useUiPluginStore = create<UiPluginState>((set, get) => ({
   activateUiMode: async (mode: string) => {
     const normalized = mode.trim().toLowerCase()
     if (normalized === UI_MODE_DEFAULT) {
+      writeUiModePreference(normalized)
+      set({ uiMode: normalized, activeRuntime: null, lastError: null })
+      applyUiModeDom(normalized, null)
+      return
+    }
+
+    // 'retroma' 是纯配色内置模式,无吉祥物图集,不走插件加载链路
+    if (normalized === UI_MODE_RETROMA) {
       writeUiModePreference(normalized)
       set({ uiMode: normalized, activeRuntime: null, lastError: null })
       applyUiModeDom(normalized, null)

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -310,6 +310,100 @@
   opacity: 0.8;
 }
 
+/* Retroma 羊皮纸浅色主题(仅浅色生效):底色 #faf9f6 / 卡片 #f5f4ef / 主色青 #0f7887 / 点缀紫红 #6e3a66 / 边框 #d8d4c8。
+   :not([data-theme='dark']) 守卫确保暗色模式下回退 Kun 默认暗色。 */
+[data-retroma-mode='on']:not([data-theme='dark']) {
+  --bg-app: #faf9f6;
+  --bg-sidebar: #f5f4ef;
+  --bg-canvas: #faf9f6;
+  --surface-1: rgba(245, 244, 239, 0.9);
+  --surface-2: rgba(238, 237, 229, 0.98);
+  --surface-3: #eeede5;
+  --border-soft: rgba(90, 74, 58, 0.14);
+  --border-strong: rgba(90, 74, 58, 0.22);
+  --text-primary: #1d011d;
+  --text-secondary: #6e6060;
+  --text-tertiary: #8a7e72;
+  --text-placeholder: #b8b0a8;
+
+  --ds-surface-subtle: #eeede5;
+  --ds-surface-hover: rgba(15, 120, 135, 0.07);
+  --ds-border-muted: rgba(90, 74, 58, 0.09);
+  --ds-bubble-user: rgba(110, 58, 102, 0.12);
+  --ds-bubble-user-fg: #6e3a66;
+  --ds-accent: #0f7887;
+  --ds-accent-soft: rgba(15, 120, 135, 0.15);
+  --ds-success: #737f16;
+  --ds-success-soft: rgba(115, 127, 22, 0.14);
+  --ds-danger: #b03030;
+  --ds-danger-soft: rgba(176, 48, 48, 0.14);
+  --ds-warning-soft: rgba(176, 122, 16, 0.16);
+  --ds-diff-added: #737f16;
+  --ds-diff-added-soft: rgba(115, 127, 22, 0.1);
+  --ds-diff-removed: #b03030;
+  --ds-diff-removed-soft: rgba(176, 48, 48, 0.1);
+  --ds-skill: #6e3a66;
+  --ds-skill-soft: rgba(110, 58, 102, 0.13);
+  --ds-selection: rgba(110, 58, 102, 0.2);
+  --ds-shadow-shell: 0 12px 30px rgba(90, 74, 58, 0.08);
+  --ds-shadow-panel: 0 16px 44px rgba(90, 74, 58, 0.06);
+  --ds-shadow-composer: 0 18px 46px rgba(90, 74, 58, 0.1),
+    0 5px 16px rgba(90, 74, 58, 0.06);
+  --ds-stage-gradient: linear-gradient(180deg, #faf9f6 0%, #ffffff 100%);
+  --ds-topbar-bg:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.58) 58%, rgba(255, 255, 255, 0.3) 100%);
+  --ds-topbar-shadow:
+    0 16px 42px rgba(90, 74, 58, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.64);
+  --ds-sidebar-gradient:
+    linear-gradient(180deg, rgba(250, 249, 246, 0.98) 0%, rgba(245, 244, 239, 0.98) 100%);
+  --ds-sidebar-haze:
+    radial-gradient(circle at 62% -14%, rgba(15, 120, 135, 0.12), transparent 38%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(255, 255, 255, 0) 30%);
+  --ds-sidebar-border: rgba(216, 212, 200, 0.6);
+  --ds-sidebar-row-hover: rgba(238, 236, 228, 0.7);
+  --ds-sidebar-row-active: rgba(224, 222, 212, 0.9);
+  --ds-sidebar-row-ring: rgba(110, 58, 102, 0.26);
+  --ds-sidebar-field-bg: rgba(245, 244, 239, 0.82);
+  --ds-sidebar-field-focus: rgba(250, 249, 246, 0.94);
+  --ds-sidebar-divider: rgba(216, 212, 200, 0.45);
+  --ds-card-soft: rgba(250, 249, 246, 0.8);
+  --ds-card-strong: rgba(255, 255, 255, 0.96);
+  --ds-card-muted: rgba(238, 237, 229, 0.86);
+  --ds-card-ghost: rgba(250, 249, 246, 0.58);
+  --ds-card-hover: rgba(255, 255, 255, 0.98);
+  --ds-chip-bg: rgba(243, 238, 226, 0.9);
+  --ds-chip-muted-bg: rgba(238, 236, 228, 0.88);
+  --ds-chip-hover: rgba(255, 255, 255, 0.98);
+  --ds-chip-border: rgba(90, 74, 58, 0.14);
+  --ds-chip-active:
+    linear-gradient(180deg, rgba(243, 238, 226, 0.98), rgba(215, 204, 183, 0.94));
+  --ds-kbd-bg: rgba(245, 244, 239, 0.88);
+  --ds-code-bg: rgba(238, 237, 229, 0.96);
+  --ds-inline-code-bg: rgba(238, 236, 228, 0.92);
+  --ds-inline-code-hover-bg: rgba(235, 233, 223, 0.98);
+  --ds-pre-bg: rgba(238, 237, 229, 0.96);
+  --ds-code-block-bg: #eeede5;
+  --ds-table-head-bg: rgba(238, 237, 229, 0.96);
+  --ds-scrollbar-thumb: rgba(90, 74, 58, 0.22);
+  --ds-scrollbar-thumb-hover: rgba(90, 74, 58, 0.32);
+  --ds-shadow-card-soft: 0 10px 28px rgba(90, 74, 58, 0.06);
+  --ds-shadow-card-strong: 0 14px 36px rgba(90, 74, 58, 0.09);
+  --ds-shadow-chip: inset 0 1px 0 rgba(255, 255, 255, 0.78);
+}
+
+[data-retroma-mode='on']:not([data-theme='dark']) body::before {
+  background: linear-gradient(180deg, #faf9f6 0%, #f5f4ef 100%);
+}
+
+[data-retroma-mode='on']:not([data-theme='dark']) body::after {
+  background:
+    radial-gradient(circle at 78% -10%, rgba(15, 120, 135, 0.1), transparent 40%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.5), transparent 22%),
+    linear-gradient(120deg, rgba(110, 58, 102, 0.06), transparent 34%, rgba(255, 252, 243, 0.14) 74%, transparent);
+  opacity: 0.7;
+}
+
 /* iKun 夜场球馆:暖炭底 + 金黄高亮,同时覆盖全局 dark 与 workbench-shell 两层 token */
 [data-theme='dark'][data-ikun-mode='on'],
 [data-theme='dark'][data-ikun-mode='on'] .ds-workbench-shell {


### PR DESCRIPTION
## Summary

把 Talkcody 的 **Retroma 羊皮纸浅色主题**作为一个内置配色模式接入 Kun 的「形象工坊」。Retroma 是纯配色(无吉祥物),沿用 iKun 的机制:`data-retroma-mode` DOM 属性 + `base-shell.css` 整块配色覆盖。与默认/iKun 的区别是它通过默认 Kun 卡片右上角的调色板按钮切换,而非独立卡片。

配色取自 Talkcody 的 `.theme-retroma.light`(羊皮纸暖色:底色 `#faf9f6` / 卡片 `#f5f4ef` / 主色青 `#0f7887` / 点缀紫红 `#6e3a66` / 边框 `#d8d4c8`),映射到 Kun 的 `--ds-*` token 体系。**仅浅色生效**:所有 Retroma 选择器带 `:not([data-theme='dark'])` 守卫,暗色模式回退 Kun 默认暗色,不强制改用户的明暗偏好。

## Changes

- **`base-shell.css`**:新增 `[data-retroma-mode='on']:not([data-theme='dark'])` 配色块(背景/边框/文字/卡片/chip/侧栏/阴影/渐变等全 token 覆盖)+ `body::before/::after` 暖色覆盖。插入点紧贴 iKun 浅色块之后、iKun 暗色覆盖之前。
- **`lib/ui-mode.ts`**:新增 `UI_MODE_RETROMA = 'retroma'` 常量(已满足现有 id 正则,无需改插件校验/保留字)。
- **`store/ui-plugin-store.ts`**:`applyUiModeDom` 点亮 `data-retroma-mode`(与 `data-ikun-mode` 同构);`activateUiMode` 加 Retroma 短路分支(纯配色,不走插件加载链路);`initUiPlugins` 启动时对 Retroma 同步应用 DOM,避免闪烁。
- **`components/settings-section-easter-egg.tsx`**:形象工坊只保留「默认 Kun」一张内置卡(不再有 Retroma 独立卡,避免两张白底卡片重叠);卡片右上角加调色板按钮,点一下在默认配色 ↔ Retroma 之间切换,`aria-pressed` 跟随状态。
- **`locales/{en,zh}/settings.json`**:新增 `uiPaletteRetromaOn` / `uiPaletteRetromaOff` 按钮文案。
- **`settings-section-easter-egg.test.ts`**:断言切换按钮 tooltip 与 `aria-pressed="false"` 渲染。

## Tests

- `npm run typecheck` ✅
- `npx vitest run` 相关套件 ✅(`easter-egg` 2、`ui-plugin` 11、`ikun-mode` 3、`register-app-ipc-handlers` 12 全过)
- `eslint` 改动文件 ✅(0 error)
- 分支基于最新 `origin/develop`(`247076f`),改动限定在上述 7 个文件,纯增无删,无与上游冲突。
