### PR TITLE
fix(rollback): hide checkpoint refs and success banner

### DIFF
--- a/src/main/services/git-checkpoint-service.test.ts
+++ b/src/main/services/git-checkpoint-service.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createGitCheckpoint, restoreGitCheckpoint } from './git-checkpoint-service'
@@ -31,6 +31,26 @@ afterEach(async () => {
 })
 
 describe('git checkpoint service', () => {
+  it('stores checkpoint heads outside visible git refs', async () => {
+    const checkpoint = await createGitCheckpoint({
+      dataDir,
+      workspaceRoot: repoRoot,
+      threadId: 'thr_1'
+    })
+    expect(checkpoint.ok).toBe(true)
+    if (!checkpoint.ok) throw new Error(checkpoint.message)
+
+    const checkpointDir = join(dataDir, 'git-checkpoints', checkpoint.checkpointId)
+    const metadata = JSON.parse(await readFile(join(checkpointDir, 'metadata.json'), 'utf-8')) as {
+      checkpointRef?: string
+    }
+    expect(metadata.checkpointRef).toBeUndefined()
+    await expect(stat(join(checkpointDir, 'head.bundle'))).resolves.toBeTruthy()
+
+    const refs = execFileSync('git', ['-C', repoRoot, 'show-ref'], { encoding: 'utf-8' })
+    expect(refs).not.toContain('refs/kun/checkpoints')
+  })
+
   it('restores staged, unstaged, and untracked files to the checkpoint state', async () => {
     await writeFile(join(repoRoot, 'tracked.txt'), 'checkpoint unstaged\n')
     await writeFile(join(repoRoot, 'staged.txt'), 'checkpoint staged\n')
@@ -94,5 +114,43 @@ describe('git checkpoint service', () => {
       checkpoint.head
     )
     expect(execFileSync('git', ['-C', repoRoot, 'status', '--porcelain=v1'], { encoding: 'utf-8' }).trim()).toBe('')
+  })
+
+  it('restores from the head bundle when the checkpoint commit was pruned', async () => {
+    const checkpoint = await createGitCheckpoint({
+      dataDir,
+      workspaceRoot: repoRoot,
+      threadId: 'thr_1'
+    })
+    expect(checkpoint.ok).toBe(true)
+    if (!checkpoint.ok) throw new Error(checkpoint.message)
+
+    execFileSync('git', ['-C', repoRoot, 'checkout', '--orphan', 'replacement'], { stdio: 'pipe' })
+    execFileSync('git', ['-C', repoRoot, 'rm', '-rf', '.'], { stdio: 'pipe' })
+    await writeFile(join(repoRoot, 'tracked.txt'), 'replacement\n')
+    execFileSync('git', ['-C', repoRoot, 'add', 'tracked.txt'], { stdio: 'pipe' })
+    execFileSync('git', ['-C', repoRoot, 'commit', '-m', 'replacement'], { stdio: 'pipe' })
+    execFileSync('git', ['-C', repoRoot, 'branch', '-D', 'main'], { stdio: 'pipe' })
+    execFileSync('git', ['-C', repoRoot, 'branch', '-m', 'main'], { stdio: 'pipe' })
+    execFileSync('git', ['-C', repoRoot, 'reflog', 'expire', '--expire=now', '--all'], { stdio: 'pipe' })
+    execFileSync('git', ['-C', repoRoot, 'gc', '--prune=now'], { stdio: 'pipe' })
+
+    expect(() => execFileSync('git', ['-C', repoRoot, 'cat-file', '-e', `${checkpoint.head}^{commit}`], {
+      stdio: 'pipe'
+    })).toThrow()
+
+    const restored = await restoreGitCheckpoint({
+      dataDir,
+      checkpointId: checkpoint.checkpointId
+    })
+    expect(restored.ok).toBe(true)
+    if (!restored.ok) throw new Error(restored.message)
+
+    expect(await readFile(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('base\n')
+    expect(execFileSync('git', ['-C', repoRoot, 'rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim()).toBe(
+      checkpoint.head
+    )
+    const refs = execFileSync('git', ['-C', repoRoot, 'show-ref'], { encoding: 'utf-8' })
+    expect(refs).not.toContain('refs/kun/checkpoints')
   })
 })

--- a/src/main/services/git-checkpoint-service.ts
+++ b/src/main/services/git-checkpoint-service.ts
@@ -12,7 +12,7 @@ type GitCheckpointMetadata = {
   threadId: string
   repositoryRoot: string
   head: string
-  checkpointRef: string
+  checkpointRef?: string | null
   currentBranch: string | null
   createdAt: string
   untrackedFiles: string[]
@@ -38,8 +38,8 @@ function checkpointDir(dataDir: string, checkpointId: string): string {
   return join(resolve(dataDir), 'git-checkpoints', checkpointId)
 }
 
-function checkpointRef(checkpointId: string): string {
-  return `refs/kun/checkpoints/${checkpointId.replace(/[^A-Za-z0-9._-]/g, '_')}`
+function checkpointHeadBundlePath(dataDir: string, checkpointId: string): string {
+  return join(checkpointDir(dataDir, checkpointId), 'head.bundle')
 }
 
 function metadataPath(dataDir: string, checkpointId: string): string {
@@ -87,6 +87,40 @@ async function applyPatchIfPresent(repositoryRoot: string, path: string, cached:
   await runGit(repositoryRoot, ['apply', '--binary', ...(cached ? ['--index'] : []), path], 30_000)
 }
 
+async function commitExists(repositoryRoot: string, rev: string): Promise<boolean> {
+  if (!rev.trim()) return false
+  try {
+    await runGit(repositoryRoot, ['cat-file', '-e', `${rev}^{commit}`])
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function writeHeadBundle(repositoryRoot: string, path: string): Promise<void> {
+  await runGit(repositoryRoot, ['bundle', 'create', path, 'HEAD'], 30_000)
+}
+
+async function resolveCheckpointTarget(
+  repositoryRoot: string,
+  dataDir: string,
+  metadata: GitCheckpointMetadata
+): Promise<string> {
+  const head = metadata.head.trim()
+  if (await commitExists(repositoryRoot, head)) return head
+
+  const bundlePath = checkpointHeadBundlePath(dataDir, metadata.checkpointId)
+  if (await fileExists(bundlePath)) {
+    await runGit(repositoryRoot, ['bundle', 'unbundle', bundlePath], 30_000)
+    if (await commitExists(repositoryRoot, head)) return head
+  }
+
+  const legacyRef = metadata.checkpointRef?.trim() ?? ''
+  if (await commitExists(repositoryRoot, legacyRef)) return legacyRef
+
+  throw new Error(`Git checkpoint target commit is unavailable: ${head || metadata.checkpointId}`)
+}
+
 async function resolveRepositoryRoot(workspaceRoot: string): Promise<string | null> {
   const cwd = await resolveGitCwd(workspaceRoot)
   if (!cwd) return null
@@ -113,12 +147,11 @@ export async function createGitCheckpoint(params: {
 
     const checkpointId = params.checkpointId?.trim() || `gcp_${Date.now()}_${randomUUID()}`
     const dir = checkpointDir(params.dataDir, checkpointId)
-    const ref = checkpointRef(checkpointId)
     await rm(dir, { recursive: true, force: true })
     await mkdir(join(dir, 'untracked'), { recursive: true })
 
     const head = (await runGit(repositoryRoot, ['rev-parse', 'HEAD'])).stdout.trim()
-    await runGit(repositoryRoot, ['update-ref', ref, head])
+    await writeHeadBundle(repositoryRoot, checkpointHeadBundlePath(params.dataDir, checkpointId))
     const currentBranchRaw = (await runGit(repositoryRoot, ['branch', '--show-current'])).stdout.trim()
     const currentBranch = currentBranchRaw || null
     const untrackedFiles = splitNul(
@@ -140,7 +173,6 @@ export async function createGitCheckpoint(params: {
       threadId: params.threadId,
       repositoryRoot,
       head,
-      checkpointRef: ref,
       currentBranch,
       createdAt: new Date().toISOString(),
       untrackedFiles
@@ -168,7 +200,7 @@ export async function restoreGitCheckpoint(params: {
   try {
     const repositoryRoot = metadata.repositoryRoot
     await assertNoUnmerged(repositoryRoot)
-    const targetRef = metadata.checkpointRef || metadata.head
+    const targetRef = await resolveCheckpointTarget(repositoryRoot, params.dataDir, metadata)
 
     const rescue = await createGitCheckpoint({
       dataDir: params.dataDir,

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1488,7 +1488,6 @@
   "rollbackWorkspaceBusyError": "Cannot roll back the workspace while the agent is running.",
   "rollbackWorkspaceConfirm": "Roll back the Git commit for this response?",
   "rollbackWorkspaceConfirmDetail": "This will run git reset --hard and git clean -fd in your workspace. Any uncommitted edits, untracked files, and commits added since this checkpoint will be permanently lost. The chat conversation will be kept as-is.",
-  "rollbackWorkspaceSuccessWithRescue": "Workspace rolled back. A safety checkpoint was saved: {{id}}",
   "sessionForked": "Forked thread",
   "sessionForkedFrom": "Forked from {{title}}",
   "sessionForkedFromCompact": "from {{title}}",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1488,7 +1488,6 @@
   "rollbackWorkspaceBusyError": "Agent 正在运行时不能回滚工作区。",
   "rollbackWorkspaceConfirm": "确定回滚这条回答对应的 Git 提交吗？",
   "rollbackWorkspaceConfirmDetail": "此操作将在您的工作区执行 git reset --hard 和 git clean -fd。所有未提交的修改、未跟踪的文件以及该检查点之后的提交都将被永久丢失。当前对话内容会保留不变。",
-  "rollbackWorkspaceSuccessWithRescue": "工作区已回滚。已保存安全检查点：{{id}}",
   "sessionForked": "分叉会话",
   "sessionForkedFrom": "分叉自 {{title}}",
   "sessionForkedFromCompact": "来自 {{title}}",

--- a/src/renderer/src/store/chat-store-maintenance-actions.test.ts
+++ b/src/renderer/src/store/chat-store-maintenance-actions.test.ts
@@ -205,11 +205,7 @@ describe('chat-store-maintenance-actions workspace rollback', () => {
       expect(provider.rewindThread).not.toHaveBeenCalled()
       expect(sendMessage).not.toHaveBeenCalled()
       expect(state.blocks).toHaveLength(2)
-      // The rollback action surfaces the rescue checkpoint id so users can
-      // recover by hand if the rollback was a mistake.
-      expect(state.error).toBe(
-        'Workspace rolled back. A safety checkpoint was saved: gcp_rescue'
-      )
+      expect(state.error).toBeNull()
     } finally {
       ;(globalThis as { window?: unknown }).window = previousWindow
     }
@@ -314,8 +310,6 @@ describe('chat-store-maintenance-actions workspace rollback', () => {
       await actions.rollbackWorkspaceToCheckpoint('gcp_1')
 
       expect(restoreGitCheckpoint).toHaveBeenCalledWith({ checkpointId: 'gcp_1' })
-      // Power-user log path: rescue id is always logged so it can be
-      // recovered even if the user dismisses the toast.
       expect(consoleInfo).toHaveBeenCalledTimes(1)
       const logArgs = consoleInfo.mock.calls[0]
       expect(logArgs[0]).toBe('[rollback] rescue checkpoint:')
@@ -323,10 +317,7 @@ describe('chat-store-maintenance-actions workspace rollback', () => {
       expect(logArgs[2]).toBe('workspace:')
       expect(logArgs[4]).toBe('thread:')
       expect(logArgs[5]).toBe('thr_existing')
-      // User-visible notice path: success message embeds the rescue id.
-      expect(state.error).toBe(
-        'Workspace rolled back. A safety checkpoint was saved: gcp_rescue_xyz'
-      )
+      expect(state.error).toBeNull()
     } finally {
       console.info = previousConsoleInfo
       ;(globalThis as { window?: unknown }).window = previousWindow

--- a/src/renderer/src/store/chat-store-maintenance-actions.ts
+++ b/src/renderer/src/store/chat-store-maintenance-actions.ts
@@ -789,11 +789,7 @@ export function createMaintenanceActions(
       'thread:',
       activeThreadId
     )
-    if (rescueId) {
-      set({ error: i18n.t('common:rollbackWorkspaceSuccessWithRescue', { id: rescueId }) })
-    } else {
-      set({ error: null })
-    }
+    set({ error: null })
   },
 
   resolveApproval: async (blockId, decision) => {


### PR DESCRIPTION
## Summary

- Store Git rollback checkpoint HEADs in Kun-managed bundle files instead of visible `refs/kun/checkpoints/*` refs.
- Keep rollback recovery working after checkpoint commits are pruned by restoring from the saved bundle.
- Stop showing rollback success/rescue checkpoint text through the global Kun error banner.

## Changes

- Replaced checkpoint `update-ref` writes with `head.bundle` storage under the existing checkpoint data directory.
- Added restore fallback logic that imports the saved bundle when the target commit is no longer present locally.
- Preserved legacy checkpoint metadata compatibility for existing `checkpointRef` entries.
- Updated rollback UI state so successful rollback clears `error`; rescue checkpoint id remains in console logs only.

## Tests

- `npm run test -- src/main/services/git-checkpoint-service.test.ts`
- `npm run test -- src/renderer/src/store/chat-store-maintenance-actions.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run dist:mac:arm64`
- Installed and launched `/Applications/Kun.app`; verified `http://127.0.0.1:18899/health`
