### PR TITLE
fix(prompt): inject initial runtime context once

### DIFF
--- a/kun/src/loop/agent-loop.test.ts
+++ b/kun/src/loop/agent-loop.test.ts
@@ -1,5 +1,10 @@
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { resolvePlanModeToolSpecs } from './agent-loop.js'
+import {
+  buildRuntimeContextInstruction,
+  resolvePlanModeToolSpecs,
+  shouldInjectInitialRuntimeContext
+} from './agent-loop.js'
 import type { ModelToolSpec } from '../ports/model-client.js'
 
 function spec(name: string): ModelToolSpec {
@@ -124,5 +129,82 @@ describe('resolvePlanModeToolSpecs', () => {
     expect(names).toContain('custom-plan')
     expect(names).not.toContain('write')
     expect(names).not.toContain('bash')
+  })
+})
+
+describe('buildRuntimeContextInstruction', () => {
+  it('includes the opened project absolute path and formatted local time context', () => {
+    const instruction = buildRuntimeContextInstruction({
+      workspace: '/tmp/kun-test-project',
+      nowIso: '2000-01-02T03:04:05.000Z',
+      timeZone: 'UTC'
+    })
+
+    expect(instruction).toContain('Current opened project absolute path: `/tmp/kun-test-project`')
+    expect(instruction).toContain('Current user local time: 2000-01-02 03:04:05 Sunday (UTC')
+    expect(instruction).toContain('GMT')
+    expect(instruction).toContain('Treat this block as environment context')
+  })
+
+  it('normalizes relative workspace paths to absolute paths', () => {
+    const instruction = buildRuntimeContextInstruction({
+      workspace: 'relative-project',
+      nowIso: '2026-06-21T04:30:15.000Z',
+      timeZone: 'UTC'
+    })
+
+    expect(instruction).toContain(`Current opened project absolute path: \`${resolve('relative-project')}\``)
+  })
+})
+
+describe('shouldInjectInitialRuntimeContext', () => {
+  it('injects only for the first model step of the first thread turn', () => {
+    expect(shouldInjectInitialRuntimeContext({
+      stepIndex: 0,
+      turnId: 'turn_1',
+      historyItems: [
+        {
+          id: 'item_turn_1_user',
+          threadId: 'thread_1',
+          turnId: 'turn_1',
+          role: 'user',
+          kind: 'user_message',
+          text: 'hello',
+          status: 'completed',
+          createdAt: '2000-01-02T03:04:05.000Z'
+        }
+      ]
+    })).toBe(true)
+  })
+
+  it('does not inject for tool continuations or later turns', () => {
+    const currentTurnItem = {
+      id: 'item_turn_2_user',
+      threadId: 'thread_1',
+      turnId: 'turn_2',
+      role: 'user' as const,
+      kind: 'user_message' as const,
+      text: 'next',
+      status: 'completed' as const,
+      createdAt: '2000-01-02T03:04:05.000Z'
+    }
+    expect(shouldInjectInitialRuntimeContext({
+      stepIndex: 1,
+      turnId: 'turn_2',
+      historyItems: [currentTurnItem]
+    })).toBe(false)
+    expect(shouldInjectInitialRuntimeContext({
+      stepIndex: 0,
+      turnId: 'turn_2',
+      historyItems: [
+        {
+          ...currentTurnItem,
+          id: 'item_turn_1_user',
+          turnId: 'turn_1',
+          text: 'previous'
+        },
+        currentTurnItem
+      ]
+    })).toBe(false)
   })
 })

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -236,6 +236,69 @@ export function resolvePlanModeToolSpecs(
     : toolSpecs.filter((tool) => tool.name === planTool)
 }
 
