### PR TITLE
fix(ui): update file tree button icon

### DIFF
--- a/src/renderer/src/components/chat/WorkbenchTopBar.tsx
+++ b/src/renderer/src/components/chat/WorkbenchTopBar.tsx
@@ -11,7 +11,7 @@ import {
   Download,
   ExternalLink,
   FileEdit,
-  Files,
+  Folders,
   FolderOpen,
   Globe2,
   ListTodo,
@@ -410,7 +410,7 @@ export function WorkbenchTopBar({
           aria-pressed={fileTreeOpen}
           title={t('rightPanelFiles')}
         >
-          <Files className="h-4 w-4" strokeWidth={1.75} />
+          <Folders className="h-4 w-4" strokeWidth={1.75} />
         </button>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

- Replace the workbench file tree toggle icon with the stacked folder icon.
- Keep the existing button behavior, states, label, and sizing unchanged.

## Changes

- Swaps the Lucide `Files` icon for `Folders` in the top bar file tree button.

## Tests

- `npm run typecheck`
- `npm run build`
- Opened the Electron dev preview and visually checked the top-right file button.
