### PR TITLE
feat(lsp): add language server diagnostics support

### DIFF
--- a/kun/src/adapters/tool/builtin-lsp-tool.test.ts
+++ b/kun/src/adapters/tool/builtin-lsp-tool.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  acquireLspSession: vi.fn(),
+  lspOpenDocument: vi.fn(),
+  lspCloseDocument: vi.fn(),
+  lspGetDiagnostics: vi.fn(),
+  releaseLspSession: vi.fn(),
+  findLanguageServerForFile: vi.fn(),
+  languageIdForFile: vi.fn(),
+  listLanguageServers: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: mocks.readFile
+}))
+
+vi.mock('./local-tool-host.js', () => ({
+  LocalToolHost: {
+    defineTool: (tool: unknown) => tool
+  }
+}))
+
+vi.mock('./builtin-tool-utils.js', () => ({
+  withToolBoundary: async (run: () => Promise<unknown>) => run(),
+  resolveWorkspacePath: (inputPath: string) => ({
+    workspaceRoot: '/workspace',
+    absolutePath: `/workspace/${inputPath}`,
+    relativePath: inputPath
+  })
+}))
+
+vi.mock('./lsp-client.js', () => ({
+  acquireLspSession: mocks.acquireLspSession,
+  lspCloseDocument: mocks.lspCloseDocument,
+  lspDefinition: vi.fn(),
+  lspGetDiagnostics: mocks.lspGetDiagnostics,
+  lspDocumentSymbol: vi.fn(),
+  lspHover: vi.fn(),
+  lspImplementation: vi.fn(),
+  lspOpenDocument: mocks.lspOpenDocument,
+  lspReferences: vi.fn(),
+  releaseLspSession: mocks.releaseLspSession,
+  lspWorkspaceSymbol: vi.fn()
+}))
+
+vi.mock('./lsp-servers.js', () => ({
+  findLanguageServerForFile: mocks.findLanguageServerForFile,
+  languageIdForFile: mocks.languageIdForFile,
+  listLanguageServers: mocks.listLanguageServers
+}))
+
+import { createLspLocalTool } from './builtin-lsp-tool.js'
+
+describe('builtin lsp tool diagnostics', () => {
+  it('returns simplified best-effort diagnostics from the cache-backed operation', async () => {
+    mocks.readFile.mockResolvedValue('const broken = true\n')
+    mocks.findLanguageServerForFile.mockReturnValue({
+      key: 'typescript',
+      displayName: 'TypeScript/JavaScript',
+      extensions: ['.ts']
+    })
+    mocks.languageIdForFile.mockReturnValue('typescript')
+    mocks.acquireLspSession.mockResolvedValue({ session: true })
+    mocks.lspGetDiagnostics.mockResolvedValue({
+      diagnostics: [
+        {
+          message: 'Type error',
+          severity: 1,
+          source: 'ts',
+          code: 2322,
+          range: {
+            start: { line: 2, character: 4 },
+            end: { line: 2, character: 10 }
+          }
+        }
+      ],
+      source: 'textDocument/diagnostic'
+    })
+
+    const tool = createLspLocalTool()
+    const context = {
+      workspace: '/workspace',
+      threadId: 'thread_test',
+      turnId: 'turn_test',
+      approvalPolicy: 'auto' as const,
+      abortSignal: new AbortController().signal,
+      awaitApproval: vi.fn()
+    }
+    const result = await tool.execute(
+      { operation: 'getDiagnostics', filePath: 'demo.ts' },
+      context
+    )
+
+    expect(mocks.acquireLspSession).toHaveBeenCalledWith('/workspace', 'typescript')
+    expect(mocks.lspOpenDocument).toHaveBeenCalledWith(
+      { session: true },
+      '/workspace/demo.ts',
+      'const broken = true\n',
+      'typescript'
+    )
+    expect(result).toEqual({
+      output: {
+        operation: 'getDiagnostics',
+        result: [
+          {
+            message: 'Type error',
+            severity: 1,
+            source: 'ts',
+            code: 2322,
+            range: {
+              start: { line: 3, character: 5 },
+              end: { line: 3, character: 11 }
+            }
+          }
+        ],
+        bestEffort: true,
+        source: 'textDocument/diagnostic'
+      }
+    })
+    expect(mocks.lspCloseDocument).toHaveBeenCalledWith({ session: true }, '/workspace/demo.ts')
+    expect(mocks.releaseLspSession).toHaveBeenCalledWith('/workspace', 'typescript')
+  })
+})