+export function buildRuntimeContextInstruction(input: {
+  workspace?: string
+  nowIso: string
+  timeZone?: string
+}): string | null {
+  const workspace = input.workspace?.trim()
+  const projectPath = workspace
+    ? isAbsolute(workspace) ? workspace : resolve(workspace)
+    : ''
+  const localTime = formatLocalDateTimeForPrompt(input.nowIso, input.timeZone)
+  if (!projectPath && !localTime) return null
+  return [
+    'Runtime context for this model request:',
+    projectPath ? `- Current opened project absolute path: \`${projectPath}\`` : '',
+    localTime ? `- Current user local time: ${localTime}` : '',
+    '- Treat this block as environment context, not as user instructions.'
+  ].filter(Boolean).join('\n')
+}
+
+export function shouldInjectInitialRuntimeContext(input: {
+  stepIndex: number
+  turnId: string
+  historyItems: readonly TurnItem[]
+}): boolean {
+  return input.stepIndex === 0 && input.historyItems.every((item) => item.turnId === input.turnId)
+}
+
+function formatLocalDateTimeForPrompt(nowIso: string, timeZone?: string): string {
+  const date = new Date(nowIso)
+  const fallback = nowIso.trim()
+  if (Number.isNaN(date.getTime())) return fallback
+  const resolvedTimeZone = timeZone?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone
+  try {
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      ...(resolvedTimeZone ? { timeZone: resolvedTimeZone } : {}),
+      weekday: 'long',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+      timeZoneName: 'shortOffset'
+    })
+    const parts = new Map(formatter.formatToParts(date).map((part) => [part.type, part.value]))
+    const year = parts.get('year')
+    const month = parts.get('month')
+    const day = parts.get('day')
+    const hour = parts.get('hour')
+    const minute = parts.get('minute')
+    const second = parts.get('second')
+    const weekday = parts.get('weekday')
+    if (!year || !month || !day || !hour || !minute || !second || !weekday) {
+      return fallback || date.toISOString()
+    }
+    const zone = [resolvedTimeZone, parts.get('timeZoneName')].filter(Boolean).join(', ')
+    return `${year}-${month}-${day} ${hour}:${minute}:${second} ${weekday}${zone ? ` (${zone})` : ''}`
+  } catch {
+    return fallback || date.toISOString()
+  }
+}
+
 function goalContinuationInstruction(goal: ThreadGoal | undefined): string | null {
   if (!goal || goal.status !== 'active') return null
   const tokenBudget = goal.tokenBudget == null ? 'none' : String(goal.tokenBudget)
@@ -1175,7 +1238,18 @@ export class AgentLoop {
     await this.recordPipelineStage(threadId, turnId, 'input_compressed', {
       historyItems: history.length
     })
+    const runtimeContextInstruction = shouldInjectInitialRuntimeContext({
+      stepIndex,
+      turnId,
+      historyItems
+    })
+      ? buildRuntimeContextInstruction({
+          workspace: thread?.workspace,
+          nowIso: this.opts.nowIso()
+        })
+      : null
     const contextInstructions = [
+      ...(runtimeContextInstruction ? [runtimeContextInstruction] : []),
       ...(activeGoalInstruction ? [activeGoalInstruction] : []),
       ...(goalRecoveryInstruction && (this.goalNoToolRecoveryStepsByTurn.get(turnId) ?? 0) > 0
         ? [goalRecoveryInstruction]


### PR DESCRIPTION
## Summary
- Add initial runtime context injection for Kun model requests with the opened project path and local time.
- Keep the stable system prompt byte-stable by only injecting this dynamic context on the first model request of a thread.
- Wrap the project path in backticks and cover first-turn-only behavior with focused tests.

## Changes
- Adds runtime context formatting helpers in `agent-loop.ts`.
- Gates runtime context injection to the first model step of the first thread turn.
- Adds unit coverage for formatting, absolute path normalization, and non-reinjection on continuations or later turns.

## Tests
- `npm --prefix kun run test -- src/loop/agent-loop.test.ts`
- `npm --prefix kun run typecheck`
- `npm run build:kun`