### PR TITLE
fix(installer): handle windows overwrite uninstall failures

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -11,13 +11,14 @@
   StrCpy $KunInstallerCurrentPid $0
   System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_APP_ROOT", "$INSTDIR").r0'
   System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_SELF_PID", "$KunInstallerCurrentPid").r0'
+  System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_UNINSTALL_EXE", "${UNINSTALL_FILENAME}").r0'
 
   StrCpy $KunInstallerStopAttempt 0
 
   KunStopProcessesFromInstallDir:
     IntOp $KunInstallerStopAttempt $KunInstallerStopAttempt + 1
     DetailPrint "Checking for running ${PRODUCT_NAME} processes under $INSTDIR."
-    nsExec::Exec `"$PowerShellPath" -NoProfile -ExecutionPolicy Bypass -Command "$$ErrorActionPreference='SilentlyContinue'; $$root=[System.IO.Path]::GetFullPath($$env:KUN_INSTALLER_APP_ROOT).TrimEnd('\'); $$self=[int]$$env:KUN_INSTALLER_SELF_PID; $$procs=@(Get-CimInstance -ClassName Win32_Process | Where-Object { $$_.ProcessId -ne $$self -and $$_.Path -and [System.IO.Path]::GetFullPath($$_.Path).StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); if ($$procs.Count -gt 0) { $$procs | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }; exit 0 } else { exit 1 }"`
+    nsExec::Exec `"$PowerShellPath" -NoProfile -ExecutionPolicy Bypass -Command "$$ErrorActionPreference='SilentlyContinue';$$r=[IO.Path]::GetFullPath($$env:KUN_INSTALLER_APP_ROOT).TrimEnd('\')+'\';$$s=[int]$$env:KUN_INSTALLER_SELF_PID;$$u=$$env:KUN_INSTALLER_UNINSTALL_EXE;function p{@(gcim Win32_Process|?{if(!$$_.ExecutablePath){$$false}else{$$x=[IO.Path]::GetFullPath($$_.ExecutablePath);$$n=[IO.Path]::GetFileName($$x);$$_.ProcessId -ne $$s -and $$x.StartsWith($$r,'OrdinalIgnoreCase') -and !$$n.Equals($$u,'OrdinalIgnoreCase') -and !$$n.Equals('old-uninstaller.exe','OrdinalIgnoreCase')}})};$$a=p;if($$a.Count -eq 0){exit 1};$$a|%{& $$env:SystemRoot\System32\taskkill.exe /PID $$_.ProcessId /T /F|Out-Null};Start-Sleep -Milliseconds 500;if((p).Count -gt 0){exit 0}else{exit 1}"`
     Pop $KunInstallerStopResult
 
     ${if} $KunInstallerStopResult != 0
@@ -29,8 +30,44 @@
       Goto KunStopProcessesFromInstallDir
     ${endif}
 
-    MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY KunStopProcessesFromInstallDir
-    Quit
+    !ifdef BUILD_UNINSTALLER
+      ${ifNot} ${isUpdated}
+        MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY KunStopProcessesFromInstallDir
+        Quit
+      ${endif}
+    !endif
+
+    DetailPrint "${PRODUCT_NAME} processes may still be running; continuing with managed overwrite cleanup."
 
   KunInstallDirProcessesStopped:
+  !ifndef BUILD_UNINSTALLER
+    ${if} ${FileExists} "$INSTDIR\${UNINSTALL_FILENAME}"
+      DetailPrint "Removing previous ${PRODUCT_NAME} install directory directly before overwrite install."
+      SetOutPath $TEMP
+      RMDir /r "$INSTDIR"
+      DeleteRegKey SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}"
+      !ifdef UNINSTALL_REGISTRY_KEY_2
+        DeleteRegKey SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY_2}"
+      !endif
+      DeleteRegKey SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}"
+    ${endif}
+  !endif
+!macroend
+
+!macro kunContinueAfterOldUninstallerFailure
+  ${if} $R0 != 0
+    DetailPrint "Old ${PRODUCT_NAME} uninstaller returned $R0; removing $INSTDIR directly before overwrite install."
+    SetOutPath $TEMP
+    RMDir /r "$INSTDIR"
+    ClearErrors
+    StrCpy $R0 0
+  ${endif}
+!macroend
+
+!macro customUnInstallCheck
+  !insertmacro kunContinueAfterOldUninstallerFailure
+!macroend
+
+!macro customUnInstallCheckCurrentUser
+  !insertmacro kunContinueAfterOldUninstallerFailure
 !macroend

--- a/src/main/packaging-config.test.ts
+++ b/src/main/packaging-config.test.ts
@@ -161,6 +161,27 @@ describe('electron-builder Kun packaging', () => {
     expect(builderConfig.win.icon).toBe('./build/icon.ico')
   })
 
+  it('uses a process-tree shutdown guard for Windows overwrite installs', () => {
+    const installerScript = readFileSync(join(process.cwd(), 'build/installer.nsh'), 'utf8')
+
+    expect(builderConfig.nsis.include).toBe('build/installer.nsh')
+    expect(installerScript).toContain('customCheckAppRunning')
+    expect(installerScript).toContain('customUnInstallCheck')
+    expect(installerScript).toContain('customUnInstallCheckCurrentUser')
+    expect(installerScript).toContain('kunContinueAfterOldUninstallerFailure')
+    expect(installerScript).toContain('KUN_INSTALLER_UNINSTALL_EXE')
+    expect(installerScript).toContain('${UNINSTALL_FILENAME}')
+    expect(installerScript).toContain('old-uninstaller.exe')
+    expect(installerScript).toContain('$$_.ExecutablePath')
+    expect(installerScript).toContain("$$r=[IO.Path]::GetFullPath")
+    expect(installerScript).toContain('taskkill.exe /PID $$_.ProcessId /T /F')
+    expect(installerScript).toContain('RMDir /r "$INSTDIR"')
+    expect(installerScript).toContain('!ifdef BUILD_UNINSTALLER')
+    expect(installerScript).toContain('${ifNot} ${isUpdated}')
+    expect(installerScript).toContain('MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)"')
+    expect(installerScript).not.toContain('Stop-Process -Id')
+  })
+
   it('keeps sandboxed preload free of Node builtin imports', () => {
     for (const sourcePath of preloadSourceFiles()) {
       expect(forbiddenPreloadImports(readFileSync(sourcePath, 'utf8'))).toEqual([])


### PR DESCRIPTION
Summary
- Fix Windows overwrite installs when the existing Kun uninstaller cannot close wrapped/launched processes cleanly.
- Keep the manual uninstaller close-warning dialog, but skip it for managed update uninstalls using the existing --updated path.
- Add direct install-directory cleanup fallback when the old uninstaller exits non-zero.

Changes
- Switch process detection to ExecutablePath and terminate process trees with taskkill /T /F.
- Exclude the current uninstaller and old-uninstaller.exe from process shutdown checks.
- Add packaging regression coverage for the NSIS include behavior.

Tests
- npm run test -- src/main/packaging-config.test.ts
- npm run typecheck
- git diff --check
- npx --yes electron-builder@26.8.1 --config electron-builder.config.cjs --config.npmRebuild=false --publish never --win nsis --x64

Artifact
- dist/Kun-0.1.0-win-x64.exe
- SHA256: 8ce0257aa86178c19f00f1353d15d4dae5ec45862db06a6a2d2e2482957086f9