### PR TITLE
fix(chat): update context usage while streaming

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -658,26 +658,19 @@ export function FloatingComposer({
     typeof runtimeSkillCount === 'number' ? runtimeSkillCount : lastKnownSkillCountRef.current
   const canShowContextCapacity =
     !compact && route === 'chat' && Boolean(activeThreadId) && effectiveContextWindow > 0
-  // Freeze the measured total for the duration of a turn: the runtime can emit
-  // several `usage` events while streaming, and tracking them live makes the
-  // chip jitter (visible flicker). Adopt the latest value only while idle.
   const liveMeasuredTotal =
     lastTurnUsage && lastTurnUsage.threadId === activeThreadId
       ? lastTurnUsage.snapshot.inputTokens
       : null
-  const measuredTotalRef = useRef<number | null>(null)
-  if (!busy) measuredTotalRef.current = liveMeasuredTotal
-  const measuredContextTotal = busy ? measuredTotalRef.current : liveMeasuredTotal
+  const measuredContextTotal = liveMeasuredTotal
   // The message estimate feeds the per-category split (popover), the
   // no-measured-total fallback, AND the sanity check that rejects an inflated
   // measured total (some providers over-report prompt_tokens — see
-  // buildContextCapacity). We therefore need it whenever the gauge is idle, not
-  // just when the popover is open. Never subscribe to `blocks` while streaming
-  // with the popover closed — blocks churn on every delta and re-render the
-  // whole composer; the frozen ref is good enough for that transient window.
-  const needMessageEstimate =
-    canShowContextCapacity && (contextCapacityOpen || measuredContextTotal == null || !busy)
-  const subscribeContextBlocks = needMessageEstimate && (contextCapacityOpen || !busy)
+  // buildContextCapacity). We therefore keep it live whenever the gauge can render, not
+  // just when the popover is open. Subscribe while streaming too so the context
+  // usage ring reflects the assistant reply as it becomes future context.
+  const needMessageEstimate = canShowContextCapacity
+  const subscribeContextBlocks = needMessageEstimate
   const contextBlocks = useChatStore((s) => (subscribeContextBlocks ? s.blocks : EMPTY_CONTEXT_BLOCKS))
   const conversationTokensRef = useRef(0)
   const conversationTokens = useMemo(() => {

--- a/src/renderer/src/lib/context-capacity.test.ts
+++ b/src/renderer/src/lib/context-capacity.test.ts
@@ -43,6 +43,19 @@ describe('buildContextCapacity', () => {
     expect(cap.usedRatio).toBeCloseTo(138_389 / 200_000, 5)
   })
 
+  it('lets live message estimates raise a stale measured total while streaming', () => {
+    const cap = buildContextCapacity({
+      windowTokens: 200_000,
+      lastTurnInputTokens: 20_000,
+      messageTokens: 40_000,
+      toolCount: 20,
+      skillCount: 4
+    })
+    expect(cap.hasMeasuredTotal).toBe(true)
+    expect(cap.usedTokens).toBeGreaterThan(20_000)
+    expect(cap.usedTokens).toBeGreaterThan(cap.categories.find((c) => c.key === 'messages')?.tokens ?? 0)
+  })
+
   it('clamps a measured total that exceeds the window', () => {
     const cap = buildContextCapacity({
       windowTokens: 100_000,

--- a/src/renderer/src/lib/context-capacity.ts
+++ b/src/renderer/src/lib/context-capacity.ts
@@ -196,9 +196,12 @@ export function buildContextCapacity(input: ContextCapacityInput): ContextCapaci
   let usedTokens: number
 
   if (hasMeasuredTotal) {
-    // Real total; estimate the breakdown but scale the prefix so the parts add
-    // up to the measured occupancy exactly.
-    usedTokens = clamp(Math.round(measuredTotal), 0, windowTokens)
+    // Real total from the latest provider count, with a live local floor. While
+    // an assistant reply is streaming, the provider count can still describe
+    // the request that started the turn, but the partial reply is already
+    // visible future context. Let the estimate raise the total until the next
+    // provider usage event calibrates it again.
+    usedTokens = clamp(Math.round(Math.max(measuredTotal, localEstimate)), 0, windowTokens)
     messages = clamp(messageEstimate, 0, usedTokens)
     const prefixActual = Math.max(0, usedTokens - messages)
     const scale = prefixEstimate > 0 ? prefixActual / prefixEstimate : 0


### PR DESCRIPTION
## Summary
- Update the context usage ring from live conversation blocks while a turn is streaming.
- Keep provider prompt-token usage as calibration, but let the local live estimate raise stale measured totals during streaming.
- Add regression coverage for live estimates exceeding an older measured total.

## Tests
- npm run test -- src/renderer/src/lib/context-capacity.test.ts
- npm run typecheck
- git diff --check