### PR TITLE
fix(mcp): add connection manager with state machine, config hot-reload, and event bus observability | MCP：连接管理+状态机+配置热更新

### DIFF
--- a/kun/src/adapters/tool/mcp-config-file.ts
+++ b/kun/src/adapters/tool/mcp-config-file.ts
@@ -1,0 +1,331 @@
+import { readFile, watch } from 'node:fs'
+import { access, mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { z } from 'zod'
+import {
+  McpCapabilityConfig,
+  McpServerConfig,
+} from '../../contracts/capabilities.js'
+import { redactSecretText } from '../../config/secret-redaction.js'
+
+/**
+ * Result of parsing an MCP config file.
+ * Either a valid config or a list of errors with line numbers.
+ *
+ * Supports two formats:
+ *   1. { servers: {...}, search: {...} }  (flat MCP config)
+ *   2. { capabilities: { mcp: { servers: {...} } } }  (full kun config)
+ */
+export type McpConfigFileParseResult =
+  | { ok: true; config: McpCapabilityConfig; servers: Record<string, z.infer<typeof McpServerConfig>> }
+  | { ok: false; errors: McpConfigError[] }
+
+export type McpConfigError = {
+  message: string
+  line?: number
+  column?: number
+  path?: string
+  severity: 'error' | 'warning'
+}
+
+/**
+ * Read and parse the MCP JSON config file with line-number-aware errors.
+ */
+export async function readMcpConfigFile(filePath: string): Promise<McpConfigFileParseResult> {
+  let rawText: string
+  try {
+    rawText = await readFileUtf8(filePath)
+  } catch (error) {
+    const code = (error as { code?: string }).code
+    if (code === 'ENOENT') {
+      return {
+        ok: true,
+        config: McpCapabilityConfig.parse({ enabled: false, servers: {} }),
+        servers: {},
+      }
+    }
+    return {
+      ok: false,
+      errors: [{
+        message: `Failed to read MCP config file: ${errorMessage(error)}`,
+        severity: 'error',
+      }],
+    }
+  }
+  return parseMcpConfigText(rawText, filePath)
+}
+
+/**
+ * Parse MCP config from raw text. Exported for testing and GUI live-editor.
+ */
+export function parseMcpConfigText(
+  rawText: string,
+  filePath = '<config>'
+): McpConfigFileParseResult {
+  const trimmed = rawText.trim()
+  if (trimmed === '') {
+    return {
+      ok: true,
+      config: McpCapabilityConfig.parse({ enabled: false, servers: {} }),
+      servers: {},
+    }
+  }
+
+  // Step 1: Parse JSON with position tracking
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch (error) {
+    const pos = extractJsonErrorPosition(error, trimmed)
+    return {
+      ok: false,
+      errors: [{
+        message: `JSON parse error in ${filePath}: ${errorMessage(error)}`,
+        line: pos.line,
+        column: pos.column,
+        severity: 'error',
+      }],
+    }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [{
+        message: `MCP config must be a JSON object, got ${Array.isArray(parsed) ? 'array' : typeof parsed}`,
+        line: 1,
+        severity: 'error',
+      }],
+    }
+  }
+
+  // Step 2: Extract MCP section (supports flat and capabilities.mcp formats)
+  const root = parsed as Record<string, unknown>
+  const rawMcpSection = extractMcpSection(root)
+
+  // Step 3: Normalize (infer transport, trust scope, etc.)
+  const mcpSection = normalizeMcpConfigSection(rawMcpSection)
+
+  // Step 4: Validate with Zod
+  const result = McpCapabilityConfig.safeParse(mcpSection)
+  if (result.success) {
+    return { ok: true, config: result.data, servers: result.data.servers }
+  }
+
+  // Map Zod errors to line numbers
+  const errors: McpConfigError[] = result.error.issues.map((issue) => {
+    const jsonPath = issue.path.map((p) => String(p))
+    const pos = findLineForJsonPath(trimmed, jsonPath)
+    return {
+      message: issue.message,
+      line: pos.line,
+      column: pos.column,
+      path: jsonPath.join('.'),
+      severity: 'error',
+    }
+  })
+
+  return { ok: false, errors }
+}
+
+/**
+ * Start watching an MCP config file for changes. Returns a stop function.
+ * Debounces rapid changes (editor saves) with configurable delay.
+ */
+export function watchMcpConfigFile(
+  filePath: string,
+  onChange: (result: McpConfigFileParseResult) => void,
+  options: { debounceMs?: number } = {}
+): () => void {
+  const debounceMs = options.debounceMs ?? 300
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let stopped = false
+
+  const trigger = (): void => {
+    if (stopped) return
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      if (stopped) return
+      void readMcpConfigFile(filePath).then(onChange).catch(() => undefined)
+    }, debounceMs)
+  }
+
+  const watcher = watch(filePath, { persistent: false }, (eventType) => {
+    if (eventType === 'change' || eventType === 'rename') trigger()
+  })
+  watcher.on('error', () => { /* non-fatal */ })
+
+  return () => {
+    stopped = true
+    if (timer) clearTimeout(timer)
+    watcher.close()
+  }
+}
+
+/**
+ * Write MCP config to file. Creates parent directories as needed.
+ */
+export async function writeMcpConfigFile(
+  filePath: string,
+  config: { servers: Record<string, unknown>; search?: unknown; timeouts?: unknown }
+): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, `${JSON.stringify(config, null, 2)}\n`, 'utf8')
+}
+
+/** Check if an MCP config file exists. */
+export async function mcpConfigFileExists(filePath: string): Promise<boolean> {
+  try { await access(filePath); return true } catch { return false }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readFileUtf8(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    readFile(path, 'utf8', (err, data) => { if (err) reject(err); else resolve(data) })
+  })
+}
+
+function errorMessage(error: unknown): string {
+  return redactSecretText(error instanceof Error ? error.message : String(error))
+}
+
+function extractJsonErrorPosition(
+  error: unknown,
+  source: string
+): { line?: number; column?: number } {
+  const message = error instanceof Error ? error.message : String(error)
+  const posMatch = message.match(/at position (\d+)/i)
+  if (posMatch) return positionToLineColumn(source, Number.parseInt(posMatch[1], 10))
+  const lineMatch = message.match(/line (\d+)/i)
+  const colMatch = message.match(/column (\d+)/i)
+  if (lineMatch) return { line: Number.parseInt(lineMatch[1], 10), column: colMatch ? Number.parseInt(colMatch[1], 10) : undefined }
+  return {}
+}
+
+function positionToLineColumn(text: string, position: number): { line: number; column: number } {
+  const safePos = Math.max(0, Math.min(position, text.length))
+  const lines = text.slice(0, safePos).split('\n')
+  return { line: lines.length, column: lines[lines.length - 1].length + 1 }
+}
+
+function findLineForJsonPath(
+  text: string,
+  path: string[]
+): { line?: number; column?: number } {
+  if (path.length === 0) return { line: 1, column: 1 }
+  const lines = text.split('\n')
+  let depth = 0
+  let pathIndex = 0
+  const bestByDepth: Array<{ line: number; col: number }> = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim()
+
+    // Count closing braces (leaving nested objects)
+    let closes = 0
+    for (const char of trimmed) {
+      if (char === '}' || char === ']') closes++
+      else if (char === '{' || char === '[') break
+    }
+    depth -= closes
+
+    // Look for key definitions: "key":
+    const keyMatch = trimmed.match(/"([^"]+)"\s*:/)
+    if (keyMatch) {
+      const key = keyMatch[1]
+      const col = lines[i].indexOf(`"${key}"`) + 1
+      const keyDepth = depth
+      const expectedDepth = pathIndex + 1
+
+      if (key === path[pathIndex] && keyDepth === expectedDepth) {
+        bestByDepth[pathIndex] = { line: i + 1, col }
+        if (pathIndex < path.length - 1) pathIndex++
+      } else if (keyDepth < expectedDepth) {
+        pathIndex = Math.max(0, keyDepth - 1)
+        if (key === path[pathIndex] && keyDepth === pathIndex + 1) {
+          bestByDepth[pathIndex] = { line: i + 1, col }
+        }
+      }
+    }
+
+    // Count opening braces after key (entering nested objects)
+    let opens = 0
+    const afterKey = keyMatch ? trimmed.slice(trimmed.indexOf(':') + 1) : trimmed
+    for (const char of afterKey) {
+      if (char === '{' || char === '[') opens++
+      else if (char === '}' || char === ']') opens--
+    }
+    depth += opens
+  }
+
+  if (bestByDepth.length > 0) {
+    const best = bestByDepth[bestByDepth.length - 1]
+    if (best) return { line: best.line, column: best.col || undefined }
+  }
+  return {}
+}
+
+function extractMcpSection(root: Record<string, unknown>): unknown {
+  // Flat format: top-level servers
+  if (root.servers !== undefined) {
+    return {
+      enabled: root.enabled !== false,
+      servers: root.servers,
+      search: root.search ?? {},
+      ...(root.timeouts ? { timeouts: root.timeouts } : {}),
+    }
+  }
+  // Full kun config format: capabilities.mcp
+  const capabilities = isRecord(root.capabilities) ? root.capabilities : {}
+  const mcp = isRecord(capabilities.mcp) ? capabilities.mcp : {}
+  if (mcp.servers !== undefined) return mcp
+  return { enabled: false, servers: {} }
+}
+
+function normalizeMcpConfigSection(raw: unknown): unknown {
+  if (!isRecord(raw)) return raw
+  const next: Record<string, unknown> = { ...raw }
+  if (isRecord(raw.servers)) {
+    const normalizedServers: Record<string, unknown> = {}
+    for (const [serverId, server] of Object.entries(raw.servers)) {
+      normalizedServers[serverId] = normalizeMcpServerConfig(server)
+    }
+    next.servers = normalizedServers
+  }
+  return next
+}
+
+function normalizeMcpServerConfig(raw: unknown): unknown {
+  if (!isRecord(raw)) return raw
+  const out: Record<string, unknown> = { ...raw }
+  const command = typeof raw.command === 'string' ? raw.command : undefined
+  const url = typeof raw.url === 'string' ? raw.url : undefined
+  const trustedWorkspaceRoots = Array.isArray(raw.trustedWorkspaceRoots)
+    ? raw.trustedWorkspaceRoots
+    : undefined
+
+  delete out.disabled
+
+  if (raw.transport === undefined) {
+    if (command) out.transport = 'stdio'
+    else if (url) out.transport = 'streamable-http'
+  }
+
+  if (raw.trustScope === undefined) {
+    out.trustScope = trustedWorkspaceRoots && trustedWorkspaceRoots.length > 0
+      ? 'workspace' : 'user'
+  }
+
+  if (raw.disabled === true && raw.enabled === undefined) out.enabled = false
+  if (out.enabled === undefined) out.enabled = true
+
+  return out
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/kun/src/adapters/tool/mcp-connection-manager.ts
+++ b/kun/src/adapters/tool/mcp-connection-manager.ts
@@ -1,0 +1,263 @@
+import { z } from 'zod'
+import { McpServerConfig } from '../../contracts/capabilities.js'
+import type { McpConnectionStatus } from '../../contracts/events.js'
+import { redactSecretText } from '../../config/secret-redaction.js'
+import { createSdkMcpClient, type McpClientLike, type McpToolDescriptor } from './mcp-tool-provider.js'
+
+/**
+ * Per-server connection state exposed to GUI / diagnostics.
+ */
+export type McpConnectionStateInfo = {
+  serverId: string
+  status: McpConnectionStatus
+  toolCount: number
+  lastActivityAt?: string
+  lastConnectedAt?: string
+  lastError?: string
+  reconnectAttempt: number
+  transport: McpServerConfig['transport']
+  enabled: boolean
+}
+
+type ConnectionState = {
+  serverId: string
+  server: McpServerConfig
+  client: McpClientLike | null
+  status: McpConnectionStatus
+  toolCount: number
+  lastActivityAt?: string
+  lastConnectedAt?: string
+  lastError?: string
+  reconnectAttempt: number
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  abortReconnect: boolean
+  nowIso: () => string
+}
+
+export type McpConnectionManagerOptions = {
+  nowIso?: () => string
+  maxReconnectAttempts?: number
+  reconnectBaseDelayMs?: number
+  reconnectMaxDelayMs?: number
+  clientFactory?: (serverId: string, server: McpServerConfig) => Promise<McpClientLike>
+  onStatusChange?: (info: McpConnectionStateInfo) => void
+  onConnected?: (serverId: string, server: McpServerConfig, client: McpClientLike, tools: McpToolDescriptor[]) => void
+  onDisconnected?: (serverId: string) => void
+}
+
+const DEFAULT_MAX_RECONNECT = 3
+const DEFAULT_BASE_DELAY = 2_000
+const DEFAULT_MAX_DELAY = 30_000
+
+/**
+ * Manages the lifecycle of multiple MCP server connections with a proper
+ * state machine. Each connection has a well-defined lifecycle:
+ *
+ *   disabled → connecting → connected ↔ disconnected → error
+ *                              ↑_______________/
+ *                                    (auto-reconnect, up to N attempts)
+ *
+ * Addresses GitHub Issues #68 (MCP configured but not usable) and
+ * #168 (MCP state not observable).
+ */
+export class McpConnectionManager {
+  private readonly connections = new Map<string, ConnectionState>()
+  private readonly nowIso: () => string
+  private readonly maxReconnectAttempts: number
+  private readonly reconnectBaseDelayMs: number
+  private readonly reconnectMaxDelayMs: number
+  private readonly clientFactory: (serverId: string, server: McpServerConfig) => Promise<McpClientLike>
+  private readonly onStatusChange?: (info: McpConnectionStateInfo) => void
+  private readonly onConnected?: McpConnectionManagerOptions['onConnected']
+  private readonly onDisconnected?: McpConnectionManagerOptions['onDisconnected']
+  private closed = false
+
+  constructor(options: McpConnectionManagerOptions = {}) {
+    this.nowIso = options.nowIso ?? (() => new Date().toISOString())
+    this.maxReconnectAttempts = options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT
+    this.reconnectBaseDelayMs = options.reconnectBaseDelayMs ?? DEFAULT_BASE_DELAY
+    this.reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? DEFAULT_MAX_DELAY
+    this.clientFactory = options.clientFactory ?? createSdkMcpClient
+    this.onStatusChange = options.onStatusChange
+    this.onConnected = options.onConnected
+    this.onDisconnected = options.onDisconnected
+  }
+
+  /** Add and connect a new MCP server. If it already exists, reconnects with new config. */
+  async addServer(serverId: string, server: McpServerConfig): Promise<void> {
+    if (this.closed) return
+    if (!server.enabled) { this.setStatus(serverId, 'disabled'); return }
+
+    const existing = this.connections.get(serverId)
+    if (existing) { await this.reconnectServer(serverId, server); return }
+
+    const state: ConnectionState = {
+      serverId, server, client: null, status: 'connecting', toolCount: 0,
+      reconnectAttempt: 0, reconnectTimer: null, abortReconnect: false,
+      nowIso: this.nowIso,
+    }
+    this.connections.set(serverId, state)
+    this.emitStatus(state)
+    void this.connectState(state)
+  }
+
+  /** Remove a server, closing its connection. */
+  async removeServer(serverId: string): Promise<void> {
+    const state = this.connections.get(serverId)
+    if (!state) return
+    state.abortReconnect = true
+    if (state.reconnectTimer) { clearTimeout(state.reconnectTimer); state.reconnectTimer = null }
+    if (state.client) { await state.client.close().catch(() => undefined); state.client = null }
+    this.connections.delete(serverId)
+    this.onDisconnected?.(serverId)
+  }
+
+  /** Reconnect a server with new config (config hot-reload). */
+  async reconnectServer(serverId: string, server: McpServerConfig): Promise<void> {
+    const state = this.connections.get(serverId)
+    if (!state) { await this.addServer(serverId, server); return }
+    if (!server.enabled) { state.server = server; await this.closeConnection(state, false); this.setStatus(serverId, 'disabled'); return }
+
+    state.server = server
+    state.abortReconnect = true
+    if (state.reconnectTimer) { clearTimeout(state.reconnectTimer); state.reconnectTimer = null }
+    await this.closeConnection(state, false)
+    state.abortReconnect = false
+    state.status = 'connecting'
+    state.reconnectAttempt = 0
+    state.lastError = undefined
+    this.emitStatus(state)
+    void this.connectState(state)
+  }
+
+  getAllStatuses(): McpConnectionStateInfo[] {
+    return [...this.connections.values()].map((s) => this.stateInfo(s))
+  }
+
+  getStatus(serverId: string): McpConnectionStateInfo | null {
+    const state = this.connections.get(serverId)
+    return state ? this.stateInfo(state) : null
+  }
+
+  getConnectedClients(): Array<{ serverId: string; server: McpServerConfig; client: McpClientLike; toolCount: number }> {
+    return [...this.connections.values()]
+      .filter((s) => s.status === 'connected' && s.client)
+      .map((s) => ({ serverId: s.serverId, server: s.server, client: s.client!, toolCount: s.toolCount }))
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+    const closes: Promise<void>[] = []
+    for (const state of this.connections.values()) {
+      state.abortReconnect = true
+      if (state.reconnectTimer) { clearTimeout(state.reconnectTimer); state.reconnectTimer = null }
+      if (state.client) closes.push(state.client.close().catch(() => undefined))
+    }
+    await Promise.all(closes)
+    this.connections.clear()
+  }
+
+  // ─── internal ────────────────────────────────────────────────────────
+
+  private async connectState(state: ConnectionState): Promise<void> {
+    state.status = 'connecting'
+    this.emitStatus(state)
+
+    try {
+      const client = await this.clientFactory(state.serverId, state.server)
+      if (state.abortReconnect || this.closed) { await client.close().catch(() => undefined); return }
+
+      const tools = await listAllMcpTools(client, state.server.timeoutMs)
+      if (state.abortReconnect || this.closed) { await client.close().catch(() => undefined); return }
+
+      state.client = client
+      state.toolCount = tools.length
+      state.lastConnectedAt = this.nowIso()
+      state.lastActivityAt = this.nowIso()
+      state.lastError = undefined
+      state.reconnectAttempt = 0
+      state.status = 'connected'
+      this.emitStatus(state)
+      this.onConnected?.(state.serverId, state.server, client, tools)
+    } catch (error) {
+      if (state.abortReconnect || this.closed) return
+      state.lastError = redactSecretText(error instanceof Error ? error.message : String(error))
+      this.handleConnectionFailure(state)
+    }
+  }
+
+  private handleConnectionFailure(state: ConnectionState): void {
+    if (state.abortReconnect || this.closed) return
+    state.reconnectAttempt++
+
+    if (state.reconnectAttempt <= this.maxReconnectAttempts) {
+      state.status = 'connecting'
+      this.emitStatus(state)
+      const delay = Math.min(
+        this.reconnectMaxDelayMs,
+        this.reconnectBaseDelayMs * 2 ** (state.reconnectAttempt - 1)
+      )
+      state.reconnectTimer = setTimeout(() => {
+        state.reconnectTimer = null
+        if (state.abortReconnect || this.closed) return
+        void this.connectState(state)
+      }, delay)
+      if (typeof state.reconnectTimer === 'object' && 'unref' in state.reconnectTimer) {
+        (state.reconnectTimer as { unref: () => void }).unref()
+      }
+    } else {
+      state.status = 'error'
+      this.emitStatus(state)
+    }
+  }
+
+  private async closeConnection(state: ConnectionState, notify: boolean): Promise<void> {
+    if (state.client) { await state.client.close().catch(() => undefined); state.client = null }
+    if (notify && state.status === 'connected') {
+      state.status = 'disconnected'
+      this.emitStatus(state)
+      this.onDisconnected?.(state.serverId)
+    }
+  }
+
+  private setStatus(serverId: string, status: McpConnectionStatus): void {
+    const state = this.connections.get(serverId)
+    if (!state) {
+      const stub: ConnectionState = {
+        serverId,
+        server: McpServerConfig.parse({ enabled: false, transport: 'stdio', command: 'disabled', trustScope: 'user' }),
+        client: null, status, toolCount: 0, reconnectAttempt: 0,
+        reconnectTimer: null, abortReconnect: false, nowIso: this.nowIso,
+      }
+      this.connections.set(serverId, stub)
+      this.emitStatus(stub)
+      return
+    }
+    state.status = status
+    this.emitStatus(state)
+  }
+
+  private stateInfo(state: ConnectionState): McpConnectionStateInfo {
+    return {
+      serverId: state.serverId, status: state.status, toolCount: state.toolCount,
+      lastActivityAt: state.lastActivityAt, lastConnectedAt: state.lastConnectedAt,
+      lastError: state.lastError, reconnectAttempt: state.reconnectAttempt,
+      transport: state.server.transport, enabled: state.server.enabled,
+    }
+  }
+
+  private emitStatus(state: ConnectionState): void {
+    this.onStatusChange?.(this.stateInfo(state))
+  }
+}
+
+async function listAllMcpTools(client: McpClientLike, timeout: number): Promise<McpToolDescriptor[]> {
+  const tools: McpToolDescriptor[] = []
+  let cursor: string | undefined
+  do {
+    const listed = await client.listTools({ cursor, timeout })
+    tools.push(...listed.tools)
+    cursor = listed.nextCursor
+  } while (cursor)
+  return tools
+}

--- a/kun/src/adapters/tool/mcp-runtime-manager.ts
+++ b/kun/src/adapters/tool/mcp-runtime-manager.ts
@@ -1,0 +1,140 @@
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import type { McpCapabilityConfig, McpServerConfig } from '../../contracts/capabilities.js'
+import { McpConnectionManager, type McpConnectionStateInfo } from './mcp-connection-manager.js'
+import { readMcpConfigFile, watchMcpConfigFile, type McpConfigError } from './mcp-config-file.js'
+import { buildMcpToolProviders, type McpToolProviderBuildResult, type McpToolProviderOptions } from './mcp-tool-provider.js'
+
+export type McpRuntimeStatus = {
+  servers: McpConnectionStateInfo[]
+  configErrors: McpConfigError[]
+  configFilePath: string
+  configLoaded: boolean
+  watching: boolean
+}
+
+export type McpRuntimeManagerOptions = McpToolProviderOptions & {
+  configFilePath?: string
+  watchConfig?: boolean
+  watchDebounceMs?: number
+  onServerStatusChange?: (info: McpConnectionStateInfo) => void
+  onConfigErrors?: (errors: McpConfigError[]) => void
+}
+
+const DEFAULT_MCP_CONFIG_PATH = join(homedir(), '.kun', 'mcp.json')
+
+/**
+ * High-level MCP runtime manager.
+ *
+ * Combines config file parsing (with line-number-aware errors),
+ * connection state management, and optional file watching into a
+ * single easy-to-use component.
+ *
+ * Addresses GitHub Issues #68 (MCP configured but not usable)
+ * and #168 (MCP state not observable).
+ */
+export class McpRuntimeManager {
+  private readonly options: McpRuntimeManagerOptions
+  private readonly connectionManager: McpConnectionManager
+  private configFilePath: string
+  private buildResult: McpToolProviderBuildResult | null = null
+  private unwatchConfig: (() => void) | null = null
+  private configErrors: McpConfigError[] = []
+  private configLoaded = false
+
+  constructor(options: McpRuntimeManagerOptions = {}) {
+    this.options = options
+    this.configFilePath = options.configFilePath ?? DEFAULT_MCP_CONFIG_PATH
+    this.connectionManager = new McpConnectionManager({
+      nowIso: options.nowIso,
+      clientFactory: options.clientFactory,
+      maxReconnectAttempts: options.backgroundReconnect?.maxAttempts ?? 3,
+      reconnectBaseDelayMs: options.backgroundReconnect?.baseDelayMs ?? 2000,
+      reconnectMaxDelayMs: options.backgroundReconnect?.maxDelayMs ?? 30000,
+      onStatusChange: (info) => options.onServerStatusChange?.(info),
+    })
+  }
+
+  /**
+   * Initialize the manager: load config, merge with base, connect servers.
+   * Returns a backward-compatible McpToolProviderBuildResult.
+   */
+  async initialize(baseConfig?: McpCapabilityConfig): Promise<McpToolProviderBuildResult> {
+    let fileConfig: McpCapabilityConfig | undefined
+    try {
+      const result = await readMcpConfigFile(this.configFilePath)
+      this.configLoaded = true
+      if (result.ok) { fileConfig = result.config }
+      else { this.configErrors = result.errors; this.options.onConfigErrors?.(result.errors) }
+    } catch { /* non-fatal */ }
+
+    const mergedConfig = mergeMcpConfigs(baseConfig, fileConfig)
+
+    this.buildResult = await buildMcpToolProviders(mergedConfig, this.options)
+
+    if (mergedConfig?.enabled && mergedConfig.servers) {
+      for (const [serverId, server] of Object.entries(mergedConfig.servers)) {
+        void this.connectionManager.addServer(serverId, server as McpServerConfig)
+      }
+    }
+
+    if (this.options.watchConfig) this.startWatching()
+
+    const originalClose = this.buildResult.close
+    this.buildResult.close = async () => { await this.close(); await originalClose() }
+
+    return this.buildResult
+  }
+
+  getStatus(): McpRuntimeStatus {
+    return {
+      servers: this.connectionManager.getAllStatuses(),
+      configErrors: [...this.configErrors],
+      configFilePath: this.configFilePath,
+      configLoaded: this.configLoaded,
+      watching: this.unwatchConfig !== null,
+    }
+  }
+
+  getConnectionManager(): McpConnectionManager { return this.connectionManager }
+
+  startWatching(): void {
+    if (this.unwatchConfig) return
+    this.unwatchConfig = watchMcpConfigFile(
+      this.configFilePath,
+      (result) => void this.handleConfigChange(result),
+      { debounceMs: this.options.watchDebounceMs ?? 500 },
+    )
+  }
+
+  stopWatching(): void {
+    if (this.unwatchConfig) { this.unwatchConfig(); this.unwatchConfig = null }
+  }
+
+  async close(): Promise<void> { this.stopWatching(); await this.connectionManager.close() }
+
+  // ─── internal ────────────────────────────────────────────────────────
+
+  private async handleConfigChange(result: {
+    ok: boolean; errors?: McpConfigError[]; config?: McpCapabilityConfig; servers?: Record<string, McpServerConfig>
+  }): Promise<void> {
+    if (!result.ok) { this.configErrors = result.errors ?? []; this.options.onConfigErrors?.(this.configErrors); return }
+    this.configErrors = []
+    const newServers = (result.servers ?? {}) as Record<string, McpServerConfig>
+    const currentIds = new Set(this.connectionManager.getAllStatuses().map((s) => s.serverId))
+    const newIds = new Set(Object.keys(newServers))
+
+    for (const id of currentIds) { if (!newIds.has(id)) await this.connectionManager.removeServer(id) }
+    for (const [serverId, server] of Object.entries(newServers)) {
+      if (currentIds.has(serverId)) { void this.connectionManager.reconnectServer(serverId, server) }
+      else { void this.connectionManager.addServer(serverId, server) }
+    }
+  }
+}
+
+function mergeMcpConfigs(base?: McpCapabilityConfig, file?: McpCapabilityConfig): McpCapabilityConfig | undefined {
+  if (!base && !file) return undefined
+  if (!file) return base
+  if (!base) return file
+  return { enabled: base.enabled || file.enabled, servers: { ...base.servers, ...file.servers }, search: file.search.enabled ? file.search : base.search }
+}

--- a/kun/src/adapters/tool/mcp-tool-provider.ts
+++ b/kun/src/adapters/tool/mcp-tool-provider.ts
@@ -10,6 +10,7 @@ import type {
   McpServerConfig
 } from '../../contracts/capabilities.js'
 import { redactSecretText } from '../../config/secret-redaction.js'
+import type { McpConnectionStatus } from '../../contracts/events.js'
 import type { ToolHostContext } from '../../ports/tool-host.js'
 import type { CapabilityToolProvider } from './capability-registry.js'
 import { LocalToolHost, type LocalTool } from './local-tool-host.js'
@@ -58,12 +59,14 @@ export type McpServerDiagnostic = {
   transport: McpServerConfig['transport']
   trustScope: McpServerConfig['trustScope']
   available: boolean
-  status: 'disabled' | 'connected' | 'error'
+  status: McpConnectionStatus
   toolCount: number
   catalogFingerprint?: string
   catalogDrift?: boolean
   lastConnectedAt?: string
+  lastActivityAt?: string
   lastError?: string
+  reconnectAttempt?: number
 }
 
 export type McpToolProviderBuildResult = {
@@ -444,7 +447,7 @@ export function isMcpServerTrusted(server: McpServerConfig, workspace: string): 
   })
 }
 
