### PR TITLE
fix(settings): 优化设置页布局

### DIFF
--- a/src/renderer/src/components/settings-section-agents.tsx
+++ b/src/renderer/src/components/settings-section-agents.tsx
@@ -719,10 +719,8 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
 
               <div className="mt-6">
                 <SettingsCard title={t('computerUseTitle')}>
-                  <div className="px-3 py-4">
+                  <div className="space-y-4 px-3 py-4">
                     <InlineNoticeView notice={{ tone: 'info', message: t('computerUseHint') }} />
-                  </div>
-                  <div className="px-3 pb-4">
                     <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-[12px] leading-5 text-amber-700 dark:text-amber-200">
                       <div className="font-semibold">{t('computerUseModelQualityTitle')}</div>
                       <div className="mt-1">{t('computerUseModelQualityBody')}</div>

--- a/src/renderer/src/components/settings-section-easter-egg.tsx
+++ b/src/renderer/src/components/settings-section-easter-egg.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import { useEffect, useState } from 'react'
-import { FolderPlus, Palette, Trash2 } from 'lucide-react'
+import { BookOpen, FolderPlus, Palette, Trash2 } from 'lucide-react'
 import { UI_MODE_DEFAULT, UI_MODE_RETROMA } from '../lib/ui-mode'
 import { useUiPluginStore } from '../store/ui-plugin-store'
 import kunBirdFigure from '../../../asset/img/kun_bird.png'
@@ -65,8 +65,12 @@ function ModeCardButton({
         )}
       </span>
       <span className="min-w-0">
-        <span className="block truncate text-[13.5px] font-semibold text-ds-ink">{card.title}</span>
-        <span className="mt-0.5 block truncate text-[11.5px] text-ds-faint">{card.subtitle}</span>
+        <span className="block whitespace-normal break-words text-[13.5px] font-semibold leading-5 text-ds-ink">
+          {card.title}
+        </span>
+        <span className="mt-0.5 block whitespace-normal break-words text-[11.5px] leading-4 text-ds-faint">
+          {card.subtitle}
+        </span>
       </span>
       <button
         type="button"
@@ -162,9 +166,10 @@ export function EasterEggSettingsSection({ ctx }: { ctx: Record<string, any> }):
       <SettingRow
         title={t('uiModeWorkshopTitle')}
         description={t('uiModeWorkshopDesc')}