--- a/kun/src/adapters/tool/builtin-lsp-tool.ts
+++ b/kun/src/adapters/tool/builtin-lsp-tool.ts
@@ -19,6 +19,7 @@ import {
   acquireLspSession,
   lspCloseDocument,
   lspDefinition,
+  lspGetDiagnostics,
   lspDocumentSymbol,
   lspHover,
   lspImplementation,
@@ -28,6 +29,11 @@ import {
   lspWorkspaceSymbol,
   type LspSession
 } from './lsp-client.js'
+import {
+  findLanguageServerForFile,
+  languageIdForFile,
+  listLanguageServers
+} from './lsp-servers.js'
 
 type LspOperation =
   | 'goToDefinition'
@@ -36,6 +42,7 @@ type LspOperation =
   | 'documentSymbol'
   | 'workspaceSymbol'
   | 'goToImplementation'
+  | 'getDiagnostics'
 
 const OPERATIONS: LspOperation[] = [
   'goToDefinition',
@@ -43,7 +50,8 @@ const OPERATIONS: LspOperation[] = [
   'hover',
   'documentSymbol',
   'workspaceSymbol',
-  'goToImplementation'
+  'goToImplementation',
+  'getDiagnostics'
 ]
 
 const POSITION_REQUIRED: LspOperation[] = [
@@ -57,10 +65,11 @@ export function createLspLocalTool(): LocalTool {
   return LocalToolHost.defineTool({
     name: 'lsp',
     description:
-      'Query a language server (TypeScript/JavaScript via typescript-language-server). ' +
-      'Supports: goToDefinition, findReferences, hover, documentSymbol, workspaceSymbol, goToImplementation. ' +
+      'Query a language server (currently TypeScript/JavaScript and Python). ' +
+      'Supports: goToDefinition, findReferences, hover, documentSymbol, workspaceSymbol, goToImplementation, getDiagnostics. ' +
       'Positions are 1-based (line/character as shown in editors). ' +
-      'Requires typescript-language-server to be installed.',
+      'Diagnostics are best-effort and reflect cached publishDiagnostics notifications. ' +
+      'Requires a matching language server to be installed.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -103,6 +112,26 @@ export function createLspLocalTool(): LocalTool {
         }
 
         const { absolutePath, workspaceRoot } = resolveWorkspacePath(rawPath, context)
+        const server = findLanguageServerForFile(absolutePath)
+        if (!server) {
+          const supported = listLanguageServers()
+            .map((item) => `${item.displayName} (${item.extensions.join(', ')})`)
+            .join('; ')
+          return {
+            output: {
+              error: `No language server is configured for file: ${absolutePath}`,
+              supported
+            },
+            isError: true
+          }
+        }
+        const documentLanguageId = languageIdForFile(absolutePath)
+        if (!documentLanguageId) {
+          return {
+            output: { error: `Could not determine language id for file: ${absolutePath}` },
+            isError: true
+          }
+        }
 
         const line = typeof args.line === 'number' ? args.line : 0
         const character = typeof args.character === 'number' ? args.character : 0
@@ -119,12 +148,11 @@ export function createLspLocalTool(): LocalTool {
 
         let session: LspSession
         try {
-          session = await acquireLspSession(workspaceRoot)
+          session = await acquireLspSession(workspaceRoot, server.key)
         } catch (err) {
           return {
             output: {
-              error: err instanceof Error ? err.message : String(err),
-              hint: 'Install with: npm install -g typescript-language-server typescript'
+              error: err instanceof Error ? err.message : String(err)
             },
             isError: true
           }
@@ -135,7 +163,7 @@ export function createLspLocalTool(): LocalTool {
         if (needsDocument) {
           try {
             const content = await readFile(absolutePath, 'utf-8')
-            await lspOpenDocument(session, absolutePath, content)
+            await lspOpenDocument(session, absolutePath, content, documentLanguageId)
           } catch {
             return {
               output: { error: `Could not read file: ${absolutePath}` },
@@ -165,10 +193,27 @@ export function createLspLocalTool(): LocalTool {
             case 'goToImplementation':
               result = await lspImplementation(session, absolutePath, lspLine, lspChar)
               break
+            case 'getDiagnostics': {
+              const diagnostics = await lspGetDiagnostics(session, absolutePath)
+              result = diagnostics.diagnostics
+              return {
+                output: {
+                  operation,
+                  result: simplifyResult(result),
+                  bestEffort: true,
+                  source: diagnostics.source
+                }
+              }
+            }
             default:
               return { output: { error: `Unsupported operation: ${operation}` }, isError: true }
           }
-          return { output: { operation, result: simplifyResult(result) } }
+          return {
+            output: {
+              operation,
+              result: simplifyResult(result)
+            }
+          }
         } catch (err) {
           return {
             output: { error: err instanceof Error ? err.message : String(err) },
@@ -178,7 +223,7 @@ export function createLspLocalTool(): LocalTool {
           if (needsDocument) {
             try { await lspCloseDocument(session, absolutePath) } catch { /* ignore */ }
           }
-          releaseLspSession(workspaceRoot)
+          releaseLspSession(workspaceRoot, server.key)
         }
       })
   })
@@ -221,6 +266,15 @@ function simplifyLocation(item: unknown): unknown {
       ...(obj.selectionRange ? { selectionRange: simplifyRange(obj.selectionRange) } : {}),
       ...(obj.containerName ? { containerName: obj.containerName } : {}),
       ...(obj.location ? { path: uriToPath((obj.location as Record<string, unknown>).uri as string) } : {})
+    }
+  }
+  if (obj.message && (obj.range !== undefined || obj.severity !== undefined || obj.source !== undefined)) {
+    return {
+      message: obj.message,
+      ...(obj.severity !== undefined ? { severity: obj.severity } : {}),
+      ...(obj.source ? { source: obj.source } : {}),
+      ...(obj.code !== undefined ? { code: obj.code } : {}),
+      ...(obj.range ? { range: simplifyRange(obj.range) } : {})
     }
   }
   return obj

--- a/kun/src/adapters/tool/builtin-tool-types.test.ts
+++ b/kun/src/adapters/tool/builtin-tool-types.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { allBuiltinToolNames } from './builtin-tool-types.js'
+
+describe('builtin lsp registration', () => {
+  it('includes lsp in the builtin tool name catalog', () => {
+    expect(allBuiltinToolNames.has('lsp')).toBe(true)
+  })
+})

--- a/kun/src/adapters/tool/builtin-tool-types.ts
+++ b/kun/src/adapters/tool/builtin-tool-types.ts
@@ -89,7 +89,7 @@ export type ReadClassification = {
 
 export const COMPACT_RESOURCE_FILE_NAMES = new Set(['AGENTS.md', 'AGENTS.MD', 'CLAUDE.md', 'CLAUDE.MD'])
 
-export type BuiltinToolName = 'read' | 'bash' | 'edit' | 'write' | 'grep' | 'find' | 'ls'
+export type BuiltinToolName = 'read' | 'bash' | 'edit' | 'write' | 'grep' | 'find' | 'ls' | 'lsp'
 export const allBuiltinToolNames: Set<BuiltinToolName> = new Set([
   'read',
   'bash',
@@ -97,7 +97,8 @@ export const allBuiltinToolNames: Set<BuiltinToolName> = new Set([
   'write',
   'grep',
   'find',
-  'ls'
+  'ls',
+  'lsp'
 ])
 export type ToolName = BuiltinToolName
 export const allToolNames: Set<ToolName> = allBuiltinToolNames

--- a/kun/src/adapters/tool/builtin-tools.ts
+++ b/kun/src/adapters/tool/builtin-tools.ts
@@ -37,6 +37,8 @@ export function createBuiltinLocalTool(
       return createFindLocalTool(options.find)
     case 'ls':
       return createLsLocalTool(options.ls)
+    case 'lsp':
+      return createLspLocalTool()
   }
 }
 
@@ -101,7 +103,8 @@ export function buildBuiltinLocalToolRecord(
     write: createWriteLocalTool(options.write),
     grep: createGrepLocalTool(options.grep),
     find: createFindLocalTool(options.find),
-    ls: createLsLocalTool(options.ls)
+    ls: createLsLocalTool(options.ls),
+    lsp: createLspLocalTool()
   }
 }
 

--- a/kun/src/adapters/tool/lsp-client.test.ts
+++ b/kun/src/adapters/tool/lsp-client.test.ts
@@ -1,0 +1,433 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { accessMock, spawnMock } = vi.hoisted(() => ({
+  accessMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  return {
+    ...actual,
+    access: accessMock
+  }
+})
+
+import {
+  acquireLspSession,
+  lspGetDiagnostics,
+  releaseLspSession,
+  shutdownAllLspSessions
+} from './lsp-client.js'
+import { resolveServerCommand } from './lsp-servers.js'
+
+type MockProcess = EventEmitter & {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  stdin: { write: ReturnType<typeof vi.fn> }
+  kill: ReturnType<typeof vi.fn>
+}
+
+function createMockProcess(
+  onWrite?: (chunk: string, proc: MockProcess) => void
+): MockProcess {
+  const proc = new EventEmitter() as MockProcess
+  proc.stdout = new EventEmitter()
+  proc.stderr = new EventEmitter()
+  proc.kill = vi.fn()
+  proc.stdin = {
+    write: vi.fn((chunk: string) => {
+      onWrite?.(chunk, proc)
+      return true
+    })
+  }
+  return proc
+}
+
+function parseJsonRpc(chunk: string): Record<string, unknown> {
+  const [, body = ''] = chunk.split('\r\n\r\n')
+  return JSON.parse(body)
+}
+
+function emitJsonRpc(proc: MockProcess, message: Record<string, unknown>): void {
+  const body = JSON.stringify(message)
+  proc.stdout.emit('data', Buffer.from(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`, 'utf8'))
+}
+
+afterEach(() => {
+  shutdownAllLspSessions()
+  spawnMock.mockReset()
+  accessMock.mockReset()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('resolveServerCommand', () => {
+  it('uses where on Windows when looking up a server on PATH', async () => {
+    accessMock.mockRejectedValueOnce(new Error('missing local install'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    spawnMock.mockImplementation((command: string, args: string[]) => {
+      const proc = createMockProcess()
+      queueMicrotask(() => {
+        proc.stdout.emit('data', Buffer.from('C:\\Tools\\typescript-language-server.cmd\r\n', 'utf8'))
+        proc.emit('close', 0)
+      })
+      expect(command).toBe('where')
+      expect(args).toEqual(['typescript-language-server'])
+      return proc
+    })
+
+    await expect(resolveServerCommand('/workspace', 'typescript')).resolves.toEqual({
+      command: 'typescript-language-server',
+      args: ['--stdio']
+    })
+  })
+})
+
+describe('LSP session cooldown', () => {
+  it('enters cooldown after an initialize failure and retries after the cooldown expires', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-20T00:00:00Z'))
+    accessMock.mockRejectedValue(new Error('missing local install'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    const serverProcesses: MockProcess[] = []
+
+    spawnMock.mockImplementation((command: string, args: string[]) => {
+      if (command === 'which') {
+        const proc = createMockProcess()
+        queueMicrotask(() => {
+          proc.stdout.emit('data', Buffer.from('/usr/local/bin/typescript-language-server\n', 'utf8'))
+          proc.emit('close', 0)
+        })
+        return proc
+      }
+
+      if (command === 'typescript-language-server') {
+        const attempt = serverProcesses.length + 1
+        const proc = createMockProcess((chunk, child) => {
+          const request = parseJsonRpc(chunk)
+          if (request.method === 'initialize') {
+            if (attempt === 1) {
+              queueMicrotask(() => child.emit('exit', 1, null))
+            } else {
+              queueMicrotask(() => emitJsonRpc(child, {
+                jsonrpc: '2.0',
+                id: request.id,
+                result: {}
+              }))
+            }
+          }
+        })
+        serverProcesses.push(proc)
+        return proc
+      }
+
+      throw new Error(`Unexpected spawn: ${command} ${args.join(' ')}`)
+    })
+
+    await expect(acquireLspSession('/workspace/cooldown', 'typescript')).rejects.toThrow(
+      /LSP (session closed|initialize failed)/
+    )
+    expect(serverProcesses).toHaveLength(1)
+
+    await expect(acquireLspSession('/workspace/cooldown', 'typescript')).rejects.toThrow(
+      /recently failed/
+    )
+    expect(serverProcesses).toHaveLength(1)
+
+    vi.setSystemTime(new Date('2026-06-20T00:05:01Z'))
+
+    const session = await acquireLspSession('/workspace/cooldown', 'typescript')
+    expect(session.workspaceRoot).toBe('/workspace/cooldown')
+    expect(session.serverKey).toBe('typescript')
+    expect(serverProcesses).toHaveLength(2)
+    releaseLspSession('/workspace/cooldown', 'typescript')
+  })
+})
+
+describe('LSP stderr logging', () => {
+  it('logs the tail of buffered stderr when the server exits unexpectedly', async () => {
+    accessMock.mockRejectedValue(new Error('missing local install'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    let serverProcess: MockProcess | undefined
+
+    spawnMock.mockImplementation((command: string) => {
+      if (command === 'which') {
+        const proc = createMockProcess()
+        queueMicrotask(() => {
+          proc.stdout.emit('data', Buffer.from('/usr/local/bin/typescript-language-server\n', 'utf8'))
+          proc.emit('close', 0)
+        })
+        return proc
+      }
+
+      if (command === 'typescript-language-server') {
+        const proc = createMockProcess((chunk, child) => {
+          const request = parseJsonRpc(chunk)
+          if (request.method === 'initialize') {
+            queueMicrotask(() => emitJsonRpc(child, {
+              jsonrpc: '2.0',
+              id: request.id,
+              result: {}
+            }))
+          }
+        })
+        serverProcess = proc
+        return proc
+      }
+
+      throw new Error(`Unexpected spawn: ${command}`)
+    })
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const session = await acquireLspSession('/workspace/stderr', 'typescript')
+    expect(session.workspaceRoot).toBe('/workspace/stderr')
+    expect(serverProcess).toBeDefined()
+
+    const stderrLines = Array.from({ length: 205 }, (_, index) => `stderr-line-${index}`).join('\n')
+    serverProcess?.stderr.emit('data', Buffer.from(stderrLines, 'utf8'))
+    serverProcess?.emit('exit', 1, null)
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    const [message] = errorSpy.mock.calls[0] ?? ['']
+    expect(String(message)).toContain('stderr-line-204')
+    expect(String(message)).toContain('stderr-line-185')
+    expect(String(message)).not.toContain('stderr-line-184')
+    expect(String(message)).not.toContain('stderr-line-0')
+  })
+})
+
+describe('LSP notifications', () => {
+  it('stores diagnostics pushed by the language server', async () => {
+    accessMock.mockRejectedValue(new Error('missing local install'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    let serverProcess: MockProcess | undefined
+
+    spawnMock.mockImplementation((command: string) => {
+      if (command === 'which') {
+        const proc = createMockProcess()
+        queueMicrotask(() => {
+          proc.stdout.emit('data', Buffer.from('/usr/local/bin/typescript-language-server\n', 'utf8'))
+          proc.emit('close', 0)
+        })
+        return proc
+      }
+
+      if (command === 'typescript-language-server') {
+        const proc = createMockProcess((chunk, child) => {
+          const request = parseJsonRpc(chunk)
+          if (request.method === 'initialize') {
+            queueMicrotask(() => emitJsonRpc(child, {
+              jsonrpc: '2.0',
+              id: request.id,
+              result: {}
+            }))
+          }
+        })
+        serverProcess = proc
+        return proc
+      }
+
+      throw new Error(`Unexpected spawn: ${command}`)
+    })
+
+    const session = await acquireLspSession('/workspace/diagnostics', 'typescript')
+    emitJsonRpc(serverProcess as MockProcess, {
+      jsonrpc: '2.0',
+      method: 'textDocument/publishDiagnostics',
+      params: {
+        uri: 'file:///workspace/diagnostics/app.ts',
+        diagnostics: [{ message: 'boom', severity: 1 }]
+      }
+    })
+
+    expect(session.diagnostics.get('file:///workspace/diagnostics/app.ts')).toEqual([
+      { message: 'boom', severity: 1 }
+    ])
+    await expect(lspGetDiagnostics(session, '/workspace/diagnostics/app.ts')).resolves.toEqual({
+      diagnostics: [{ message: 'boom', severity: 1 }],
+      source: 'publishDiagnostics-cache'
+    })
+    releaseLspSession('/workspace/diagnostics', 'typescript')
+  })
+
+  it('logs server messages from window/logMessage notifications', async () => {
+    accessMock.mockRejectedValue(new Error('missing local install'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    let serverProcess: MockProcess | undefined
+
+    spawnMock.mockImplementation((command: string) => {
+      if (command === 'which') {
+        const proc = createMockProcess()
+        queueMicrotask(() => {
+          proc.stdout.emit('data', Buffer.from('/usr/local/bin/typescript-language-server\n', 'utf8'))
+          proc.emit('close', 0)
+        })
+        return proc
+      }
+
+      if (command === 'typescript-language-server') {
+        const proc = createMockProcess((chunk, child) => {
+          const request = parseJsonRpc(chunk)
+          if (request.method === 'initialize') {
+            queueMicrotask(() => emitJsonRpc(child, {
+              jsonrpc: '2.0',
+              id: request.id,
+              result: {}
+            }))
+          }
+        })
+        serverProcess = proc
+        return proc
+      }
+
+      throw new Error(`Unexpected spawn: ${command}`)
+    })
+
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    await acquireLspSession('/workspace/logs', 'typescript')
+    emitJsonRpc(serverProcess as MockProcess, {
+      jsonrpc: '2.0',
+      method: 'window/logMessage',
+      params: {
+        type: 3,
+        message: 'hello from tsserver'
+      }
+    })
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[lsp] TypeScript/JavaScript: hello from tsserver'
+    )
+  })
+})
+
+describe('LSP diagnostics pull fallback', () => {
+  it('falls back to textDocument/diagnostic when no push diagnostics are cached', async () => {
+    accessMock.mockRejectedValue(new Error('missing local install'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    spawnMock.mockImplementation((command: string) => {
+      if (command === 'which') {
+        const proc = createMockProcess()
+        queueMicrotask(() => {
+          proc.stdout.emit('data', Buffer.from('/usr/local/bin/typescript-language-server\n', 'utf8'))
+          proc.emit('close', 0)
+        })
+        return proc
+      }
+
+      if (command === 'typescript-language-server') {
+        return createMockProcess((chunk, child) => {
+          const request = parseJsonRpc(chunk)
+          if (request.method === 'initialize') {
+            queueMicrotask(() => emitJsonRpc(child, {
+              jsonrpc: '2.0',
+              id: request.id,
+              result: {}
+            }))
+          }
+          if (request.method === 'textDocument/diagnostic') {
+            queueMicrotask(() => emitJsonRpc(child, {
+              jsonrpc: '2.0',
+              id: request.id,
+              result: {
+                kind: 'full',
+                items: [{ message: 'pulled diagnostic', severity: 1 }]
+              }
+            }))
+          }
+        })
+      }
+
+      throw new Error(`Unexpected spawn: ${command}`)
+    })
+
+    const session = await acquireLspSession('/workspace/pull', 'typescript')
+    await expect(lspGetDiagnostics(session, '/workspace/pull/app.ts')).resolves.toEqual({
+      diagnostics: [{ message: 'pulled diagnostic', severity: 1 }],
+      source: 'textDocument/diagnostic'
+    })
+    releaseLspSession('/workspace/pull', 'typescript')
+  })
+
+  it('parses pulled diagnostics with multibyte JSON-RPC framing', async () => {
+    accessMock.mockRejectedValue(new Error('missing local install'))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    spawnMock.mockImplementation((command: string) => {
+      if (command === 'which') {
+        const proc = createMockProcess()
+        queueMicrotask(() => {
+          proc.stdout.emit('data', Buffer.from('/usr/local/bin/typescript-language-server\n', 'utf8'))
+          proc.emit('close', 0)
+        })
+        return proc
+      }
+
+      if (command === 'typescript-language-server') {
+        return createMockProcess((chunk, child) => {
+          const request = parseJsonRpc(chunk)
+          if (request.method === 'initialize') {
+            queueMicrotask(() => emitJsonRpc(child, {
+              jsonrpc: '2.0',
+              id: request.id,
+              result: {}
+            }))
+          }
+          if (request.method === 'textDocument/diagnostic') {
+            queueMicrotask(() => {
+              const response = {
+                jsonrpc: '2.0',
+                id: request.id,
+                result: {
+                  kind: 'full',
+                  items: [{ message: '类型错误：需要字符串', severity: 1 }]
+                }
+              }
+              const logMessage = {
+                jsonrpc: '2.0',
+                method: 'window/logMessage',
+                params: {
+                  type: 3,
+                  message: 'diagnostics complete'
+                }
+              }
+              const responseBody = JSON.stringify(response)
+              const logBody = JSON.stringify(logMessage)
+              child.stdout.emit('data', Buffer.concat([
+                Buffer.from(`Content-Length: ${Buffer.byteLength(responseBody)}\r\n\r\n${responseBody}`, 'utf8'),
+                Buffer.from(`Content-Length: ${Buffer.byteLength(logBody)}\r\n\r\n${logBody}`, 'utf8')
+              ]))
+            })
+          }
+        })
+      }
+
+      throw new Error(`Unexpected spawn: ${command}`)
+    })
+
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    const session = await acquireLspSession('/workspace/multibyte-pull', 'typescript')
+    await expect(lspGetDiagnostics(session, '/workspace/multibyte-pull/app.ts')).resolves.toEqual({
+      diagnostics: [{ message: '类型错误：需要字符串', severity: 1 }],
+      source: 'textDocument/diagnostic'
+    })
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[lsp] TypeScript/JavaScript: diagnostics complete'
+    )
+    releaseLspSession('/workspace/multibyte-pull', 'typescript')
+  })
+})

--- a/kun/src/adapters/tool/lsp-client.ts
+++ b/kun/src/adapters/tool/lsp-client.ts
@@ -13,26 +13,44 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process'
-import { randomUUID } from 'node:crypto'
 import { pathToFileURL } from 'node:url'
+import { getLanguageServer, resolveServerCommand } from './lsp-servers.js'
+import { handleNotification } from './lsp-notifications.js'
 
 const CLEANUP_DELAY = 30_000
 const REQUEST_TIMEOUT = 30_000
-const SERVER_PROBE_TIMEOUT = 3_000
+const BROKEN_SERVER_COOLDOWN_MS = 5 * 60_000
+const STDERR_LOG_LIMIT = 200
+const STDERR_LOG_TAIL = 20
+
+type PendingRequest = {
+  resolve: (v: unknown) => void
+  reject: (e: Error) => void
+  timer: NodeJS.Timeout
+}
 
 interface LspSession {
   process: ChildProcess
   workspaceRoot: string
+  serverKey: string
+  serverDisplayName: string
+  pythonPath: string | null
   refCount: number
   cleanupTimer: NodeJS.Timeout | null
   /** Sequential buffer for stdout framing. */
-  stdoutBuffer: string
+  stdoutBuffer: Buffer
   /** Pending JSON-RPC requests awaiting a response, keyed by id. */
-  pending: Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout }>
+  pending: Map<string, PendingRequest>
   /** Monotonic request id counter. */
   nextId: number
   initialized: boolean
   initPromise: Promise<void> | null
+  stderrLog: string[]
+  diagnostics: Map<string, unknown[]>
+  diagnosticIdentifier: string | null
+  diagnosticRefreshRequested: boolean
+  closing: boolean
+  closed: boolean
 }
 
 /**
@@ -44,43 +62,35 @@ interface LspSession {
  * Promise.
  */
 const sessions = new Map<string, Promise<LspSession>>()
+const brokenServers = new Map<string, number>()
 
-/**
- * Check whether a language server binary is available on PATH.
- * Returns the binary name if found, null otherwise.
- */
-async function probeServerBinary(binary: string): Promise<string | null> {
-  return new Promise((resolve) => {
-    const child = spawn('which', [binary], { stdio: ['ignore', 'pipe', 'ignore'], timeout: SERVER_PROBE_TIMEOUT })
-    let stdout = ''
-    child.stdout?.on('data', (chunk) => { stdout += chunk })
-    child.on('error', () => resolve(null))
-    child.on('close', (code) => {
-      resolve(code === 0 && stdout.trim() ? stdout.trim() : null)
-    })
-  })
+function sessionKey(workspaceRoot: string, serverKey: string): string {
+  return `${workspaceRoot}::${serverKey}`
 }
 
-/**
- * Resolve the typescript-language-server binary.
- * Returns the spawn command + args, or null if not available.
- */
-export async function resolveTsLsCommand(workspaceRoot: string): Promise<{ command: string; args: string[] } | null> {
-  // Prefer a project-local install.
-  const localPath = `${workspaceRoot}/node_modules/.bin/typescript-language-server`
-  try {
-    const { access } = await import('node:fs/promises')
-    await access(localPath)
-    return { command: localPath, args: ['--stdio'] }
-  } catch {
-    // fall through to PATH lookup
+function markBrokenServer(workspaceRoot: string, serverKey: string): void {
+  brokenServers.set(sessionKey(workspaceRoot, serverKey), Date.now())
+}
+
+function clearBrokenServer(workspaceRoot: string, serverKey: string): void {
+  brokenServers.delete(sessionKey(workspaceRoot, serverKey))
+}
+
+function remainingCooldownMs(workspaceRoot: string, serverKey: string): number {
+  const key = sessionKey(workspaceRoot, serverKey)
+  const failedAt = brokenServers.get(key)
+  if (failedAt === undefined) return 0
+  const remaining = BROKEN_SERVER_COOLDOWN_MS - (Date.now() - failedAt)
+  if (remaining <= 0) {
+    brokenServers.delete(key)
+    return 0
   }
-  const found = await probeServerBinary('typescript-language-server')
-  if (found) return { command: 'typescript-language-server', args: ['--stdio'] }
-  return null
+  return remaining
 }
 
-function killSession(session: LspSession): void {
+function disposeSession(session: LspSession, terminateProcess: boolean): void {
+  if (session.closed) return
+  session.closed = true
   if (session.cleanupTimer) {
     clearTimeout(session.cleanupTimer)
     session.cleanupTimer = null
@@ -90,6 +100,8 @@ function killSession(session: LspSession): void {
     entry.reject(new Error('LSP session closed'))
     session.pending.delete(id)
   }
+  if (!terminateProcess) return
+  session.closing = true
   try {
     session.process.kill('SIGTERM')
   } catch {
@@ -99,6 +111,10 @@ function killSession(session: LspSession): void {
   setTimeout(() => {
     try { session.process.kill('SIGKILL') } catch { /* ignore */ }
   }, 2_000)
+}
+
+function killSession(session: LspSession): void {
+  disposeSession(session, true)
 }
 
 function sendMessage(session: LspSession, message: Record<string, unknown>): void {
@@ -122,28 +138,131 @@ function handleResponse(session: LspSession, msg: Record<string, unknown>): void
   }
 }
 
+function configurationValueForSection(session: LspSession, section: string): Record<string, unknown> {
+  switch (section) {
+    case 'python':
+      return session.pythonPath ? { pythonPath: session.pythonPath } : {}
+    case 'python.analysis':
+      return {
+        diagnosticMode: 'openFilesOnly',
+        typeCheckingMode: 'basic'
+      }
+    case 'basedpyright':
+      return {
+        disableLanguageServices: false,
+        disablePullDiagnostics: false
+      }
+    case 'basedpyright.analysis':
+      return {
+        diagnosticMode: 'openFilesOnly',
+        typeCheckingMode: 'basic'
+      }
+    default:
+      return {}
+  }
+}
+
+function handleServerRequest(session: LspSession, msg: Record<string, unknown>): void {
+  const method = typeof msg.method === 'string' ? msg.method : ''
+  const id = msg.id
+  if (!method || id === undefined) return
+
+  switch (method) {
+    case 'workspace/configuration': {
+      const params = msg.params
+      const items = params && typeof params === 'object' && Array.isArray((params as { items?: unknown[] }).items)
+        ? (params as { items: Array<Record<string, unknown>> }).items
+        : []
+      sendMessage(session, {
+        jsonrpc: '2.0',
+        id,
+        result: items.map((item) => {
+          const section = typeof item.section === 'string' ? item.section : ''
+          return configurationValueForSection(session, section)
+        })
+      })
+      return
+    }
+    case 'workspace/workspaceFolders': {
+      sendMessage(session, {
+        jsonrpc: '2.0',
+        id,
+        result: [
+          {
+            uri: pathToFileURL(session.workspaceRoot).href,
+            name: session.workspaceRoot
+          }
+        ]
+      })
+      return
+    }
+    case 'client/registerCapability': {
+      const registrations = msg.params && typeof msg.params === 'object'
+        ? (msg.params as { registrations?: Array<Record<string, unknown>> }).registrations
+        : null
+      const diagnosticRegistration = registrations?.find((registration) => (
+        registration.method === 'textDocument/diagnostic'
+      ))
+      const registerOptions = diagnosticRegistration?.registerOptions
+      if (registerOptions && typeof registerOptions === 'object') {
+        const identifier = (registerOptions as { identifier?: unknown }).identifier
+        if (typeof identifier === 'string' && identifier.trim()) {
+          session.diagnosticIdentifier = identifier
+        }
+      }
+      sendMessage(session, {
+        jsonrpc: '2.0',
+        id,
+        result: null
+      })
+      return
+    }
+    case 'workspace/diagnostic/refresh': {
+      session.diagnosticRefreshRequested = true
+      sendMessage(session, {
+        jsonrpc: '2.0',
+        id,
+        result: null
+      })
+      return
+    }
+    default: {
+      sendMessage(session, {
+        jsonrpc: '2.0',
+        id,
+        result: null
+      })
+    }
+  }
+}
+
 function processBuffer(session: LspSession): void {
+  const headerSeparator = Buffer.from('\r\n\r\n')
   while (true) {
-    const headerEnd = session.stdoutBuffer.indexOf('\r\n\r\n')
+    const headerEnd = session.stdoutBuffer.indexOf(headerSeparator)
     if (headerEnd === -1) return
-    const header = session.stdoutBuffer.slice(0, headerEnd)
+    const header = session.stdoutBuffer.subarray(0, headerEnd).toString('utf8')
     const lengthMatch = header.match(/Content-Length:\s*(\d+)/i)
     if (!lengthMatch) {
       // Malformed; drop the header to resync.
-      session.stdoutBuffer = session.stdoutBuffer.slice(headerEnd + 4)
+      session.stdoutBuffer = session.stdoutBuffer.subarray(headerEnd + headerSeparator.length)
       continue
     }
     const contentLength = Number(lengthMatch[1])
-    const bodyStart = headerEnd + 4
+    const bodyStart = headerEnd + headerSeparator.length
     if (session.stdoutBuffer.length < bodyStart + contentLength) return // incomplete
-    const body = session.stdoutBuffer.slice(bodyStart, bodyStart + contentLength)
-    session.stdoutBuffer = session.stdoutBuffer.slice(bodyStart + contentLength)
+    const body = session.stdoutBuffer.subarray(bodyStart, bodyStart + contentLength)
+    session.stdoutBuffer = session.stdoutBuffer.subarray(bodyStart + contentLength)
     try {
-      const msg = JSON.parse(body) as Record<string, unknown>
+      const msg = JSON.parse(body.toString('utf8')) as Record<string, unknown>
       if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
         handleResponse(session, msg)
+      } else if (msg.id !== undefined && typeof msg.method === 'string') {
+        handleServerRequest(session, msg)
+        handleNotification(session, msg.method, msg.params)
+      } else if (typeof msg.method === 'string') {
+        handleNotification(session, msg.method, msg.params)
       }
-      // Notifications (no id) are ignored — this client doesn't subscribe to anything.
     } catch {
       // Malformed JSON; skip.
     }
@@ -161,6 +280,14 @@ async function initialize(session: LspSession): Promise<void> {
       capabilities: {
         textDocument: {
           synchronization: { didOpen: true, didChange: false, willSave: false },
+          publishDiagnostics: {
+            relatedInformation: true,
+            versionSupport: false
+          },
+          diagnostic: {
+            dynamicRegistration: true,
+            relatedDocumentSupport: false
+          },
           hover: { contentFormat: ['markdown', 'plaintext'] },
           definition: { linkSupport: false },
           references: {},
@@ -169,10 +296,23 @@ async function initialize(session: LspSession): Promise<void> {
           callHierarchy: { dynamicRegistration: false }
         },
         workspace: {
+          configuration: true,
+          workspaceFolders: true,
           symbol: {}
         }
       },
-      workspaceFolders: null
+      initializationOptions: session.serverKey === 'python'
+        ? {
+            diagnosticMode: 'openFilesOnly',
+            disablePullDiagnostics: false
+          }
+        : undefined,
+      workspaceFolders: [
+        {
+          uri: pathToFileURL(session.workspaceRoot).href,
+          name: session.workspaceRoot
+        }
+      ]
     }).catch((err) => {
       throw new Error(`LSP initialize failed: ${err instanceof Error ? err.message : String(err)}`)
     })
@@ -180,6 +320,7 @@ async function initialize(session: LspSession): Promise<void> {
     // ts_ls / typescript-language-server: pull out tsserver path from init result if present.
     void initResult
     sendNotification(session, 'initialized', {})
+    sendDidChangeConfiguration(session)
     session.initialized = true
   })()
 
@@ -202,6 +343,11 @@ function sendNotification(session: LspSession, method: string, params: Record<st
   sendMessage(session, { jsonrpc: '2.0', method, params })
 }
 
+function sendDidChangeConfiguration(session: LspSession): void {
+  if (session.serverKey !== 'python') return
+  sendNotification(session, 'workspace/didChangeConfiguration', { settings: null })
+}
+
 /**
  * Acquire (or reuse) an LSP session for the given workspace.
  * The returned session is initialized and ready for requests.
@@ -210,8 +356,21 @@ function sendNotification(session: LspSession, method: string, params: Record<st
  * Race-safe: the in-flight Promise is written to the sessions map before
  * any await, so concurrent callers get the same session.
  */
-export async function acquireLspSession(workspaceRoot: string): Promise<LspSession> {
-  const existing = sessions.get(workspaceRoot)
+export async function acquireLspSession(workspaceRoot: string, serverKey: string): Promise<LspSession> {
+  const server = getLanguageServer(serverKey)
+  if (!server) {
+    throw new Error(`Unknown language server: ${serverKey}`)
+  }
+  const key = sessionKey(workspaceRoot, serverKey)
+  const cooldown = remainingCooldownMs(workspaceRoot, serverKey)
+  if (cooldown > 0) {
+    const seconds = Math.ceil(cooldown / 1000)
+    throw new Error(
+      `${server.displayName} language server recently failed for this workspace. Retry in about ${seconds}s.`
+    )
+  }
+
+  const existing = sessions.get(key)
   if (existing) {
     const session = await existing
     if (session.cleanupTimer) {
@@ -224,24 +383,28 @@ export async function acquireLspSession(workspaceRoot: string): Promise<LspSessi
   }
 
   // Write the Promise immediately to prevent concurrent spawns.
-  const sessionPromise = createSession(workspaceRoot)
-  sessions.set(workspaceRoot, sessionPromise)
+  const sessionPromise = createSession(workspaceRoot, serverKey)
+  sessions.set(key, sessionPromise)
 
   try {
     const session = await sessionPromise
     return session
   } catch (err) {
     // If spawn/init fails, remove the placeholder so the next call can retry.
-    sessions.delete(workspaceRoot)
+    sessions.delete(key)
     throw err
   }
 }
 
-async function createSession(workspaceRoot: string): Promise<LspSession> {
-  const cmd = await resolveTsLsCommand(workspaceRoot)
+async function createSession(workspaceRoot: string, serverKey: string): Promise<LspSession> {
+  const server = getLanguageServer(serverKey)
+  if (!server) {
+    throw new Error(`Unknown language server: ${serverKey}`)
+  }
+  const cmd = await resolveServerCommand(workspaceRoot, serverKey)
   if (!cmd) {
     throw new Error(
-      'typescript-language-server is not installed. Install it with `npm install -g typescript-language-server typescript` and try again.'
+      `${server.displayName} language server is not installed or not available on PATH. ${server.installHint}`
     )
   }
 
@@ -255,36 +418,78 @@ async function createSession(workspaceRoot: string): Promise<LspSession> {
   const session: LspSession = {
     process: proc,
     workspaceRoot,
+    serverKey,
+    serverDisplayName: server.displayName,
+    pythonPath: process.env.PYTHON_PATH ?? 'python3',
     refCount: 1,
     cleanupTimer: null,
-    stdoutBuffer: '',
+    stdoutBuffer: Buffer.alloc(0),
     pending: new Map(),
     nextId: 1,
     initialized: false,
-    initPromise: null
+    initPromise: null,
+    stderrLog: [],
+    diagnostics: new Map(),
+    diagnosticIdentifier: null,
+    diagnosticRefreshRequested: false,
+    closing: false,
+    closed: false
   }
 
   proc.stdout?.on('data', (chunk: Buffer) => {
-    session.stdoutBuffer += chunk.toString('utf-8')
+    session.stdoutBuffer = Buffer.concat([session.stdoutBuffer, chunk])
     processBuffer(session)
+  })
+
+  proc.stderr?.on('data', (chunk: Buffer) => {
+    const lines = chunk
+      .toString('utf-8')
+      .split(/\r?\n/)
+      .map((line) => line.trimEnd())
+      .filter(Boolean)
+    if (lines.length === 0) return
+    session.stderrLog.push(...lines)
+    if (session.stderrLog.length > STDERR_LOG_LIMIT) {
+      session.stderrLog.splice(0, session.stderrLog.length - STDERR_LOG_LIMIT)
+    }
   })
 
   proc.on('error', (err) => {
     // Kill + reject pending rather than throwing (throw in an event handler
     // becomes an uncaught exception).
+    markBrokenServer(workspaceRoot, serverKey)
     killSession(session)
-    sessions.delete(workspaceRoot)
+    sessions.delete(sessionKey(workspaceRoot, serverKey))
     void err
   })
 
-  proc.on('exit', () => {
+  proc.on('exit', (code, signal) => {
     // Reject all pending requests so callers don't hang for 30s.
-    killSession(session)
-    sessions.delete(workspaceRoot)
+    if (!session.closing) {
+      markBrokenServer(workspaceRoot, serverKey)
+      if (code !== 0 || !session.initialized) {
+        const stderrTail = session.stderrLog.slice(-STDERR_LOG_TAIL).join('\n')
+        const suffix = stderrTail ? `\n${stderrTail}` : ''
+        console.error(
+          `[lsp] ${session.serverDisplayName} language server exited unexpectedly ` +
+          `(code=${code ?? 'null'}, signal=${signal ?? 'null'})${suffix}`
+        )
+      }
+    }
+    disposeSession(session, false)
+    sessions.delete(sessionKey(workspaceRoot, serverKey))
   })
 
-  await initialize(session)
-  return session
+  try {
+    await initialize(session)
+    clearBrokenServer(workspaceRoot, serverKey)
+    return session
+  } catch (err) {
+    markBrokenServer(workspaceRoot, serverKey)
+    killSession(session)
+    sessions.delete(sessionKey(workspaceRoot, serverKey))
+    throw err
+  }
 }
 
 /**
@@ -292,28 +497,29 @@ async function createSession(workspaceRoot: string): Promise<LspSession> {
  * to prevent orphaned language-server processes.
  */
 export function shutdownAllLspSessions(): void {
-  for (const [workspaceRoot, sessionPromise] of sessions) {
-    sessions.delete(workspaceRoot)
+  for (const [key, sessionPromise] of sessions) {
+    sessions.delete(key)
     sessionPromise
       .then((session) => killSession(session))
       .catch(() => { /* session failed to init — nothing to kill */ })
   }
 }
 
-export function releaseLspSession(workspaceRoot: string): void {
-  const sessionPromise = sessions.get(workspaceRoot)
+export function releaseLspSession(workspaceRoot: string, serverKey: string): void {
+  const key = sessionKey(workspaceRoot, serverKey)
+  const sessionPromise = sessions.get(key)
   if (!sessionPromise) return
   sessionPromise
     .then((session) => {
       session.refCount -= 1
       if (session.refCount <= 0) {
         session.cleanupTimer = setTimeout(() => {
-          const sp = sessions.get(workspaceRoot)
+          const sp = sessions.get(key)
           if (!sp) return
           sp.then((s) => {
             if (s.refCount <= 0) {
               killSession(s)
-              sessions.delete(workspaceRoot)
+              sessions.delete(key)
             }
           }).catch(() => { /* ignore */ })
         }, CLEANUP_DELAY)
@@ -328,19 +534,16 @@ function filePathToUri(filePath: string): string {
   return pathToFileURL(filePath).href
 }
 
-function languageIdForFile(filePath: string): string {
-  if (filePath.endsWith('.ts')) return 'typescript'
-  if (filePath.endsWith('.tsx')) return 'typescriptreact'
-  if (filePath.endsWith('.js')) return 'javascript'
-  if (filePath.endsWith('.jsx')) return 'javascriptreact'
-  return 'typescript'
-}
-
-export async function lspOpenDocument(session: LspSession, filePath: string, content: string): Promise<void> {
+export async function lspOpenDocument(
+  session: LspSession,
+  filePath: string,
+  content: string,
+  languageId: string
+): Promise<void> {
   sendNotification(session, 'textDocument/didOpen', {
     textDocument: {
       uri: filePathToUri(filePath),
-      languageId: languageIdForFile(filePath),
+      languageId,
       version: 1,
       text: content
     }
@@ -412,10 +615,88 @@ export async function lspWorkspaceSymbol(session: LspSession, query: string): Pr
   return sendRequest(session, 'workspace/symbol', { query })
 }
 
+type DiagnosticsFetchResult = {
+  diagnostics: unknown[]
+  source: 'publishDiagnostics-cache' | 'textDocument/diagnostic' | 'none'
+}
+
+function normalizeDiagnosticReport(result: unknown): unknown[] | null {
+  if (Array.isArray(result)) return result
+  if (!result || typeof result !== 'object') return null
+  const report = result as Record<string, unknown>
+  if (Array.isArray(report.items)) return report.items
+  return null
+}
+
+function collectWorkspaceDiagnostics(result: unknown, uri: string): unknown[] {
+  if (!result || typeof result !== 'object') return []
+  const report = result as Record<string, unknown>
+  const items = Array.isArray(report.items) ? report.items : []
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue
+    const entry = item as Record<string, unknown>
+    if (entry.uri !== uri) continue
+    const diagnostics = normalizeDiagnosticReport(entry.value)
+    if (diagnostics) return diagnostics
+  }
+  return []
+}
+
+export async function lspGetDiagnostics(
+  session: LspSession,
+  filePath: string
+): Promise<DiagnosticsFetchResult> {
+  const cached = session.diagnostics.get(filePathToUri(filePath)) ?? []
+  if (cached.length > 0) {
+    return {
+      diagnostics: cached,
+      source: 'publishDiagnostics-cache'
+    }
+  }
+
+  try {
+    const result = await sendRequest(session, 'textDocument/diagnostic', {
+      textDocument: { uri: filePathToUri(filePath) },
+      ...(session.diagnosticIdentifier ? { identifier: session.diagnosticIdentifier } : {}),
+      previousResultId: null
+    })
+    const pulled = normalizeDiagnosticReport(result) ?? []
+    if (pulled.length > 0) {
+      return {
+        diagnostics: pulled,
+        source: 'textDocument/diagnostic'
+      }
+    }
+  } catch {
+    // Fall back to whatever push diagnostics have accumulated.
+  }
+
+  try {
+    const result = await sendRequest(session, 'workspace/diagnostic', {
+      previousResultIds: [],
+      ...(session.diagnosticIdentifier ? { identifier: session.diagnosticIdentifier } : {})
+    })
+    const workspaceDiagnostics = collectWorkspaceDiagnostics(result, filePathToUri(filePath))
+    if (workspaceDiagnostics.length > 0) {
+      return {
+        diagnostics: workspaceDiagnostics,
+        source: 'textDocument/diagnostic'
+      }
+    }
+  } catch {
+    // Workspace diagnostics are optional and not supported by all servers.
+  }
+
+  return {
+    diagnostics: session.diagnostics.get(filePathToUri(filePath)) ?? [],
+    source: cached.length > 0 ? 'publishDiagnostics-cache' : 'none'
+  }
+}
+
 /**
  * Synchronous last-resort cleanup on process exit. The exit handler can only
  * run synchronous code, so we SIGKILL immediately (no grace period). This
- * prevents orphaned typescript-language-server / tsserver processes when the
+ * prevents orphaned language-server processes when the
  * host process (Electron / kun serve) terminates.
  */
 function syncKillAll(): void {

--- a/kun/src/adapters/tool/lsp-notifications.ts
+++ b/kun/src/adapters/tool/lsp-notifications.ts
@@ -1,0 +1,58 @@
+type LspNotificationSession = {
+  diagnostics: Map<string, unknown[]>
+  serverDisplayName: string
+}
+
+type LspMessageParams = {
+  type?: unknown
+  message?: unknown
+}
+
+type LspDiagnosticsParams = {
+  uri?: unknown
+  diagnostics?: unknown
+}
+
+function logMessage(session: LspNotificationSession, params: unknown): void {
+  const messageParams = (params ?? {}) as LspMessageParams
+  const message = typeof messageParams.message === 'string' ? messageParams.message : ''
+  if (!message) return
+
+  const prefix = `[lsp] ${session.serverDisplayName}: ${message}`
+  switch (messageParams.type) {
+    case 1:
+      console.error(prefix)
+      break
+    case 2:
+      console.warn(prefix)
+      break
+    default:
+      console.info(prefix)
+      break
+  }
+}
+
+function storeDiagnostics(session: LspNotificationSession, params: unknown): void {
+  const diagnosticsParams = (params ?? {}) as LspDiagnosticsParams
+  if (typeof diagnosticsParams.uri !== 'string') return
+  if (!Array.isArray(diagnosticsParams.diagnostics)) return
+  session.diagnostics.set(diagnosticsParams.uri, diagnosticsParams.diagnostics)
+}
+
+export function handleNotification(
+  session: LspNotificationSession,
+  method: string,
+  params: unknown
+): void {
+  switch (method) {
+    case 'textDocument/publishDiagnostics':
+      storeDiagnostics(session, params)
+      break
+    case 'window/logMessage':
+    case '$/logTrace':
+      logMessage(session, params)
+      break
+    default:
+      break
+  }
+}

--- a/kun/src/adapters/tool/lsp-servers.test.ts
+++ b/kun/src/adapters/tool/lsp-servers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findLanguageServerForFile,
+  getLanguageServer,
+  languageIdForFile,
+  listLanguageServers
+} from './lsp-servers.js'
+
+describe('lsp server registry', () => {
+  it('registers the default language servers', () => {
+    const servers = listLanguageServers().map((server) => server.key).sort()
+    expect(servers).toEqual(['python', 'typescript'])
+    expect(getLanguageServer('typescript')?.displayName).toBe('TypeScript/JavaScript')
+    expect(getLanguageServer('python')?.displayName).toBe('Python')
+  })
+
+  it('maps TypeScript and Python files to the expected servers', () => {
+    expect(findLanguageServerForFile('/workspace/src/app.tsx')?.key).toBe('typescript')
+    expect(findLanguageServerForFile('/workspace/src/app.py')?.key).toBe('python')
+    expect(findLanguageServerForFile('/workspace/src/app.txt')).toBeUndefined()
+  })
+
+  it('derives document language ids from the matched server', () => {
+    expect(languageIdForFile('/workspace/src/app.ts')).toBe('typescript')
+    expect(languageIdForFile('/workspace/src/app.tsx')).toBe('typescriptreact')
+    expect(languageIdForFile('/workspace/src/app.jsx')).toBe('javascriptreact')
+    expect(languageIdForFile('/workspace/src/app.pyi')).toBe('python')
+    expect(languageIdForFile('/workspace/src/app.txt')).toBeNull()
+  })
+})

--- a/kun/src/adapters/tool/lsp-servers.ts
+++ b/kun/src/adapters/tool/lsp-servers.ts
@@ -1,0 +1,133 @@
+import { spawn } from 'node:child_process'
+import { access } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const SERVER_PROBE_TIMEOUT = 3_000
+
+export type LspServerCommand = {
+  command: string
+  args: string[]
+}
+
+export interface LanguageServerDef {
+  key: string
+  displayName: string
+  extensions: string[]
+  installHint: string
+  resolveCommand: (workspaceRoot: string) => Promise<LspServerCommand | null>
+  languageIdForFile: (filePath: string) => string
+}
+
+const registry = new Map<string, LanguageServerDef>()
+
+function normalizeExtension(filePath: string): string {
+  return filePath.toLowerCase()
+}
+
+function registerDefaultLanguageServers(): void {
+  if (!registry.has('typescript')) {
+    registerLanguageServer({
+      key: 'typescript',
+      displayName: 'TypeScript/JavaScript',
+      extensions: ['.ts', '.tsx', '.js', '.jsx', '.mts', '.mjs', '.cts', '.cjs'],
+      installHint: 'Install with: npm install -g typescript-language-server typescript',
+      resolveCommand: async (workspaceRoot) => {
+        const localPath = join(workspaceRoot, 'node_modules', '.bin', 'typescript-language-server')
+        try {
+          await access(localPath)
+          return { command: localPath, args: ['--stdio'] }
+        } catch {
+          // fall through to PATH lookup
+        }
+        const found = await probeServerBinary('typescript-language-server')
+        return found ? { command: 'typescript-language-server', args: ['--stdio'] } : null
+      },
+      languageIdForFile: (filePath) => {
+        const normalized = normalizeExtension(filePath)
+        if (normalized.endsWith('.tsx')) return 'typescriptreact'
+        if (normalized.endsWith('.jsx')) return 'javascriptreact'
+        if (normalized.endsWith('.js') || normalized.endsWith('.mjs') || normalized.endsWith('.cjs')) {
+          return 'javascript'
+        }
+        return 'typescript'
+      }
+    })
+  }
+
+  if (!registry.has('python')) {
+    registerLanguageServer({
+      key: 'python',
+      displayName: 'Python',
+      extensions: ['.py', '.pyi'],
+      installHint: 'Install one of: pip install basedpyright, npm install -g pyright, or pip install python-lsp-server',
+      resolveCommand: async () => {
+        const candidates: Array<{ binary: string; args: string[] }> = [
+          { binary: 'basedpyright-langserver', args: ['--stdio'] },
+          { binary: 'pyright-langserver', args: ['--stdio'] },
+          { binary: 'pylsp', args: [] }
+        ]
+        for (const candidate of candidates) {
+          const found = await probeServerBinary(candidate.binary)
+          if (found) {
+            return { command: candidate.binary, args: candidate.args }
+          }
+        }
+        return null
+      },
+      languageIdForFile: () => 'python'
+    })
+  }
+}
+
+export function registerLanguageServer(def: LanguageServerDef): void {
+  registry.set(def.key, def)
+}
+
+export function getLanguageServer(key: string): LanguageServerDef | undefined {
+  registerDefaultLanguageServers()
+  return registry.get(key)
+}
+
+export function listLanguageServers(): LanguageServerDef[] {
+  registerDefaultLanguageServers()
+  return [...registry.values()]
+}
+
+export function findLanguageServerForFile(filePath: string): LanguageServerDef | undefined {
+  registerDefaultLanguageServers()
+  const normalized = normalizeExtension(filePath)
+  return [...registry.values()].find((def) => def.extensions.some((ext) => normalized.endsWith(ext)))
+}
+
+export function languageIdForFile(filePath: string): string | null {
+  const server = findLanguageServerForFile(filePath)
+  return server ? server.languageIdForFile(filePath) : null
+}
+
+export async function resolveServerCommand(
+  workspaceRoot: string,
+  serverKey: string
+): Promise<LspServerCommand | null> {
+  const server = getLanguageServer(serverKey)
+  if (!server) return null
+  return server.resolveCommand(workspaceRoot)
+}
+
+export async function probeServerBinary(binary: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const command = process.platform === 'win32' ? 'where' : 'which'
+    const child = spawn(command, [binary], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: SERVER_PROBE_TIMEOUT,
+      windowsHide: true
+    })
+    let stdout = ''
+    child.stdout?.on('data', (chunk) => { stdout += chunk })
+    child.on('error', () => resolve(null))
+    child.on('close', (code) => {
+      resolve(code === 0 && stdout.trim() ? stdout.trim().split(/\r?\n/)[0] ?? null : null)
+    })
+  })
+}
+
+registerDefaultLanguageServers()

--- a/kun/tests/builtin-tools.test.ts
+++ b/kun/tests/builtin-tools.test.ts
@@ -339,7 +339,7 @@ describe('Kun built-in tools', () => {
       ls: { defaultLimit: 1 },
       bash: { defaultTimeoutSeconds: 5 }
     })
-    expect(Object.keys(toolRecord).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'read', 'write'])
+    expect(Object.keys(toolRecord).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'lsp', 'read', 'write'])
 
     await writeFile(join(workspace, 'limited.txt'), 'one\ntwo\nthree\n', 'utf8')
     const customHost = new LocalToolHost({ tools: [toolRecord.read, toolRecord.ls] })
@@ -361,8 +361,8 @@ describe('Kun built-in tools', () => {
     expect(createReadOnlyToolDefinitions().map((tool) => tool.name)).toEqual(['read', 'grep', 'find', 'ls'])
     const allTools = createAllTools()
     const allDefinitions = createAllToolDefinitions()
-    expect(Object.keys(allTools).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'read', 'write'])
-    expect(Object.keys(allDefinitions).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'read', 'write'])
+    expect(Object.keys(allTools).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'lsp', 'read', 'write'])
+    expect(Object.keys(allDefinitions).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'lsp', 'read', 'write'])
     expect(createReadTool).toBe(createReadLocalTool)
     expect(createReadToolDefinition).toBe(createReadLocalTool)
     expect(createWriteTool).toBeTypeOf('function')


### PR DESCRIPTION
Summary
- Add the `lsp` builtin tool to Kun's tool catalog and execution records.
- Add a reusable language-server registry for TypeScript/JavaScript and Python.
- Add diagnostics support for push diagnostics and pull diagnostics, including basedpyright compatibility.

Changes
- Probe project-local and PATH language server binaries with cooldown for broken servers.
- Track stderr tails for unexpected language-server exits.
- Handle key LSP server requests/notifications, including `workspace/configuration`, `workspace/workspaceFolders`, `client/registerCapability`, and diagnostics notifications.
- Parse JSON-RPC stdio framing by UTF-8 byte length instead of JS string length.
- Add focused coverage for tool registration, server resolution, diagnostics, and multibyte JSON-RPC framing.

Tests
- `npm --prefix kun run typecheck`
- `npm --prefix kun run test -- src/adapters/tool/lsp-client.test.ts src/adapters/tool/lsp-servers.test.ts src/adapters/tool/builtin-lsp-tool.test.ts src/adapters/tool/builtin-tool-types.test.ts`
- Real basedpyright diagnostics smoke via `/tmp/kun-lsp-success/py-diagnostics-once.mts`
- Real TypeScript language-server diagnostics smoke via `lspGetDiagnostics`
- `npm run typecheck`