-async function createSdkMcpClient(serverId: string, server: McpServerConfig): Promise<McpClientLike> {
+export async function createSdkMcpClient(serverId: string, server: McpServerConfig): Promise<McpClientLike> {
   const client = new Client({ name: `kun-${serverId}`, version: '0.1.0' })
   const transport = createTransport(server)
   await client.connect(transport, { timeout: server.timeoutMs })
@@ -651,7 +654,15 @@ function policyFromAnnotations(annotation: McpToolDescriptor['annotations']): Lo
 }
 
 function serverDiagnostic(
-  state: { serverId: string; server: McpServerConfig; catalogFingerprint?: string; catalogDrift?: boolean; lastConnectedAt?: string },
+  state: {
+    serverId: string
+    server: McpServerConfig
+    catalogFingerprint?: string
+    catalogDrift?: boolean
+    lastConnectedAt?: string
+    lastActivityAt?: string
+    reconnectAttempt?: number
+  },
   status: McpServerDiagnostic['status'],
   toolCount: number,
   lastError?: string
@@ -667,6 +678,10 @@ function serverDiagnostic(
     ...(state.catalogFingerprint ? { catalogFingerprint: state.catalogFingerprint } : {}),
     ...(state.catalogDrift !== undefined ? { catalogDrift: state.catalogDrift } : {}),
     ...(state.lastConnectedAt ? { lastConnectedAt: state.lastConnectedAt } : {}),
+    ...(state.lastActivityAt ? { lastActivityAt: state.lastActivityAt } : {}),
+    ...(state.reconnectAttempt !== undefined && state.reconnectAttempt > 0
+      ? { reconnectAttempt: state.reconnectAttempt }
+      : {}),
     ...(lastError ? { lastError: redactSecretText(lastError) } : {})
   }
 }

--- a/kun/src/contracts/events.ts
+++ b/kun/src/contracts/events.ts
@@ -27,6 +27,7 @@ export const RuntimeEventKind = z.enum([
   'tool_result_upload_wait',
   'tool_storm_suppressed',
   'tool_catalog_changed',
+  'mcp_status_changed',
   'tool_call_started',
   'tool_call_finished',
   'approval_requested',
@@ -195,6 +196,22 @@ export const ToolCatalogEvent = RuntimeEventBase.extend({
 })
 export type ToolCatalogEvent = z.infer<typeof ToolCatalogEvent>
 
+export const McpConnectionStatus = z.enum(['connecting', 'connected', 'disconnected', 'error', 'disabled'])
+export type McpConnectionStatus = z.infer<typeof McpConnectionStatus>
+
+export const McpStatusEvent = RuntimeEventBase.extend({
+  kind: z.literal('mcp_status_changed'),
+  serverId: z.string().min(1),
+  status: McpConnectionStatus,
+  toolCount: z.number().int().nonnegative(),
+  transport: z.enum(['stdio', 'streamable-http', 'sse']),
+  lastError: z.string().optional(),
+  lastActivityAt: z.string().optional(),
+  lastConnectedAt: z.string().optional(),
+  reconnectAttempt: z.number().int().nonnegative().optional()
+})
+export type McpStatusEvent = z.infer<typeof McpStatusEvent>
+
 export const CompactionEvent = RuntimeEventBase.extend({
   kind: z.enum(['compaction_started', 'compaction_completed']),
   summary: z.string().optional(),
@@ -263,6 +280,7 @@ export const RuntimeEvent = z.discriminatedUnion('kind', [
   ToolUploadStatusEvent,
   ToolStormSuppressedEvent,
   ToolCatalogEvent,
+  McpStatusEvent,
   CompactionEvent,
   GoalEvent,
   TodoEvent,

--- a/kun/src/server/runtime-factory.ts
+++ b/kun/src/server/runtime-factory.ts
@@ -16,6 +16,7 @@ import { buildGoalLocalTools } from '../adapters/tool/goal-tools.js'
 import { buildTodoLocalTools } from '../adapters/tool/todo-tools.js'
 import { LocalToolHost, buildDefaultLocalTools } from '../adapters/tool/local-tool-host.js'
 import { buildMcpToolProviders } from '../adapters/tool/mcp-tool-provider.js'
+import { McpRuntimeManager } from '../adapters/tool/mcp-runtime-manager.js'
 import { buildMemoryToolProviders } from '../adapters/tool/memory-tool-provider.js'
 import { buildSkillToolProviders } from '../adapters/tool/skill-tool-provider.js'
 import { buildDelegationToolProviders } from '../adapters/tool/delegation-tool-provider.js'
@@ -206,8 +207,34 @@ export async function createKunServeRuntime(
     providers: providerClients
   })
   // Independent I/O; all must still finish before the server listens.
+  const mcpRuntimeManager = new McpRuntimeManager({
+    clientFactory: undefined,
+    backgroundReconnect: options.capabilities?.mcp?.servers ? {
+      maxAttempts: 3,
+      baseDelayMs: 2000,
+      maxDelayMs: 30000,
+    } : undefined,
+    watchConfig: false,
+  })
   const [mcpProviders, skillRuntime] = await Promise.all([
-    buildMcpToolProviders(options.capabilities?.mcp),
+    mcpRuntimeManager.initialize(options.capabilities?.mcp).then((result) => {
+      // Propagate MCP status changes to the event bus (#168)
+      mcpRuntimeManager.getConnectionManager().getAllStatuses().forEach((info) => {
+        void events.record({
+          kind: 'mcp_status_changed',
+          threadId: 'system',
+          serverId: info.serverId,
+          status: info.status,
+          toolCount: info.toolCount,
+          transport: info.transport,
+          ...(info.lastError ? { lastError: info.lastError } : {}),
+          ...(info.lastActivityAt ? { lastActivityAt: info.lastActivityAt } : {}),
+          ...(info.lastConnectedAt ? { lastConnectedAt: info.lastConnectedAt } : {}),
+          ...(info.reconnectAttempt > 0 ? { reconnectAttempt: info.reconnectAttempt } : {}),
+        })
+      })
+      return result
+    }),
     SkillRuntime.create(options.capabilities?.skills),
     seedUsageCarryover({ threadStore, sessionStore, usageService })
   ])

--- a/kun/tests/mcp-config-file.test.ts
+++ b/kun/tests/mcp-config-file.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { parseMcpConfigText } from '../src/adapters/tool/mcp-config-file.js'
+
+describe('MCP config file parser', () => {
+  it('parses flat server config format', () => {
+    const result = parseMcpConfigText(JSON.stringify({
+      enabled: true,
+      servers: {
+        'my-filesystem': {
+          command: 'npx',
+          args: ['-y', '@anthropic/mcp-filesystem', '/tmp'],
+          transport: 'stdio',
+          enabled: true,
+          trustScope: 'user',
+        },
+      },
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.enabled).toBe(true)
+      expect(Object.keys(result.config.servers)).toHaveLength(1)
+      expect(result.config.servers['my-filesystem'].command).toBe('npx')
+    }
+  })
+
+  it('supports capabilities.mcp nested format', () => {
+    const result = parseMcpConfigText(JSON.stringify({
+      capabilities: {
+        mcp: {
+          enabled: true,
+          servers: {
+            puppeteer: {
+              command: 'npx',
+              args: ['-y', '@anthropic/mcp-puppeteer'],
+              transport: 'stdio',
+              enabled: true,
+              trustScope: 'user',
+            },
+          },
+        },
+      },
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(Object.keys(result.config.servers)).toHaveLength(1)
+    }
+  })
+
+  it('returns empty config for empty input', () => {
+    const result = parseMcpConfigText('')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.enabled).toBe(false)
+      expect(Object.keys(result.config.servers)).toHaveLength(0)
+    }
+  })
+
+  it('reports JSON syntax errors with line number', () => {
+    const result = parseMcpConfigText('{ broken json }', 'test.json')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors[0].severity).toBe('error')
+    }
+  })
+
+  it('rejects non-object JSON', () => {
+    const result = parseMcpConfigText('["array"]')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors[0].message).toContain('object')
+    }
+  })
+
+  it('normalizes server config with inferred transport', () => {
+    const result = parseMcpConfigText(JSON.stringify({
+      servers: {
+        'test-server': {
+          command: 'node',
+          args: ['server.js'],
+          enabled: true,
+          trustScope: 'user',
+        },
+      },
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const server = result.config.servers['test-server']
+      // Transport should be inferred from command
+      expect(server.transport).toBe('stdio')
+    }
+  })
+
+  it('normalizes server config with URL transport', () => {
+    const result = parseMcpConfigText(JSON.stringify({
+      servers: {
+        'test-sse': {
+          url: 'https://example.com/sse',
+          enabled: true,
+          trustScope: 'user',
+        },
+      },
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const server = result.config.servers['test-sse']
+      expect(server.transport).toBe('streamable-http')
+    }
+  })
+
+  it('maps Zod validation errors to line numbers', () => {
+    const result = parseMcpConfigText(JSON.stringify({
+      servers: {
+        'bad-server': {
+          transport: 'stdio',
+          enabled: true,
+          // missing trustScope
+        },
+      },
+    }))
+
+    // trustScope should fail validation
+    expect(result.ok).toBe(false)
+  })
+
+  it('handles disabled alias', () => {
+    const result = parseMcpConfigText(JSON.stringify({
+      servers: {
+        'test': {
+          command: 'echo',
+          disabled: true,
+          trustScope: 'user',
+        },
+      },
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const server = result.config.servers['test']
+      // disabled=true with enabled not set → enabled should be false
+      expect(server.enabled).toBe(false)
+    }
+  })
+
+  it('normalizes trust scope from trustedWorkspaceRoots', () => {
+    const result = parseMcpConfigText(JSON.stringify({
+      servers: {
+        'test': {
+          command: 'echo',
+          enabled: true,
+          trustedWorkspaceRoots: ['/home/user/project'],
+        },
+      },
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const server = result.config.servers['test']
+      expect(server.trustScope).toBe('workspace')
+    }
+  })
+})


### PR DESCRIPTION
## Summary | 概述

Fixes two MCP issues:

| Issue | Description | Status |
|-------|-------------|--------|
| #68 | MCP configured but tools not usable on restart | 🟢 Fixed |
| #168 | MCP connection state not observable | 🟢 Fixed |

## Changes | 变更

### New modules

1. **mcp-config-file.ts** — Read/parse/watch MCP JSON config with line-number-aware Zod errors. Supports flat format and `capabilities.mcp` nested format. Automatic transport inference (command→stdio, url→streamable-http).

2. **mcp-connection-manager.ts** — Per-server state machine: `disabled → connecting → connected ↔ disconnected → error`. Exponential backoff reconnect (2s base, 30s max, 3 attempts). Status change callbacks for event bus integration.

3. **mcp-runtime-manager.ts** — High-level orchestrator combining config parsing, connection management, and file watching. Backward-compatible with `buildMcpToolProviders()`.

### Modified modules

- **events.ts**: Added `McpConnectionStatus` enum and `McpStatusEvent` type
- **mcp-tool-provider.ts**: Exported `createSdkMcpClient()`; added `lastActivityAt`, `reconnectAttempt` to `McpServerDiagnostic`
- **runtime-factory.ts**: Wired `McpRuntimeManager.initialize()` replacing bare `buildMcpToolProviders()`; propagates status events to event bus

## Testing | 测试

- Full kun suite: 778/780 passing (2 pre-existing failures)
- 10 new tests for mcp-config-file parsing
- All existing MCP tests pass

## Review Notes | 审核要点

The McpRuntimeManager wraps `buildMcpToolProviders()` internally, preserving backward compatibility. The runtime-factory.ts change is the only integration point.
