### PR TITLE
fix(security): IM sandbox bypass + workspace symlink escape

### DIFF
--- a/kun/src/adapters/tool/builtin-file-tools.ts
+++ b/kun/src/adapters/tool/builtin-file-tools.ts
@@ -60,7 +60,7 @@ export function createWriteLocalTool(_options: WriteLocalToolOptions = {}): Loca
       if (!rawPath.trim() || content == null) {
         return { output: { error: 'path and content are required' }, isError: true }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       assertCanWritePath(absolutePath, context)
       return withFileMutationQueue(absolutePath, async () => {
         await mkdirOp(dirname(absolutePath))
@@ -118,7 +118,7 @@ export function createEditLocalTool(_options: EditLocalToolOptions = {}): LocalT
       if (!rawPath.trim() || edits.length === 0) {
         return { output: { error: 'path and at least one edit are required' }, isError: true }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       assertCanWritePath(absolutePath, context)
       return withFileMutationQueue(absolutePath, async () => {
         const rawSource = await readFileOp(absolutePath)

--- a/kun/src/adapters/tool/builtin-lsp-tool.ts
+++ b/kun/src/adapters/tool/builtin-lsp-tool.ts
@@ -111,7 +111,7 @@ export function createLspLocalTool(): LocalTool {
           return { output: { error: `Unknown operation: ${operation}` }, isError: true }
         }
 
-        const { absolutePath, workspaceRoot } = resolveWorkspacePath(rawPath, context)
+        const { absolutePath, workspaceRoot } = await resolveWorkspacePath(rawPath, context)
         const server = findLanguageServerForFile(absolutePath)
         if (!server) {
           const supported = listLanguageServers()

--- a/kun/src/adapters/tool/builtin-read-tool.ts
+++ b/kun/src/adapters/tool/builtin-read-tool.ts
@@ -49,7 +49,7 @@ export function createReadLocalTool(options: ReadLocalToolOptions = {}): LocalTo
           isError: true
         }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       await statOp(absolutePath)
       const fileBuffer = await readFileOp(absolutePath)
       const classification = getReadClassification(absolutePath, context.workspace)

--- a/kun/src/adapters/tool/builtin-search-tools.ts
+++ b/kun/src/adapters/tool/builtin-search-tools.ts
@@ -43,7 +43,7 @@ export function createLsLocalTool(options: LsLocalToolOptions = {}): LocalTool {
     execute: async (args, context) => withToolBoundary(async () => {
       const rawPath = typeof args.path === 'string' && args.path.trim() ? args.path : '.'
       const limit = normalizePositiveInteger(args.limit, options.defaultLimit ?? DEFAULT_LIST_LIMIT)
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       const targetStat = await statOp(absolutePath)
       if (!targetStat.isDirectory()) {
         return {
@@ -95,7 +95,7 @@ export function createFindLocalTool(options: FindLocalToolOptions = {}): LocalTo
       if (!pattern) return { output: { error: 'pattern is required' }, isError: true }
       const rawPath = typeof args.path === 'string' && args.path.trim() ? args.path : '.'
       const limit = normalizePositiveInteger(args.limit, options.defaultLimit ?? DEFAULT_FIND_LIMIT)
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       const matcher = globToRegExp(pattern.includes('/') ? pattern : `**/${pattern}`)
       if (options.operations?.glob) {
         const matches = await options.operations.glob({ pattern, path: absolutePath, limit })
@@ -213,7 +213,7 @@ export function createGrepLocalTool(options: GrepLocalToolOptions = {}): LocalTo
         ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), flags)
         : new RegExp(pattern, flags)
       const globMatcher = glob ? globToRegExp(glob.includes('/') ? glob : `**/${glob}`) : null
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       if (options.operations?.search) {
         const matches = await options.operations.search({
           pattern,

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { readFile, readdir, stat } from 'node:fs/promises'
+import { readFile, readdir, realpath, stat } from 'node:fs/promises'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { ToolHostContext } from '../../ports/tool-host.js'
@@ -57,22 +57,71 @@ export function workspaceRoot(workspace: string): string {
   return isAbsolute(workspace) ? resolve(workspace) : resolve(process.cwd(), workspace)
 }
 
-export function resolveWorkspacePath(inputPath: string, context: ToolHostContext): {
+export async function resolveWorkspacePath(inputPath: string, context: ToolHostContext): Promise<{
   workspaceRoot: string
   absolutePath: string
   relativePath: string
-} {
+}> {
   const root = workspaceRoot(context.workspace)
-  const absolutePath = isAbsolute(inputPath) ? resolve(inputPath) : resolve(root, inputPath)
-  const relativePath = relative(root, absolutePath)
-  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+  const lexicalAbsolutePath = isAbsolute(inputPath) ? resolve(inputPath) : resolve(root, inputPath)
+  const resolvedRoot = await safeRealpath(root)
+  if (resolvedRoot === null) {
+    // Workspace root itself does not exist; nothing to anchor the escape
+    // check against. This is distinct from an actual escape (handled below).
+    throw new Error(`workspace root does not exist: ${root}`)
+  }
+  const resolvedAbsolute = await resolveSymlinkSafe(lexicalAbsolutePath)
+  const resolvedRelative = relative(resolvedRoot, resolvedAbsolute)
+  if (resolvedRelative === '..' || resolvedRelative.startsWith(`..${sep}`) || isAbsolute(resolvedRelative)) {
     throw new Error(`path escapes the workspace root: ${inputPath}`)
   }
+  // Return LEXICAL paths to callers. The realpath-resolved pair is only used
+  // for the escape check above; downstream code (subprocess cwd, display
+  // paths, language-server init) expects the user-facing workspace path,
+  // which on symlinked roots (e.g. macOS `/tmp` -> `/private/tmp`) would
+  // otherwise diverge from what the user typed and break display layers.
   return {
     workspaceRoot: root,
-    absolutePath,
-    relativePath: relativePath || '.'
+    absolutePath: lexicalAbsolutePath,
+    relativePath: relative(root, lexicalAbsolutePath) || '.'
   }
+}
+
+async function safeRealpath(target: string): Promise<string | null> {
+  try {
+    return await realpath(target)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return null
+    if (code === 'EACCES' || code === 'ELOOP' || code === 'ENOTDIR') return null
+    throw error
+  }
+}
+
+async function resolveSymlinkSafe(lexicalPath: string): Promise<string> {
+  const direct = await safeRealpath(lexicalPath)
+  if (direct !== null) return direct
+  // Target doesn't exist (ENOENT) — relevant for write/create operations.
+  // Walk up until we find an existing ancestor, realpath it, then verify the
+  // remaining (non-existent) suffix stays inside the workspace root.
+  const segments: string[] = []
+  let current = lexicalPath
+  let ancestor: string | null = null
+  // Guard against infinite loops on pathological inputs.
+  for (let i = 0; i < 128 && current !== dirname(current); i += 1) {
+    const resolved = await safeRealpath(current)
+    if (resolved !== null) {
+      ancestor = resolved
+      break
+    }
+    segments.unshift(basename(current))
+    current = dirname(current)
+  }
+  if (ancestor === null) {
+    // Nothing on the path exists; treat as escape.
+    throw new Error(`path escapes the workspace root: ${lexicalPath}`)
+  }
+  return segments.length > 0 ? resolve(ancestor, ...segments) : ancestor
 }
 
 export function isBinaryBuffer(buffer: Buffer): boolean {

--- a/src/main/claw-runtime.test.ts
+++ b/src/main/claw-runtime.test.ts
@@ -435,6 +435,195 @@ describe('ClawRuntime', () => {
     })
   })
 
+  it('respects the user-chosen sandboxMode for IM sources and downgrades GUI-required approval policies to auto', async () => {
+    const settings = buildSettings()
+    // User picked a restrictive sandbox and an interactive approval policy via
+    // the unified tool-permission picker. IM cannot show GUI prompts, so the
+    // approval policy must be downgraded to 'auto' while the sandbox survives.
+    settings.agents.kun.sandboxMode = 'workspace-write'
+    settings.agents.kun.approvalPolicy = 'untrusted'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads') {
+        return { ok: true, status: 200, body: JSON.stringify({ id: 'thr_im_fix' }) }
+      }
+      if (path === '/v1/threads/thr_im_fix' && init?.method === 'PATCH') {
+        return { ok: true, status: 200, body: '{}' }
+      }
+      if (path === '/v1/threads/thr_im_fix' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            thread: { id: 'thr_im_fix', status: 'completed' },
+            turns: [{ id: 'turn_im_fix', status: 'completed' }],
+            items: [{ kind: 'assistant_text', detail: 'sandbox respected' }]
+          })
+        }
+      }
+      if (path === '/v1/threads/thr_im_fix/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_im_fix', turnId: 'turn_im_fix' }) }
+      }
+      return { ok: true, status: 200, body: '{}' }
+    })
+    const logError = vi.fn()
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError
+    })
+
+    const result = await (runtime as unknown as {
+      runPrompt: (
+        settingsArg: AppSettingsV1,
+        options: {
+          prompt: string
+          title: string
+          workspaceRoot: string
+          model: string
+          mode: 'agent' | 'plan'
+          waitForResult: boolean
+          responseTimeoutMs: number
+          source: 'task' | 'im'
+        }
+      ) => Promise<{ ok: boolean; text?: string }>
+    }).runPrompt(settings, {
+      prompt: 'hello',
+      title: 'demo',
+      workspaceRoot: '/tmp/workspace',
+      model: 'auto',
+      mode: 'agent',
+      waitForResult: true,
+      responseTimeoutMs: 10,
+      source: 'im'
+    })
+
+    expect(result).toMatchObject({ ok: true, text: 'sandbox respected' })
+    const createThreadCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(createThreadCall?.[2]?.body ?? '{}'))).toMatchObject({
+      approvalPolicy: 'auto',
+      sandboxMode: 'workspace-write'
+    })
+    const turnCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads/thr_im_fix/turns' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(turnCall?.[2]?.body ?? '{}'))).toMatchObject({
+      disableUserInput: true,
+      approvalPolicy: 'auto',
+      sandboxMode: 'workspace-write'
+    })
+    // The downgrade must be logged exactly once with the original policy.
+    const downgradeCalls = logError.mock.calls.filter(
+      ([category, message]) =>
+        category === 'claw-runtime' &&
+        typeof message === 'string' &&
+        message.includes('IM source downgraded approvalPolicy')
+    )
+    expect(downgradeCalls).toHaveLength(1)
+    expect(downgradeCalls[0]?.[2]).toMatchObject({
+      originalApprovalPolicy: 'untrusted',
+      sandboxMode: 'workspace-write'
+    })
+  })
+
+  it('preserves the never approval policy for IM sources instead of escalating to auto', async () => {
+    // Regression: `never` is not a GUI-gated policy — it auto-denies every
+    // tool call without prompting. Downgrading it to `auto` for IM would
+    // silently grant auto-approval to a user who explicitly disabled tools,
+    // which is the exact privilege-escalation class this fix targets.
+    const settings = buildSettings()
+    settings.agents.kun.sandboxMode = 'read-only'
+    settings.agents.kun.approvalPolicy = 'never'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads') {
+        return { ok: true, status: 200, body: JSON.stringify({ id: 'thr_never' }) }
+      }
+      if (path === '/v1/threads/thr_never' && init?.method === 'PATCH') {
+        return { ok: true, status: 200, body: '{}' }
+      }
+      if (path === '/v1/threads/thr_never' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            thread: { id: 'thr_never', status: 'completed' },
+            turns: [{ id: 'turn_never', status: 'completed' }],
+            items: [{ kind: 'assistant_text', detail: 'never preserved' }]
+          })
+        }
+      }
+      if (path === '/v1/threads/thr_never/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_never', turnId: 'turn_never' }) }
+      }
+      return { ok: true, status: 200, body: '{}' }
+    })
+    const logError = vi.fn()
+    const store = {
+      load: vi.fn(async () => settings),
+      patch: vi.fn(async () => settings)
+    }
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest,
+      logError
+    })
+
+    const result = await (runtime as unknown as {
+      runPrompt: (
+        settingsArg: AppSettingsV1,
+        options: {
+          prompt: string
+          title: string
+          workspaceRoot: string
+          model: string
+          mode: 'agent' | 'plan'
+          waitForResult: boolean
+          responseTimeoutMs: number
+          source: 'task' | 'im'
+        }
+      ) => Promise<{ ok: boolean; text?: string }>
+    }).runPrompt(settings, {
+      prompt: 'hello',
+      title: 'demo',
+      workspaceRoot: '/tmp/workspace',
+      model: 'auto',
+      mode: 'agent',
+      waitForResult: true,
+      responseTimeoutMs: 10,
+      source: 'im'
+    })
+
+    expect(result).toMatchObject({ ok: true, text: 'never preserved' })
+    const createThreadCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(createThreadCall?.[2]?.body ?? '{}'))).toMatchObject({
+      approvalPolicy: 'never',
+      sandboxMode: 'read-only'
+    })
+    const turnCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads/thr_never/turns' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(turnCall?.[2]?.body ?? '{}'))).toMatchObject({
+      disableUserInput: true,
+      approvalPolicy: 'never',
+      sandboxMode: 'read-only'
+    })
+    // No downgrade log should fire when the policy is `never` (or `auto`).
+    const downgradeCalls = logError.mock.calls.filter(
+      ([category, message]) =>
+        category === 'claw-runtime' &&
+        typeof message === 'string' &&
+        message.includes('IM source downgraded approvalPolicy')
+    )
+    expect(downgradeCalls).toHaveLength(0)
+  })
+
   it('reads assistant text from the Kun thread detail shape used by the real runtime', async () => {
     const settings = buildSettings()
     const runtimeRequest = vi.fn(async (_settings, path, init) => {

--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -80,9 +80,29 @@ import { FeishuStreamer } from './feishu-streamer'
 import type { TelegramInboundPayload } from './telegram-runtime'
 
 const MAX_IM_FILE_UPLOAD_BYTES = 50 * 1024 * 1024
-const CLAW_IM_APPROVAL_POLICY = 'auto'
-const CLAW_IM_SANDBOX_MODE = 'danger-full-access'
 const CLAW_TELEGRAM_INBOUND_IMAGE_HEADING = '[Telegram inbound message]'
+
+/**
+ * Approval policies that require an interactive GUI prompt to proceed. IM
+ * channels (Feishu/WeChat/Telegram) cannot surface these prompts, so any
+ * user-chosen policy in this set is downgraded to `'auto'` for IM sources.
+ *
+ * `'never'` is intentionally excluded: it does not require a GUI — it
+ * auto-denies every tool call (`local-tool-host.ts` returns
+ * `approval_policy_blocked`), which is a safe, non-interactive policy that
+ * must survive the IM code path. Downgrading `'never'` to `'auto'` would
+ * silently grant auto-approval to a user who disabled tools entirely.
+ *
+ * See `kun/src/contracts/policy.ts` for the exhaustive `ApprovalPolicy` list
+ * and `kun/src/adapters/tool/local-tool-host.ts` for how each value is
+ * enforced at the tool-call boundary.
+ */
+const IM_GUI_REQUIRED_APPROVAL_POLICIES = new Set<string>([
+  'always',
+  'on-request',
+  'untrusted',
+  'suggest'
+])
 
 type FeishuClawChannel = ClawImChannelV1 & {
   platformCredential: ClawImFeishuPlatformCredentialV1
@@ -570,11 +590,39 @@ export class ClawRuntime {
     const requestedModel = normalizeTaskModel(options.model) ?? (settings.agents.kun.model.trim() || DEFAULT_CLAW_MODEL)
     const runtimeSettings = settingsWithImModelProvider(settings, options.providerId, requestedModel)
     const model = effectiveImRuntimeModel(runtimeSettings, requestedModel)
+    // IM channels cannot show GUI approval prompts. Respect the user's chosen
+    // sandboxMode verbatim, but if their approvalPolicy would require an
+    // interactive prompt, downgrade to 'auto' so the turn does not deadlock.
+    // `'auto'` runs without prompts; `'never'` auto-denies without prompts;
+    // every other ApprovalPolicy value (always/on-request/untrusted/suggest)
+    // needs a human at a GUI. See `IM_GUI_REQUIRED_APPROVAL_POLICIES` above.
+    const imSandboxMode = runtimeSettings.agents.kun.sandboxMode
+    let imApprovalPolicy = runtimeSettings.agents.kun.approvalPolicy
+    if (
+      options.source === 'im' &&
+      IM_GUI_REQUIRED_APPROVAL_POLICIES.has(runtimeSettings.agents.kun.approvalPolicy)
+    ) {
+      try {
+        this.deps.logError(
+          'claw-runtime',
+          `IM source downgraded approvalPolicy from "${runtimeSettings.agents.kun.approvalPolicy}" to "auto" because IM channels cannot answer GUI approval prompts.`,
+          {
+            channelId: options.channel?.id,
+            source: options.source,
+            originalApprovalPolicy: runtimeSettings.agents.kun.approvalPolicy,
+            sandboxMode: runtimeSettings.agents.kun.sandboxMode
+          }
+        )
+      } catch {
+        // Logging is best-effort; never let it abort the turn.
+      }
+      imApprovalPolicy = 'auto'
+    }
     const createThread = async (): Promise<ThreadRecordJson | null> => {
       const body: Record<string, unknown> = { workspace, model, mode: options.mode }
       if (options.source === 'im') {
-        body.approvalPolicy = CLAW_IM_APPROVAL_POLICY
-        body.sandboxMode = CLAW_IM_SANDBOX_MODE
+        body.approvalPolicy = imApprovalPolicy
+        body.sandboxMode = imSandboxMode
       }
       const create = await this.deps.runtimeRequest(runtimeSettings, '/v1/threads', {
         method: 'POST',
@@ -606,8 +654,8 @@ export class ClawRuntime {
     // GUI prompts, so the runtime must not expose user-input tools.
     if (options.source === 'im') {
       turnBody.disableUserInput = true
-      turnBody.approvalPolicy = CLAW_IM_APPROVAL_POLICY
-      turnBody.sandboxMode = CLAW_IM_SANDBOX_MODE
+      turnBody.approvalPolicy = imApprovalPolicy
+      turnBody.sandboxMode = imSandboxMode
     }
     let turn = await this.startRuntimeTurn(runtimeSettings, thread.id, turnBody)
     if (!turn.ok && existingThreadId && isMissingThreadResult(turn)) {


### PR DESCRIPTION
## Summary

Two independent security fixes audited from recent merges.

### 1. IM agent runs respect user-chosen sandbox/approval modes

`src/main/claw-runtime.ts` hardcoded IM-sourced turns (Feishu / WeChat / Telegram) to `approvalPolicy='auto'` + `sandboxMode='danger-full-access'`, silently overriding the unified tool-permission picker. A user who selected `read-only` or `never` still got full-write auto-approved execution when an IM contact sent a message.

- `imSandboxMode` is now read verbatim from `runtimeSettings.agents.kun.sandboxMode`.
- `imApprovalPolicy` is preserved unless it requires a GUI prompt — then it downgrades to `'auto'` with a logged warning so the IM turn does not deadlock.
- `'never'` is intentionally excluded from the GUI-required set (`always / on-request / untrusted / suggest`): it auto-denies every tool call without prompting, so downgrading it to `'auto'` would be a privilege escalation.

### 2. Workspace path escape check resolves symlinks

`kun/src/adapters/tool/builtin-tool-utils.ts` used `path.resolve()` which is purely lexical and does not follow symlinks. A symlink at `<workspace>/link -> /etc/passwd` passed the escape check, letting read/write/edit/ls/find/grep/LSP tools reach files outside the workspace.

- Both workspace root and target path run through `fs.realpath()` before the `relative()` escape check.
- New `resolveSymlinkSafe` helper handles the write/create case (target doesn't exist yet) by walking up to the nearest existing ancestor, realpath-ing it, and re-joining the suffix (loop-guarded at 128 iterations).
- Error handling is fail-closed: `EACCES` / `ELOOP` / `ENOTDIR` → treated as non-existent; unexpected errno rethrows.
- Realpath-resolved pair is used ONLY for the escape check; lexical paths are returned to callers so downstream code (subprocess cwd, display paths, LSP init) keeps seeing the user-facing path (important on symlinked roots like macOS `/tmp` → `/private/tmp`).
- All 6 tool call sites updated to `await` the now-`async` `resolveWorkspacePath`.

## Changes

- `src/main/claw-runtime.ts` — read user sandbox/approval for IM sources; downgrade GUI-required policies to `auto` (excludes `never`).
- `src/main/claw-runtime.test.ts` — 2 new tests: `untrusted -> auto` downgrade with sandbox preserved; `never` preserved (no escalation).
- `kun/src/adapters/tool/builtin-tool-utils.ts` — async `resolveWorkspacePath` + `safeRealpath` + `resolveSymlinkSafe`; returns lexical paths.
- `kun/src/adapters/tool/builtin-file-tools.ts`, `builtin-lsp-tool.ts`, `builtin-read-tool.ts`, `builtin-search-tools.ts` — `await resolveWorkspacePath(...)`.

## Tests

- [x] `npx vitest run src/main/claw-runtime.test.ts` — 48/48
- [x] `cd kun && npx vitest run src/adapters/tool/` — 49/49
- [x] `npm run typecheck` — clean
