### PR TITLE
fix(security): IM permission passthrough + workspace symlink escape

### DIFF
--- a/kun/src/adapters/tool/builtin-file-tools.ts
+++ b/kun/src/adapters/tool/builtin-file-tools.ts
@@ -60,7 +60,7 @@ export function createWriteLocalTool(_options: WriteLocalToolOptions = {}): Loca
       if (!rawPath.trim() || content == null) {
         return { output: { error: 'path and content are required' }, isError: true }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       assertCanWritePath(absolutePath, context)
       return withFileMutationQueue(absolutePath, async () => {
         await mkdirOp(dirname(absolutePath))
@@ -118,7 +118,7 @@ export function createEditLocalTool(_options: EditLocalToolOptions = {}): LocalT
       if (!rawPath.trim() || edits.length === 0) {
         return { output: { error: 'path and at least one edit are required' }, isError: true }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       assertCanWritePath(absolutePath, context)
       return withFileMutationQueue(absolutePath, async () => {
         const rawSource = await readFileOp(absolutePath)

--- a/kun/src/adapters/tool/builtin-lsp-tool.ts
+++ b/kun/src/adapters/tool/builtin-lsp-tool.ts
@@ -111,7 +111,7 @@ export function createLspLocalTool(): LocalTool {
           return { output: { error: `Unknown operation: ${operation}` }, isError: true }
         }
 
-        const { absolutePath, workspaceRoot } = resolveWorkspacePath(rawPath, context)
+        const { absolutePath, workspaceRoot } = await resolveWorkspacePath(rawPath, context)
         const server = findLanguageServerForFile(absolutePath)
         if (!server) {
           const supported = listLanguageServers()

--- a/kun/src/adapters/tool/builtin-read-tool.ts
+++ b/kun/src/adapters/tool/builtin-read-tool.ts
@@ -49,7 +49,7 @@ export function createReadLocalTool(options: ReadLocalToolOptions = {}): LocalTo
           isError: true
         }
       }
-      const { absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       await statOp(absolutePath)
       const fileBuffer = await readFileOp(absolutePath)
       const classification = getReadClassification(absolutePath, context.workspace)

--- a/kun/src/adapters/tool/builtin-search-tools.ts
+++ b/kun/src/adapters/tool/builtin-search-tools.ts
@@ -43,7 +43,7 @@ export function createLsLocalTool(options: LsLocalToolOptions = {}): LocalTool {
     execute: async (args, context) => withToolBoundary(async () => {
       const rawPath = typeof args.path === 'string' && args.path.trim() ? args.path : '.'
       const limit = normalizePositiveInteger(args.limit, options.defaultLimit ?? DEFAULT_LIST_LIMIT)
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       const targetStat = await statOp(absolutePath)
       if (!targetStat.isDirectory()) {
         return {
@@ -95,7 +95,7 @@ export function createFindLocalTool(options: FindLocalToolOptions = {}): LocalTo
       if (!pattern) return { output: { error: 'pattern is required' }, isError: true }
       const rawPath = typeof args.path === 'string' && args.path.trim() ? args.path : '.'
       const limit = normalizePositiveInteger(args.limit, options.defaultLimit ?? DEFAULT_FIND_LIMIT)
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       const matcher = globToRegExp(pattern.includes('/') ? pattern : `**/${pattern}`)
       if (options.operations?.glob) {
         const matches = await options.operations.glob({ pattern, path: absolutePath, limit })
@@ -213,7 +213,7 @@ export function createGrepLocalTool(options: GrepLocalToolOptions = {}): LocalTo
         ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), flags)
         : new RegExp(pattern, flags)
       const globMatcher = glob ? globToRegExp(glob.includes('/') ? glob : `**/${glob}`) : null
-      const { workspaceRoot: root, absolutePath, relativePath } = resolveWorkspacePath(rawPath, context)
+      const { workspaceRoot: root, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       if (options.operations?.search) {
         const matches = await options.operations.search({
           pattern,

--- a/kun/src/adapters/tool/builtin-tool-utils.symlink.test.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.symlink.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { ToolHostContext } from '../../ports/tool-host.js'
+import { resolveWorkspacePath } from './builtin-tool-utils.js'
+
+function context(workspace: string): ToolHostContext {
+  return {
+    threadId: 'thread_symlink',
+    turnId: 'turn_symlink',
+    workspace,
+    approvalPolicy: 'always',
+    sandboxMode: 'workspace-write',
+    abortSignal: new AbortController().signal,
+    awaitApproval: async () => 'allow'
+  }
+}
+
+describe('resolveWorkspacePath symlink escape', () => {
+  let base: string
+  let workspace: string
+  let outside: string
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'kun-symlink-'))
+    workspace = join(base, 'ws')
+    outside = join(base, 'outside')
+    await mkdir(workspace, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true })
+  })
+
+  it('rejects a DANGLING symlink whose target is outside the workspace (write/create case)', async () => {
+    // `outside` deliberately does NOT exist — realpath() reports ENOENT for the
+    // link exactly as for a missing file. This is the hole the fix closes.
+    await symlink(outside, join(workspace, 'evil'))
+    await expect(resolveWorkspacePath('evil', context(workspace))).rejects.toThrow(/escapes the workspace root/)
+  })
+
+  it('rejects a path that traverses through a dangling symlink to an outside dir', async () => {
+    await symlink(outside, join(workspace, 'dlink'))
+    await expect(resolveWorkspacePath('dlink/sub/new.txt', context(workspace))).rejects.toThrow(
+      /escapes the workspace root/
+    )
+  })
+
+  it('rejects an EXISTING symlink that points outside the workspace', async () => {
+    await mkdir(outside, { recursive: true })
+    await symlink(outside, join(workspace, 'link'))
+    await expect(resolveWorkspacePath('link/file.txt', context(workspace))).rejects.toThrow(
+      /escapes the workspace root/
+    )
+  })
+
+  it('allows a dangling symlink that stays inside the workspace', async () => {
+    // Link target is absent but in-workspace — a legitimate write/create target.
+    await symlink(join(workspace, 'data', 'note.txt'), join(workspace, 'good'))
+    const resolved = await resolveWorkspacePath('good', context(workspace))
+    expect(resolved.absolutePath).toBe(join(workspace, 'good'))
+  })
+
+  it('allows creating a new nested file with no symlinks involved', async () => {
+    const resolved = await resolveWorkspacePath('sub/dir/new.txt', context(workspace))
+    expect(resolved.absolutePath).toBe(join(workspace, 'sub', 'dir', 'new.txt'))
+  })
+
+  it('allows reading an existing in-workspace file', async () => {
+    await writeFile(join(workspace, 'real.txt'), 'hi')
+    const resolved = await resolveWorkspacePath('real.txt', context(workspace))
+    expect(resolved.absolutePath).toBe(join(workspace, 'real.txt'))
+    expect(resolved.relativePath).toBe('real.txt')
+  })
+})

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { readFile, readdir, stat } from 'node:fs/promises'
+import { readFile, readdir, realpath, stat } from 'node:fs/promises'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { ToolHostContext } from '../../ports/tool-host.js'
@@ -57,22 +57,71 @@ export function workspaceRoot(workspace: string): string {
   return isAbsolute(workspace) ? resolve(workspace) : resolve(process.cwd(), workspace)
 }
 
-export function resolveWorkspacePath(inputPath: string, context: ToolHostContext): {
+export async function resolveWorkspacePath(inputPath: string, context: ToolHostContext): Promise<{
   workspaceRoot: string
   absolutePath: string
   relativePath: string
-} {
+}> {
   const root = workspaceRoot(context.workspace)
-  const absolutePath = isAbsolute(inputPath) ? resolve(inputPath) : resolve(root, inputPath)
-  const relativePath = relative(root, absolutePath)
-  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+  const lexicalAbsolutePath = isAbsolute(inputPath) ? resolve(inputPath) : resolve(root, inputPath)
+  const resolvedRoot = await safeRealpath(root)
+  if (resolvedRoot === null) {
+    // Workspace root itself does not exist; nothing to anchor the escape
+    // check against. This is distinct from an actual escape (handled below).
+    throw new Error(`workspace root does not exist: ${root}`)
+  }
+  const resolvedAbsolute = await resolveSymlinkSafe(lexicalAbsolutePath)
+  const resolvedRelative = relative(resolvedRoot, resolvedAbsolute)
+  if (resolvedRelative === '..' || resolvedRelative.startsWith(`..${sep}`) || isAbsolute(resolvedRelative)) {
     throw new Error(`path escapes the workspace root: ${inputPath}`)
   }
+  // Return LEXICAL paths to callers. The realpath-resolved pair is only used
+  // for the escape check above; downstream code (subprocess cwd, display
+  // paths, language-server init) expects the user-facing workspace path,
+  // which on symlinked roots (e.g. macOS `/tmp` -> `/private/tmp`) would
+  // otherwise diverge from what the user typed and break display layers.
   return {
     workspaceRoot: root,
-    absolutePath,
-    relativePath: relativePath || '.'
+    absolutePath: lexicalAbsolutePath,
+    relativePath: relative(root, lexicalAbsolutePath) || '.'
   }
+}
+
+async function safeRealpath(target: string): Promise<string | null> {
+  try {
+    return await realpath(target)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return null
+    if (code === 'EACCES' || code === 'ELOOP' || code === 'ENOTDIR') return null
+    throw error
+  }
+}
+
+async function resolveSymlinkSafe(lexicalPath: string): Promise<string> {
+  const direct = await safeRealpath(lexicalPath)
+  if (direct !== null) return direct
+  // Target doesn't exist (ENOENT) — relevant for write/create operations.
+  // Walk up until we find an existing ancestor, realpath it, then verify the
+  // remaining (non-existent) suffix stays inside the workspace root.
+  const segments: string[] = []
+  let current = lexicalPath
+  let ancestor: string | null = null
+  // Guard against infinite loops on pathological inputs.
+  for (let i = 0; i < 128 && current !== dirname(current); i += 1) {
+    const resolved = await safeRealpath(current)
+    if (resolved !== null) {
+      ancestor = resolved
+      break
+    }
+    segments.unshift(basename(current))
+    current = dirname(current)
+  }
+  if (ancestor === null) {
+    // Nothing on the path exists; treat as escape.
+    throw new Error(`path escapes the workspace root: ${lexicalPath}`)
+  }
+  return segments.length > 0 ? resolve(ancestor, ...segments) : ancestor
 }
 
 export function isBinaryBuffer(buffer: Buffer): boolean {

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { readFile, readdir, realpath, stat } from 'node:fs/promises'
+import { lstat, readFile, readdir, readlink, realpath, stat } from 'node:fs/promises'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { ToolHostContext } from '../../ports/tool-host.js'
@@ -98,30 +98,55 @@ async function safeRealpath(target: string): Promise<string | null> {
   }
 }
 
-async function resolveSymlinkSafe(lexicalPath: string): Promise<string> {
+// Whether `target` is itself a symbolic link, without following it. Returns
+// false when the entry is absent or cannot be stat-ed (treated as "not a link"
+// — the escape check still anchors against the nearest existing ancestor).
+async function isSymlink(target: string): Promise<boolean> {
+  try {
+    return (await lstat(target)).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+async function resolveSymlinkSafe(lexicalPath: string, depth = 0): Promise<string> {
+  // Guard against symlink loops (dangling link A -> B -> A never resolves).
+  if (depth > 40) {
+    throw new Error(`too many symbolic links resolving: ${lexicalPath}`)
+  }
   const direct = await safeRealpath(lexicalPath)
   if (direct !== null) return direct
-  // Target doesn't exist (ENOENT) — relevant for write/create operations.
-  // Walk up until we find an existing ancestor, realpath it, then verify the
-  // remaining (non-existent) suffix stays inside the workspace root.
+  // Target doesn't fully resolve — either a genuinely missing path (write/create
+  // case) or a *dangling* symlink whose target is absent. `realpath` reports
+  // both as ENOENT, so we must walk the components ourselves: anchor on the
+  // nearest existing ancestor, but if a non-resolving component is actually a
+  // symlink, follow it explicitly so the redirection is reflected in the escape
+  // check. Re-anchoring a dangling symlink lexically (the old behavior) let a
+  // planted link like `<ws>/evil -> /etc/passwd` (target absent) pass as an
+  // in-workspace path and escape on the subsequent write.
   const segments: string[] = []
   let current = lexicalPath
-  let ancestor: string | null = null
-  // Guard against infinite loops on pathological inputs.
+  // Guard against pathological component counts.
   for (let i = 0; i < 128 && current !== dirname(current); i += 1) {
     const resolved = await safeRealpath(current)
     if (resolved !== null) {
-      ancestor = resolved
-      break
+      return segments.length > 0 ? resolve(resolved, ...segments) : resolved
+    }
+    if (await isSymlink(current)) {
+      // Dangling (or otherwise non-resolving) symlink: follow its target so the
+      // redirection is reflected, then re-resolve the target plus the suffix
+      // collected below this component.
+      const linkTarget = await readlink(current)
+      const resolvedParent = (await safeRealpath(dirname(current))) ?? dirname(current)
+      const followed = isAbsolute(linkTarget) ? resolve(linkTarget) : resolve(resolvedParent, linkTarget)
+      const rejoined = segments.length > 0 ? resolve(followed, ...segments) : followed
+      return resolveSymlinkSafe(rejoined, depth + 1)
     }
     segments.unshift(basename(current))
     current = dirname(current)
   }
-  if (ancestor === null) {
-    // Nothing on the path exists; treat as escape.
-    throw new Error(`path escapes the workspace root: ${lexicalPath}`)
-  }
-  return segments.length > 0 ? resolve(ancestor, ...segments) : ancestor
+  // Nothing on the path exists; treat as escape.
+  throw new Error(`path escapes the workspace root: ${lexicalPath}`)
 }
 
 export function isBinaryBuffer(buffer: Buffer): boolean {

--- a/src/main/claw-runtime.test.ts
+++ b/src/main/claw-runtime.test.ts
@@ -435,6 +435,230 @@ describe('ClawRuntime', () => {
     })
   })
 
+  it('passes non-default agent approval/sandbox settings through to IM turns without downgrading', async () => {
+    const settings = buildSettings()
+    settings.agents.kun.approvalPolicy = 'untrusted'
+    settings.agents.kun.sandboxMode = 'read-only'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads') {
+        return { ok: true, status: 200, body: JSON.stringify({ id: 'thr_1' }) }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'PATCH') {
+        return { ok: true, status: 200, body: '{}' }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            thread: { id: 'thr_1', status: 'completed' },
+            turns: [{ id: 'turn_1', status: 'completed' }],
+            items: [{ kind: 'assistant_text', detail: 'ok' }]
+          })
+        }
+      }
+      if (path === '/v1/threads/thr_1/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_1', turnId: 'turn_1' }) }
+      }
+      return { ok: true, status: 200, body: '{}' }
+    })
+    const runtime = createClawRuntime({
+      store: { load: vi.fn(async () => settings), patch: vi.fn(async () => settings) } as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+
+    await (runtime as unknown as {
+      runPrompt: (
+        settingsArg: AppSettingsV1,
+        options: {
+          prompt: string
+          title: string
+          workspaceRoot: string
+          model: string
+          mode: 'agent' | 'plan'
+          waitForResult: boolean
+          responseTimeoutMs: number
+          source: 'task' | 'im'
+        }
+      ) => Promise<{ ok: boolean; text?: string }>
+    }).runPrompt(settings, {
+      prompt: 'hello',
+      title: 'demo',
+      workspaceRoot: '/tmp/workspace',
+      model: 'auto',
+      mode: 'agent',
+      waitForResult: true,
+      responseTimeoutMs: 10,
+      source: 'im'
+    })
+
+    const createThreadCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(createThreadCall?.[2]?.body ?? '{}'))).toMatchObject({
+      approvalPolicy: 'untrusted',
+      sandboxMode: 'read-only'
+    })
+    const turnCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads/thr_1/turns' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(turnCall?.[2]?.body ?? '{}'))).toMatchObject({
+      disableUserInput: true,
+      approvalPolicy: 'untrusted',
+      sandboxMode: 'read-only'
+    })
+  })
+
+  it('passes the never approval policy through to IM turns without escalating to auto', async () => {
+    const settings = buildSettings()
+    settings.agents.kun.approvalPolicy = 'never'
+    settings.agents.kun.sandboxMode = 'read-only'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads') {
+        return { ok: true, status: 200, body: JSON.stringify({ id: 'thr_1' }) }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'PATCH') {
+        return { ok: true, status: 200, body: '{}' }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            thread: { id: 'thr_1', status: 'completed' },
+            turns: [{ id: 'turn_1', status: 'completed' }],
+            items: [{ kind: 'assistant_text', detail: 'ok' }]
+          })
+        }
+      }
+      if (path === '/v1/threads/thr_1/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_1', turnId: 'turn_1' }) }
+      }
+      return { ok: true, status: 200, body: '{}' }
+    })
+    const runtime = createClawRuntime({
+      store: { load: vi.fn(async () => settings), patch: vi.fn(async () => settings) } as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+
+    await (runtime as unknown as {
+      runPrompt: (
+        settingsArg: AppSettingsV1,
+        options: {
+          prompt: string
+          title: string
+          workspaceRoot: string
+          model: string
+          mode: 'agent' | 'plan'
+          waitForResult: boolean
+          responseTimeoutMs: number
+          source: 'task' | 'im'
+        }
+      ) => Promise<{ ok: boolean; text?: string }>
+    }).runPrompt(settings, {
+      prompt: 'hello',
+      title: 'demo',
+      workspaceRoot: '/tmp/workspace',
+      model: 'auto',
+      mode: 'agent',
+      waitForResult: true,
+      responseTimeoutMs: 10,
+      source: 'im'
+    })
+
+    const createThreadCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(createThreadCall?.[2]?.body ?? '{}'))).toMatchObject({
+      approvalPolicy: 'never',
+      sandboxMode: 'read-only'
+    })
+    const turnCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads/thr_1/turns' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(turnCall?.[2]?.body ?? '{}'))).toMatchObject({
+      disableUserInput: true,
+      approvalPolicy: 'never',
+      sandboxMode: 'read-only'
+    })
+  })
+
+  it('does not attach IM-only permission fields when source is not im', async () => {
+    const settings = buildSettings()
+    settings.agents.kun.approvalPolicy = 'untrusted'
+    settings.agents.kun.sandboxMode = 'read-only'
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads') {
+        return { ok: true, status: 200, body: JSON.stringify({ id: 'thr_1' }) }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'PATCH') {
+        return { ok: true, status: 200, body: '{}' }
+      }
+      if (path === '/v1/threads/thr_1' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            thread: { id: 'thr_1', status: 'completed' },
+            turns: [{ id: 'turn_1', status: 'completed' }],
+            items: [{ kind: 'assistant_text', detail: 'ok' }]
+          })
+        }
+      }
+      if (path === '/v1/threads/thr_1/turns') {
+        return { ok: true, status: 202, body: JSON.stringify({ threadId: 'thr_1', turnId: 'turn_1' }) }
+      }
+      return { ok: true, status: 200, body: '{}' }
+    })
+    const runtime = createClawRuntime({
+      store: { load: vi.fn(async () => settings), patch: vi.fn(async () => settings) } as never,
+      runtimeRequest,
+      logError: () => undefined
+    })
+
+    await (runtime as unknown as {
+      runPrompt: (
+        settingsArg: AppSettingsV1,
+        options: {
+          prompt: string
+          title: string
+          workspaceRoot: string
+          model: string
+          mode: 'agent' | 'plan'
+          waitForResult: boolean
+          responseTimeoutMs: number
+          source: 'task' | 'im'
+        }
+      ) => Promise<{ ok: boolean; text?: string }>
+    }).runPrompt(settings, {
+      prompt: 'hello',
+      title: 'demo',
+      workspaceRoot: '/tmp/workspace',
+      model: 'auto',
+      mode: 'agent',
+      waitForResult: true,
+      responseTimeoutMs: 10,
+      source: 'task'
+    })
+
+    const createThreadCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads' && init?.method === 'POST'
+    )
+    const createBody = JSON.parse(String(createThreadCall?.[2]?.body ?? '{}'))
+    expect(createBody).not.toHaveProperty('approvalPolicy')
+    expect(createBody).not.toHaveProperty('sandboxMode')
+    expect(createBody).not.toHaveProperty('disableUserInput')
+    const turnCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads/thr_1/turns' && init?.method === 'POST'
+    )
+    const turnBody = JSON.parse(String(turnCall?.[2]?.body ?? '{}'))
+    expect(turnBody).not.toHaveProperty('approvalPolicy')
+    expect(turnBody).not.toHaveProperty('sandboxMode')
+    expect(turnBody).not.toHaveProperty('disableUserInput')
+  })
+
   it('reads assistant text from the Kun thread detail shape used by the real runtime', async () => {
     const settings = buildSettings()
     const runtimeRequest = vi.fn(async (_settings, path, init) => {
@@ -1211,6 +1435,105 @@ describe('ClawRuntime', () => {
       disableUserInput: true,
       approvalPolicy: 'auto',
       sandboxMode: 'danger-full-access'
+    })
+  })
+
+  it('passes non-default agent approval/sandbox settings through the WeChat webhook path without downgrading', async () => {
+    const settings = buildSettings()
+    settings.claw.im.enabled = true
+    settings.claw.im.responseTimeoutMs = 2_500
+    settings.agents.kun.approvalPolicy = 'untrusted'
+    settings.agents.kun.sandboxMode = 'read-only'
+    settings.claw.channels = [buildChannel({
+      provider: 'weixin' as const,
+      id: 'channel_weixin',
+      label: 'WeChat',
+      threadId: '',
+      conversations: []
+    })]
+    const { store } = mutableSettingsStore(settings)
+    const runtimeRequest = vi.fn(async (_settings, path, init) => {
+      if (path === '/v1/threads' && init?.method === 'POST') {
+        return { ok: true, status: 201, body: JSON.stringify({ id: 'thr_weixin' }) }
+      }
+      if (path === '/v1/threads/thr_weixin' && init?.method === 'PATCH') {
+        return { ok: true, status: 200, body: '{}' }
+      }
+      if (path === '/v1/threads/thr_weixin/turns' && init?.method === 'POST') {
+        return { ok: true, status: 202, body: JSON.stringify({ turnId: 'turn_weixin' }) }
+      }
+      if (path === '/v1/threads/thr_weixin' && init?.method === 'GET') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            id: 'thr_weixin',
+            status: 'idle',
+            turns: [
+              {
+                id: 'turn_weixin',
+                status: 'completed',
+                items: [{ kind: 'assistant_text', text: 'hello from GUI' }]
+              }
+            ]
+          })
+        }
+      }
+      throw new Error(`unexpected path ${path}`)
+    })
+    const runtime = createClawRuntime({
+      store: store as never,
+      runtimeRequest: runtimeRequest as never,
+      logError: () => undefined,
+      createScheduledTaskFromText: vi.fn(async () => ({ kind: 'noop' as const }))
+    })
+    const body = JSON.stringify({
+      text: '你好',
+      provider: 'weixin',
+      channelId: 'channel_weixin',
+      chatId: 'wx_user_1',
+      messageId: 'wx_msg_1',
+      senderId: 'wx_user_1',
+      senderName: 'Alice'
+    })
+    const req = {
+      method: 'POST',
+      url: settings.claw.im.path,
+      headers: {},
+      async *[Symbol.asyncIterator]() {
+        yield Buffer.from(body)
+      }
+    }
+    let status = 0
+    let responseBody = ''
+    const res = {
+      writeHead: vi.fn((nextStatus: number) => {
+        status = nextStatus
+      }),
+      end: vi.fn((payload: string) => {
+        responseBody = payload
+      })
+    }
+
+    await (runtime as unknown as {
+      handleWebhook: (request: typeof req, response: typeof res) => Promise<void>
+    }).handleWebhook(req, res)
+
+    expect(status).toBe(200)
+    const createThreadCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(createThreadCall?.[2]?.body ?? '{}'))).toMatchObject({
+      approvalPolicy: 'untrusted',
+      sandboxMode: 'read-only'
+    })
+    const turnCall = runtimeRequest.mock.calls.find(
+      ([, path, init]) => path === '/v1/threads/thr_weixin/turns' && init?.method === 'POST'
+    )
+    expect(JSON.parse(String(turnCall?.[2]?.body ?? '{}'))).toMatchObject({
+      disableUserInput: true,
+      approvalPolicy: 'untrusted',
+      sandboxMode: 'read-only'
     })
   })
 

