### PR TITLE
fix(security): git-checkpoint restore busy guard reads thread.status

### DIFF
--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -958,7 +958,18 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
     const request = parseIpcPayload('git:checkpoint:restore', gitCheckpointRestorePayloadSchema, payload)
     return restoreGitCheckpoint({
       dataDir: await resolveKunThreadsDataDir(),
-      checkpointId: request.checkpointId
+      checkpointId: request.checkpointId,
+      // Bridge the main-process runtimeRequest into the shape restoreGitCheckpoint
+      // expects ((path, {method, body}) => {ok,status,body}). On a transport-level
+      // failure (runtime not up, connection refused) we return a non-ok result so
+      // the busy guard fails closed instead of throwing past the handler.
+      runtimeRequest: async (path, init) => {
+        try {
+          return await runtimeRequest(path, init?.method, init?.body)
+        } catch (error) {
+          return { ok: false, status: 0, body: error instanceof Error ? error.message : String(error) }
+        }
+      }
     })
   })
   ipcMain.handle(

--- a/src/main/services/git-checkpoint-service.test.ts
+++ b/src/main/services/git-checkpoint-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -152,5 +152,80 @@ describe('git checkpoint service', () => {
     )
     const refs = execFileSync('git', ['-C', repoRoot, 'show-ref'], { encoding: 'utf-8' })
     expect(refs).not.toContain('refs/kun/checkpoints')
+  })
+
+  it('refuses to restore while a thread is running and leaves the working tree untouched', async () => {
+    const checkpoint = await createGitCheckpoint({
+      dataDir,
+      workspaceRoot: repoRoot,
+      threadId: 'thr_busy'
+    })
+    expect(checkpoint.ok).toBe(true)
+    if (!checkpoint.ok) throw new Error(checkpoint.message)
+
+    // Mutate the working tree after the checkpoint so we can assert the restore
+    // did NOT clobber it. If the busy guard fails open, these changes vanish.
+    await writeFile(join(repoRoot, 'tracked.txt'), 'agent editing\n')
+    await writeFile(join(repoRoot, 'post-checkpoint.txt'), 'should survive\n')
+    const headBefore = execFileSync('git', ['-C', repoRoot, 'rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim()
+
+    const runtimeRequest = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      // ThreadSummary exposes `status` (idle|running|archived|deleted), NOT
+      // `state`. A running thread must be reported as status === 'running'.
+      body: JSON.stringify({ threads: [{ id: 'thr_running', status: 'running' }] })
+    }))
+
+    const restored = await restoreGitCheckpoint({
+      dataDir,
+      checkpointId: checkpoint.checkpointId,
+      runtimeRequest
+    })
+
+    expect(restored.ok).toBe(false)
+    if (restored.ok) throw new Error('expected restore to be refused')
+    expect(restored.reason).toBe('error')
+    expect(restored.message).toMatch(/Cannot restore checkpoint while a thread is running/)
+
+    // The busy guard must fire BEFORE any destructive git op, so the runtime
+    // probe is the only call made and the working tree is byte-for-byte intact.
+    expect(runtimeRequest).toHaveBeenCalledTimes(1)
+    expect(await readFile(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('agent editing\n')
+    expect(await readFile(join(repoRoot, 'post-checkpoint.txt'), 'utf-8')).toBe('should survive\n')
+    expect(execFileSync('git', ['-C', repoRoot, 'rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim()).toBe(headBefore)
+  })
+
+  it('restores when the runtime reports all threads idle (runtimeRequest exercised)', async () => {
+    const checkpoint = await createGitCheckpoint({
+      dataDir,
+      workspaceRoot: repoRoot,
+      threadId: 'thr_idle'
+    })
+    expect(checkpoint.ok).toBe(true)
+    if (!checkpoint.ok) throw new Error(checkpoint.message)
+
+    await writeFile(join(repoRoot, 'tracked.txt'), 'changed after checkpoint\n')
+    await writeFile(join(repoRoot, 'new-after.txt'), 'new\n')
+
+    const runtimeRequest = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      body: JSON.stringify({ threads: [{ id: 'thr_a', status: 'idle' }, { id: 'thr_b', status: 'archived' }] })
+    }))
+
+    const restored = await restoreGitCheckpoint({
+      dataDir,
+      checkpointId: checkpoint.checkpointId,
+      runtimeRequest
+    })
+    expect(restored.ok).toBe(true)
+    if (!restored.ok) throw new Error(restored.message)
+    // The guard ran and let the restore proceed.
+    expect(runtimeRequest).toHaveBeenCalledTimes(1)
+    // Restore rewound the tracked file to its checkpoint content and removed the
+    // post-checkpoint untracked file (git clean -fd).
+    expect(await readFile(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('base\n')
+    await expect(stat(join(repoRoot, 'new-after.txt'))).rejects.toThrow()
   })
 })

--- a/src/main/services/git-checkpoint-service.ts
+++ b/src/main/services/git-checkpoint-service.ts
@@ -191,6 +191,14 @@ export async function createGitCheckpoint(params: {
 export async function restoreGitCheckpoint(params: {
   dataDir: string
   checkpointId: string
+  /**
+   * Optional runtime bridge used to verify that no thread is mid-turn before
+   * running the destructive `git reset --hard` / `git clean -fd`. When omitted
+   * (e.g. from existing callers and unit tests) the check is skipped and the
+   * function behaves as before. When provided, a non-ok response or any thrown
+   * error fails closed: the restore is refused rather than proceeding.
+   */
+  runtimeRequest?: (path: string, init: { method?: string; body?: string }) => Promise<{ ok: boolean; status: number; body: string }>
 }): Promise<GitCheckpointRestoreResult> {
   const checkpointId = params.checkpointId.trim()
   const metadata = await readMetadata(params.dataDir, checkpointId)
@@ -201,6 +209,46 @@ export async function restoreGitCheckpoint(params: {
     const repositoryRoot = metadata.repositoryRoot
     await assertNoUnmerged(repositoryRoot)
     const targetRef = await resolveCheckpointTarget(repositoryRoot, params.dataDir, metadata)
+
+    // Busy guard: a checkpoint restore runs `git reset --hard` + `git clean
+    // -fd`, which would destroy files the agent is actively editing. Before
+    // those destructive ops, ask the runtime whether any thread is currently
+    // running a turn. `GET /v1/threads` serializes ThreadSummary, whose only
+    // activity-relevant field is `status` with the enum
+    // `idle | running | archived | deleted`; a thread is busy exactly when its
+    // status is `running`. Fail closed if the runtime cannot be queried.
+    //
+    // (An earlier version of this guard read a non-existent `thread.state`
+    // field and compared it against turn-level states that never appear on a
+    // thread summary; that made the guard a no-op and the race still fired.)
+    if (params.runtimeRequest) {
+      try {
+        const response = await params.runtimeRequest('/v1/threads?limit=500&include=side', { method: 'GET' })
+        if (!response.ok) {
+          return {
+            ok: false,
+            reason: 'error',
+            message: 'Cannot verify runtime state before checkpoint restore. Please ensure the runtime is healthy and try again.'
+          }
+        }
+        const data = JSON.parse(response.body) as { threads?: Array<{ status?: string }> }
+        const hasRunning = data.threads?.some((thread) => thread.status === 'running')
+        if (hasRunning) {
+          return {
+            ok: false,
+            reason: 'error',
+            message: 'Cannot restore checkpoint while a thread is running. Please wait for the current turn to finish.'
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          ok: false,
+          reason: 'error',
+          message: `Cannot verify runtime state before checkpoint restore: ${message}`
+        }
+      }
+    }
 
     const rescue = await createGitCheckpoint({
       dataDir: params.dataDir,


### PR DESCRIPTION
## Summary

Fixes a fail-open TOCTOU race in `git:checkpoint:restore`. Split from #525 (reviewer feedback: split the security bundle into independent, independently-testable PRs).

### Bug: the busy guard was dead code

The restore path runs `git reset --hard` + `git clean -fd`, which destroy files the agent may be actively editing. A guard was added to check whether any thread is mid-turn before those destructive ops — but it read `thread.state` and compared against `['streaming','tool','queued','pending']`.

Both halves are wrong against the real contract:
- `GET /v1/threads` serializes `ThreadSummary`, whose only activity-relevant field is `status` (there is no `state` field).
- `ThreadStatus = z.enum(['idle','running','archived','deleted'])` — `streaming`/`tool`/`queued`/`pending` are turn-level states that **never** appear on a thread summary.

Result: `thread.state` was always `undefined` → `hasRunning` was always `false` → `git reset --hard` ran during active turns, exactly the race the guard claimed to close. The missing field did not throw, so the fail-closed `catch` could not save it.

### Fix

`src/main/services/git-checkpoint-service.ts` — `restoreGitCheckpoint` gains an optional `runtimeRequest` param. Before any destructive op it calls `GET /v1/threads?limit=500&include=side`, parses `{ threads: [{ status }] }`, and if any `thread.status === 'running'` it returns `{ ok:false, reason:'error' }`. Fail-closed on a non-ok response or thrown error.

`src/main/ipc/register-app-ipc-handlers.ts` — the `git:checkpoint:restore` IPC handler now passes a `runtimeRequest` adapter that bridges the main-process `runtimeRequest(path, method, body)` into the service's `(path, { method, body })` shape, with a try/catch mapping transport errors to `{ ok:false, status:0 }` so the guard fails closed instead of propagating past the handler.

`include=side` is required: side conversations are hidden from the default listing, so without it a running side thread would be invisible to the guard.

## Changes

- `src/main/services/git-checkpoint-service.ts` — optional `runtimeRequest` param + busy guard reading `thread.status === 'running'`, before `createGitCheckpoint(rescue)` and before any `git reset`/`git clean`.
- `src/main/ipc/register-app-ipc-handlers.ts` — wire the runtime bridge into the restore handler.
- `src/main/services/git-checkpoint-service.test.ts` — 2 new tests (busy + healthy paths).

## Tests

- [x] `npx vitest run src/main/services/git-checkpoint-service.test.ts` — 6/6
- [x] `npm run typecheck` — clean

The busy-path test asserts the working tree is byte-for-byte untouched (tracked file content, post-checkpoint untracked file survives, HEAD unchanged), proving the guard fires *before* any destructive op — not merely that `ok:false` is returned.
