### PR TITLE
feat(provider): add LongCat preset

### DIFF
--- a/src/renderer/src/components/settings-section-agents.test.ts
+++ b/src/renderer/src/components/settings-section-agents.test.ts
@@ -649,8 +649,9 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
     })
   })
 
-  it('defines coding provider presets for the Providers menu', () => {
+  it('defines OpenAI-compatible provider presets for the Providers menu', () => {
     const expected = [
+      ['longcat', 'LongCat', 'https://api.longcat.chat/openai'],
       ['zhipu-coding-plan', 'Zhipu Coding Plan', 'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions', 'custom_endpoint'],
       ['zai-coding-plan', 'Z.ai Coding Plan', 'https://api.z.ai/api/coding/paas/v4/chat/completions', 'custom_endpoint'],
       ['kimi-code', 'Kimi Code', 'https://api.kimi.com/coding/v1'],

--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -955,12 +955,28 @@ describe('provider presets', () => {
     })
   })
 
-  it('includes Zhipu, Z.ai, Kimi Code, and Moonshot presets', () => {
+  it('includes LongCat, Zhipu, Z.ai, Kimi Code, and Moonshot presets', () => {
+    const longcat = getModelProviderPreset('longcat')
     const zhipu = getModelProviderPreset('zhipu-coding-plan')
     const zai = getModelProviderPreset('zai-coding-plan')
     const kimiCode = getModelProviderPreset('kimi-code')
     const moonshotCn = getModelProviderPreset('moonshot-cn')
     const moonshotGlobal = getModelProviderPreset('moonshot-global')
+
+    expect(longcat && modelProviderPresetProfile(longcat)).toMatchObject({
+      id: 'longcat',
+      name: 'LongCat',
+      baseUrl: 'https://api.longcat.chat/openai',
+      endpointFormat: 'chat_completions',
+      models: ['LongCat-2.0-Preview'],
+      modelProfiles: {
+        'LongCat-2.0-Preview': expect.objectContaining({
+          contextWindowTokens: 1_000_000,
+          supportsToolCalling: true,
+          inputModalities: ['text']
+        })
+      }
+    })
 
     expect(zhipu && modelProviderPresetProfile(zhipu)).toMatchObject({
       id: 'zhipu-coding-plan',
@@ -1062,6 +1078,7 @@ describe('provider presets', () => {
 
   it('resolves new OpenAI-compatible presets through the selected provider', () => {
     const cases = [
+      ['longcat', 'https://api.longcat.chat/openai', 'LongCat-2.0-Preview'],
       ['zhipu-coding-plan', 'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions', 'glm-5.2', 'custom_endpoint'],
       ['zai-coding-plan', 'https://api.z.ai/api/coding/paas/v4/chat/completions', 'glm-5.1', 'custom_endpoint'],
       ['kimi-code', 'https://api.kimi.com/coding/v1', 'kimi-for-coding'],
@@ -1097,7 +1114,7 @@ describe('provider presets', () => {
         endpointFormat,
         model
       }))
-      expect(resolved.modelProfiles[model]).toEqual(expect.objectContaining({
+      expect(resolved.modelProfiles[model.toLowerCase()]).toEqual(expect.objectContaining({
         supportsToolCalling: true
       }))
     }

--- a/src/shared/model-provider-presets.ts
+++ b/src/shared/model-provider-presets.ts
@@ -17,6 +17,7 @@ import type {
 
 export type ModelProviderPresetId =
   | 'litellm'
+  | 'longcat'
   | 'zhipu-coding-plan'
   | 'zai-coding-plan'
   | 'kimi-code'
@@ -204,6 +205,18 @@ export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
     models: [],
     docsUrl: 'https://docs.litellm.ai/docs/',
     apiKeyUrl: 'https://docs.litellm.ai/docs/proxy/quick_start'
+  },
+  {
+    id: 'longcat',
+    name: 'LongCat',
+    baseUrl: 'https://api.longcat.chat/openai',
+    endpointFormat: 'chat_completions',
+    models: ['LongCat-2.0-Preview'],
+    modelProfiles: {
+      'LongCat-2.0-Preview': textChatProfile(1_000_000)
+    },
+    docsUrl: 'https://longcat.chat/platform/docs/zh/',
+    apiKeyUrl: 'https://longcat.chat/platform/'
   },
   {
     id: 'zhipu-coding-plan',


### PR DESCRIPTION
Summary
- Add LongCat as a built-in OpenAI-compatible model provider preset.
- Configure the LongCat OpenAI base URL, LongCat-2.0-Preview model, and 1M context profile.
- Cover provider settings resolution and the Agents providers menu with tests.

Changes
- Adds the `longcat` provider preset using `https://api.longcat.chat/openai` with `chat_completions`.
- Keeps the runtime request path aligned with LongCat docs, resolving to `/v1/chat/completions`.

Tests
- `npm test -- --run src/shared/app-settings-provider.test.ts src/renderer/src/components/settings-section-agents.test.ts`
- `npm run typecheck`
- `npm run dist:mac:arm64`
- Unzipped `dist/Kun-0.1.0-mac-arm64.zip` and verified `http://127.0.0.1:8899/health`.
- Replaced `/Applications/Kun.app` directly from the unzipped app and verified installed app `/health`.

Artifacts
- `dist/Kun-0.1.0-mac-arm64.zip`
- SHA-256: `1445de08084da8af288fa451b16f82b81372278f812a73c5908d8b197663878e`