+        wideControl
         control={
           <div className="flex w-full flex-col gap-3">
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {[...builtinCards, ...pluginCards].map((card) => {
                 const isBuiltin = card.mode === UI_MODE_DEFAULT
                 // 默认 Kun 卡承载 Retroma 配色:default 或 retroma 均视为该卡激活
@@ -172,44 +177,47 @@ export function EasterEggSettingsSection({ ctx }: { ctx: Record<string, any> }):
                   isBuiltin ? uiMode === UI_MODE_DEFAULT || uiMode === UI_MODE_RETROMA : uiMode === card.mode
                 const retromaOn = uiMode === UI_MODE_RETROMA
                 return (
-                <ModeCardButton
-                  key={card.mode}
-                  card={card}
-                  active={cardActive}
-                  busy={busy}
-                  onActivate={() => void activateUiMode(card.mode)}
-                  onRemove={
-                    card.removable ? () => void removeUiPluginById(card.mode) : undefined
-                  }
-                  onTogglePalette={
-                    isBuiltin
-                      ? () => void activateUiMode(retromaOn ? UI_MODE_DEFAULT : UI_MODE_RETROMA)
-                      : undefined
-                  }
-                  paletteOn={isBuiltin ? retromaOn : undefined}
-                  activeLabel={t('uiPluginActive')}
-                  activateLabel={t('uiPluginActivate')}
-                  removeLabel={t('uiPluginRemove')}
-                  paletteOnLabel={t('uiPaletteRetromaOn')}
-                  paletteOffLabel={t('uiPaletteRetromaOff')}
-                />
+                  <ModeCardButton
+                    key={card.mode}
+                    card={card}
+                    active={cardActive}
+                    busy={busy}
+                    onActivate={() => void activateUiMode(card.mode)}
+                    onRemove={
+                      card.removable ? () => void removeUiPluginById(card.mode) : undefined
+                    }
+                    onTogglePalette={
+                      isBuiltin
+                        ? () => void activateUiMode(retromaOn ? UI_MODE_DEFAULT : UI_MODE_RETROMA)
+                        : undefined
+                    }
+                    paletteOn={isBuiltin ? retromaOn : undefined}
+                    activeLabel={t('uiPluginActive')}
+                    activateLabel={t('uiPluginActivate')}
+                    removeLabel={t('uiPluginRemove')}
+                    paletteOnLabel={t('uiPaletteRetromaOn')}
+                    paletteOffLabel={t('uiPaletteRetromaOff')}
+                  />
                 )
               })}
             </div>
             {pluginCards.length === 0 ? (
               <p className="text-[12.5px] leading-5 text-ds-faint">{t('uiPluginEmpty')}</p>
             ) : null}
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="grid gap-2 sm:grid-cols-2">
               <button
                 type="button"
                 disabled={busy}
                 onClick={() => void handleInstall()}
-                className="inline-flex items-center gap-2 rounded-full bg-accent/12 px-4 py-2 text-[12.5px] font-medium text-accent transition hover:bg-accent/18 disabled:opacity-60"
+                className="inline-flex min-w-0 items-center justify-center gap-2 rounded-full bg-accent/12 px-4 py-2 text-[12.5px] font-medium leading-5 text-accent transition hover:bg-accent/18 disabled:opacity-60"
               >
                 <FolderPlus className="h-3.5 w-3.5" strokeWidth={1.8} />
-                {t('uiPluginInstall')}
+                <span className="min-w-0 whitespace-normal break-words text-center">{t('uiPluginInstall')}</span>
               </button>
-              <span className="text-[12px] text-ds-faint">{t('uiPluginDocsHint')}</span>
+              <span className="inline-flex min-w-0 items-center justify-center gap-2 rounded-full border border-ds-border bg-ds-card px-4 py-2 text-[12px] leading-5 text-ds-faint">
+                <BookOpen className="h-3.5 w-3.5 shrink-0" strokeWidth={1.8} />
+                <span className="min-w-0 whitespace-normal break-words text-center">{t('uiPluginDocsHint')}</span>
+              </span>
             </div>
             {installErrors.length > 0 ? (
               <ul className="rounded-xl bg-ds-danger-soft px-3 py-2 text-[12px] leading-5 text-ds-danger">

--- a/src/renderer/src/components/settings-section-write.tsx
+++ b/src/renderer/src/components/settings-section-write.tsx
@@ -596,83 +596,87 @@ export function WriteSettingsSection({ ctx }: { ctx: Record<string, any> }): Rea
               </SettingsCard>
 
               <SettingsCard title={t('writeAgentPresets')} className="mt-5">
-                <p className="text-[12.5px] leading-5 text-ds-faint">
-                  {t('writeAgentPresetsDesc')}
-                </p>
-                <div className="mt-3 flex flex-col gap-3">
-                  {agentPresets.map((preset: WriteAgentPresetV1, index: number) => {
-                    return (
-                      <div
-                        key={preset.id}
-                        className="rounded-xl border border-ds-border-muted bg-ds-card/70 p-3"
-                      >
-                        <div className="flex items-center gap-2">
-                          <input
-                            className={`${textInputClass} max-w-[56px] text-center`}
-                            value={preset.emoji}
-                            placeholder="🤖"
-                            spellCheck={false}
-                            onChange={(e) => {
-                              const next = [...agentPresets]
-                              next[index] = { ...preset, emoji: e.target.value }
-                              updateAgentPresets(next)
-                            }}
-                          />
-                          <input
-                            className={`${textInputClass} max-w-[220px]`}
-                            value={preset.name}
-                            placeholder={t('writeAgentPresetNamePlaceholder')}
-                            spellCheck={false}
-                            onChange={(e) => {
-                              const next = [...agentPresets]
-                              next[index] = { ...preset, name: e.target.value }
-                              updateAgentPresets(next)
-                            }}
-                          />
-                          <button
-                            type="button"
-                            className="ml-auto inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-ds-faint transition hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-300"
-                            title={t('writeAgentPresetRemove')}
-                            aria-label={t('writeAgentPresetRemove')}
-                            onClick={() =>
-                              updateAgentPresets(
-                                agentPresets.filter((item: WriteAgentPresetV1) => item.id !== preset.id)
-                              )
-                            }
+                <div className="px-3 py-4">
+                  <p className="text-[12.5px] leading-5 text-ds-faint">
+                    {t('writeAgentPresetsDesc')}
+                  </p>
+                  {agentPresets.length > 0 ? (
+                    <div className="mt-3 flex flex-col gap-3">
+                      {agentPresets.map((preset: WriteAgentPresetV1, index: number) => {
+                        return (
+                          <div
+                            key={preset.id}
+                            className="rounded-xl border border-ds-border-muted bg-ds-card/70 p-3"
                           >
-                            <Trash2 className="h-4 w-4" strokeWidth={1.8} />
-                          </button>
-                        </div>
-                        <textarea
-                          className={`${textInputClass} mt-2 min-h-[84px] resize-y leading-5`}
-                          value={preset.persona}
-                          placeholder={t('writeAgentPersonaPlaceholder')}
-                          spellCheck={false}
-                          onChange={(e) => {
-                            const next = [...agentPresets]
-                            next[index] = { ...preset, persona: e.target.value }
-                            updateAgentPresets(next)
-                          }}
-                        />
-                      </div>
-                    )
-                  })}
-                </div>
-                <div className="mt-3 flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    className={ghostButtonClass}
-                    disabled={agentPresets.length >= WRITE_AGENT_PRESET_MAX_COUNT}
-                    onClick={() =>
-                      updateAgentPresets([
-                        ...agentPresets,
-                        { id: `custom-${Date.now().toString(36)}`, name: '', emoji: '🤖', persona: '' }
-                      ])
-                    }
-                  >
-                    <Plus className="h-4 w-4" strokeWidth={2} />
-                    {t('writeAgentPresetAdd')}
-                  </button>
+                            <div className="flex items-center gap-2">
+                              <input
+                                className={`${textInputClass} max-w-[56px] text-center`}
+                                value={preset.emoji}
+                                placeholder="🤖"
+                                spellCheck={false}
+                                onChange={(e) => {
+                                  const next = [...agentPresets]
+                                  next[index] = { ...preset, emoji: e.target.value }
+                                  updateAgentPresets(next)
+                                }}
+                              />
+                              <input
+                                className={`${textInputClass} max-w-[220px]`}
+                                value={preset.name}
+                                placeholder={t('writeAgentPresetNamePlaceholder')}
+                                spellCheck={false}
+                                onChange={(e) => {
+                                  const next = [...agentPresets]
+                                  next[index] = { ...preset, name: e.target.value }
+                                  updateAgentPresets(next)
+                                }}
+                              />
+                              <button
+                                type="button"
+                                className="ml-auto inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-ds-faint transition hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-300"
+                                title={t('writeAgentPresetRemove')}
+                                aria-label={t('writeAgentPresetRemove')}
+                                onClick={() =>
+                                  updateAgentPresets(
+                                    agentPresets.filter((item: WriteAgentPresetV1) => item.id !== preset.id)
+                                  )
+                                }
+                              >
+                                <Trash2 className="h-4 w-4" strokeWidth={1.8} />
+                              </button>
+                            </div>
+                            <textarea
+                              className={`${textInputClass} mt-2 min-h-[84px] resize-y leading-5`}
+                              value={preset.persona}
+                              placeholder={t('writeAgentPersonaPlaceholder')}
+                              spellCheck={false}
+                              onChange={(e) => {
+                                const next = [...agentPresets]
+                                next[index] = { ...preset, persona: e.target.value }
+                                updateAgentPresets(next)
+                              }}
+                            />
+                          </div>
+                        )
+                      })}
+                    </div>
+                  ) : null}
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      className={ghostButtonClass}
+                      disabled={agentPresets.length >= WRITE_AGENT_PRESET_MAX_COUNT}
+                      onClick={() =>
+                        updateAgentPresets([
+                          ...agentPresets,
+                          { id: `custom-${Date.now().toString(36)}`, name: '', emoji: '🤖', persona: '' }
+                        ])
+                      }
+                    >
+                      <Plus className="h-4 w-4" strokeWidth={2} />
+                      {t('writeAgentPresetAdd')}
+                    </button>
+                  </div>
                 </div>
               </SettingsCard>
 


### PR DESCRIPTION
## 概要
- 修复自定义写作 Agent 空状态下多余分隔线的问题。
- 修复电脑操控设置中提示框边框与分隔线重叠的问题。
- 优化形象工坊的形象卡片、安装入口和开发指南入口，避免文字被截断。

## 变更
- 将写作 Agent 设置内容收进单个内容块，并仅在有自定义 Agent 时渲染列表区域。
- 将电脑操控说明和模型效果提示合并为同组内容，避免 SettingsCard 自动分隔线压到提示框上。
- 让形象工坊使用宽控件布局，卡片标题/副标题和底部操作入口都支持换行展示。

## 测试
- `npx eslint src/renderer/src/components/settings-section-agents.tsx src/renderer/src/components/settings-section-easter-egg.tsx src/renderer/src/components/settings-section-write.tsx`
- `npm run typecheck`
- `npm run test -- src/renderer/src/components/settings-section-agents.test.ts src/renderer/src/components/settings-section-archives.test.ts`
- `git diff --check`
