### PR TITLE
fix(provider): add RouteRegistry, parameter validation, and stream timeout | Provider层：动态路由+参数校验+流超时

### DIFF
--- a/kun/src/adapters/model/compat-model-client.ts
+++ b/kun/src/adapters/model/compat-model-client.ts
@@ -9,6 +9,9 @@ import { isToolResultBridgeItem, repairModelHistoryItems } from '../../domain/mo
 import { extractToolResultImages, toolResultTextWithoutImages } from '../../loop/tool-result-image.js'
 import { repairToolArguments } from './tool-argument-repair.js'
 import { isDeepSeekHost, probeDeepSeekReachable } from './model-error-probe.js'
+import { validateModelRequest, detectProviderRules, type ModelValidationRules } from './model-request-validator.js'
+import { StreamTimeoutTracker } from './stream-timeout.js'
+import { streamTimeoutTelemetry } from '../../telemetry/stream-timeout-telemetry.js'
 import {
   DEFAULT_MODEL_ENDPOINT_FORMAT,
   isCustomModelEndpointFormat,
@@ -252,12 +255,32 @@ export class CompatModelClient implements ModelClient {
     const url = buildModelEndpointUrl(this.config.baseUrl, configuredEndpointFormat)
     const stream = request.stream ?? !this.config.nonStreaming
     const body = this.buildRequestBody(request, stream, { endpointFormat })
+    // Validate model request parameters before sending (#281)
+    const providerRules = detectProviderRules(this.config.baseUrl)
+    const validation = validateModelRequest(request, providerRules)
+    if (!validation.valid) {
+      yield { kind: 'error', message: `Parameter validation failed: ${validation.error} (field: ${validation.field})` }
+      return
+    }
     if (round) {
       round.requestBody = body
       round.url = redactUrlForLog(url)
     }
     const headers = this.buildHeaders(stream, endpointFormat)
+    // Stream timeout tracking (#299): T1=first token, T2=inter-token, T3=total
+    const timeoutTracker = new StreamTimeoutTracker(
+      { firstTokenTimeoutMs: 30_000, interTokenTimeoutMs: 45_000, totalTimeoutMs: 600_000 },
+      { provider: this.provider, model: requestModel, threadId: request.threadId, turnId: request.turnId }
+    )
+    timeoutTracker.start()
     let result = await this.postChatCompletion(url, headers, body, request.abortSignal)
+    // T1 check — first token timeout (#299)
+    const t1Check = timeoutTracker.checkFirstToken()
+    if (t1Check.kind === 'timeout') {
+      streamTimeoutTelemetry.record(timeoutTracker.createTelemetryEvent(t1Check.timeoutKind))
+      yield { kind: 'error', message: t1Check.message, code: 'first_token_timeout' }
+      return
+    }
     // Retry transient gateway failures (502/503/504) a few times before giving
     // up. These are upstream load-balancer hiccups (e.g. an ALB returning
     // "502 Bad Gateway"), not request errors — failing the whole turn on the

--- a/kun/src/adapters/model/model-request-validator.ts
+++ b/kun/src/adapters/model/model-request-validator.ts
@@ -1,0 +1,173 @@
+/**
+ * Provider layer parameter validation.
+ *
+ * Before a provider adapter sends a request to a model API, this validator
+ * checks that known parameters (reasoning_effort, max_tokens, temperature,
+ * top_p) have valid types and values. Invalid parameters produce a clear
+ * error instead of silently dropping them or sending a malformed request.
+ *
+ * Addresses GitHub Issue #281: reasoning_effort not transmitted to backend.
+ */
+
+import type { ModelRequest } from '../../ports/model-client.js'
+
+export const REASONING_EFFORT_VALUES = ['auto', 'off', 'low', 'medium', 'high', 'max'] as const
+export type ReasoningEffort = (typeof REASONING_EFFORT_VALUES)[number]
+
+export function isReasoningEffort(value: unknown): value is ReasoningEffort {
+  return typeof value === 'string' && REASONING_EFFORT_VALUES.includes(value as ReasoningEffort)
+}
+
+/** Normalize reasoning effort aliases to canonical form. */
+export function normalizeReasoningEffort(value: unknown): ReasoningEffort | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim().toLowerCase()
+  switch (normalized) {
+    case 'auto': case 'adaptive': return 'auto'
+    case 'off': case 'disabled': case 'none': case 'false': return 'off'
+    case 'low': case 'minimal': return 'low'
+    case 'medium': case 'mid': return 'medium'
+    case 'high': return 'high'
+    case 'max': case 'maximum': case 'xhigh': return 'max'
+    default: return undefined
+  }
+}
+
+export type ModelValidationRules = {
+  supportedReasoningEfforts?: readonly ReasoningEffort[]
+  maxTokensRange?: [number, number]
+  temperatureRange?: [number, number]
+  topPRange?: [number, number]
+  supportsStreaming?: boolean
+  supportsToolCalls?: boolean
+  supportsResponseFormat?: boolean
+}
+
+export type ValidationResult =
+  | { valid: true; normalized: NormalizedModelParams }
+  | { valid: false; error: string; field: string }
+
+export type NormalizedModelParams = {
+  reasoningEffort?: ReasoningEffort
+  maxTokens?: number
+  temperature?: number
+  topP?: number
+  stream: boolean
+}
+
+export const DEFAULT_VALIDATION_RULES: Required<ModelValidationRules> = {
+  supportedReasoningEfforts: REASONING_EFFORT_VALUES as unknown as ReasoningEffort[],
+  maxTokensRange: [1, 1_000_000],
+  temperatureRange: [0, 2],
+  topPRange: [0, 1],
+  supportsStreaming: true,
+  supportsToolCalls: true,
+  supportsResponseFormat: true,
+}
+
+/**
+ * Validate a model request against provider-specific rules.
+ * On success returns normalized params; on failure returns field + message.
+ */
+export function validateModelRequest(
+  request: Pick<ModelRequest, 'reasoningEffort' | 'maxTokens' | 'temperature' | 'topP' | 'stream'>,
+  rules: ModelValidationRules = {}
+): ValidationResult {
+  const merged: NormalizedModelParams = { stream: request.stream ?? true }
+
+  if (request.reasoningEffort !== undefined && request.reasoningEffort !== null) {
+    const normalized = normalizeReasoningEffort(request.reasoningEffort)
+    if (normalized === undefined) {
+      return {
+        valid: false, field: 'reasoningEffort',
+        error: `Invalid reasoning_effort: "${String(request.reasoningEffort)}". Valid: ${REASONING_EFFORT_VALUES.join(', ')}`,
+      }
+    }
+    const supported = rules.supportedReasoningEfforts ?? DEFAULT_VALIDATION_RULES.supportedReasoningEfforts
+    if (!(supported as readonly string[]).includes(normalized)) {
+      return {
+        valid: false, field: 'reasoningEffort',
+        error: `reasoning_effort "${normalized}" not supported by this provider. Supported: ${supported.join(', ')}`,
+      }
+    }
+    merged.reasoningEffort = normalized
+  }
+
+  if (request.maxTokens !== undefined && request.maxTokens !== null) {
+    if (typeof request.maxTokens !== 'number' || !Number.isFinite(request.maxTokens)) {
+      return { valid: false, field: 'maxTokens', error: `max_tokens must be a number, got ${typeof request.maxTokens}` }
+    }
+    const [min, max] = rules.maxTokensRange ?? DEFAULT_VALIDATION_RULES.maxTokensRange
+    if (request.maxTokens < min || request.maxTokens > max) {
+      return { valid: false, field: 'maxTokens', error: `max_tokens ${request.maxTokens} out of range [${min}, ${max}]` }
+    }
+    if (!Number.isInteger(request.maxTokens)) {
+      return { valid: false, field: 'maxTokens', error: `max_tokens must be an integer, got ${request.maxTokens}` }
+    }
+    merged.maxTokens = request.maxTokens
+  }
+
+  if (request.temperature !== undefined && request.temperature !== null) {
+    if (typeof request.temperature !== 'number' || !Number.isFinite(request.temperature)) {
+      return { valid: false, field: 'temperature', error: `temperature must be a number, got ${typeof request.temperature}` }
+    }
+    const [min, max] = rules.temperatureRange ?? DEFAULT_VALIDATION_RULES.temperatureRange
+    if (request.temperature < min || request.temperature > max) {
+      return { valid: false, field: 'temperature', error: `temperature ${request.temperature} out of range [${min}, ${max}]` }
+    }
+    merged.temperature = request.temperature
+  }
+
+  if (request.topP !== undefined && request.topP !== null) {
+    if (typeof request.topP !== 'number' || !Number.isFinite(request.topP)) {
+      return { valid: false, field: 'topP', error: `top_p must be a number, got ${typeof request.topP}` }
+    }
+    const [min, max] = rules.topPRange ?? DEFAULT_VALIDATION_RULES.topPRange
+    if (request.topP < min || request.topP > max) {
+      return { valid: false, field: 'topP', error: `top_p ${request.topP} out of range [${min}, ${max}]` }
+    }
+    merged.topP = request.topP
+  }
+
+  return { valid: true, normalized: merged }
+}
+
+/** Per-provider validation rules. */
+export const PROVIDER_VALIDATION_RULES: Record<string, ModelValidationRules> = {
+  openai: {
+    supportedReasoningEfforts: ['auto', 'low', 'medium', 'high'],
+    maxTokensRange: [1, 200000], temperatureRange: [0, 2], topPRange: [0, 1],
+    supportsStreaming: true, supportsToolCalls: true, supportsResponseFormat: true,
+  },
+  deepseek: {
+    supportedReasoningEfforts: ['auto', 'off', 'low', 'medium', 'high', 'max'],
+    maxTokensRange: [1, 32768], temperatureRange: [0, 2], topPRange: [0, 1],
+    supportsStreaming: true, supportsToolCalls: true, supportsResponseFormat: true,
+  },
+  siliconflow: {
+    supportedReasoningEfforts: ['off', 'low', 'medium', 'high'],
+    maxTokensRange: [1, 32768], temperatureRange: [0, 2], topPRange: [0, 1],
+    supportsStreaming: true, supportsToolCalls: true, supportsResponseFormat: true,
+  },
+  anthropic: {
+    supportedReasoningEfforts: ['off', 'low', 'medium', 'high', 'max'],
+    maxTokensRange: [1, 8192], temperatureRange: [0, 1], topPRange: [0, 1],
+    supportsStreaming: true, supportsToolCalls: true, supportsResponseFormat: false,
+  },
+  gemini: {
+    supportedReasoningEfforts: ['off', 'low', 'medium', 'high'],
+    maxTokensRange: [1, 65536], temperatureRange: [0, 2], topPRange: [0, 1],
+    supportsStreaming: true, supportsToolCalls: true, supportsResponseFormat: true,
+  },
+}
+
+/** Detect provider rules from base URL. */
+export function detectProviderRules(baseUrl: string): ModelValidationRules {
+  const lower = baseUrl.toLowerCase()
+  if (lower.includes('api.deepseek.com')) return PROVIDER_VALIDATION_RULES.deepseek
+  if (lower.includes('api.openai.com')) return PROVIDER_VALIDATION_RULES.openai
+  if (lower.includes('api.siliconflow.cn') || lower.includes('siliconflow')) return PROVIDER_VALIDATION_RULES.siliconflow
+  if (lower.includes('api.anthropic.com')) return PROVIDER_VALIDATION_RULES.anthropic
+  if (lower.includes('generativelanguage') || lower.includes('gemini')) return PROVIDER_VALIDATION_RULES.gemini
+  return DEFAULT_VALIDATION_RULES
+}

--- a/kun/src/adapters/model/stream-timeout.ts
+++ b/kun/src/adapters/model/stream-timeout.ts
@@ -1,0 +1,121 @@
+/**
+ * Streaming timeout policy for model requests.
+ *
+ * Three-tier timeout strategy (Addresses GitHub Issue #299):
+ * - T1 (first token): time from request start to first data chunk
+ * - T2 (inter-token): maximum idle time between consecutive chunks
+ * - T3 (total): maximum total wait time for the entire request
+ *
+ * Timeout events are recorded to telemetry for observability.
+ */
+
+export type TimeoutFallbackStrategy = 'retry' | 'fallback_provider' | 'error'
+
+export type StreamTimeoutConfig = {
+  firstTokenTimeoutMs: number
+  interTokenTimeoutMs: number
+  totalTimeoutMs: number
+  fallback: TimeoutFallbackStrategy
+  maxRetries: number
+  retryDelayMs: number
+}
+
+export const DEFAULT_STREAM_TIMEOUT_CONFIG: StreamTimeoutConfig = {
+  firstTokenTimeoutMs: 30_000,
+  interTokenTimeoutMs: 45_000,
+  totalTimeoutMs: 600_000,
+  fallback: 'retry',
+  maxRetries: 2,
+  retryDelayMs: 1_000,
+}
+
+export type TimeoutKind = 'first_token' | 'inter_token' | 'total'
+
+export type StreamTimeoutEvent = {
+  kind: TimeoutKind
+  provider: string
+  model: string
+  threadId: string
+  turnId: string
+  durationMs: number
+  fallback: TimeoutFallbackStrategy
+  retryAttempt: number
+}
+
+export type TimeoutCheckResult =
+  | { kind: 'ok' }
+  | { kind: 'timeout'; timeoutKind: TimeoutKind; message: string }
+
+/**
+ * Tracks timing for a single streaming request.
+ */
+export class StreamTimeoutTracker {
+  private readonly config: StreamTimeoutConfig
+  private readonly metadata: { provider: string; model: string; threadId: string; turnId: string }
+  private startTime = 0
+  private lastChunkTime = 0
+  private chunkCount = 0
+  private retryCount = 0
+
+  constructor(
+    config: Partial<StreamTimeoutConfig>,
+    metadata: { provider: string; model: string; threadId: string; turnId: string }
+  ) {
+    this.config = { ...DEFAULT_STREAM_TIMEOUT_CONFIG, ...config }
+    this.metadata = metadata
+  }
+
+  start(): void {
+    this.startTime = Date.now()
+    this.lastChunkTime = this.startTime
+    this.chunkCount = 0
+  }
+
+  onChunk(): TimeoutCheckResult {
+    const elapsed = Date.now() - this.startTime
+
+    if (this.config.totalTimeoutMs > 0 && elapsed > this.config.totalTimeoutMs) {
+      return { kind: 'timeout', timeoutKind: 'total', message: `Total timeout after ${elapsed}ms (limit: ${this.config.totalTimeoutMs}ms)` }
+    }
+
+    if (this.chunkCount > 0 && this.config.interTokenTimeoutMs > 0) {
+      const idleMs = Date.now() - this.lastChunkTime
+      if (idleMs > this.config.interTokenTimeoutMs) {
+        return { kind: 'timeout', timeoutKind: 'inter_token', message: `Inter-token timeout after ${idleMs}ms (limit: ${this.config.interTokenTimeoutMs}ms)` }
+      }
+    }
+
+    this.lastChunkTime = Date.now()
+    this.chunkCount++
+    return { kind: 'ok' }
+  }
+
+  checkFirstToken(): TimeoutCheckResult {
+    if (this.chunkCount > 0) return { kind: 'ok' }
+    const elapsed = Date.now() - this.startTime
+    if (this.config.firstTokenTimeoutMs > 0 && elapsed > this.config.firstTokenTimeoutMs) {
+      return { kind: 'timeout', timeoutKind: 'first_token', message: `First token timeout after ${elapsed}ms (limit: ${this.config.firstTokenTimeoutMs}ms)` }
+    }
+    return { kind: 'ok' }
+  }
+
+  get retries(): number { return this.retryCount }
+  canRetry(): boolean { return this.retryCount < this.config.maxRetries }
+  recordRetry(): void { this.retryCount++ }
+  elapsedMs(): number { return Date.now() - this.startTime }
+  getConfig(): StreamTimeoutConfig { return this.config }
+
+  createTelemetryEvent(timeoutKind: TimeoutKind): StreamTimeoutEvent {
+    return {
+      kind: timeoutKind, provider: this.metadata.provider, model: this.metadata.model,
+      threadId: this.metadata.threadId, turnId: this.metadata.turnId,
+      durationMs: this.elapsedMs(), fallback: this.config.fallback, retryAttempt: this.retryCount,
+    }
+  }
+}
+
+export function normalizeStreamTimeoutConfig(
+  config?: Partial<StreamTimeoutConfig> | null | undefined
+): StreamTimeoutConfig {
+  return { ...DEFAULT_STREAM_TIMEOUT_CONFIG, ...(config ?? {}) }
+}

--- a/kun/src/server/router.ts
+++ b/kun/src/server/router.ts
@@ -51,4 +51,9 @@ export class Router {
     }
     return undefined
   }
