### PR TITLE
feat(onboarding): configure default agent permissions

### DIFF
--- a/src/renderer/src/components/InitialSetupDialog.tsx
+++ b/src/renderer/src/components/InitialSetupDialog.tsx
@@ -2,9 +2,12 @@ import { type ReactElement, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   DEFAULT_MODEL_PROVIDER_ID,
+  KUN_TOOL_PERMISSION_MODES,
+  kunToolPermissionModeSettings,
   normalizeAppSettings,
   type AppSettingsPatch,
   type AppSettingsV1,
+  type KunToolPermissionMode,
   type ModelProviderPreset
 } from '@shared/app-settings'
 import {
@@ -27,9 +30,13 @@ import {
   Eye,
   EyeOff,
   ExternalLink,
+  FolderPen,
+  Hand,
   Image as ImageIcon,
+  LockKeyholeOpen,
   MessageCircle,
   Mic,
+  ShieldQuestion,
   Sparkles,
   Sun,
   Moon,
@@ -50,6 +57,59 @@ const themeOptions: { value: ThemePref; icon: typeof Sun; labelKey: string }[] =
   { value: 'dark', icon: Moon, labelKey: 'themeDark' }
 ]
 const DEEPSEEK_USAGE_URL = 'https://platform.deepseek.com/usage'
+
+type PermissionOption = {
+  value: KunToolPermissionMode
+  labelKey: string
+  descriptionKey: string
+  Icon: typeof Hand
+  iconClass: string
+}
+
+const PERMISSION_OPTIONS: PermissionOption[] = KUN_TOOL_PERMISSION_MODES.map((value) => {
+  switch (value) {
+    case 'always-ask':
+      return {
+        value,
+        labelKey: 'toolPermissionAlwaysAsk',
+        descriptionKey: 'toolPermissionAlwaysAskDesc',
+        Icon: Hand,
+        iconClass: 'border-sky-400/30 bg-sky-500/10 text-sky-700 dark:text-sky-200'
+      }
+    case 'read-only':
+      return {
+        value,
+        labelKey: 'toolPermissionReadOnly',
+        descriptionKey: 'toolPermissionReadOnlyDesc',
+        Icon: Eye,
+        iconClass: 'border-emerald-400/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+      }
+    case 'sensitive-ask':
+      return {
+        value,
+        labelKey: 'toolPermissionSensitiveAsk',
+        descriptionKey: 'toolPermissionSensitiveAskDesc',
+        Icon: ShieldQuestion,
+        iconClass: 'border-amber-400/35 bg-amber-500/10 text-amber-700 dark:text-amber-200'
+      }
+    case 'workspace-write':
+      return {
+        value,
+        labelKey: 'toolPermissionWorkspaceWrite',
+        descriptionKey: 'toolPermissionWorkspaceWriteDesc',
+        Icon: FolderPen,
+        iconClass: 'border-indigo-400/30 bg-indigo-500/10 text-indigo-700 dark:text-indigo-200'
+      }
+    case 'bypass':
+      return {
+        value,
+        labelKey: 'toolPermissionBypass',
+        descriptionKey: 'toolPermissionBypassDesc',
+        Icon: LockKeyholeOpen,
+        iconClass: 'border-orange-400/35 bg-orange-500/10 text-orange-700 dark:text-orange-200'
+      }
+  }
+})
 
 type SetupProviderCard = {
   presetId: string
@@ -141,7 +201,8 @@ export function InitialSetupDialog(): ReactElement {
   const [drafts, setDrafts] = useState<InitialSetupDrafts | null>(null)
   const [selection, setSelection] = useState<InitialSetupSelection>({
     presetId: DEFAULT_MODEL_PROVIDER_ID,
-    mode: 'api'
+    mode: 'api',
+    permissionMode: 'read-only'
   })
   const [showApiKey, setShowApiKey] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -211,12 +272,28 @@ export function InitialSetupDialog(): ReactElement {
 
   const selectCard = (presetId: string): void => {
     setError(null)
-    setSelection((current) => (current.presetId === presetId ? current : { presetId, mode: 'api' }))
+    setSelection((current) => (current.presetId === presetId ? current : { ...current, presetId, mode: 'api' }))
   }
 
   const selectMode = (mode: InitialSetupSelection['mode']): void => {
     setError(null)
     setSelection((current) => ({ ...current, mode }))
+  }
+
+  const selectPermissionMode = (permissionMode: KunToolPermissionMode): void => {
+    setError(null)
+    setSelection((current) => ({ ...current, permissionMode }))
+    const current = formRef.current
+    if (!current) return
+    updateForm({
+      agents: {
+        ...current.agents,
+        kun: {
+          ...current.agents.kun,
+          ...kunToolPermissionModeSettings(permissionMode)
+        }
+      }
+    } as SetupFormPatch)
   }
 
   const cardFilled = (card: SetupProviderCard): boolean => {
@@ -464,6 +541,39 @@ export function InitialSetupDialog(): ReactElement {
               </div>
             </div>
           )}
+
+          <div className="space-y-2.5 sm:space-y-3.5">
+            <label className={labelClass}>
+              {t('firstRunPermissionLabel')}
+            </label>
+            <div className="grid grid-cols-1 gap-2 sm:gap-2.5 min-[520px]:grid-cols-2">
+              {PERMISSION_OPTIONS.map((option) => {
+                const isActive = selection.permissionMode === option.value
+                const Icon = option.Icon
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => selectPermissionMode(option.value)}
+                    className={cardButtonClass(isActive)}
+                  >
+                    <span className="flex min-w-0 items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-100">
+                      <span className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border ${option.iconClass}`}>
+                        <Icon className="h-3.5 w-3.5" strokeWidth={1.9} />
+                      </span>
+                      <span className="min-w-0 truncate">{t(option.labelKey)}</span>
+                    </span>
+                    <span className="text-[12px] leading-5 text-slate-500 dark:text-slate-400">
+                      {t(option.descriptionKey)}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+            <div className="rounded-xl border border-orange-300/60 bg-orange-50/80 px-4 py-3 text-[12.5px] leading-5 text-orange-800 dark:border-orange-800/60 dark:bg-orange-950/30 dark:text-orange-200">
+              {t('firstRunPermissionFullAccessRisk')}
+            </div>
+          </div>
 
           {regions.length > 0 && (
             <div className="space-y-2.5 sm:space-y-3.5">

--- a/src/renderer/src/components/initial-setup-save.test.ts
+++ b/src/renderer/src/components/initial-setup-save.test.ts
@@ -35,20 +35,31 @@ function settingsWithActiveXiaomiWithoutKey(): AppSettingsV1 {
 describe('initialSetupSelection', () => {
   it('preselects the active provider card when it is a known preset', () => {
     const selection = initialSetupSelection(settingsWithActiveXiaomiWithoutKey())
-    expect(selection).toEqual({ presetId: 'xiaomi', mode: 'api' })
+    expect(selection).toEqual({ presetId: 'xiaomi', mode: 'api', permissionMode: 'bypass' })
   })
 
   it('preselects the token plan mode for token plan profiles', () => {
     const current = settings({ agents: { kun: { providerId: 'minimax-token-plan' } } })
-    expect(initialSetupSelection(current)).toEqual({ presetId: 'minimax', mode: 'token-plan' })
+    expect(initialSetupSelection(current)).toEqual({
+      presetId: 'minimax',
+      mode: 'token-plan',
+      permissionMode: 'bypass'
+    })
   })
 
   it('falls back to deepseek for unknown or empty active providers', () => {
-    expect(initialSetupSelection(settings())).toEqual({ presetId: 'deepseek', mode: 'api' })
+    expect(initialSetupSelection(settings())).toEqual({ presetId: 'deepseek', mode: 'api', permissionMode: 'bypass' })
     expect(initialSetupSelection(settings({ agents: { kun: { providerId: 'custom-provider-2' } } })))
-      .toEqual({ presetId: 'deepseek', mode: 'api' })
+      .toEqual({ presetId: 'deepseek', mode: 'api', permissionMode: 'bypass' })
     expect(initialSetupSelection(settings({ agents: { kun: { providerId: 'litellm' } } })))
-      .toEqual({ presetId: 'deepseek', mode: 'api' })
+      .toEqual({ presetId: 'deepseek', mode: 'api', permissionMode: 'bypass' })
+  })
+
+  it('preselects the saved permission mode', () => {
+    const current = settings({
+      agents: { kun: { approvalPolicy: 'on-request', sandboxMode: 'workspace-write' } }
+    })
+    expect(initialSetupSelection(current).permissionMode).toBe('workspace-write')
   })
 })
 
@@ -83,7 +94,7 @@ describe('initialSetupDrafts', () => {
     for (const id of excludedIds) {
       expect(drafts[id]).toBeUndefined()
       expect(initialSetupSelection(settings({ agents: { kun: { providerId: id } } })))
-        .toEqual({ presetId: 'deepseek', mode: 'api' })
+        .toEqual({ presetId: 'deepseek', mode: 'api', permissionMode: 'bypass' })
     }
   })
 })
@@ -96,6 +107,20 @@ describe('buildInitialSetupSettings', () => {
 
     expect(getKunRuntimeSettings(next).providerId).toBe('deepseek')
     expect(getActiveAgentApiKey(next)).toBe('sk-deepseek-key')
+  })
+
+  it('stores the selected default Agent permission mode', () => {
+    const current = settingsWithActiveXiaomiWithoutKey()
+    const drafts = initialSetupDrafts(current)
+    const next = buildInitialSetupSettings(current, drafts, {
+      presetId: 'deepseek',
+      mode: 'api',
+      permissionMode: 'workspace-write'
+    })
+
+    const runtime = getKunRuntimeSettings(next)
+    expect(runtime.approvalPolicy).toBe('on-request')
+    expect(runtime.sandboxMode).toBe('workspace-write')
   })
 
   it('syncs the deepseek draft into the provider profile used by settings', () => {

--- a/src/renderer/src/components/initial-setup-save.test.ts
+++ b/src/renderer/src/components/initial-setup-save.test.ts
@@ -123,6 +123,54 @@ describe('buildInitialSetupSettings', () => {
     expect(runtime.sandboxMode).toBe('workspace-write')
   })
 
+  it('preserves a non-UI permission policy when the selector is untouched', () => {
+    // A persisted policy the 5-mode UI cannot represent: stricter approval gate
+    // plus a sandboxed filesystem. Reopening onboarding seeds the selector from
+    // the lossy fromSettings mapping (-> 'read-only'); when the user does not
+    // move it, the save must leave the strict pair intact rather than rewrite it
+    // to 'on-request'/'danger-full-access'.
+    const current = settings({
+      provider: { apiKey: 'sk-deepseek-key' },
+      agents: {
+        kun: { providerId: 'deepseek', approvalPolicy: 'never', sandboxMode: 'external-sandbox' }
+      }
+    })
+    const seededMode = initialSetupSelection(current).permissionMode
+    expect(seededMode).toBe('read-only')
+
+    const next = buildInitialSetupSettings(current, initialSetupDrafts(current), {
+      presetId: 'deepseek',
+      mode: 'api',
+      permissionMode: seededMode
+    })
+
+    const runtime = getKunRuntimeSettings(next)
+    expect(runtime.approvalPolicy).toBe('never')
+    expect(runtime.sandboxMode).toBe('external-sandbox')
+    expect(runtime.approvalPolicy).not.toBe('on-request')
+    expect(runtime.sandboxMode).not.toBe('danger-full-access')
+  })
+
+  it('writes the permission pair only when the user picks a different mode', () => {
+    // Same strict starting policy, but this time the user explicitly chooses a
+    // representable mode, so the concrete pair for that mode must be written.
+    const current = settings({
+      provider: { apiKey: 'sk-deepseek-key' },
+      agents: {
+        kun: { providerId: 'deepseek', approvalPolicy: 'never', sandboxMode: 'external-sandbox' }
+      }
+    })
+    const next = buildInitialSetupSettings(current, initialSetupDrafts(current), {
+      presetId: 'deepseek',
+      mode: 'api',
+      permissionMode: 'workspace-write'
+    })
+
+    const runtime = getKunRuntimeSettings(next)
+    expect(runtime.approvalPolicy).toBe('on-request')
+    expect(runtime.sandboxMode).toBe('workspace-write')
+  })
+
   it('syncs the deepseek draft into the provider profile used by settings', () => {
     const current = settings({
       provider: {

--- a/src/renderer/src/components/initial-setup-save.ts
+++ b/src/renderer/src/components/initial-setup-save.ts
@@ -1,14 +1,18 @@
 import {
   DEFAULT_MODEL_PROVIDER_ID,
+  KUN_TOOL_PERMISSION_MODES,
   MODEL_PROVIDER_PRESETS,
   applyKunRuntimePatch,
   getKunRuntimeSettings,
   getModelProviderSettings,
+  kunToolPermissionModeFromSettings,
+  kunToolPermissionModeSettings,
   modelProviderPresetProfile,
   modelProviderTokenPlanProfile,
   normalizeAppSettings,
   tokenPlanProviderId,
   type AppSettingsV1,
+  type KunToolPermissionMode,
   type KunRuntimeSettingsPatchV1,
   type ModelProviderPreset,
   type ModelProviderProfileV1
@@ -27,6 +31,7 @@ export type InitialSetupDrafts = Record<string, InitialSetupDraft>
 export type InitialSetupSelection = {
   presetId: string
   mode: InitialSetupAccessMode
+  permissionMode: KunToolPermissionMode
 }
 
 const INITIAL_SETUP_PROVIDER_PRESET_IDS = new Set(['xiaomi', 'minimax'])
@@ -35,7 +40,7 @@ export const INITIAL_SETUP_PROVIDER_PRESETS = MODEL_PROVIDER_PRESETS.filter(
   (preset) => INITIAL_SETUP_PROVIDER_PRESET_IDS.has(preset.id)
 )
 
-export function initialSetupProfileId(selection: InitialSetupSelection): string {
+export function initialSetupProfileId(selection: Pick<InitialSetupSelection, 'presetId' | 'mode'>): string {
   if (selection.presetId === DEFAULT_MODEL_PROVIDER_ID) return DEFAULT_MODEL_PROVIDER_ID
   return selection.mode === 'token-plan' ? tokenPlanProviderId(selection.presetId) : selection.presetId
 }
@@ -66,14 +71,16 @@ export function initialSetupDrafts(settings: AppSettingsV1): InitialSetupDrafts 
 
 /** Card and mode to preselect: the active provider when it is one of ours, DeepSeek otherwise. */
 export function initialSetupSelection(settings: AppSettingsV1): InitialSetupSelection {
-  const activeId = getKunRuntimeSettings(settings).providerId.trim()
+  const runtime = getKunRuntimeSettings(settings)
+  const activeId = runtime.providerId.trim()
+  const permissionMode = kunToolPermissionModeFromSettings(runtime)
   for (const preset of INITIAL_SETUP_PROVIDER_PRESETS) {
-    if (activeId === preset.id) return { presetId: preset.id, mode: 'api' }
+    if (activeId === preset.id) return { presetId: preset.id, mode: 'api', permissionMode }
     if (preset.tokenPlan && activeId === tokenPlanProviderId(preset.id)) {
-      return { presetId: preset.id, mode: 'token-plan' }
+      return { presetId: preset.id, mode: 'token-plan', permissionMode }
     }
   }
-  return { presetId: DEFAULT_MODEL_PROVIDER_ID, mode: 'api' }
+  return { presetId: DEFAULT_MODEL_PROVIDER_ID, mode: 'api', permissionMode }
 }
 
 export type InitialSetupAutoWirePlan = {
@@ -126,7 +133,7 @@ export function initialSetupAutoWirePlan(
 export function buildInitialSetupSettings(
   settings: AppSettingsV1,
   drafts: InitialSetupDrafts,
-  selection: InitialSetupSelection
+  selection: Pick<InitialSetupSelection, 'presetId' | 'mode'> & Partial<Pick<InitialSetupSelection, 'permissionMode'>>
 ): AppSettingsV1 {
   const provider = getModelProviderSettings(settings)
   const profiles = new Map(provider.providers.map((profile) => [profile.id, profile]))
@@ -170,10 +177,14 @@ export function buildInitialSetupSettings(
   )
   const switchingProvider = (runtime.providerId.trim() || DEFAULT_MODEL_PROVIDER_ID) !== selectedId
   const wire = initialSetupAutoWirePlan(settings, drafts)
+  const permissionMode = selection.permissionMode && KUN_TOOL_PERMISSION_MODES.includes(selection.permissionMode)
+    ? selection.permissionMode
+    : kunToolPermissionModeFromSettings(runtime)
   const kunPatch: KunRuntimeSettingsPatchV1 = {
     providerId: selectedId,
     apiKey: '',
     baseUrl: '',
+    ...kunToolPermissionModeSettings(permissionMode),
     ...(switchingProvider && selectedProfile?.models[0] ? { model: selectedProfile.models[0] } : {}),
     ...(wire.speechProviderId
       ? { speechToText: { enabled: true, providerId: wire.speechProviderId } }

--- a/src/renderer/src/components/initial-setup-save.ts
+++ b/src/renderer/src/components/initial-setup-save.ts
@@ -177,14 +177,23 @@ export function buildInitialSetupSettings(
   )
   const switchingProvider = (runtime.providerId.trim() || DEFAULT_MODEL_PROVIDER_ID) !== selectedId
   const wire = initialSetupAutoWirePlan(settings, drafts)
-  const permissionMode = selection.permissionMode && KUN_TOOL_PERMISSION_MODES.includes(selection.permissionMode)
+  // Only rewrite approvalPolicy/sandboxMode when the user actually moved the
+  // permission selector. The mode<->settings mapping is lossy (only 5 of the
+  // policy/sandbox combos are representable), so emitting the pair when the
+  // selection still matches the persisted policy would silently weaken values
+  // the UI cannot represent — e.g. demote approvalPolicy 'never'/'suggest' or
+  // escalate an 'external-sandbox' sandbox. When unchanged we omit the spread
+  // so applyKunRuntimePatch leaves the existing pair untouched.
+  const currentPermissionMode = kunToolPermissionModeFromSettings(runtime)
+  const selectedPermissionMode = selection.permissionMode && KUN_TOOL_PERMISSION_MODES.includes(selection.permissionMode)
     ? selection.permissionMode
-    : kunToolPermissionModeFromSettings(runtime)
+    : currentPermissionMode
+  const permissionChanged = selectedPermissionMode !== currentPermissionMode
   const kunPatch: KunRuntimeSettingsPatchV1 = {
     providerId: selectedId,
     apiKey: '',
     baseUrl: '',
-    ...kunToolPermissionModeSettings(permissionMode),
+    ...(permissionChanged ? kunToolPermissionModeSettings(selectedPermissionMode) : {}),
     ...(switchingProvider && selectedProfile?.models[0] ? { model: selectedProfile.models[0] } : {}),
     ...(wire.speechProviderId
       ? { speechToText: { enabled: true, providerId: wire.speechProviderId } }

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -855,6 +855,8 @@
   "firstRunModeLabel": "Access mode",
   "firstRunModeApi": "Pay-as-you-go API",
   "firstRunModeTokenPlan": "Token Plan",
+  "firstRunPermissionLabel": "Default Agent permissions",
+  "firstRunPermissionFullAccessRisk": "\"Full access\" lets the Agent run tools without asking and gives it full local access. Choose it only when you fully trust the current task and input.",
   "firstRunRegionLabel": "Plan region",
   "firstRunRegion_cn": "China",
   "firstRunRegion_global": "Global",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -855,6 +855,8 @@
   "firstRunModeLabel": "接入方式",
   "firstRunModeApi": "按量 API",
   "firstRunModeTokenPlan": "Token Plan 套餐",
+  "firstRunPermissionLabel": "默认 Agent 权限",
+  "firstRunPermissionFullAccessRisk": "“完全访问”会让 Agent 在不询问的情况下执行工具，并拥有完整本地访问权限。只有在你充分信任当前任务和输入内容时才应选择。",
   "firstRunRegionLabel": "套餐区域",
   "firstRunRegion_cn": "国内",
   "firstRunRegion_global": "海外",


### PR DESCRIPTION
Summary
- Add a default Agent permission selector to the first-run setup guide.
- Persist the selected permission mode into Kun runtime approval and sandbox settings.
- Warn users that Full access runs tools without asking and has full local access.

Changes
- Reuse the shared Kun tool permission modes so onboarding lists every current option.
- Preserve saved permission mode when reopening onboarding and keep provider selection behavior unchanged.
- Add Chinese and English setup copy plus coverage for the saved permission mapping.

Tests
- npm run test -- src/renderer/src/components/initial-setup-save.test.ts
- npm run typecheck
- git diff --check