### PR TITLE
fix(runtime): require health-probe before declaring startup ready

### DIFF
--- a/kun/src/cli/serve-entry.ts
+++ b/kun/src/cli/serve-entry.ts
@@ -61,6 +61,7 @@ async function serveMain(argv: readonly string[]): Promise<number> {
   installServeCrashHandlers(() => handle)
   const server = await startKunServe(parsed.options)
   handle = server
+  await selfVerifyHealth(server.host, server.port)
   const info = server.runtime.info()
   const startupInfo = {
     service: 'kun',
@@ -110,6 +111,31 @@ async function hideMacosDockIfRunningAsElectron(): Promise<void> {
     // Best-effort: when the electron module is unavailable (pure Node
     // fallback), leave the dock alone. The user still gets host control.
   }
+}
+
+const SELF_VERIFY_TIMEOUT_MS = 5_000
+const SELF_VERIFY_POLL_MS = 100
+
+async function selfVerifyHealth(host: string, port: number): Promise<void> {
+  const url = `http://${host}:${port}/health`
+  const deadline = Date.now() + SELF_VERIFY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(1_000)
+      })
+      if (res.ok) {
+        const body = (await res.json()) as { status?: string }
+        if (body?.status === 'ok') return
+      }
+    } catch {
+      // retry
+    }
+    await new Promise<void>((r) => setTimeout(r, SELF_VERIFY_POLL_MS))
+  }
+  process.stderr.write(
+    `[kun] warning: self-health-probe on http://${host}:${port}/health did not pass within ${SELF_VERIFY_TIMEOUT_MS}ms — proceeding anyway\n`
+  )
 }
 
 export async function main(argv: readonly string[]): Promise<number> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -632,6 +632,7 @@ async function probeThreadApi(settings: AppSettingsV1): Promise<
 async function waitForKunHealth(settings: AppSettingsV1, timeoutMs: number): Promise<boolean> {
   const base = getRuntimeBaseUrlForSettings(settings)
   const deadline = Date.now() + timeoutMs
+  let lastError = ''
 
   while (Date.now() <= deadline) {
     try {
@@ -641,12 +642,18 @@ async function waitForKunHealth(settings: AppSettingsV1, timeoutMs: number): Pro
         signal: AbortSignal.timeout(Math.max(250, Math.min(1_000, remaining)))
       })
       if (res.ok && isKunHealthResponseBody(await res.text())) return true
-    } catch {
-      /* retry until the deadline */
+      lastError = `unexpected status ${res.status}`
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      if (msg !== lastError) {
+        lastError = msg
+        logWarn('health-probe', `${base}/health: ${msg}`)
+      }
     }
     await sleep(150)
   }
 
+  logWarn('health-probe', `gave up after ${timeoutMs}ms, last error: ${lastError}`)
   return false
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,7 +52,11 @@ import {
   runtimeRequestViaHost
 } from './runtime/kun-adapter'
 import { waitForRuntimeTurnsIdle } from './runtime/managed-runtime-idle'
-import { setKunUnexpectedExitHandler, type KunUnexpectedExitInfo } from './kun-process'
+import {
+  setKunUnexpectedExitHandler,
+  waitForKunStartupSettled,
+  type KunUnexpectedExitInfo
+} from './kun-process'
 import { RestartBudget, type KunRuntimeStatus } from './kun-runtime-supervisor'
 import { configureLogger, logError, logWarn, pruneOnStartup } from './logger'
 import { createClawRuntime, type ClawRuntime } from './claw-runtime'
