### PR TITLE
fix(chat): keep timeline jump rail fixed

### DIFF
--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -2795,25 +2795,27 @@ pre {
 }
 
 .timeline-jump-rail {
-  position: sticky;
-  top: 0.75rem;
-  z-index: 30;
+  position: fixed;
+  top: 7.6rem;
+  right: 1.55rem;
+  z-index: 45;
   display: flex;
-  width: max-content;
-  min-width: 2.25rem;
+  box-sizing: border-box;
+  width: 2.4rem;
+  min-width: 2.4rem;
   max-height: min(48vh, 22rem);
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
-  align-self: flex-end;
+  gap: 0.3rem;
   overflow-y: auto;
-  margin: 0.65rem 0.65rem -0.65rem 0;
-  border: 1px solid var(--ds-border-muted);
+  border: 1px solid color-mix(in srgb, var(--ds-border) 82%, transparent);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--ds-surface-card) 88%, transparent);
-  padding: 0.3rem;
-  box-shadow: 0 12px 34px rgba(15, 23, 42, 0.12);
-  backdrop-filter: blur(18px);
+  background: color-mix(in srgb, var(--ds-surface-card) 96%, transparent);
+  padding: 0.34rem;
+  box-shadow:
+    0 12px 34px rgba(15, 23, 42, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(20px);
   scrollbar-width: none;
 }
 
@@ -2823,20 +2825,23 @@ pre {
 
 .timeline-jump-rail-button {
   display: inline-flex;
-  min-width: 1.65rem;
-  height: 1.55rem;
+  box-sizing: border-box;
+  width: 1.7rem;
+  min-width: 1.7rem;
+  height: 1.7rem;
   align-items: center;
   justify-content: center;
-  padding-inline: 0.35rem;
+  padding: 0;
   border: 0;
   border-radius: 999px;
-  background: transparent;
-  color: var(--ds-text-faint);
-  font-size: 0.72rem;
+  background: color-mix(in srgb, var(--ds-text) 7%, transparent);
+  color: var(--ds-text-muted);
+  font-size: 0.76rem;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   line-height: 1;
   white-space: nowrap;
+  text-align: center;
   transition:
     background 140ms ease,
     color 140ms ease,


### PR DESCRIPTION
Summary
- Keep the timeline jump rail fixed in the viewport while the chat scrolls.
- Stabilize the rail and numeric button sizing/background so the control does not collapse into a thin pill.

Tests
- git diff --check
- npm run test -- MessageTimeline.initial-heatmap.test.ts
- npm run typecheck
- npm run build
- npm run dist:mac:arm64
- Installed /Applications/Kun.app and verified /health