### PR TITLE
feat(provider): add Vercel AI Gateway preset

### DIFF
--- a/docs/model-provider-presets.md
+++ b/docs/model-provider-presets.md
@@ -35,6 +35,17 @@ make all of their models appear in the composer before credentials are set.
 
 ## Built-in Providers
 
+Vercel AI Gateway:
+
+- id: `vercel-ai-gateway`
+- base URL: `https://ai-gateway.vercel.sh/v1`
+- endpoint format: OpenAI Chat Completions
+- models: imported on demand from the gateway `GET /models` endpoint
+- role: optional multi-provider gateway with Vercel-managed routing, fallback,
+  spend monitoring, and BYOK support
+- behavior: direct providers remain the default; adding this preset does not
+  route existing providers through Vercel
+
 DeepSeek:
 
 - id: `deepseek`
@@ -119,5 +130,6 @@ if provider endpoints change, and they can add custom compatible providers at
 any time.
 
 First-run setup intentionally remains focused on the default stack. It only
-shows DeepSeek plus the Xiaomi and MiniMax presets; LiteLLM, Zhipu, Z.ai, Kimi
-Code, and Moonshot presets are opt-in from Settings > Providers.
+shows DeepSeek plus the Xiaomi and MiniMax presets; Vercel AI Gateway, LiteLLM,
+Zhipu, Z.ai, Kimi Code, and Moonshot presets are opt-in from Settings >
+Providers.

--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -943,8 +943,10 @@ describe('model provider settings', () => {
 })
 
 describe('provider presets', () => {
-  it('includes a LiteLLM preset', () => {
+  it('includes optional LiteLLM and Vercel AI Gateway presets', () => {
     const litellm = getModelProviderPreset('litellm')
+    const vercel = getModelProviderPreset('vercel-ai-gateway')
+
     expect(litellm).not.toBeNull()
     expect(litellm && modelProviderPresetProfile(litellm)).toMatchObject({
       id: 'litellm',
@@ -953,6 +955,18 @@ describe('provider presets', () => {
       endpointFormat: 'chat_completions',
       models: []
     })
+
+    expect(vercel).not.toBeNull()
+    expect(vercel && modelProviderPresetProfile(vercel)).toMatchObject({
+      id: 'vercel-ai-gateway',
+      name: 'Vercel AI Gateway',
+      baseUrl: 'https://ai-gateway.vercel.sh/v1',
+      endpointFormat: 'chat_completions',
+      models: []
+    })
+    expect(vercel?.docsUrl).toBe(
+      'https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions'
+    )
   })
 
   it('includes Zhipu, Z.ai, Kimi Code, and Moonshot presets', () => {

--- a/src/shared/model-provider-presets.ts
+++ b/src/shared/model-provider-presets.ts
@@ -28,6 +28,7 @@ export type ModelProviderPresetId =
   | 'minimax'
   | 'aliyun'
   | 'tencentcloud'
+  | 'vercel-ai-gateway'
 
 export const TOKEN_PLAN_PROVIDER_ID_SUFFIX = '-token-plan'
 
@@ -597,6 +598,15 @@ export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
     },
     docsUrl: 'https://cloud.tencent.com/document/product/1729/111006',
     apiKeyUrl: 'https://console.cloud.tencent.com/hunyuan/start'
+  },
+  {
+    id: 'vercel-ai-gateway',
+    name: 'Vercel AI Gateway',
+    baseUrl: 'https://ai-gateway.vercel.sh/v1',
+    endpointFormat: 'chat_completions',
+    models: [],
+    docsUrl: 'https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions',
+    apiKeyUrl: 'https://vercel.com/ai-gateway'
   }
 ]
 


### PR DESCRIPTION
﻿## Summary
- add Vercel AI Gateway as an opt-in provider preset
- keep the preset on the existing OpenAI Chat Completions-compatible provider path
- document that existing direct providers stay unchanged and Vercel models are imported on demand

## Changes
- adds `vercel-ai-gateway` to the shared provider preset catalog
- covers the preset in provider settings tests
- documents the base URL, endpoint format, and opt-in behavior in provider preset docs

## Tests
- `git diff --check`
- `npm run test -- src/shared/app-settings-provider.test.ts`
- `npm run typecheck`