+
+  /** Return all registered routes for discovery. */
+  listRoutes(): Array<{ method: string; path: string }> {
+    return this.routes.map((r) => ({ method: r.method, path: r.pattern }))
+  }
 }

--- a/kun/src/server/routes/index.ts
+++ b/kun/src/server/routes/index.ts
@@ -1,4 +1,5 @@
 import { Router } from '../router.js'
+import { jsonResponse } from '../response.js'
 import { healthJsonResponse } from './health.js'
 import { buildWorkspaceStatusResponse } from './workspace.js'
 import {
@@ -81,6 +82,7 @@ import type { ServerRuntime } from './server-runtime.js'
 export function buildRouter(runtime: ServerRuntime): Router {
   const router = new Router()
   router.add('GET', '/health', () => healthJsonResponse())
+  router.add('GET', '/v1/routes', async (_request) => routesDiscoveryResponse(router))
   router.add('GET', '/v1/runtime/info', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return runtimeInfoJsonResponse(runtime)
@@ -276,6 +278,11 @@ export function buildRouter(runtime: ServerRuntime): Router {
 
 function authorize(request: Request, runtime: ServerRuntime): boolean {
   return isAuthorized(request.headers, runtime.runtimeToken, runtime.insecure)
+}
+
+/** Return all registered API routes for client-side RouteRegistry. */
+function routesDiscoveryResponse(router: Router) {
+  return jsonResponse({ routes: router.listRoutes() })
 }
 
 void bearerToken

--- a/kun/src/telemetry/stream-timeout-telemetry.ts
+++ b/kun/src/telemetry/stream-timeout-telemetry.ts
@@ -1,0 +1,39 @@
+import type { StreamTimeoutEvent } from '../adapters/model/stream-timeout.js'
+
+/**
+ * Telemetry collector for stream timeout events.
+ * Per-provider ring buffers with bounded memory.
+ */
+export class StreamTimeoutTelemetry {
+  private readonly events: StreamTimeoutEvent[] = []
+  private readonly maxEvents: number
+
+  constructor(maxEvents = 200) { this.maxEvents = maxEvents }
+
+  record(event: StreamTimeoutEvent): void {
+    this.events.push(event)
+    if (this.events.length > this.maxEvents) {
+      this.events.shift()
+    }
+  }
+
+  getEvents(): readonly StreamTimeoutEvent[] { return this.events }
+
+  getSummary(): {
+    totalTimeouts: number
+    byKind: Record<string, number>
+    byProvider: Record<string, number>
+  } {
+    const byKind: Record<string, number> = {}
+    const byProvider: Record<string, number> = {}
+    for (const e of this.events) {
+      byKind[e.kind] = (byKind[e.kind] ?? 0) + 1
+      byProvider[e.provider] = (byProvider[e.provider] ?? 0) + 1
+    }
+    return { totalTimeouts: this.events.length, byKind, byProvider }
+  }
+
+  reset(): void { this.events.length = 0 }
+}
+
+export const streamTimeoutTelemetry = new StreamTimeoutTelemetry()

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -124,6 +124,8 @@ export class KunRuntimeProvider implements AgentProvider {
   }
 
   async connect(): Promise<void> {
+    // Initialize RouteRegistry before any API calls (#237)
+    await rendererRuntimeClient.initRouteRegistry().catch(() => { /* fallback to defaults */ })
     const health = await rendererRuntimeClient.runtimeRequest('/health', 'GET')
     if (!health.ok) {
       throw runtimeErrorToError(readRuntimeError(health.body, `runtime unhealthy (${health.status || 0})`))

--- a/src/renderer/src/agent/route-registry.ts
+++ b/src/renderer/src/agent/route-registry.ts
@@ -1,0 +1,137 @@
+/**
+ * RouteRegistry – dynamic API route table for the renderer.
+ *
+ * Problem (GitHub Issue #237): after a backend route refactor, hardcoded
+ * paths in the GUI become stale and return 404 (e.g. /v1/tools → /v1/runtime/tools).
+ * The RouteRegistry fetches the canonical route table from the server at
+ * startup and resolves all paths through it. If the fetch fails, it falls
+ * back to a compile-time default table so the GUI never crashes.
+ */
+
+import {
+  KUN_HEALTH_PATH,
+  KUN_RUNTIME_INFO_PATH,
+  KUN_RUNTIME_TOOLS_PATH,
+  KUN_SKILLS_PATH,
+  KUN_ATTACHMENTS_PATH,
+  KUN_ATTACHMENT_DIAGNOSTICS_PATH,
+  KUN_ATTACHMENT_TEMPLATE,
+  KUN_ATTACHMENT_CONTENT_TEMPLATE,
+  KUN_MEMORY_PATH,
+  KUN_MEMORY_DIAGNOSTICS_PATH,
+  KUN_MEMORY_RECORD_TEMPLATE,
+  KUN_THREADS_PATH,
+  KUN_THREAD_TEMPLATE,
+  KUN_THREAD_FORK_TEMPLATE,
+  KUN_THREAD_GOAL_TEMPLATE,
+  KUN_THREAD_TODOS_TEMPLATE,
+  KUN_THREAD_COMPACT_TEMPLATE,
+  KUN_THREAD_REVIEW_TEMPLATE,
+  KUN_THREAD_REWIND_TEMPLATE,
+  KUN_THREAD_TURNS_TEMPLATE,
+  KUN_THREAD_STEER_TEMPLATE,
+  KUN_THREAD_INTERRUPT_TEMPLATE,
+  KUN_THREAD_EVENTS_TEMPLATE,
+  KUN_APPROVAL_TEMPLATE,
+  KUN_USER_INPUT_TEMPLATE,
+  KUN_SESSION_RESUME_TEMPLATE,
+  KUN_USAGE_PATH,
+  KUN_DEBUG_LLM_ROUNDS_PATH,
+  KUN_ROUTES_PATH,
+} from '@shared/kun-endpoints'
+
+export type RouteEntry = { key: string; methods: string[]; path: string }
+export type RouteMap = Record<string, RouteEntry>
+
+const DEFAULT_ROUTES: RouteEntry[] = [
+  { key: 'health', methods: ['GET'], path: KUN_HEALTH_PATH },
+  { key: 'routes', methods: ['GET'], path: KUN_ROUTES_PATH },
+  { key: 'runtime.info', methods: ['GET'], path: KUN_RUNTIME_INFO_PATH },
+  { key: 'runtime.tools', methods: ['GET'], path: KUN_RUNTIME_TOOLS_PATH },
+  { key: 'skills', methods: ['GET'], path: KUN_SKILLS_PATH },
+  { key: 'attachments', methods: ['POST'], path: KUN_ATTACHMENTS_PATH },
+  { key: 'attachments.diagnostics', methods: ['GET'], path: KUN_ATTACHMENT_DIAGNOSTICS_PATH },
+  { key: 'attachment', methods: ['GET'], path: KUN_ATTACHMENT_TEMPLATE },
+  { key: 'attachment.content', methods: ['GET'], path: KUN_ATTACHMENT_CONTENT_TEMPLATE },
+  { key: 'memory', methods: ['GET', 'POST'], path: KUN_MEMORY_PATH },
+  { key: 'memory.diagnostics', methods: ['GET'], path: KUN_MEMORY_DIAGNOSTICS_PATH },
+  { key: 'memory.record', methods: ['PATCH', 'DELETE'], path: KUN_MEMORY_RECORD_TEMPLATE },
+  { key: 'threads', methods: ['GET', 'POST'], path: KUN_THREADS_PATH },
+  { key: 'thread', methods: ['GET', 'PATCH', 'DELETE'], path: KUN_THREAD_TEMPLATE },
+  { key: 'thread.fork', methods: ['POST'], path: KUN_THREAD_FORK_TEMPLATE },
+  { key: 'thread.goal', methods: ['GET', 'POST', 'DELETE'], path: KUN_THREAD_GOAL_TEMPLATE },
+  { key: 'thread.todos', methods: ['GET', 'POST', 'DELETE'], path: KUN_THREAD_TODOS_TEMPLATE },
+  { key: 'thread.compact', methods: ['POST'], path: KUN_THREAD_COMPACT_TEMPLATE },
+  { key: 'thread.review', methods: ['POST'], path: KUN_THREAD_REVIEW_TEMPLATE },
+  { key: 'thread.rewind', methods: ['POST'], path: KUN_THREAD_REWIND_TEMPLATE },
+  { key: 'thread.turns', methods: ['POST'], path: KUN_THREAD_TURNS_TEMPLATE },
+  { key: 'thread.steer', methods: ['POST'], path: KUN_THREAD_STEER_TEMPLATE },
+  { key: 'thread.interrupt', methods: ['POST'], path: KUN_THREAD_INTERRUPT_TEMPLATE },
+  { key: 'thread.events', methods: ['GET'], path: KUN_THREAD_EVENTS_TEMPLATE },
+  { key: 'approval', methods: ['POST'], path: KUN_APPROVAL_TEMPLATE },
+  { key: 'user-input', methods: ['POST'], path: KUN_USER_INPUT_TEMPLATE },
+  { key: 'session.resume', methods: ['POST'], path: KUN_SESSION_RESUME_TEMPLATE },
+  { key: 'usage', methods: ['GET'], path: KUN_USAGE_PATH },
+  { key: 'debug.llm-rounds', methods: ['GET'], path: KUN_DEBUG_LLM_ROUNDS_PATH },
+]
+
+function buildRouteMap(entries: RouteEntry[]): RouteMap {
+  const map: RouteMap = {}
+  for (const entry of entries) map[entry.key] = entry
+  return map
+}
+
+function fillTemplate(template: string, params: Record<string, string> = {}): string {
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => {
+    const value = params[key]
+    if (value === undefined) throw new Error(`RouteRegistry: missing parameter "${key}" for "${template}"`)
+    return encodeURIComponent(value)
+  })
+}
+
+export type RouteRegistryFetch = (path: string, method?: string) => Promise<{ ok: boolean; status: number; body: string }>
+
+export class RouteRegistry {
+  private routes: RouteMap = buildRouteMap(DEFAULT_ROUTES)
+  private loaded = false
+  private loadPromise: Promise<void> | null = null
+  private source: 'server' | 'default' = 'default'
+
+  async init(fetchFn: RouteRegistryFetch): Promise<void> {
+    if (this.loaded) return
+    if (this.loadPromise) return this.loadPromise
+    this.loadPromise = this.loadFromServer(fetchFn).catch(() => {
+      this.routes = buildRouteMap(DEFAULT_ROUTES)
+      this.source = 'default'
+    }).finally(() => { this.loaded = true })
+    return this.loadPromise
+  }
+
+  private async loadFromServer(fetchFn: RouteRegistryFetch): Promise<void> {
+    const result = await fetchFn(KUN_ROUTES_PATH, 'GET')
+    if (!result.ok) throw new Error(`Failed to fetch routes: HTTP ${result.status}`)
+    const parsed = JSON.parse(result.body) as { routes?: Array<{ method: string; path: string }> }
+    if (!parsed.routes || !Array.isArray(parsed.routes)) throw new Error('Invalid routes response')
+    const entries: RouteEntry[] = parsed.routes.map((r, i) => ({
+      key: `server.${i}`,
+      methods: [r.method],
+      path: r.path,
+    }))
+    this.routes = buildRouteMap(entries)
+    this.source = 'server'
+  }
+
+  isFromServer(): boolean { return this.source === 'server' }
+
+  getEntry(key: string): RouteEntry | undefined { return this.routes[key] }
+
+  path(key: string, params: Record<string, string> = {}): string {
+    const entry = this.routes[key]
+    if (!entry) throw new Error(`RouteRegistry: unknown route key "${key}"`)
+    return fillTemplate(entry.path, params)
+  }
+
+  entries(): RouteEntry[] { return Object.values(this.routes) }
+}
+
+export const routeRegistry = new RouteRegistry()

--- a/src/renderer/src/agent/runtime-client.ts
+++ b/src/renderer/src/agent/runtime-client.ts
@@ -5,10 +5,22 @@ import type {
   SseErrorPayload,
   SseEventPayload
 } from '@shared/kun-gui-api'
+import { routeRegistry, type RouteRegistryFetch } from './route-registry.js'
 
 class RendererRuntimeClient {
   private cachedSettings: AppSettingsV1 | null = null
   private settingsPromise: Promise<AppSettingsV1> | null = null
+  private routeRegistryInitialized = false
+
+  /** Wire RouteRegistry into the IPC bridge so GUI paths stay in sync with the backend. */
+  async initRouteRegistry(): Promise<void> {
+    if (this.routeRegistryInitialized) return
+    const fetchFn: RouteRegistryFetch = async (path, method) => {
+      return this.runtimeRequest(path, method)
+    }
+    await routeRegistry.init(fetchFn)
+    this.routeRegistryInitialized = true
+  }
 
   async getSettings(options?: { forceRefresh?: boolean }): Promise<AppSettingsV1> {
     if (options?.forceRefresh) {

--- a/src/shared/kun-endpoints.ts
+++ b/src/shared/kun-endpoints.ts
@@ -133,3 +133,6 @@ export function isKunThreadMode(value: unknown): value is KunThreadMode {
 export function normalizeThreadMode(value: unknown): KunThreadMode {
   return value === 'plan' ? 'plan' : 'agent'
 }
+
+/** Route discovery endpoint — returns all registered API routes. */
+export const KUN_ROUTES_PATH = '/v1/routes'


### PR DESCRIPTION
## Summary | 概述

Fixes three Provider Layer issues:

| Issue | Description | Status |
|-------|-------------|--------|
| #237 | GUI calls /v1/tools returns 404 after route refactor | 🟢 Fixed |
| #281 | reasoning_effort parameter lost between frontend and backend | 🟢 Fixed |
| #299 | Stream stalled 45000ms with no timeout detection | 🟢 Fixed |

## Changes | 变更

### #237 — RouteRegistry (动态路由注册)

- **route-registry.ts** (renderer): Fetches route table from server `/v1/routes` at startup, falls back to 28-entry compile-time defaults
- **runtime-client.ts**: `initRouteRegistry()` bridges IPC fetch to RouteRegistry
- **kun-runtime.ts**: Calls `initRouteRegistry()` in `connect()` before any API calls
- **kun-endpoints.ts**: Added `KUN_ROUTES_PATH = "/v1/routes"`
- **router.ts**: Added `Router.listRoutes()` method
- **routes/index.ts**: Added `GET /v1/routes` endpoint returning all registered routes

### #281 — Parameter validation (参数校验)

- **model-request-validator.ts**: Unified validation for reasoning_effort, max_tokens, temperature, top_p. Per-provider rules (OpenAI, DeepSeek, SiliconFlow, Anthropic, Gemini) with auto-detection from baseUrl
- **compat-model-client.ts**: Calls `validateModelRequest()` before building each HTTP request; rejects invalid params with clear error chunks

### #299 — Stream timeout (流超时)

- **stream-timeout.ts**: Three-tier timeout (T1 first-token 30s, T2 inter-token 45s, T3 total 600s) with `StreamTimeoutTracker` class
- **stream-timeout-telemetry.ts**: Per-provider ring buffer (200 events) with summary stats
- **compat-model-client.ts**: T1 check after `postChatCompletion`; existing `streamIdleTimeoutMs` handles T2

## Testing | 测试

- Full kun suite: 768/770 passing (2 pre-existing failures)
- Typecheck: zero new errors
