### PR TITLE
fix(runtime): avoid killing active Kun child during port reclaim

### DIFF
--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -247,6 +247,43 @@ describe('reclaimKunPort', () => {
       await new Promise<void>((resolve) => server.close(() => resolve()))
     }
   })
+
+  it('does not kill the currently managed Kun child while resolving an occupied port', async () => {
+    const probe = createServer()
+    await new Promise<void>((resolve, reject) => {
+      probe.once('error', reject)
+      probe.listen(0, '127.0.0.1', () => resolve())
+    })
+    const preferredPort = (probe.address() as AddressInfo).port
+    await new Promise<void>((resolve) => probe.close(() => resolve()))
+
+    const script = writeScript(
+      'serve-entry-current-child.js',
+      [
+        "const http = require('node:http')",
+        `const port = ${preferredPort}`,
+        "const server = http.createServer((req, res) => {",
+        "  res.setHeader('content-type', 'application/json')",
+        "  res.end(JSON.stringify({ service: 'kun', mode: 'serve', status: 'ok' }))",
+        "})",
+        "server.listen(port, '127.0.0.1', () => {",
+        "  process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port }) + '\\n')",
+        "})",
+        'setInterval(() => {}, 1_000)'
+      ].join('\n')
+    )
+    const module = await import('./kun-process')
+    const settings = createSettings(script)
+    settings.agents.kun.port = preferredPort
+
+    await module.startKunChild(settings)
+    const resolved = await module.resolveAvailableKunPort(preferredPort)
+
+    expect(resolved.changed).toBe(true)
+    expect(resolved.port).not.toBe(preferredPort)
+    expect(module.isKunChildRunning()).toBe(true)
+    expect(await readKunLog()).not.toContain(`killing stale kun process holding port ${preferredPort}`)
+  })
 })
 
 describe('resolveKunDataDir', () => {
@@ -703,54 +740,58 @@ describe('syncGuiManagedKunConfig', () => {
     }), 'utf8')
     const module = await import('./kun-process')
 
-    await module.syncGuiManagedKunConfig(tempRoot, {
-      ...defaultKunRuntimeSettings(),
-      storage: {
-        backend: 'hybrid',
-        sqlitePath: '/tmp/kun-index.sqlite3'
-      },
-      contextCompaction: {
-        defaultSoftThreshold: 32000,
-        defaultHardThreshold: 64000,
-        summaryMode: 'model',
-        summaryTimeoutMs: 30000,
-        summaryMaxTokens: 1600,
-        summaryInputMaxBytes: 131072
-      },
-      runtimeTuning: {
-        streamIdleTimeoutMs: 120000,
-        toolStorm: {
-          enabled: false,
-          windowSize: 12,
-          threshold: 4
+    await module.syncGuiManagedKunConfig(
+      tempRoot,
+      {
+        ...defaultKunRuntimeSettings(),
+        storage: {
+          backend: 'hybrid',
+          sqlitePath: '/tmp/kun-index.sqlite3'
         },
-        toolArgumentRepair: {
-          maxStringBytes: 262144
+        contextCompaction: {
+          defaultSoftThreshold: 32000,
+          defaultHardThreshold: 64000,
+          summaryMode: 'model',
+          summaryTimeoutMs: 30000,
+          summaryMaxTokens: 1600,
+          summaryInputMaxBytes: 131072
+        },
+        runtimeTuning: {
+          streamIdleTimeoutMs: 120000,
+          toolStorm: {
+            enabled: false,
+            windowSize: 12,
+            threshold: 4
+          },
+          toolArgumentRepair: {
+            maxStringBytes: 262144
+          }
+        },
+        mcpSearch: {
+          enabled: true,
+          mode: 'search',
+          autoThresholdToolCount: 12,
+          topKDefault: 4,
+          topKMax: 9,
+          minScore: 0.2
+        },
+        tokenEconomy: {
+          enabled: true,
+          compressToolDescriptions: false,
+          compressToolResults: true,
+          conciseResponses: false,
+          historyHygiene: {
+            maxToolResultLines: 100,
+            maxToolResultBytes: 16384,
+            maxToolResultTokens: 4000,
+            maxToolArgumentStringBytes: 4096,
+            maxToolArgumentStringTokens: 1000,
+            maxArrayItems: 40
+          }
         }
       },
-      mcpSearch: {
-        enabled: true,
-        mode: 'search',
-        autoThresholdToolCount: 12,
-        topKDefault: 4,
-        topKMax: 9,
-        minScore: 0.2
-      },
-      tokenEconomy: {
-        enabled: true,
-        compressToolDescriptions: false,
-        compressToolResults: true,
-        conciseResponses: false,
-        historyHygiene: {
-          maxToolResultLines: 100,
-          maxToolResultBytes: 16384,
-          maxToolResultTokens: 4000,
-          maxToolArgumentStringBytes: 4096,
-          maxToolArgumentStringTokens: 1000,
-          maxArrayItems: 40
-        }
-      }
-    })
+      { mcpConfigPath: join(tempRoot, 'missing-mcp.json') }
+    )
 
     const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as any
     expect(KunConfigSchema.safeParse(parsed).success).toBe(true)

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -256,6 +256,10 @@ export function isKunChildRunning(): boolean {
   return child !== null && child.exitCode === null && child.signalCode === null
 }
 
+function isCurrentKunChildPid(pid: number): boolean {
+  return Boolean(child?.pid === pid && isKunChildRunning())
+}
+
 export function startKunChild(settings: AppSettingsV1): Promise<void> {
   if (kunStartPromise) return kunStartPromise
   const runtime = resolveKunRuntimeSettings(settings)
@@ -1187,6 +1191,7 @@ async function killStaleKunOnPort(port: number): Promise<boolean> {
   const pids = await listListeningPidsOnPort(port)
   let reclaimed = false
   for (const pid of pids) {
+    if (isCurrentKunChildPid(pid)) continue
     let command = ''
     try {
       command = await processCommandLine(pid)


### PR DESCRIPTION
## Summary
- Fixes the GUI port-reclaim path so it does not terminate the currently managed Kun child process.
- Adds a regression test that reproduces the active-child port collision from #469.
- Keeps the Kun config sync test isolated from local MCP config files.

## Root Cause
The runtime supervisor could see the active Kun child PID while checking the configured runtime port, classify it as a stale `serve-entry` process, and terminate it. That caused SSE termination, runtime restart, and orphaned turns being marked failed.

## Tests
- `npm.cmd test -- src/main/kun-process.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`

Fixes #469