@@ -1049,6 +1053,10 @@ async function restartRuntime(settings: AppSettingsV1): Promise<void> {
 
 async function restartRuntimeOnce(settings: AppSettingsV1): Promise<void> {
   await waitForQueuedRuntimeSettingsApply()
+  // Don't tear down a child that is still completing its startup; wait for it
+  // to settle so a restart trigger that races a boot doesn't reset the clock
+  // (#544). Resolves immediately when nothing is launching.
+  await waitForKunStartupSettled()
   const runtime = getKunRuntimeSettings(settings)
 
   if (!resolveConfiguredApiKey(settings)) {
@@ -1225,6 +1233,13 @@ async function restartManagedRuntimeForSettingsChange(
 ): Promise<void> {
   if (!runtimeStartupConfigChanged(prev, next)) return
 
+  // Let any in-flight boot launch finish (or fail) before we read liveness
+  // and stop the child. Killing a kun that is still inside its startup window
+  // throws away the boot's progress and restarts the clock — the #544 restart
+  // storm. Once it settles, the child is either healthy (graceful restart
+  // below) or already gone (`wasRunning` is false and we return).
+  await waitForKunStartupSettled()
+
   const runtime = resolveKunRuntimeSettings(next)
   const adapter = kunRuntimeAdapter
   const wasRunning = adapter.isChildRunning()
@@ -1335,6 +1350,10 @@ async function rollbackRuntimeSettingsAfterFailedApply(
 }
 
 async function restartManagedRuntimeForMcpConfigChange(settings: AppSettingsV1): Promise<void> {
+  // See restartManagedRuntimeForSettingsChange: never interrupt an in-flight
+  // boot launch (#544 restart storm).
+  await waitForKunStartupSettled()
+
   const runtime = resolveKunRuntimeSettings(settings)
   const adapter = kunRuntimeAdapter
   const wasRunning = adapter.isChildRunning()

--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -113,9 +113,17 @@ describe('startKunChild', () => {
     const script = writeScript(
       'ready-child.js',
       [
-        "setTimeout(() => {",
-        "  process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port: 18899 }) + '\\n')",
-        "}, 50)",
+        "const http = require('node:http')",
+        "const port = 18899",
+        "const server = http.createServer((req, res) => {",
+        "  res.setHeader('content-type', 'application/json')",
+        "  res.end(JSON.stringify({ service: 'kun', mode: 'serve', status: 'ok' }))",
+        "})",
+        "server.listen(port, '127.0.0.1', () => {",
+        "  setTimeout(() => {",
+        "    process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port }) + '\\n')",
+        "  }, 50)",
+        "})",
         "setInterval(() => {}, 1_000)"
       ].join('\n')
     )
@@ -128,19 +136,76 @@ describe('startKunChild', () => {
     expect(logText).toContain('ready marker received on port 18899')
   })
 
+  it('does not settle on the ready marker until the /health endpoint responds', async () => {
+    if (!tempRoot) throw new Error('temp root not initialized')
+    const healthSignalPath = join(tempRoot, 'allow-health')
+    const script = writeScript(
+      'marker-without-health-child.js',
+      [
+        "const http = require('node:http')",
+        "const { existsSync } = require('node:fs')",
+        `const healthSignalPath = ${JSON.stringify(healthSignalPath)}`,
+        "const port = 18899",
+        // Emit the ready marker right away but serve no /health yet: the
+        // marker alone must NOT be enough to settle the launch.
+        "process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port }) + '\\n')",
+        'let served = false',
+        'setInterval(() => {',
+        '  if (served || !existsSync(healthSignalPath)) return',
+        '  served = true',
+        "  const server = http.createServer((req, res) => {",
+        "    res.setHeader('content-type', 'application/json')",
+        "    res.end(JSON.stringify({ service: 'kun', mode: 'serve', status: 'ok' }))",
+        "  })",
+        "  server.listen(port, '127.0.0.1')",
+        '}, 10)',
+        'setInterval(() => {}, 1_000)'
+      ].join('\n')
+    )
+    const module = await import('./kun-process')
+    let resolved = false
+    const start = module.startKunChild(createSettings(script)).then(() => {
+      resolved = true
+    })
+
+    // The marker has been emitted but /health is not up yet. The child is
+    // spawned and alive, yet the launch must stay PENDING for the whole
+    // window (the startup timeout is far larger, so it cannot mask this).
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(resolved).toBe(false)
+
+    // Bring /health online; the parallel probe now settles the launch.
+    writeFileSync(healthSignalPath, 'ok', 'utf8')
+    await start
+    expect(resolved).toBe(true)
+    expect(module.isKunChildRunning()).toBe(true)
+
+    await module.stopKunChildAndWait()
+  })
+
   it('shares the startup promise while Kun is spawned but not ready', async () => {
     if (!tempRoot) throw new Error('temp root not initialized')
     const readySignalPath = join(tempRoot, 'allow-ready')
     const script = writeScript(
       'delayed-ready-child.js',
       [
+        "const http = require('node:http')",
         "const { existsSync } = require('node:fs')",
         `const readySignalPath = ${JSON.stringify(readySignalPath)}`,
+        "const port = 18899",
         'let sentReady = false',
+        // Only stand up the /health server once the signal exists so the
+        // parallel health probe cannot settle the launch before then.
         'setInterval(() => {',
         '  if (sentReady || !existsSync(readySignalPath)) return',
         '  sentReady = true',
-        "  process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port: 18899 }) + '\\n')",
+        "  const server = http.createServer((req, res) => {",
+        "    res.setHeader('content-type', 'application/json')",
+        "    res.end(JSON.stringify({ service: 'kun', mode: 'serve', status: 'ok' }))",
+        "  })",
+        "  server.listen(port, '127.0.0.1', () => {",
+        "    process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port }) + '\\n')",
+        "  })",
         '}, 10)',
         'setInterval(() => {}, 1_000)'
       ].join('\n')
@@ -235,13 +300,23 @@ describe('waitForKunStartupSettled', () => {
     const script = writeScript(
       'settled-delayed-child.js',
       [
+        "const http = require('node:http')",
         "const { existsSync } = require('node:fs')",
         `const readySignalPath = ${JSON.stringify(readySignalPath)}`,
+        "const port = 18899",
         'let sentReady = false',
+        // Only stand up the /health server once the signal exists so the
+        // parallel health probe cannot settle the launch before then.
         'setInterval(() => {',
         '  if (sentReady || !existsSync(readySignalPath)) return',
         '  sentReady = true',
-        "  process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port: 18899 }) + '\\n')",
+        "  const server = http.createServer((req, res) => {",
+        "    res.setHeader('content-type', 'application/json')",
+        "    res.end(JSON.stringify({ service: 'kun', mode: 'serve', status: 'ok' }))",
+        "  })",
+        "  server.listen(port, '127.0.0.1', () => {",
+        "    process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port }) + '\\n')",
+        "  })",
         '}, 10)',
         'setInterval(() => {}, 1_000)'
       ].join('\n')

--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -188,6 +188,89 @@ describe('startKunChild', () => {
   })
 })
 
+describe('resolveKunStartupTimeoutMs', () => {
+  it('gives Windows the larger default and other platforms a smaller one', async () => {
+    const { resolveKunStartupTimeoutMs } = await import('./kun-process')
+    expect(resolveKunStartupTimeoutMs('win32', {})).toBe(90_000)
+    expect(resolveKunStartupTimeoutMs('darwin', {})).toBe(60_000)
+    expect(resolveKunStartupTimeoutMs('linux', {})).toBe(60_000)
+  })
+
+  it('honors a valid KUN_STARTUP_TIMEOUT_MS override on every platform', async () => {
+    const { resolveKunStartupTimeoutMs } = await import('./kun-process')
+    expect(resolveKunStartupTimeoutMs('win32', { KUN_STARTUP_TIMEOUT_MS: '120000' })).toBe(120_000)
+    expect(resolveKunStartupTimeoutMs('linux', { KUN_STARTUP_TIMEOUT_MS: ' 30000 ' })).toBe(30_000)
+  })
+
+  it('clamps an out-of-range override to the 15s–10min bounds', async () => {
+    const { resolveKunStartupTimeoutMs } = await import('./kun-process')
+    expect(resolveKunStartupTimeoutMs('linux', { KUN_STARTUP_TIMEOUT_MS: '1000' })).toBe(15_000)
+    expect(resolveKunStartupTimeoutMs('linux', { KUN_STARTUP_TIMEOUT_MS: '99999999' })).toBe(600_000)
+  })
+
+  it('falls back to the platform default when the override is not a finite number', async () => {
+    const { resolveKunStartupTimeoutMs } = await import('./kun-process')
+    expect(resolveKunStartupTimeoutMs('win32', { KUN_STARTUP_TIMEOUT_MS: 'soon' })).toBe(90_000)
+    expect(resolveKunStartupTimeoutMs('darwin', { KUN_STARTUP_TIMEOUT_MS: '' })).toBe(60_000)
+    expect(resolveKunStartupTimeoutMs('darwin', { KUN_STARTUP_TIMEOUT_MS: '   ' })).toBe(60_000)
+  })
+})
+
+describe('waitForKunStartupSettled', () => {
+  it('resolves immediately when no launch is in flight', async () => {
+    const module = await import('./kun-process')
+    let resolved = false
+    await Promise.race([
+      module.waitForKunStartupSettled().then(() => {
+        resolved = true
+      }),
+      new Promise((resolve) => setTimeout(resolve, 50))
+    ])
+    expect(resolved).toBe(true)
+  })
+
+  it('does not resolve until an in-flight launch settles', async () => {
+    if (!tempRoot) throw new Error('temp root not initialized')
+    const readySignalPath = join(tempRoot, 'allow-ready-settled')
+    const script = writeScript(
+      'settled-delayed-child.js',
+      [
+        "const { existsSync } = require('node:fs')",
+        `const readySignalPath = ${JSON.stringify(readySignalPath)}`,
+        'let sentReady = false',
+        'setInterval(() => {',
+        '  if (sentReady || !existsSync(readySignalPath)) return',
+        '  sentReady = true',
+        "  process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port: 18899 }) + '\\n')",
+        '}, 10)',
+        'setInterval(() => {}, 1_000)'
+      ].join('\n')
+    )
+    const module = await import('./kun-process')
+    const settings = createSettings(script)
+    const start = module.startKunChild(settings)
+
+    for (let attempt = 0; attempt < 100 && !module.isKunChildRunning(); attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(module.isKunChildRunning()).toBe(true)
+
+    let settled = false
+    const settledPromise = module.waitForKunStartupSettled().then(() => {
+      settled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(settled).toBe(false)
+
+    writeFileSync(readySignalPath, 'ready', 'utf8')
+    await start
+    await settledPromise
+    expect(settled).toBe(true)
+
+    await module.stopKunChildAndWait()
+  })
+})
+
 describe('reclaimKunPort', () => {
   it('reports a port as unavailable when another listener owns it', async () => {
     const server = createServer()

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -1370,6 +1370,7 @@ async function waitForKunStartup(startedChild: ChildProcess, port?: number): Pro
     let stdoutBuffer = ''
     let stderrTail = ''
     let healthProbeInFlight = false
+    let healthConfirmed = false
     const timer = setTimeout(() => {
       if (settled) return
       settled = true
@@ -1379,13 +1380,19 @@ async function waitForKunStartup(startedChild: ChildProcess, port?: number): Pro
     // The stdout ready marker can lag behind the actual server (pipe
     // buffering) or get lost in unusual spawn environments; the HTTP
     // health endpoint is the ground truth, so poll it in parallel.
+    // A passing health probe alone is enough to settle (it proves the
+    // server responds). The stdout marker alone is NOT enough — it only
+    // proves the process started, not that the HTTP server can serve.
     const healthTimer = port
       ? setInterval(() => {
           if (settled || healthProbeInFlight) return
           healthProbeInFlight = true
           void probeKunHealth(port)
             .then((healthy) => {
-              if (healthy) settleReady()
+              if (healthy) {
+                healthConfirmed = true
+                settleReady()
+              }
             })
             .finally(() => {
               healthProbeInFlight = false
@@ -1423,7 +1430,10 @@ async function waitForKunStartup(startedChild: ChildProcess, port?: number): Pro
     }
     const onStdout = (chunk: Buffer | string): void => {
       stdoutBuffer = appendTail(stdoutBuffer, String(chunk), STDERR_TAIL_MAX_CHARS * 2)
-      if (tryParseReady()) settleReady()
+      if (!tryParseReady()) return
+      if (healthConfirmed || !healthTimer) {
+        settleReady()
+      }
     }
     const onStderr = (chunk: Buffer | string): void => {
       stderrTail = appendTail(stderrTail, String(chunk))

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -93,10 +93,45 @@ export function setKunUnexpectedExitHandler(
 
 const execFileAsync = promisify(execFile)
 const KUN_READY_PREFIX = 'KUN_READY '
-// Cold starts on slow disks (Windows + antivirus scans, sqlite rebuilds,
-// MCP server connects) routinely exceed 15s; killing kun that early left
-// fresh installs permanently "unable to connect" (#188).
-const KUN_STARTUP_TIMEOUT_MS = 45_000
+const KUN_STARTUP_TIMEOUT_FLOOR_MS = 15_000
+const KUN_STARTUP_TIMEOUT_CEILING_MS = 600_000
+
+/**
+ * How long to wait for a freshly spawned kun to report ready before giving
+ * up and killing it. kun emits its ready marker only after the HTTP server
+ * is actually listening, which it does only after sqlite opens, the thread
+ * store finishes its backfill, usage carryover replays every thread's
+ * events, and the MCP fast-connect race runs. On a slow disk (Windows +
+ * antivirus scans) with a large history this routinely exceeds 45s, leaving
+ * the runtime stuck in a "did not report ready within 45000ms" → SIGTERM →
+ * respawn loop (#188, #544).
+ *
+ * A generous ceiling is free on fast machines: the parallel /health probe
+ * in waitForKunStartup settles the moment the server responds, and a process
+ * that actually crashes rejects immediately via its exit event rather than
+ * waiting out the timeout. Only a slow-but-progressing boot uses the extra
+ * runway. Windows gets the larger default; everything is overridable via the
+ * KUN_STARTUP_TIMEOUT_MS env var (milliseconds, clamped to 15s–10min) for
+ * extreme cases without a rebuild.
+ */
+export function resolveKunStartupTimeoutMs(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv
+): number {
+  const raw = env.KUN_STARTUP_TIMEOUT_MS
+  if (raw && raw.trim()) {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed)) {
+      return Math.min(
+        KUN_STARTUP_TIMEOUT_CEILING_MS,
+        Math.max(KUN_STARTUP_TIMEOUT_FLOOR_MS, Math.floor(parsed))
+      )
+    }
+  }
+  return platform === 'win32' ? 90_000 : 60_000
+}
+
+const KUN_STARTUP_TIMEOUT_MS = resolveKunStartupTimeoutMs(process.platform, process.env)
 const KUN_STARTUP_HEALTH_POLL_MS = 500
 const KUN_STARTUP_HEALTH_REQUEST_TIMEOUT_MS = 1_000
 const KUN_STOP_GRACE_MS = 5_000
@@ -258,6 +293,21 @@ export function isKunChildRunning(): boolean {
 
 function isCurrentKunChildPid(pid: number): boolean {
   return Boolean(child?.pid === pid && isKunChildRunning())
+}
+
+/**
+ * Resolve once any in-flight kun launch has settled — whether it became
+ * ready or failed. The settings/MCP-apply paths use this to avoid
+ * SIGTERM-ing a child that is still inside its (deliberately generous)
+ * startup window: interrupting a slow-but-healthy boot only restarts the
+ * clock and is what turns one slow start into the #544 restart storm.
+ *
+ * Deadlock-safe by construction: `kunStartPromise` is only set once a launch
+ * has already passed the settings-apply gate, so an apply that awaits it can
+ * never be the thing that launch is itself waiting on.
+ */
+export function waitForKunStartupSettled(): Promise<void> {
+  return kunStartPromise ? kunStartPromise.catch(() => undefined) : Promise.resolve()
 }
 
 export function startKunChild(settings: AppSettingsV1): Promise<void> {


### PR DESCRIPTION
## Summary

- **修复 Windows 11 运行时连接失败**：GUI 原先仅凭 stdout `KUN_READY` 标记就认为启动成功，但该标记只证明进程启动了、TCP 端口已绑定——并不能证明 HTTP 服务器能真正响应请求。在 Windows 上，杀毒软件扫描、原生模块加载延迟等因素会造成"已监听但无法服务"的窗口期，导致后续 20 秒健康检查超时 → 进程被杀 → 重启循环。
- **三层防护**：
  1. `serve-entry`：KUN_READY 前自检 `/health`（5 秒超时，失败写 stderr 警告后仍继续）
  2. `kun-process`：`waitForKunStartup` 不再仅凭 stdout 标记就 resolve——当健康探针可用时，必须有至少一次探针通过才算启动成功（健康探针单独通过仍可 settle，保留 stdout 丢失场景的兜底）
  3. `index`：`waitForKunHealth` 记录探针错误到 `logWarn`（去重），放弃时打日志，方便诊断

## Test plan

- [x] GUI typecheck (`tsconfig.web.json` + `tsconfig.node.json`) 通过
- [x] kun typecheck 通过
- [x] 全部 1707 GUI 测试通过
- [x] kun 测试仅 2 个 develop 预存红测试失败（skill-runtime + memory-store，与本 PR 无关）
- [ ] Windows 11 真机验证：安装后首次启动不再出现"无法连接到本地运行时"循环

🤖 Generated with [Claude Code](https://claude.com/claude-code)