### PR TITLE
feat(lsp): add common language server presets

### DIFF
--- a/kun/src/adapters/tool/builtin-lsp-tool.ts
+++ b/kun/src/adapters/tool/builtin-lsp-tool.ts
@@ -1,8 +1,8 @@
 /**
  * `lsp` tool — exposes Language Server Protocol queries to the AI agent.
  *
- * Currently supports TypeScript / JavaScript via typescript-language-server.
- * The server binary must be installed (locally or on PATH); if missing the
+ * Supports the configured language servers in lsp-servers.ts.
+ * The matching server binary must be installed (locally or on PATH); if missing the
  * tool returns a helpful error instead of crashing.
  *
  * Operations: goToDefinition, findReferences, hover, documentSymbol,
@@ -65,10 +65,10 @@ export function createLspLocalTool(): LocalTool {
   return LocalToolHost.defineTool({
     name: 'lsp',
     description:
-      'Query a language server (currently TypeScript/JavaScript and Python). ' +
+      'Query a language server for TypeScript/JavaScript, Python, Rust, Go, C/C++, JSON, and YAML. ' +
       'Supports: goToDefinition, findReferences, hover, documentSymbol, workspaceSymbol, goToImplementation, getDiagnostics. ' +
       'Positions are 1-based (line/character as shown in editors). ' +
-      'Diagnostics are best-effort and reflect cached publishDiagnostics notifications. ' +
+      'Diagnostics are best-effort and use publishDiagnostics caches or pull diagnostics when supported. ' +
       'Requires a matching language server to be installed.',
     inputSchema: {
       type: 'object',

--- a/kun/src/adapters/tool/lsp-servers.test.ts
+++ b/kun/src/adapters/tool/lsp-servers.test.ts
@@ -9,14 +9,26 @@ import {
 describe('lsp server registry', () => {
   it('registers the default language servers', () => {
     const servers = listLanguageServers().map((server) => server.key).sort()
-    expect(servers).toEqual(['python', 'typescript'])
+    expect(servers).toEqual(['clangd', 'go', 'json', 'python', 'rust', 'typescript', 'yaml'])
     expect(getLanguageServer('typescript')?.displayName).toBe('TypeScript/JavaScript')
     expect(getLanguageServer('python')?.displayName).toBe('Python')
+    expect(getLanguageServer('rust')?.displayName).toBe('Rust')
+    expect(getLanguageServer('go')?.displayName).toBe('Go')
+    expect(getLanguageServer('clangd')?.displayName).toBe('C/C++')
+    expect(getLanguageServer('json')?.displayName).toBe('JSON')
+    expect(getLanguageServer('yaml')?.displayName).toBe('YAML')
   })
 
-  it('maps TypeScript and Python files to the expected servers', () => {
+  it('maps common source and config files to the expected servers', () => {
     expect(findLanguageServerForFile('/workspace/src/app.tsx')?.key).toBe('typescript')
     expect(findLanguageServerForFile('/workspace/src/app.py')?.key).toBe('python')
+    expect(findLanguageServerForFile('/workspace/src/main.rs')?.key).toBe('rust')
+    expect(findLanguageServerForFile('/workspace/src/main.go')?.key).toBe('go')
+    expect(findLanguageServerForFile('/workspace/src/main.cpp')?.key).toBe('clangd')
+    expect(findLanguageServerForFile('/workspace/src/main.h')?.key).toBe('clangd')
+    expect(findLanguageServerForFile('/workspace/package.json')?.key).toBe('json')
+    expect(findLanguageServerForFile('/workspace/tsconfig.jsonc')?.key).toBe('json')
+    expect(findLanguageServerForFile('/workspace/.github/workflows/ci.yml')?.key).toBe('yaml')
     expect(findLanguageServerForFile('/workspace/src/app.txt')).toBeUndefined()
   })
 
@@ -25,6 +37,13 @@ describe('lsp server registry', () => {
     expect(languageIdForFile('/workspace/src/app.tsx')).toBe('typescriptreact')
     expect(languageIdForFile('/workspace/src/app.jsx')).toBe('javascriptreact')
     expect(languageIdForFile('/workspace/src/app.pyi')).toBe('python')
+    expect(languageIdForFile('/workspace/src/main.rs')).toBe('rust')
+    expect(languageIdForFile('/workspace/src/main.go')).toBe('go')
+    expect(languageIdForFile('/workspace/src/main.c')).toBe('c')
+    expect(languageIdForFile('/workspace/src/main.hpp')).toBe('cpp')
+    expect(languageIdForFile('/workspace/package.json')).toBe('json')
+    expect(languageIdForFile('/workspace/tsconfig.jsonc')).toBe('jsonc')
+    expect(languageIdForFile('/workspace/config.yaml')).toBe('yaml')
     expect(languageIdForFile('/workspace/src/app.txt')).toBeNull()
   })
 })

--- a/kun/src/adapters/tool/lsp-servers.ts
+++ b/kun/src/adapters/tool/lsp-servers.ts
@@ -24,6 +24,23 @@ function normalizeExtension(filePath: string): string {
   return filePath.toLowerCase()
 }
 
+async function resolveLocalOrPath(
+  workspaceRoot: string,
+  binary: string,
+  args: string[]
+): Promise<LspServerCommand | null> {
+  const localBinary = process.platform === 'win32' ? `${binary}.cmd` : binary
+  const localPath = join(workspaceRoot, 'node_modules', '.bin', localBinary)
+  try {
+    await access(localPath)
+    return { command: localPath, args }
+  } catch {
+    // fall through to PATH lookup
+  }
+  const found = await probeServerBinary(binary)
+  return found ? { command: binary, args } : null
+}
+
 function registerDefaultLanguageServers(): void {
   if (!registry.has('typescript')) {
     registerLanguageServer({
@@ -32,15 +49,7 @@ function registerDefaultLanguageServers(): void {
       extensions: ['.ts', '.tsx', '.js', '.jsx', '.mts', '.mjs', '.cts', '.cjs'],
       installHint: 'Install with: npm install -g typescript-language-server typescript',
       resolveCommand: async (workspaceRoot) => {
-        const localPath = join(workspaceRoot, 'node_modules', '.bin', 'typescript-language-server')
-        try {
-          await access(localPath)
-          return { command: localPath, args: ['--stdio'] }
-        } catch {
-          // fall through to PATH lookup
-        }
-        const found = await probeServerBinary('typescript-language-server')
-        return found ? { command: 'typescript-language-server', args: ['--stdio'] } : null
+        return resolveLocalOrPath(workspaceRoot, 'typescript-language-server', ['--stdio'])
       },
       languageIdForFile: (filePath) => {
         const normalized = normalizeExtension(filePath)
@@ -75,6 +84,79 @@ function registerDefaultLanguageServers(): void {
         return null
       },
       languageIdForFile: () => 'python'
+    })
+  }
+
+  if (!registry.has('rust')) {
+    registerLanguageServer({
+      key: 'rust',
+      displayName: 'Rust',
+      extensions: ['.rs'],
+      installHint: 'Install with: rustup component add rust-analyzer',
+      resolveCommand: async () => {
+        const found = await probeServerBinary('rust-analyzer')
+        return found ? { command: 'rust-analyzer', args: [] } : null
+      },
+      languageIdForFile: () => 'rust'
+    })
+  }
+
+  if (!registry.has('go')) {
+    registerLanguageServer({
+      key: 'go',
+      displayName: 'Go',
+      extensions: ['.go'],
+      installHint: 'Install with: go install golang.org/x/tools/gopls@latest',
+      resolveCommand: async () => {
+        const found = await probeServerBinary('gopls')
+        return found ? { command: 'gopls', args: [] } : null
+      },
+      languageIdForFile: () => 'go'
+    })
+  }
+
+  if (!registry.has('clangd')) {
+    registerLanguageServer({
+      key: 'clangd',
+      displayName: 'C/C++',
+      extensions: ['.c', '.h', '.cc', '.cpp', '.cxx', '.hh', '.hpp', '.hxx'],
+      installHint: 'Install clangd from LLVM or your system package manager',
+      resolveCommand: async () => {
+        const found = await probeServerBinary('clangd')
+        return found ? { command: 'clangd', args: [] } : null
+      },
+      languageIdForFile: (filePath) => {
+        const normalized = normalizeExtension(filePath)
+        return normalized.endsWith('.c') ? 'c' : 'cpp'
+      }
+    })
+  }
+
+  if (!registry.has('json')) {
+    registerLanguageServer({
+      key: 'json',
+      displayName: 'JSON',
+      extensions: ['.json', '.jsonc'],
+      installHint: 'Install with: npm install -g vscode-langservers-extracted',
+      resolveCommand: async (workspaceRoot) => {
+        return resolveLocalOrPath(workspaceRoot, 'vscode-json-languageserver', ['--stdio'])
+      },
+      languageIdForFile: (filePath) => (
+        normalizeExtension(filePath).endsWith('.jsonc') ? 'jsonc' : 'json'
+      )
+    })
+  }
+
+  if (!registry.has('yaml')) {
+    registerLanguageServer({
+      key: 'yaml',
+      displayName: 'YAML',
+      extensions: ['.yaml', '.yml'],
+      installHint: 'Install with: npm install -g yaml-language-server',
+      resolveCommand: async (workspaceRoot) => {
+        return resolveLocalOrPath(workspaceRoot, 'yaml-language-server', ['--stdio'])
+      },
+      languageIdForFile: () => 'yaml'
     })
   }
 }


### PR DESCRIPTION
Summary
- Add common LSP server presets for Rust, Go, C/C++, JSON, and YAML.
- Reuse local-or-PATH binary resolution for npm-based language servers.
- Update the LSP tool description and registry coverage tests.

Tests
- npm --prefix kun run typecheck
- npm --prefix kun run test -- src/adapters/tool/lsp-servers.test.ts src/adapters/tool/builtin-lsp-tool.test.ts src/adapters/tool/lsp-client.test.ts src/adapters/tool/builtin-tool-types.test.ts
- npm run typecheck
