### PR TITLE
fix(settings): accept long provider model ids

### DIFF
--- a/src/main/ipc/app-ipc-schemas.test.ts
+++ b/src/main/ipc/app-ipc-schemas.test.ts
@@ -254,6 +254,60 @@ describe('app-ipc-schemas', () => {
     expect(payload.agents?.kun?.videoGeneration?.defaultResolution).toBe('1080P')
   })
 
+  it('accepts long provider model ids imported from upstream catalogs', () => {
+    const longModelId = `openrouter/${'provider-routed-model-id-'.repeat(6)}preview`
+
+    expect(longModelId.length).toBeGreaterThan(128)
+
+    const payload = settingsPatchSchema.parse({
+      provider: {
+        providers: [{
+          id: 'openrouter',
+          name: 'OpenRouter',
+          baseUrl: 'https://openrouter.ai/api/v1',
+          endpointFormat: 'chat_completions',
+          models: [longModelId],
+          modelProfiles: {
+            [longModelId]: {
+              aliases: [longModelId],
+              contextWindowTokens: 128000
+            }
+          },
+          image: {
+            protocol: 'openai-images',
+            baseUrl: 'https://openrouter.ai/api/v1',
+            models: [longModelId]
+          }
+        }]
+      },
+      agents: {
+        kun: {
+          model: longModelId,
+          modelProfiles: {
+            [longModelId]: {
+              aliases: [longModelId],
+              contextWindowTokens: 128000
+            }
+          },
+          imageGeneration: {
+            model: longModelId
+          }
+        }
+      },
+      schedule: {
+        model: longModelId
+      },
+      workflow: {
+        model: longModelId
+      }
+    })
+
+    expect(payload.provider?.providers?.[0]?.models).toEqual([longModelId])
+    expect(payload.agents?.kun?.model).toBe(longModelId)
+    expect(payload.schedule?.model).toBe(longModelId)
+    expect(payload.workflow?.model).toBe(longModelId)
+  })
+
   it('accepts schedule settings patches and task payloads', () => {
     const payload = settingsPatchSchema.parse({
       schedule: {

--- a/src/main/ipc/app-ipc-schemas.ts
+++ b/src/main/ipc/app-ipc-schemas.ts
@@ -66,6 +66,8 @@ const MAX_BODY_BYTES = 2_000_000
 const MAX_PATH_LENGTH = 4_096
 const MAX_URL_LENGTH = 4_096
 const MAX_ID_LENGTH = 256
+// Provider catalogs can expose routed model ids longer than local object ids.
+const MAX_MODEL_ID_LENGTH = 512
 const MAX_BRANCH_LENGTH = 255
 const MAX_EDITOR_ID_LENGTH = 64
 const MAX_NOTIFICATION_TITLE_LENGTH = 200
@@ -215,9 +217,11 @@ const clawImProviderSchema = z.enum(['feishu', 'weixin', 'telegram'])
 const clawScheduleKindSchema = z.enum(['manual', 'interval', 'daily', 'at'])
 const clawTaskStatusSchema = z.enum(['idle', 'running', 'success', 'error'])
 const scheduleReasoningEffortSchema = z.enum(SCHEDULE_REASONING_EFFORT_IDS)
+const modelIdSchema = z.string().trim().min(1).max(MAX_MODEL_ID_LENGTH)
+const optionalModelIdSchema = z.string().trim().max(MAX_MODEL_ID_LENGTH).optional()
 const writeInlineCompletionModelSchema = z.union([
   z.enum(WRITE_INLINE_COMPLETION_MODEL_IDS),
-  trimmedString(128)
+  modelIdSchema
 ])
 const modelEndpointFormatSchema = z.enum(MODEL_ENDPOINT_FORMATS)
 const imageGenerationProtocolSchema = z.enum(IMAGE_GENERATION_PROTOCOLS)
@@ -239,7 +243,7 @@ const speechToTextSettingsSchema = z.object({
   protocol: speechToTextProtocolSchema,
   baseUrl: z.string().trim().max(MAX_URL_LENGTH),
   apiKey: z.string().max(MAX_BODY_BYTES),
-  model: z.string().trim().max(128),
+  model: z.string().trim().max(MAX_MODEL_ID_LENGTH),
   localWhisperDownloadSource: localWhisperDownloadSourceSchema,
   language: z.string().trim().max(16),
   timeoutMs: z.number().int().positive().max(600_000)
@@ -249,7 +253,7 @@ const modelProviderMessagePartSchema = z.enum(MODEL_PROVIDER_MESSAGE_PARTS)
 const modelReasoningEffortSchema = z.enum(MODEL_REASONING_EFFORTS)
 const modelReasoningRequestProtocolSchema = z.enum(MODEL_REASONING_REQUEST_PROTOCOLS)
 const modelProfilePatchSchema = z.object({
-  aliases: z.array(z.string().trim().min(1).max(128)).max(50).optional(),
+  aliases: z.array(modelIdSchema).max(50).optional(),
   contextWindowTokens: z.number().int().positive().max(10_000_000).optional(),
   inputModalities: z.array(modelProviderInputModalitySchema).max(8).optional(),
   outputModalities: z.array(modelProviderInputModalitySchema).max(8).optional(),
@@ -280,37 +284,37 @@ const modelProviderPatchSchema = z.object({
     // models in a single /v1/models response. The previous 200/50 caps caused
     // settings:set to silently fail with no toast (#397). Raised to leave
     // plenty of headroom while still bounding pathological payloads.
-    models: z.array(z.string().trim().min(1).max(128)).max(2000).optional(),
+    models: z.array(modelIdSchema).max(2000).optional(),
     // 兼容旧版保存的视觉识别能力字段。当前能力已经迁移到 modelProfiles 的 inputModalities/messageParts。
     imageRecognition: z.unknown().optional(),
     modelProfiles: z.record(
-      z.string().trim().min(1).max(128),
+      modelIdSchema,
       modelProfilePatchSchema.nullable()
     ).optional(),
     image: z.object({
       protocol: imageGenerationProtocolSchema.optional(),
       baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
-      models: z.array(z.string().trim().min(1).max(128)).max(500).optional()
+      models: z.array(modelIdSchema).max(500).optional()
     }).strict().nullable().optional(),
     speech: z.object({
       protocol: speechToTextProtocolSchema.optional(),
       baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
-      models: z.array(z.string().trim().min(1).max(128)).max(500).optional()
+      models: z.array(modelIdSchema).max(500).optional()
     }).strict().nullable().optional(),
     textToSpeech: z.object({
       protocol: textToSpeechProtocolSchema.optional(),
       baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
-      models: z.array(z.string().trim().min(1).max(128)).max(500).optional()
+      models: z.array(modelIdSchema).max(500).optional()
     }).strict().nullable().optional(),
     music: z.object({
       protocol: musicGenerationProtocolSchema.optional(),
       baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
-      models: z.array(z.string().trim().min(1).max(128)).max(500).optional()
+      models: z.array(modelIdSchema).max(500).optional()
     }).strict().nullable().optional(),
     video: z.object({
       protocol: videoGenerationProtocolSchema.optional(),
       baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
-      models: z.array(z.string().trim().min(1).max(128)).max(500).optional()
+      models: z.array(modelIdSchema).max(500).optional()
     }).strict().nullable().optional()
   }).strict()).max(50).optional()
 }).strict()
@@ -325,7 +329,7 @@ const kunRuntimePatchSchema = z.object({
   endpointFormat: modelEndpointFormatSchema.optional(),
   runtimeToken: z.string().max(MAX_BODY_BYTES).optional(),
   dataDir: defaultPathSchema,
-  model: z.string().trim().min(1).max(128).optional(),
+  model: modelIdSchema.optional(),
   approvalPolicy: approvalPolicySchema.optional(),
   sandboxMode: sandboxModeSchema.optional(),
   tokenEconomyMode: z.boolean().optional(),
@@ -388,7 +392,7 @@ const kunRuntimePatchSchema = z.object({
     protocol: imageGenerationProtocolSchema.optional(),
     baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
     apiKey: z.string().max(MAX_BODY_BYTES).optional(),
-    model: z.string().trim().max(128).optional(),
+    model: optionalModelIdSchema,
     defaultSize: z.string().trim().max(16).optional(),
     timeoutMs: z.number().int().positive().max(600_000).optional()
   }).strict().optional(),
@@ -398,7 +402,7 @@ const kunRuntimePatchSchema = z.object({
     protocol: speechToTextProtocolSchema.optional(),
     baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
     apiKey: z.string().max(MAX_BODY_BYTES).optional(),
-    model: z.string().trim().max(128).optional(),
+    model: optionalModelIdSchema,
     localWhisperDownloadSource: localWhisperDownloadSourceSchema.optional(),
     language: z.string().trim().max(16).optional(),
     timeoutMs: z.number().int().positive().max(600_000).optional()
@@ -409,7 +413,7 @@ const kunRuntimePatchSchema = z.object({
     protocol: textToSpeechProtocolSchema.optional(),
     baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
     apiKey: z.string().max(MAX_BODY_BYTES).optional(),
-    model: z.string().trim().max(128).optional(),
+    model: optionalModelIdSchema,
     voice: z.string().trim().max(128).optional(),
     format: z.string().trim().max(16).optional(),
     timeoutMs: z.number().int().positive().max(900_000).optional()
@@ -420,7 +424,7 @@ const kunRuntimePatchSchema = z.object({
     protocol: musicGenerationProtocolSchema.optional(),
     baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
     apiKey: z.string().max(MAX_BODY_BYTES).optional(),
-    model: z.string().trim().max(128).optional(),
+    model: optionalModelIdSchema,
     format: z.string().trim().max(16).optional(),
     timeoutMs: z.number().int().positive().max(1_800_000).optional()
   }).strict().optional(),
@@ -430,7 +434,7 @@ const kunRuntimePatchSchema = z.object({
     protocol: videoGenerationProtocolSchema.optional(),
     baseUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
     apiKey: z.string().max(MAX_BODY_BYTES).optional(),
-    model: z.string().trim().max(128).optional(),
+    model: optionalModelIdSchema,
     defaultDuration: z.number().int().positive().max(30).optional(),
     defaultResolution: z.string().trim().max(32).optional(),
     timeoutMs: z.number().int().positive().max(3_600_000).optional(),
@@ -445,7 +449,7 @@ const kunRuntimePatchSchema = z.object({
   // 兼容旧版保存的独立视觉识别设置。当前能力已经迁移到 provider modelProfiles。
   imageRecognition: z.unknown().optional(),
   modelProfiles: z.record(
-    z.string().trim().min(1).max(128),
+    modelIdSchema,
     modelProfilePatchSchema.nullable()
   ).optional(),
   memoryEnabled: z.boolean().optional()
@@ -552,7 +556,7 @@ const clawImPatchSchema = z.object({
   openClawGatewayUrl: z.string().trim().max(MAX_URL_LENGTH).optional(),
   workspaceRoot: defaultPathSchema,
   providerId: z.string().trim().max(64).optional(),
-  model: z.string().trim().min(1).max(128).optional(),
+  model: modelIdSchema.optional(),
   mode: clawRunModeSchema.optional(),
   responseTimeoutMs: z.number().int().min(5_000).max(600_000).optional()
 }).strict()
@@ -617,7 +621,7 @@ const clawImChannelPatchSchema = z.object({
   label: z.string().max(512).optional(),
   enabled: z.boolean().optional(),
   providerId: z.string().trim().max(64).optional(),
-  model: z.string().trim().min(1).max(128).optional(),
+  model: modelIdSchema.optional(),
   threadId: z.string().max(MAX_ID_LENGTH).optional(),
   workspaceRoot: defaultPathSchema,
   agentProfile: clawImAgentProfilePatchSchema.optional(),
@@ -645,7 +649,7 @@ const clawTaskPatchSchema = z.object({
   workspaceRoot: defaultPathSchema,
   clawChannelId: z.string().trim().max(MAX_ID_LENGTH).optional(),
   providerId: z.string().trim().max(64).optional(),
-  model: z.string().trim().min(1).max(128).optional(),
+  model: modelIdSchema.optional(),
   reasoningEffort: scheduleReasoningEffortSchema.optional(),
   mode: clawRunModeSchema.optional(),
   schedule: clawTaskSchedulePatchSchema.optional(),
@@ -692,7 +696,7 @@ const scheduledTaskPatchSchema = z.object({
   workspaceRoot: defaultPathSchema,
   clawChannelId: z.string().trim().max(MAX_ID_LENGTH).optional(),
   providerId: z.string().trim().max(64).optional(),
-  model: z.string().trim().min(1).max(128).optional(),
+  model: modelIdSchema.optional(),
   reasoningEffort: scheduleReasoningEffortSchema.optional(),
   mode: clawRunModeSchema.optional(),
   schedule: scheduledTaskSchedulePatchSchema.optional(),
@@ -709,7 +713,7 @@ const scheduleSettingsPatchSchema = z.object({
   enabled: z.boolean().optional(),
   defaultWorkspaceRoot: defaultPathSchema,
   providerId: z.string().trim().max(64).optional(),
-  model: z.union([z.enum(SCHEDULE_MODEL_IDS), trimmedString(128)]).optional(),
+  model: z.union([z.enum(SCHEDULE_MODEL_IDS), modelIdSchema]).optional(),
   mode: clawRunModeSchema.optional(),
   promptPrefix: z.string().max(MAX_CHANNEL_TEXT_LENGTH).optional(),
   skills: scheduleSkillPatchSchema.optional(),
@@ -757,7 +761,7 @@ const workflowAiAgentConfigSchema = z
     prompt: z.string().max(MAX_CHANNEL_TEXT_LENGTH).optional(),
     workspaceRoot: defaultPathSchema,
     providerId: z.string().trim().max(64).optional(),
-    model: optionalTrimmedString(128),
+    model: optionalModelIdSchema,
     reasoningEffort: scheduleReasoningEffortSchema.optional(),
     mode: clawRunModeSchema.optional()
   })
@@ -767,7 +771,7 @@ const workflowGenerateImageConfigSchema = z
   .object({
     prompt: z.string().max(MAX_CHANNEL_TEXT_LENGTH).optional(),
     providerId: z.string().max(MAX_ID_LENGTH).optional(),
-    model: z.string().max(256).optional(),
+    model: optionalModelIdSchema,
     size: z.string().max(32).optional(),
     outputDir: z.string().max(1024).optional()
   })
@@ -969,7 +973,7 @@ const workflowParameterExtractorConfigSchema = z
     instruction: z.string().max(MAX_BODY_BYTES).optional(),
     fields: z.array(workflowInputFieldSchema).max(50).optional(),
     providerId: z.string().trim().max(64).optional(),
-    model: optionalTrimmedString(128),
+    model: optionalModelIdSchema,
     reasoningEffort: scheduleReasoningEffortSchema.optional()
   })
   .strict()
@@ -983,7 +987,7 @@ const workflowQuestionClassifierConfigSchema = z
       .max(20)
       .optional(),
     providerId: z.string().trim().max(64).optional(),
-    model: optionalTrimmedString(128),
+    model: optionalModelIdSchema,
     reasoningEffort: scheduleReasoningEffortSchema.optional()
   })
   .strict()
@@ -1159,7 +1163,7 @@ const workflowSettingsPatchSchema = z
     enabled: z.boolean().optional(),
     defaultWorkspaceRoot: defaultPathSchema,
     providerId: z.string().trim().max(64).optional(),
-    model: optionalTrimmedString(128),
+    model: optionalModelIdSchema,
     mode: clawRunModeSchema.optional(),
     keepAwake: z.boolean().optional(),
     webhookPort: z.number().int().min(1024).max(65_535).optional(),
@@ -1559,7 +1563,7 @@ export const writeInlineCompletionPayloadSchema = z
       .strict(),
     editCandidate: writeInlineCompletionEditCandidateSchema.optional(),
     recentEdits: z.array(writeInlineEditRecentEditSchema).max(12).optional(),
-    model: optionalTrimmedString(128)
+    model: optionalModelIdSchema
   })
   .strict()
 


### PR DESCRIPTION
﻿## Summary
- Raises the IPC settings payload limit for provider model IDs from the local object-id limit to a dedicated model-id limit.
- Reuses that model-id schema across provider catalogs, model profile keys/aliases, Kun model selections, media models, schedule/workflow models, and write inline model hints.
- Adds regression coverage for an upstream-imported provider model ID longer than 128 characters.

## Root Cause
The settings page can import model IDs directly from provider `/models` catalogs. Some routed/aggregated providers return model IDs that are longer than the previous 128-character IPC schema limit. After import, autosave sent the full settings snapshot through `settings:set`, the main process rejected the payload, and the UI showed `Invalid payload for settings:set`.

## Tests
- `npm.cmd test -- src/main/ipc/app-ipc-schemas.test.ts`
- `npm.cmd test -- src/main/ipc/register-app-ipc-handlers.test.ts --testTimeout=10000`
- `npm.cmd run typecheck`
- `git diff --check`

Fixes #473
