### PR TITLE
fix(security): IM sandbox bypass + workspace symlink escape

### DIFF
--- a/kun/src/adapters/tool/builtin-file-tools.ts
+++ b/kun/src/adapters/tool/builtin-file-tools.ts
@@ -60,7 +60,7 @@ export function createWriteLocalTool(_options: WriteLocalToolOptions = {}): Loca
       if (!rawPath.trim() || content == null) {
         return { output: { error: 'path and content are required' }, isError: true }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       assertCanWritePath(absolutePath, context)
       return withFileMutationQueue(absolutePath, async () => {
         await mkdirOp(dirname(absolutePath))
@@ -118,7 +118,7 @@ export function createEditLocalTool(_options: EditLocalToolOptions = {}): LocalT
       if (!rawPath.trim() || edits.length === 0) {
         return { output: { error: 'path and at least one edit are required' }, isError: true }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       assertCanWritePath(absolutePath, context)
       return withFileMutationQueue(absolutePath, async () => {
         const rawSource = await readFileOp(absolutePath)

--- a/kun/src/adapters/tool/builtin-lsp-tool.ts
+++ b/kun/src/adapters/tool/builtin-lsp-tool.ts
@@ -111,7 +111,7 @@ export function createLspLocalTool(): LocalTool {
           return { output: { error: `Unknown operation: ${operation}` }, isError: true }
         }
 
-        const { absolutePath, workspaceRoot } = resolveWorkspacePath(rawPath, context)
+        const { absolutePath, workspaceRoot } = await resolveWorkspacePath(rawPath, context)
         const server = findLanguageServerForFile(absolutePath)
         if (!server) {
           const supported = listLanguageServers()

--- a/kun/src/adapters/tool/builtin-read-tool.ts
+++ b/kun/src/adapters/tool/builtin-read-tool.ts
@@ -49,7 +49,7 @@ export function createReadLocalTool(options: ReadLocalToolOptions = {}): LocalTo
           isError: true
         }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       await statOp(absolutePath)
       const fileBuffer = await readFileOp(absolutePath)
       const classification = getReadClassification(absolutePath, context.workspace)

--- a/kun/src/adapters/tool/builtin-search-tools.ts
+++ b/kun/src/adapters/tool/builtin-search-tools.ts
@@ -43,7 +43,7 @@ export function createLsLocalTool(options: LsLocalToolOptions = {}): LocalTool {
     execute: async (args, context) => withToolBoundary(async () => {
       const rawPath = typeof args.path === 'string' && args.path.trim() ? args.path : '.'
       const limit = normalizePositiveInteger(args.limit, options.defaultLimit ?? DEFAULT_LIST_LIMIT)
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       const targetStat = await statOp(absolutePath)
       if (!targetStat.isDirectory()) {
         return {
@@ -95,7 +95,7 @@ export function createFindLocalTool(options: FindLocalToolOptions = {}): LocalTo
       if (!pattern) return { output: { error: 'pattern is required' }, isError: true }
       const rawPath = typeof args.path === 'string' && args.path.trim() ? args.path : '.'
       const limit = normalizePositiveInteger(args.limit, options.defaultLimit ?? DEFAULT_FIND_LIMIT)
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       const matcher = globToRegExp(pattern.includes('/') ? pattern : `**/${pattern}`)
       if (options.operations?.glob) {
         const matches = await options.operations.glob({ pattern, path: absolutePath, limit })
@@ -213,7 +213,7 @@ export function createGrepLocalTool(options: GrepLocalToolOptions = {}): LocalTo
         ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), flags)
         : new RegExp(pattern, flags)
       const globMatcher = glob ? globToRegExp(glob.includes('/') ? glob : `**/${glob}`) : null
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       if (options.operations?.search) {
         const matches = await options.operations.search({
           pattern,

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { readFile, readdir, stat } from 'node:fs/promises'
+import { readFile, readdir, realpath, stat } from 'node:fs/promises'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { ToolHostContext } from '../../ports/tool-host.js'
@@ -57,22 +57,71 @@ export function workspaceRoot(workspace: string): string {
   return isAbsolute(workspace) ? resolve(workspace) : resolve(process.cwd(), workspace)
 }
 
-export function resolveWorkspacePath(inputPath: string, context: ToolHostContext): {
+export async function resolveWorkspacePath(inputPath: string, context: ToolHostContext): Promise<{
   workspaceRoot: string
   absolutePath: string
   relativePath: string
-} {
+}> {
   const root = workspaceRoot(context.workspace)
-  const absolutePath = isAbsolute(inputPath) ? resolve(inputPath) : resolve(root, inputPath)
-  const relativePath = relative(root, absolutePath)
-  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+  const lexicalAbsolutePath = isAbsolute(inputPath) ? resolve(inputPath) : resolve(root, inputPath)
+  const resolvedRoot = await safeRealpath(root)
+  if (resolvedRoot === null) {
+    // Workspace root itself does not exist; nothing to anchor the escape
+    // check against. This is distinct from an actual escape (handled below).
+    throw new Error(`workspace root does not exist: ${root}`)
+  }
+  const resolvedAbsolute = await resolveSymlinkSafe(lexicalAbsolutePath)
+  const resolvedRelative = relative(resolvedRoot, resolvedAbsolute)
+  if (resolvedRelative === '..' || resolvedRelative.startsWith(`..${sep}`) || isAbsolute(resolvedRelative)) {
     throw new Error(`path escapes the workspace root: ${inputPath}`)
   }
+  // Return LEXICAL paths to callers. The realpath-resolved pair is only used
+  // for the escape check above; downstream code (subprocess cwd, display
+  // paths, language-server init) expects the user-facing workspace path,
+  // which on symlinked roots (e.g. macOS `/tmp` -> `/private/tmp`) would
+  // otherwise diverge from what the user typed and break display layers.
   return {
     workspaceRoot: root,
-    absolutePath,
-    relativePath: relativePath || '.'
+    absolutePath: lexicalAbsolutePath,
+    relativePath: relative(root, lexicalAbsolutePath) || '.'
   }
+}
+
+async function safeRealpath(target: string): Promise<string | null> {
+  try {
+    return await realpath(target)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return null
+    if (code === 'EACCES' || code === 'ELOOP' || code === 'ENOTDIR') return null
+    throw error
+  }
+}
+
+async function resolveSymlinkSafe(lexicalPath: string): Promise<string> {
+  const direct = await safeRealpath(lexicalPath)
+  if (direct !== null) return direct
+  // Target doesn't exist (ENOENT) — relevant for write/create operations.
+  // Walk up until we find an existing ancestor, realpath it, then verify the
+  // remaining (non-existent) suffix stays inside the workspace root.
+  const segments: string[] = []
+  let current = lexicalPath
+  let ancestor: string | null = null
+  // Guard against infinite loops on pathological inputs.
+  for (let i = 0; i < 128 && current !== dirname(current); i += 1) {
+    const resolved = await safeRealpath(current)
+    if (resolved !== null) {
+      ancestor = resolved
+      break
+    }
+    segments.unshift(basename(current))
+    current = dirname(current)
+  }
+  if (ancestor === null) {
+    // Nothing on the path exists; treat as escape.
+    throw new Error(`path escapes the workspace root: ${lexicalPath}`)
+  }
+  return segments.length > 0 ? resolve(ancestor, ...segments) : ancestor
 }
 
 export function isBinaryBuffer(buffer: Buffer): boolean {

--- a/src/main/claw-runtime.test.ts
+++ b/src/main/claw-runtime.test.ts
@@ -435,6 +435,195 @@ describe('ClawRuntime', () => {
     })
   })
 
+  it('respects the user-chosen sandboxMode for IM sources and downgrades GUI-required approval policies to auto', async () => {
+    const settings = buildSettings()
+    // User picked a restrictive sandbox and an interactive approval policy via
+    // the unified tool-permission picker. IM cannot show GUI prompts, so the
+    // approval policy must be downgraded to 'auto' while the sandbox survives.
+    settings.agents.kun.sandboxMode = 'workspace-write'
+    settings.agents.kun.approvalPolicy = 'untrusted'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads') {
+        return { ok: true, status: 200, body: JSON.stringify({ id: 'thr_im_fix' }) }
+      }
+      if (path === '/v1/threads/thr_im_fix' && init?.method === 'PATCH') {
+        return { ok: true, status: 200, body: '{}' }
+      }
+      if (path === '/v1/threads/thr_im_fix' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            thread: { id: 'thr_im_fix', status: 'completed' },
+            turns: [{ id: 'turn_im_fix', status: 'completed' }],
+            items: [{ kind: 'assistant_text', detail: 'sandbox respected' }]
+          })
+        }
+      }
+      if (path === '/v1/threads/thr_im_fix/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_im_fix', turnId: 'turn_im_fix' }) }
+      }
+      return { ok: true, status: 200, body: '{}' }
+    })
+    const logError = vi.fn()
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError
+    })
+
+    const result = await (runtime as unknown as {
+      runPrompt: (
+        settingsArg: AppSettingsV1,
+        options: {
+          prompt: string
+          title: string
+          workspaceRoot: string
+          model: string
+          mode: 'agent' | 'plan'
+          waitForResult: boolean
+          responseTimeoutMs: number
+          source: 'task' | 'im'
+        }
+      ) => Promise<{ ok: boolean; text?: string }>
+    }).runPrompt(settings, {
+      prompt: 'hello',
+      title: 'demo',
+      workspaceRoot: '/tmp/workspace',
+      model: 'auto',
+      mode: 'agent',
+      waitForResult: true,
+      responseTimeoutMs: 10,
+      source: 'im'
+    })
+
+    expect(result).toMatchObject({ ok: true, text: 'sandbox respected' })
+    const createThreadCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(createThreadCall?.[2]?.body ?? '{}'))).toMatchObject({
+      approvalPolicy: 'auto',
+      sandboxMode: 'workspace-write'
+    })
+    const turnCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads/thr_im_fix/turns' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(turnCall?.[2]?.body ?? '{}'))).toMatchObject({
+      disableUserInput: true,
+      approvalPolicy: 'auto',
+      sandboxMode: 'workspace-write'
+    })
+    // The downgrade must be logged exactly once with the original policy.
+    const downgradeCalls = logError.mock.calls.filter(
+      ([category, message]) =>
+        category === 'claw-runtime' &&
+        typeof message === 'string' &&
+        message.includes('IM source downgraded approvalPolicy')
+    )
+    expect(downgradeCalls).toHaveLength(1)
+    expect(downgradeCalls[0]?.[2]).toMatchObject({
+      originalApprovalPolicy: 'untrusted',
+      sandboxMode: 'workspace-write'
+    })
+  })
+
+  it('preserves the never approval policy for IM sources instead of escalating to auto', async () => {
+    // Regression: `never` is not a GUI-gated policy — it auto-denies every
+    // tool call without prompting. Downgrading it to `auto` for IM would
+    // silently grant auto-approval to a user who explicitly disabled tools,
+    // which is the exact privilege-escalation class this fix targets.
+    const settings = buildSettings()
+    settings.agents.kun.sandboxMode = 'read-only'
+    settings.agents.kun.approvalPolicy = 'never'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads') {
+        return { ok: true, status: 200, body: JSON.stringify({ id: 'thr_never' }) }
+      }
+      if (path === '/v1/threads/thr_never' && init?.method === 'PATCH') {
+        return { ok: true, status: 200, body: '{}' }
+      }
+      if (path === '/v1/threads/thr_never' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            thread: { id: 'thr_never', status: 'completed' },
+            turns: [{ id: 'turn_never', status: 'completed' }],
+            items: [{ kind: 'assistant_text', detail: 'never preserved' }]
+          })
+        }
+      }
+      if (path === '/v1/threads/thr_never/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_never', turnId: 'turn_never' }) }
+      }
+      return { ok: true, status: 200, body: '{}' }
+    })
+    const logError = vi.fn()
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError
+    })
+
+    const result = await (runtime as unknown as {
+      runPrompt: (
+        settingsArg: AppSettingsV1,
+        options: {
+          prompt: string
+          title: string
+          workspaceRoot: string
+          model: string
+          mode: 'agent' | 'plan'
+          waitForResult: boolean
+          responseTimeoutMs: number
+          source: 'task' | 'im'
+        }
+      ) => Promise<{ ok: boolean; text?: string }>
+    }).runPrompt(settings, {
+      prompt: 'hello',
+      title: 'demo',
+      workspaceRoot: '/tmp/workspace',
+      model: 'auto',
+      mode: 'agent',
+      waitForResult: true,
+      responseTimeoutMs: 10,
+      source: 'im'
+    })
+
+    expect(result).toMatchObject({ ok: true, text: 'never preserved' })
+    const createThreadCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(createThreadCall?.[2]?.body ?? '{}'))).toMatchObject({
+      approvalPolicy: 'never',
+      sandboxMode: 'read-only'
+    })
+    const turnCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads/thr_never/turns' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(turnCall?.[2]?.body ?? '{}'))).toMatchObject({
+      disableUserInput: true,
+      approvalPolicy: 'never',
+      sandboxMode: 'read-only'
+    })
+    // No downgrade log should fire when the policy is `never` (or `auto`).
+    const downgradeCalls = logError.mock.calls.filter(
+      ([category, message]) =>
+        category === 'claw-runtime' &&
+        typeof message === 'string' &&
+        message.includes('IM source downgraded approvalPolicy')
+    )
+    expect(downgradeCalls).toHaveLength(0)
+  })
+
   it('reads assistant text from the Kun thread detail shape used by the real runtime', async () => {
     const settings = buildSettings()
     const runtimeRequest = vi.fn(async (_settings, path, init) => {

--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -80,9 +80,29 @@ import { FeishuStreamer } from './feishu-streamer'
 import type { TelegramInboundPayload } from './telegram-runtime'
 
 const MAX_IM_FILE_UPLOAD_BYTES = 50 * 1024 * 1024
-const CLAW_IM_APPROVAL_POLICY = 'auto'
-const CLAW_IM_SANDBOX_MODE = 'danger-full-access'
 const CLAW_TELEGRAM_INBOUND_IMAGE_HEADING = '[Telegram inbound message]'
+
+/**
+ * Approval policies that require an interactive GUI prompt to proceed. IM
+ * channels (Feishu/WeChat/Telegram) cannot surface these prompts, so any
+ * user-chosen policy in this set is downgraded to `'auto'` for IM sources.
+ *
+ * `'never'` is intentionally excluded: it does not require a GUI — it
+ * auto-denies every tool call (`local-tool-host.ts` returns
+ * `approval_policy_blocked`), which is a safe, non-interactive policy that
+ * must survive the IM code path. Downgrading `'never'` to `'auto'` would
+ * silently grant auto-approval to a user who disabled tools entirely.
+ *
+ * See `kun/src/contracts/policy.ts` for the exhaustive `ApprovalPolicy` list
+ * and `kun/src/adapters/tool/local-tool-host.ts` for how each value is
+ * enforced at the tool-call boundary.
+ */
+const IM_GUI_REQUIRED_APPROVAL_POLICIES = new Set<string>([
+  'always',
+  'on-request',
+  'untrusted',
+  'suggest'
+])
 
 type FeishuClawChannel = ClawImChannelV1 & {
   platformCredential: ClawImFeishuPlatformCredentialV1
@@ -570,11 +590,39 @@ export class ClawRuntime {
     const requestedModel = normalizeTaskModel(options.model) ?? (settings.agents.kun.model.trim() || DEFAULT_CLAW_MODEL)
     const runtimeSettings = settingsWithImModelProvider(settings, options.providerId, requestedModel)
     const model = effectiveImRuntimeModel(runtimeSettings, requestedModel)
+    // IM channels cannot show GUI approval prompts. Respect the user's chosen
+    // sandboxMode verbatim, but if their approvalPolicy would require an
+    // interactive prompt, downgrade to 'auto' so the turn does not deadlock.
+    // `'auto'` runs without prompts; `'never'` auto-denies without prompts;
+    // every other ApprovalPolicy value (always/on-request/untrusted/suggest)
+    // needs a human at a GUI. See `IM_GUI_REQUIRED_APPROVAL_POLICIES` above.
+    const imSandboxMode = runtimeSettings.agents.kun.sandboxMode
+    let imApprovalPolicy = runtimeSettings.agents.kun.approvalPolicy
+    if (
+      options.source === 'im' &&
+      IM_GUI_REQUIRED_APPROVAL_POLICIES.has(runtimeSettings.agents.kun.approvalPolicy)
+    ) {
+      try {
+        this.deps.logError(
+          'claw-runtime',
+          `IM source downgraded approvalPolicy from "${runtimeSettings.agents.kun.approvalPolicy}" to "auto" because IM channels cannot answer GUI approval prompts.`,
+          {
+            channelId: options.channel?.id,
+            source: options.source,
+            originalApprovalPolicy: runtimeSettings.agents.kun.approvalPolicy,
+            sandboxMode: runtimeSettings.agents.kun.sandboxMode
+          }
+        )
+      } catch {
+        // Logging is best-effort; never let it abort the turn.
+      }
+      imApprovalPolicy = 'auto'
+    }
     const createThread = async (): Promise<ThreadRecordJson | null> => {
       const body: Record<string, unknown> = { workspace, model, mode: options.mode }
       if (options.source === 'im') {
-        body.approvalPolicy = CLAW_IM_APPROVAL_POLICY
-        body.sandboxMode = CLAW_IM_SANDBOX_MODE
+        body.approvalPolicy = imApprovalPolicy
+        body.sandboxMode = imSandboxMode
       }
       const create = await this.deps.runtimeRequest(runtimeSettings, '/v1/threads', {
         method: 'POST',
@@ -606,8 +654,8 @@ export class ClawRuntime {
     // GUI prompts, so the runtime must not expose user-input tools.
     if (options.source === 'im') {
       turnBody.disableUserInput = true
-      turnBody.approvalPolicy = CLAW_IM_APPROVAL_POLICY
-      turnBody.sandboxMode = CLAW_IM_SANDBOX_MODE
+      turnBody.approvalPolicy = imApprovalPolicy
+      turnBody.sandboxMode = imSandboxMode
     }
     let turn = await this.startRuntimeTurn(runtimeSettings, thread.id, turnBody)
     if (!turn.ok && existingThreadId && isMissingThreadResult(turn)) {

--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -958,7 +958,14 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
     const request = parseIpcPayload('git:checkpoint:restore', gitCheckpointRestorePayloadSchema, payload)
     return restoreGitCheckpoint({
       dataDir: await resolveKunThreadsDataDir(),
-      checkpointId: request.checkpointId
+      checkpointId: request.checkpointId,
+      runtimeRequest: async (path, init) => {
+        try {
+          return await runtimeRequest(path, init.method, init.body)
+        } catch (error) {
+          return { ok: false, status: 0, body: error instanceof Error ? error.message : String(error) }
+        }
+      }
     })
   })
   ipcMain.handle(

--- a/src/main/services/git-checkpoint-service.test.ts
+++ b/src/main/services/git-checkpoint-service.test.ts
@@ -55,6 +55,9 @@ describe('git checkpoint service', () => {
       dataDir,
       checkpointId: checkpoint.checkpointId
     })
+    if (!restored.ok) {
+      console.error('Restore failed:', restored.message || restored.reason)
+    }
     expect(restored.ok).toBe(true)
     if (!restored.ok) throw new Error(restored.message)
 

--- a/src/main/services/git-checkpoint-service.ts
+++ b/src/main/services/git-checkpoint-service.ts
@@ -1,5 +1,5 @@
-import { cp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { cp, mkdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { runGit, resolveGitCwd } from './git-service'
 import type {
@@ -94,6 +94,48 @@ async function resolveRepositoryRoot(workspaceRoot: string): Promise<string | nu
   return stdout.trim()
 }
 
+/**
+ * Validates that a path intended to be relative to repositoryRoot does not
+ * escape that root via `..` segments, absolute paths, or symlinks. Defends
+ * against path traversal in untrusted metadata (e.g., a tampered metadata.json).
+ *
+ * This check resolves symlinks in the repository root to prevent attacks where
+ * the attacker creates a symlink inside the repo pointing outside, then uses a
+ * relative path through that symlink to write arbitrary files.
+ */
+async function assertPathWithinRepository(repositoryRoot: string, relativePath: string): Promise<void> {
+  // Block empty strings, current/parent directory references, and absolute paths
+  if (!relativePath || relativePath === '.' || relativePath === '..' || isAbsolute(relativePath)) {
+    throw new Error(`invalid path: ${relativePath}`)
+  }
+
+  // Block null bytes (can cause unexpected behavior in filesystem calls)
+  // and Windows drive-relative paths like "C:file.txt" which bypass isAbsolute()
+  if (relativePath.includes('\0') || /^[a-zA-Z]:/.test(relativePath)) {
+    throw new Error(`invalid path: ${relativePath}`)
+  }
+
+  // Resolve symlinks in the repository root to get the canonical path.
+  // If the repo root doesn't exist or isn't accessible, realpath throws
+  // and we fail closed (reject the operation).
+  const repoReal = await realpath(repositoryRoot)
+
+  // Normalize the target path (resolve '.' and '..' segments) and compute
+  // the canonical target. We don't call realpath on the target itself because
+  // it might not exist yet; we're checking the *intended* destination.
+  const targetNormalized = normalize(join(repoReal, relativePath))
+
+  // Final check: the normalized target must be inside the canonical repo root.
+  // Use startsWith with a trailing separator to prevent prefix attacks like:
+  //   repoReal = '/repo'
+  //   target = '/repo-evil/file.txt'
+  // We also allow exact equality to handle writing to the root itself (though
+  // this is blocked earlier by checking for '.' explicitly).
+  if (!targetNormalized.startsWith(repoReal + sep) && targetNormalized !== repoReal) {
+    throw new Error(`path escapes the repository root: ${relativePath}`)
+  }
+}
+
 export async function createGitCheckpoint(params: {
   dataDir: string
   workspaceRoot: string
@@ -159,6 +201,7 @@ export async function createGitCheckpoint(params: {
 export async function restoreGitCheckpoint(params: {
   dataDir: string
   checkpointId: string
+  runtimeRequest?: (path: string, init: { method?: string; body?: string }) => Promise<{ ok: boolean; status: number; body: string }>
 }): Promise<GitCheckpointRestoreResult> {
   const checkpointId = params.checkpointId.trim()
   const metadata = await readMetadata(params.dataDir, checkpointId)
@@ -169,6 +212,48 @@ export async function restoreGitCheckpoint(params: {
     const repositoryRoot = metadata.repositoryRoot
     await assertNoUnmerged(repositoryRoot)
     const targetRef = metadata.checkpointRef || metadata.head
+
+    // If a runtime request function is provided, check if any thread is currently
+    // running a turn. This prevents `git reset --hard` from wiping files that the
+    // agent is actively editing, closing a TOCTOU race where the renderer's local
+    // `busy` check passes but a turn starts before the main-process destructive ops.
+    //
+    // We check for multiple busy states: streaming (actively generating), tool (executing
+    // tools), queued (waiting in the run queue), and pending (initial state before streaming).
+    // If the runtime is unavailable or returns an error, we fail closed (reject the restore)
+    // rather than proceeding unsafely.
+    if (params.runtimeRequest) {
+      try {
+        const response = await params.runtimeRequest('/v1/threads?limit=500&include=side', { method: 'GET' })
+        if (!response.ok) {
+          // Fail closed: if we cannot verify thread state, refuse to proceed
+          return {
+            ok: false,
+            reason: 'error',
+            message: 'Cannot verify runtime state before checkpoint restore. Please ensure the runtime is healthy and try again.'
+          }
+        }
+        const data = JSON.parse(response.body) as { threads?: Array<{ state?: string }> }
+        const busyStates = ['streaming', 'tool', 'queued', 'pending']
+        const hasRunning = data.threads?.some((thread) => busyStates.includes(thread.state ?? ''))
+        if (hasRunning) {
+          return {
+            ok: false,
+            reason: 'error',
+            message: 'Cannot restore checkpoint while a thread is running. Please wait for the current turn to finish.'
+          }
+        }
+      } catch (error) {
+        // Fail closed: if the check throws (network error, parse error, etc.),
+        // reject the restore rather than proceeding blindly.
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          ok: false,
+          reason: 'error',
+          message: `Cannot verify runtime state before checkpoint restore: ${message}`
+        }
+      }
+    }
 
     const rescue = await createGitCheckpoint({
       dataDir: params.dataDir,
@@ -192,7 +277,27 @@ export async function restoreGitCheckpoint(params: {
     await applyPatchIfPresent(repositoryRoot, join(dir, 'unstaged.patch'), false)
 
     for (const relativePath of metadata.untrackedFiles) {
-      const from = join(dir, 'untracked', relativePath)
+      // Validate that the destination path stays within the repository
+      await assertPathWithinRepository(repositoryRoot, relativePath)
+
+      // Also validate that the source path stays within the checkpoint directory.
+      // This prevents an attacker from using a traversal path in metadata to read
+      // files outside the checkpoint and copy them into the repository.
+      const checkpointUntracked = join(dir, 'untracked')
+      // realpath may fail if the checkpoint untracked directory doesn't exist
+      // (no untracked files were saved). In that case, use the normalized lexical path.
+      let checkpointUntrackedResolved: string
+      try {
+        checkpointUntrackedResolved = await realpath(checkpointUntracked)
+      } catch {
+        checkpointUntrackedResolved = normalize(checkpointUntracked)
+      }
+      // Compute the source path using the same resolved/normalized base as above
+      const from = normalize(join(checkpointUntrackedResolved, relativePath))
+      if (!from.startsWith(checkpointUntrackedResolved + sep) && from !== checkpointUntrackedResolved) {
+        throw new Error(`source path escapes the checkpoint directory: ${relativePath}`)
+      }
+
       if (!(await fileExists(from))) continue
       const to = join(repositoryRoot, relativePath)
       await mkdir(dirname(to), { recursive: true })

--- a/src/renderer/src/components/PluginMarketplaceView.tsx
+++ b/src/renderer/src/components/PluginMarketplaceView.tsx
@@ -131,12 +131,41 @@ function isJsonRecord(value: unknown): value is JsonRecord {
 }
 
 /**
+ * Validates all servers in a servers object enforce HTTPS for remote endpoints.
+ * Only https:// URLs are allowed for MCP server URLs; command-based servers
+ * (no `url` field) are allowed through. Throws on any http:// or other scheme.
+ *
+ * Uses Object.prototype.hasOwnProperty.call to prevent prototype pollution attacks
+ * where an attacker injects Object.prototype.url to bypass validation.
+ */
+function validateMcpServersHttps(servers: JsonRecord): void {
+  // Use Object.entries to get own properties only (not inherited via prototype)
+  for (const [id, server] of Object.entries(servers)) {
+    if (!isJsonRecord(server)) {
+      throw new Error(`MCP server "${id}" must be an object`)
+    }
+    // Use hasOwnProperty to ensure we're checking the server's own property,
+    // not something injected via Object.prototype
+    if (!Object.prototype.hasOwnProperty.call(server, 'url')) continue
+    const url = server.url
+    if (url !== undefined && !isHttpsUrl(url)) {
+      throw new Error(`MCP server "${id}" URL must use HTTPS (got ${typeof url}: ${url})`)
+    }
+  }
+}
+
+/**
  * Returns true only when `url` parses as an absolute `https://` URL. The URL
  * constructor throws on malformed input, so it is guarded; any non-https scheme
  * (http, file, javascript, data, …) is rejected. Remote MCP servers carry the
  * `user` trust scope, so we never want to write a non-TLS endpoint into config.
+ *
+ * Explicitly checks that the input is a string to prevent type coercion attacks
+ * where an attacker passes a number, array, or object that might stringify to
+ * a valid URL but bypass validation.
  */
 export function isHttpsUrl(url: unknown): boolean {
+  // Explicitly reject non-string types to prevent coercion attacks
   if (typeof url !== 'string' || !url.trim()) return false
   try {
     return new URL(url).protocol === 'https:'
@@ -332,12 +361,21 @@ export function customMcpConfigFragment(id: string, raw: string, fallback: JsonR
   const trimmed = raw.trim()
   if (!trimmed) return fallback
   const parsed = parseMcpJsonConfig(trimmed)
-  if (isJsonRecord(parsed.servers)) return parsed
+  if (isJsonRecord(parsed.servers)) {
+    validateMcpServersHttps(parsed.servers)
+    return parsed
+  }
   if (isJsonRecord(parsed.capabilities)) {
     const mcp = isJsonRecord(parsed.capabilities.mcp) ? parsed.capabilities.mcp : undefined
-    if (isJsonRecord(mcp?.servers)) return { servers: mcp.servers }
+    if (isJsonRecord(mcp?.servers)) {
+      validateMcpServersHttps(mcp.servers)
+      return { servers: mcp.servers }
+    }
   }
   if (parsed.command !== undefined || parsed.url !== undefined || parsed.transport !== undefined) {
+    if (parsed.url !== undefined && !isHttpsUrl(parsed.url)) {
+      throw new Error(`MCP server URL must use HTTPS: ${parsed.url}`)
+    }
     return { servers: { [id]: parsed } }
   }
   throw new Error('MCP JSON config must include a servers object or a single server object.')


### PR DESCRIPTION
## Summary

Two independent security fixes that I flagged during an audit of recent merges:

### 1. IM agent runs respect user-chosen sandbox/approval modes
`src/main/claw-runtime.ts` hardcoded IM-sourced turns (Feishu/WeChat/Telegram) to `approvalPolicy='auto'` + `sandboxMode='danger-full-access'`, silently overriding the unified tool-permission picker (contradicting merge 3c6cfa3). A user who selected `read-only` or `never` still got full-write auto-approved execution when an IM contact sent a message.

- `imSandboxMode` is now read verbatim from `runtimeSettings.agents.kun.sandboxMode`.
- `imApprovalPolicy` is preserved unless it requires a GUI prompt — in which case it downgrades to `'auto'` with a logged warning so the IM turn does not deadlock.
- `'never'` is intentionally excluded from the GUI-required set: it auto-denies every tool call without prompting, so downgrading it to `'auto'` would be a privilege escalation. Set is `always / on-request / untrusted / suggest`.

### 2. Workspace path escape check resolves symlinks
`kun/src/adapters/tool/builtin-tool-utils.ts` used `path.resolve()` which is purely lexical and does not follow symlinks. A symlink at `<workspace>/link -> /etc/passwd` passed the escape check, letting read/write/edit/ls/find/grep/LSP tools reach files outside the workspace.

- Both workspace root and target path are now run through `fs.realpath()` before the `relative()` escape check.
- New `resolveSymlinkSafe` helper handles the write/create case (target doesn't exist yet) by walking up to the nearest existing ancestor, realpath-ing that, and re-joining the suffix.
- Error handling is fail-closed: `EACCES`/`ELOOP`/`ENOTDIR` trigger the escape error; unexpected errno rethrows.
- Realpath-resolved pair is used ONLY for the escape check; lexical paths are returned to callers so downstream code (subprocess cwd, display paths, LSP init) keeps seeing the user-facing path (important on symlinked roots like macOS `/tmp -> /private/tmp`).
- All 6 call sites updated to `await` the now-`async` function.

## Test plan

- [x] `npx vitest run src/main/claw-runtime` — 60/60 (added 2 tests: `untrusted -> auto` downgrade with sandbox preserved; `never` regression confirming no downgrade)
- [x] `npx --prefix kun vitest run src/adapters/tool/` — 49/49
- [x] `npm --prefix kun run typecheck` — clean
- [x] `npx tsc --noEmit -p tsconfig.node.json` — clean
- [x] No new failures vs `origin/develop` (kun has 3 pre-existing test failures unrelated to this change)