### PR TITLE
fix(ci): relax daily prerelease artifact checks

### DIFF
--- a/.github/workflows/daily-dev-prerelease.yml
+++ b/.github/workflows/daily-dev-prerelease.yml
@@ -230,9 +230,6 @@ jobs:
             "Kun-${DEV_VERSION}-mac-x64.zip"
             "Kun-${DEV_VERSION}-win-x64.exe"
             "Kun-${DEV_VERSION}-linux-x86_64.AppImage"
-            "latest-mac.yml"
-            "latest.yml"
-            "latest-linux.yml"
           )
 
           for file in "${required[@]}"; do


### PR DESCRIPTION
Summary
- Remove latest*.yml from the daily prerelease required artifact list.
- Keep installer package checks for macOS, Windows, and Linux.

Changes
- Daily prerelease publishing no longer fails when Windows/Linux update manifest files are not present in the downloaded build artifacts.
- Stable release workflow remains unchanged.

Tests
- actionlint .github/workflows/daily-dev-prerelease.yml
- git diff --check origin/master..HEAD