### PR TITLE
fix(write): keep markdown rename visible and export docx

### DIFF
--- a/src/main/services/write-export-service.test.ts
+++ b/src/main/services/write-export-service.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -18,9 +18,10 @@ import {
   buildWriteClipboardHtmlFragment,
   buildWriteExportFileName,
   buildWriteExportHtmlDocument,
-  copyWriteDocumentAsRichText
+  copyWriteDocumentAsRichText,
+  exportWriteDocument
 } from './write-export-service'
-import { clipboard } from 'electron'
+import { clipboard, dialog } from 'electron'
 
 describe('write-export-service helpers', () => {
   let workspaceRoot = ''
@@ -28,6 +29,7 @@ describe('write-export-service helpers', () => {
   beforeEach(async () => {
     workspaceRoot = await mkdtemp(join(tmpdir(), 'ds-gui-write-export-'))
     vi.mocked(clipboard.write).mockReset()
+    vi.mocked(dialog.showSaveDialog).mockReset()
   })
 
   it('builds export file names with the requested extension', () => {
@@ -101,5 +103,31 @@ describe('write-export-service helpers', () => {
         html: expect.stringContaining('src="data:image/png;base64,')
       })
     )
+  })
+
+  it('exports markdown documents as docx files', async () => {
+    const sourcePath = join(workspaceRoot, 'draft.md')
+    const targetPath = join(workspaceRoot, 'draft.docx')
+    await writeFile(sourcePath, '# Heading\n\n**Bold** text\n\n- item', 'utf8')
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({
+      canceled: false,
+      filePath: targetPath
+    })
+
+    const result = await exportWriteDocument({
+      path: sourcePath,
+      workspaceRoot,
+      format: 'docx',
+      content: '# Heading\n\n**Bold** text\n\n- item'
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      path: targetPath,
+      format: 'docx'
+    })
+    const bytes = await readFile(targetPath)
+    expect(bytes.subarray(0, 2).toString('utf8')).toBe('PK')
+    expect(bytes.length).toBeGreaterThan(1000)
   })
 })

--- a/src/main/services/write-export-service.ts
+++ b/src/main/services/write-export-service.ts
@@ -33,7 +33,7 @@ type HtmlToDocxConverter = (
   headerHtmlString?: string | null,
   documentOptions?: HtmlToDocxDocumentOptions,
   footerHtmlString?: string | null
-) => Promise<ArrayBuffer | Blob>
+) => Promise<ArrayBuffer | Blob | Buffer | Uint8Array>
 
 const require = createRequire(import.meta.url)
 const htmlToDocx = require('html-to-docx') as HtmlToDocxConverter
@@ -440,7 +440,13 @@ export async function copyWriteDocumentAsRichText(
   }
 }
 
-async function bufferFromDocxResult(result: ArrayBuffer | Blob): Promise<Buffer> {
+async function bufferFromDocxResult(result: ArrayBuffer | Blob | Buffer | Uint8Array): Promise<Buffer> {
+  if (Buffer.isBuffer(result)) {
+    return result
+  }
+  if (ArrayBuffer.isView(result)) {
+    return Buffer.from(result.buffer, result.byteOffset, result.byteLength)
+  }
   if (typeof ArrayBuffer !== 'undefined' && result instanceof ArrayBuffer) {
     return Buffer.from(new Uint8Array(result))
   }

--- a/src/renderer/src/write/write-workspace-file-actions.test.ts
+++ b/src/renderer/src/write/write-workspace-file-actions.test.ts
@@ -129,6 +129,38 @@ describe('write workspace file actions', () => {
     expect(get().fileError).toBe('rename failed')
   })
 
+  it('keeps markdown files visible when renaming without an extension', async () => {
+    const renameWorkspaceEntry = vi.fn(async () => ({
+      ok: true as const,
+      path: '/tmp/write/final.md',
+      previousPath: '/tmp/write/draft.md',
+      renamedAt: '2026-06-21T00:00:00.000Z'
+    }))
+    installDsGui({
+      renameWorkspaceEntry,
+      listWorkspaceDirectory: vi.fn(async () => ({
+        ok: true as const,
+        root: '/tmp/write',
+        entries: [{
+          name: 'final.md',
+          path: '/tmp/write/final.md',
+          type: 'file' as const,
+          ext: '.md'
+        }]
+      }))
+    })
+    const { actions } = createHarness()
+
+    const result = await actions.renameEntry('/tmp/write', '/tmp/write/draft.md', 'final')
+
+    expect(result).toBe('/tmp/write/final.md')
+    expect(renameWorkspaceEntry).toHaveBeenCalledWith({
+      workspaceRoot: '/tmp/write',
+      path: '/tmp/write/draft.md',
+      newName: 'final.md'
+    })
+  })
+
   it('returns false and reports file errors when delete IPC throws', async () => {
     installDsGui({
       deleteWorkspaceEntry: vi.fn(async () => {

--- a/src/renderer/src/write/write-workspace-file-actions.ts
+++ b/src/renderer/src/write/write-workspace-file-actions.ts
@@ -39,6 +39,21 @@ function formatActionError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function extensionFromWritePath(path: string): string {
+  const normalized = path.replaceAll('\\', '/')
+  const slash = normalized.lastIndexOf('/')
+  const dot = normalized.lastIndexOf('.')
+  return dot > slash ? normalized.slice(dot) : ''
+}
+
+function ensureMarkdownRenameExtension(path: string, newName: string): string {
+  if (extensionFromWritePath(newName)) return newName
+  const currentExtension = extensionFromWritePath(path)
+  return /^(?:\.md|\.markdown|\.mdx)$/i.test(currentExtension)
+    ? `${newName}${currentExtension.toLowerCase()}`
+    : newName
+}
+
 function withoutLoadingDirs(
   loadingDirs: Record<string, boolean>,
   keys: Array<string | undefined>
@@ -319,9 +334,10 @@ export function createWriteFileActions({
 
     renameEntry: async (workspaceRoot, path, newName) => {
       cancelExternalSyncAnimation()
+      const nextName = ensureMarkdownRenameExtension(path, newName.trim())
       let result: Awaited<ReturnType<typeof window.kunGui.renameWorkspaceEntry>>
       try {
-        result = await window.kunGui.renameWorkspaceEntry({ workspaceRoot, path, newName })
+        result = await window.kunGui.renameWorkspaceEntry({ workspaceRoot, path, newName: nextName })
       } catch (error) {
         set({ fileError: formatActionError(error) })
         return null


### PR DESCRIPTION
## Summary

Fixes two Writing Space regressions:

- Keep Markdown files visible after rename when the user omits the extension.
- Allow Markdown documents to export as `.docx` when `html-to-docx` returns a Node `Buffer` or typed array.

## Changes

- Preserve the existing Markdown extension (`.md`, `.markdown`, `.mdx`) during Writing Space rename when the new name has no extension.
- Normalize DOCX converter results from `Buffer`, typed arrays, `ArrayBuffer`, or `Blob` before writing the file.
- Added focused regression coverage for extension-preserving rename and real DOCX export output.

## Tests

- `npm.cmd test -- write-workspace-file-actions.test.ts write-export-service.test.ts`
- `git diff --check`
- `npm.cmd run typecheck`
- `npm.cmd run build`

Fixes KunAgent/Kun#495
Fixes KunAgent/Kun#496