--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -80,8 +80,6 @@ import { FeishuStreamer } from './feishu-streamer'
 import type { TelegramInboundPayload } from './telegram-runtime'
 
 const MAX_IM_FILE_UPLOAD_BYTES = 50 * 1024 * 1024
-const CLAW_IM_APPROVAL_POLICY = 'auto'
-const CLAW_IM_SANDBOX_MODE = 'danger-full-access'
 const CLAW_TELEGRAM_INBOUND_IMAGE_HEADING = '[Telegram inbound message]'
 
 type FeishuClawChannel = ClawImChannelV1 & {
@@ -573,8 +571,8 @@ export class ClawRuntime {
     const createThread = async (): Promise<ThreadRecordJson | null> => {
       const body: Record<string, unknown> = { workspace, model, mode: options.mode }
       if (options.source === 'im') {
-        body.approvalPolicy = CLAW_IM_APPROVAL_POLICY
-        body.sandboxMode = CLAW_IM_SANDBOX_MODE
+        body.approvalPolicy = runtimeSettings.agents.kun.approvalPolicy
+        body.sandboxMode = runtimeSettings.agents.kun.sandboxMode
       }
       const create = await this.deps.runtimeRequest(runtimeSettings, '/v1/threads', {
         method: 'POST',
@@ -604,10 +602,12 @@ export class ClawRuntime {
     if (model) turnBody.model = model
     // IM senders can only reply in their chat app; they cannot answer
     // GUI prompts, so the runtime must not expose user-input tools.
+    // Permission fields are pure passthrough from the agent settings so
+    // IM turns follow the same policy the user picked for the GUI.
     if (options.source === 'im') {
       turnBody.disableUserInput = true
-      turnBody.approvalPolicy = CLAW_IM_APPROVAL_POLICY
-      turnBody.sandboxMode = CLAW_IM_SANDBOX_MODE
+      turnBody.approvalPolicy = runtimeSettings.agents.kun.approvalPolicy
+      turnBody.sandboxMode = runtimeSettings.agents.kun.sandboxMode
     }
     let turn = await this.startRuntimeTurn(runtimeSettings, thread.id, turnBody)
     if (!turn.ok && existingThreadId && isMissingThreadResult(turn)) {


### PR DESCRIPTION
## Summary

Supersedes #536 (closed). Two independent security fixes, audited from the same investigation. The IM permission approach is changed from #536's downgrade-to-`auto` to **pure passthrough**, per review feedback.

### 1. IM agent runs follow the user-chosen sandbox/approval policy (pure passthrough)

`src/main/claw-runtime.ts` hardcoded IM-sourced turns (Feishu / WeChat / Telegram) to `approvalPolicy='auto'` + `sandboxMode='danger-full-access'`, silently overriding the unified tool-permission picker. A user who selected `read-only` or `never` still got full-write auto-approved execution when an IM contact sent a message.

#536 fixed this by downgrading GUI-required policies to `auto` for IM. Review rejected that approach: the IM path was making a second permission decision on top of the agent settings, which the GUI never does. This PR instead makes IM **identical to the GUI** — pure passthrough:

- `approvalPolicy` and `sandboxMode` are read verbatim from `runtimeSettings.agents.kun` (the same object the GUI reads via `getKunRuntimeSettings(settings)`) and forwarded unchanged on both the thread-create body and the turn body.
- `IM_GUI_REQUIRED_APPROVAL_POLICIES`, `imSandboxMode`, `imApprovalPolicy`, and the downgrade `logError` are all removed. The claw-runtime no longer makes any permission decision for IM.
- `disableUserInput: true` is retained — it is a UX constraint (IM senders cannot answer structured GUI prompts), not a permission.

Consequence (intended): if the user sets `untrusted` (GUI confirmation) and sends via IM while away from the computer, that turn's tool calls will wait at the approval gate. This is predictable, transparent behavior — the user chose a strict policy, so it is enforced strictly. No silent downgrade.

### 2. Workspace path escape check resolves symlinks

`kun/src/adapters/tool/builtin-tool-utils.ts` used `path.resolve()` which is purely lexical and does not follow symlinks. A symlink at `<workspace>/link -> /etc/passwd` passed the escape check, letting read/write/edit/ls/find/grep/LSP tools reach files outside the workspace.

- Both workspace root and target path run through `fs.realpath()` before the `relative()` escape check.
- New `resolveSymlinkSafe` helper handles the write/create case (target doesn't exist yet) by walking up to the nearest existing ancestor, realpath-ing it, and re-joining the suffix (loop-guarded at 128 iterations).
- Error handling is fail-closed: `EACCES` / `ELOOP` / `ENOTDIR` → treated as non-existent; unexpected errno rethrows.
- Realpath-resolved pair is used ONLY for the escape check; lexical paths are returned to callers so downstream code (subprocess cwd, display paths, LSP init) keeps seeing the user-facing path (important on symlinked roots like macOS `/tmp` → `/private/tmp`).
- All 6 tool call sites updated to `await` the now-`async` `resolveWorkspacePath`.

## Changes

- `src/main/claw-runtime.ts` — remove hardcoded `CLAW_IM_APPROVAL_POLICY`/`CLAW_IM_SANDBOX_MODE` constants; pass `runtimeSettings.agents.kun.approvalPolicy`/`.sandboxMode` through verbatim on both thread-create and turn bodies; keep `disableUserInput: true`.
- `src/main/claw-runtime.test.ts` — 4 new tests:
  - `untrusted`/`read-only` passthrough (no downgrade)
  - `never`/`read-only` passthrough (no escalation to `auto`)
  - `source: 'task'` negative test (no IM-only fields on body)
  - end-to-end WeChat webhook test (non-default policy arrives on both bodies)
- `kun/src/adapters/tool/builtin-tool-utils.ts` — async `resolveWorkspacePath` + `safeRealpath` + `resolveSymlinkSafe`; returns lexical paths.
- `kun/src/adapters/tool/builtin-file-tools.ts`, `builtin-lsp-tool.ts`, `builtin-read-tool.ts`, `builtin-search-tools.ts` — `await resolveWorkspacePath(...)`.

## Tests

- [x] `npx vitest run src/main/claw-runtime.test.ts` — 50/50
- [x] `cd kun && npx vitest run src/adapters/tool/` — 49/49
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
