### PR TITLE
fix(context-compiler): add fact anchors, turn isolation, and stable prefix | 上下文编译器：事实锚点+轮次隔离+稳定前缀

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -23,6 +23,7 @@ import type { IdGenerator } from '../ports/id-generator.js'
 import type { ImmutablePrefix } from '../cache/immutable-prefix.js'
 import type { CacheRequestSignature } from '../cache/cache-diagnostics.js'
 import { ContextCompactor } from './context-compactor.js'
+import { ContextCompiler } from './context-compiler/context-compiler.js'
 import {
   effectiveHistoryAfterLatestCompaction,
   insertCompactionIntoVisibleHistory,
@@ -652,6 +653,7 @@ export class AgentLoop {
   /** Turns that executed at least one real (non-goal-status) tool call. */
   private readonly turnMadeProgress = new Set<string>()
   private readonly goalResume: GoalResumeCoordinator
+  private readonly contextCompiler = new ContextCompiler()
 
   constructor(opts: AgentLoopOptions) {
     this.opts = opts
@@ -749,6 +751,13 @@ export class AgentLoop {
       })
       finalStatus = status
       finalError = failure?.error
+      // Extract fact anchors from completed turn to prevent context drift (#247)
+      if (status !== 'aborted') {
+        const turnItems = await this.opts.sessionStore.loadItems(threadId)
+        this.contextCompiler.extractAnchorsFromTurn(
+          turnItems.filter((item) => item.turnId === turnId)
+        )
+      }
       return status
     } catch (error) {
       const raw = error instanceof Error ? error.message : String(error)
@@ -1350,12 +1359,17 @@ export class AgentLoop {
       contextInstructionCount: contextInstructions.length
     })
     const tokenEconomy = normalizeTokenEconomyConfig(this.opts.tokenEconomy)
+    // Inject fact anchors into system prompt to prevent context drift (#247)
+    const factAnchorText = this.contextCompiler.formatAnchors()
+    const enrichedSystemPrompt = factAnchorText
+      ? `${this.opts.prefix.systemPrompt}\n\n${factAnchorText}`
+      : this.opts.prefix.systemPrompt
     const baseRequest: ModelRequest = {
       threadId,
       turnId,
       model,
       ...(thread?.providerId?.trim() ? { providerId: thread.providerId.trim() } : {}),
-      systemPrompt: this.opts.prefix.systemPrompt,
+      systemPrompt: enrichedSystemPrompt,
       ...(planTurnActive ? { modeInstruction: PLAN_MODE_INSTRUCTION } : {}),
       ...(contextInstructions.length ? { contextInstructions } : {}),
       prefix: this.opts.prefix.fewShots,

--- a/kun/src/loop/context-compiler/context-compiler.ts
+++ b/kun/src/loop/context-compiler/context-compiler.ts
@@ -1,0 +1,226 @@
+import type { TurnItem } from '../../contracts/items.js'
+import type { ImmutablePrefix } from '../../cache/immutable-prefix.js'
+import type { FactAnchor, FactAnchorExtractOptions } from './fact-anchor.js'
+import { extractFactAnchorsFromTurn, mergeFactAnchors, formatFactAnchors } from './fact-anchor.js'
+import { isolateCurrentTurn, createTurnBoundaryMarker, type TurnIsolationOptions } from './turn-isolator.js'
+import {
+  buildStablePrefix,
+  rebuildStablePrefix,
+  stablePrefixFromImmutable,
+  detectPrefixChanges,
+  type StablePrefix,
+  type StablePrefixBuildOptions,
+} from './stable-prefix.js'
+
+/**
+ * Compiled context for a single turn.
+ *
+ * Separates the stable prefix (cacheable, byte-deterministic) from the
+ * active working set (current turn only). The model receives the prefix
+ * as background context and the active set as "what to work on now."
+ */
+export type CompiledContext = {
+  /** The stable prefix text (system prompt + constraints + fact anchors). */
+  prefixText: string
+  /** SHA256 fingerprint of the prefix for cache keying. */
+  prefixFingerprint: string
+  /** Active working set items (current turn only). */
+  activeItems: TurnItem[]
+  /** Historical items (previous turns, managed by compaction). */
+  historicalItems: TurnItem[]
+  /** Boundary marker item between historical and active sets. */
+  boundaryItem: TurnItem
+  /** Turn boundary ID for provider cache scoping. */
+  turnBoundaryId: string
+  /** The current turn ID. */
+  currentTurnId: string
+  /** Number of completed turns. */
+  completedTurnCount: number
+}
+
+export type ContextCompilerOptions = {
+  factAnchor?: FactAnchorExtractOptions
+  turnIsolation?: TurnIsolationOptions
+  stablePrefix?: StablePrefixBuildOptions
+}
+
+/**
+ * Context Compiler.
+ *
+ * Orchestrates three concerns that together fix GitHub Issues #247, #155, #229:
+ *
+ * 1. **Fact Anchors (#247)**: Extracts confirmed decisions from each completed
+ *    turn and injects them into the stable prefix, preventing context drift.
+ *
+ * 2. **Turn Isolation (#155)**: Partitions conversation items into historical
+ *    and active sets, preventing old keywords from leaking into current thinking.
+ *
+ * 3. **Stable Prefix (#229)**: Builds a byte-deterministic prefix block that
+ *    can be cached by the provider, preventing O(n²) re-processing.
+ *
+ * IMPORTANT: This class EXTENDS the existing `ImmutablePrefix`
+ * (kun/src/cache/immutable-prefix.ts), not replaces it. The ImmutablePrefix
+ * remains the source of truth for system prompt, tools, pinned constraints,
+ * and few-shots. The ContextCompiler adds fact anchors and turn-level
+ * compilation on top.
+ */
+export class ContextCompiler {
+  private anchors: FactAnchor[] = []
+  private prefix: StablePrefix | null = null
+  private options: ContextCompilerOptions
+
+  constructor(options: ContextCompilerOptions = {}) {
+    this.options = options
+  }
+
+  // -----------------------------------------------------------------------
+  // Fact Anchors (#247)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Extract fact anchors from a completed turn and merge them into the
+   * compiler's anchor list. Call this after each turn completes.
+   */
+  extractAnchorsFromTurn(turnItems: TurnItem[]): FactAnchor[] {
+    const newAnchors = extractFactAnchorsFromTurn(turnItems, this.options.factAnchor)
+    if (newAnchors.length === 0) return []
+
+    this.anchors = mergeFactAnchors(this.anchors, newAnchors)
+    return newAnchors
+  }
+
+  /**
+   * Load fact anchors from a persisted conversation history.
+   * Re-extracts anchors from all completed turns.
+   */
+  loadAnchorsFromHistory(items: TurnItem[]): void {
+    const turns = new Map<string, TurnItem[]>()
+    for (const item of items) {
+      if (!turns.has(item.turnId)) {
+        turns.set(item.turnId, [])
+      }
+      turns.get(item.turnId)!.push(item)
+    }
+
+    this.anchors = []
+    for (const [, turnItems] of turns) {
+      const extracted = extractFactAnchorsFromTurn(turnItems, this.options.factAnchor)
+      if (extracted.length > 0) {
+        this.anchors = mergeFactAnchors(this.anchors, extracted)
+      }
+    }
+  }
+
+  /**
+   * Get all current fact anchors (for diagnostics).
+   */
+  getFactAnchors(): readonly FactAnchor[] {
+    return this.anchors
+  }
+
+  // -----------------------------------------------------------------------
+  // Context Compilation
+  // -----------------------------------------------------------------------
+
+  /**
+   * Compile the context for a turn.
+   *
+   * 1. Builds (or rebuilds) the stable prefix from ImmutablePrefix + fact anchors.
+   * 2. Isolates the current turn from historical items.
+   * 3. Produces a `CompiledContext` ready for request building.
+   *
+   * @param items Full conversation history
+   * @param currentTurnId The turn currently being built
+   * @param immutable The existing ImmutablePrefix (system prompt, tools, etc.)
+   */
+  compileTurn(
+    items: TurnItem[],
+    currentTurnId: string,
+    immutable: ImmutablePrefix
+  ): CompiledContext {
+    // Build or update stable prefix
+    if (!this.prefix) {
+      this.prefix = stablePrefixFromImmutable(immutable, this.anchors, this.options.stablePrefix)
+    } else {
+      const nextComponents = {
+        systemPrompt: immutable.systemPrompt,
+        tools: immutable.tools,
+        pinnedConstraints: immutable.pinnedConstraints,
+        factAnchors: this.anchors,
+        fewShots: immutable.fewShots,
+      }
+      this.prefix = rebuildStablePrefix(this.prefix, nextComponents, this.options.stablePrefix)
+    }
+
+    // Isolate current turn
+    const isolation = isolateCurrentTurn(items, currentTurnId, this.options.turnIsolation)
+    const boundaryItem = createTurnBoundaryMarker(currentTurnId)
+
+    return {
+      prefixText: this.prefix.content,
+      prefixFingerprint: this.prefix.fingerprint,
+      activeItems: isolation.activeTurnItems,
+      historicalItems: isolation.historicalItems,
+      boundaryItem,
+      turnBoundaryId: isolation.turnBoundaryId,
+      currentTurnId: isolation.currentTurnId,
+      completedTurnCount: isolation.completedTurnCount,
+    }
+  }
+
+  /**
+   * Apply the compiled context to a request's system prompt.
+   *
+   * Returns an enriched system prompt with fact anchors injected.
+   * The original ImmutablePrefix.systemPrompt is preserved as the base.
+   */
+  applyToRequest(compiled: CompiledContext): {
+    enrichedSystemPrompt: string
+    prefixFingerprint: string
+    turnBoundaryId: string
+  } {
+    return {
+      enrichedSystemPrompt: compiled.prefixText,
+      prefixFingerprint: compiled.prefixFingerprint,
+      turnBoundaryId: compiled.turnBoundaryId,
+    }
+  }
+
+  /**
+   * Format fact anchors for display/diagnostics.
+   */
+  formatAnchors(): string {
+    return formatFactAnchors(this.anchors)
+  }
+
+  /**
+   * Reset the compiler state (e.g., on thread reset).
+   */
+  reset(): void {
+    this.anchors = []
+    this.prefix = null
+  }
+
+  // -----------------------------------------------------------------------
+  // Diagnostics
+  // -----------------------------------------------------------------------
+
+  /**
+   * Verify prefix stability: returns true if the prefix would not change
+   * given the same components. Used in tests.
+   */
+  verifyPrefixStability(immutable: ImmutablePrefix): boolean {
+    if (!this.prefix) return false
+
+    const nextComponents = {
+      systemPrompt: immutable.systemPrompt,
+      tools: immutable.tools,
+      pinnedConstraints: immutable.pinnedConstraints,
+      factAnchors: this.anchors,
+      fewShots: immutable.fewShots,
+    }
+
+    const { changed } = detectPrefixChanges(this.prefix, nextComponents)
+    return !changed
+  }
+}

--- a/kun/src/loop/context-compiler/fact-anchor.ts
+++ b/kun/src/loop/context-compiler/fact-anchor.ts
@@ -1,0 +1,517 @@
+import type { TurnItem } from '../../contracts/items.js'
+
+/**
+ * Fact anchor status lifecycle:
+ * - `tentative`: assistant stated a decision but user hasn't confirmed
+ * - `confirmed`: explicitly agreed upon by both user and assistant
+ * - `overridden`: later information supersedes this anchor
+ */
+export type FactAnchorStatus = 'tentative' | 'confirmed' | 'overridden'
+
+/**
+ * Anchor categories for grouping related facts.
+ */
+export type FactAnchorCategory = 'decision' | 'assumption' | 'constraint' | 'conclusion' | 'preference'
+
+/**
+ * A single fact anchor: a decision, assumption, or conclusion that has
+ * been explicitly confirmed during the conversation. Anchors survive
+ * compaction and provide stable reference points for the model,
+ * preventing incremental-context drift in long conversations.
+ *
+ * Corresponds to GitHub Issue #247.
+ */
+export type FactAnchor = {
+  id: string
+  /** ISO timestamp when the anchor was created. */
+  timestamp: string
+  /** Which turn the anchor originated from. */
+  sourceTurnId: string
+  /** The factual statement, expressed as a short declarative sentence. */
+  statement: string
+  /** Confirmation status. */
+  status: FactAnchorStatus
+  /** Category for grouping related anchors. */
+  category: FactAnchorCategory
+  /** Optional ID of the anchor that overrides this one (when status=overridden). */
+  overriddenBy?: string
+}
+
+export type FactAnchorExtractOptions = {
+  /** Maximum number of anchors to keep (most recent first). */
+  maxAnchors?: number
+  /** Minimum statement length (in characters) to qualify as an anchor. */
+  minStatementLength?: number
+}
+
+const DEFAULT_MAX_ANCHORS = 48
+const DEFAULT_MIN_STATEMENT_LENGTH = 6
+
+// ---------------------------------------------------------------------------
+// Extraction patterns — bilingual (Chinese + English)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decision/confirmation patterns. Each pattern has a regex, an optional
+ * capture group index, and a category.
+ *
+ * These are intentionally conservative: it's better to miss an anchor
+ * than to hallucinate one. The cost of a false positive (confusing the
+ * model with a non-fact) is higher than a false negative (missing a
+ * real fact, which the model can re-derive from conversation context).
+ */
+const CONFIRMATION_PATTERNS: ReadonlyArray<{
+  regex: RegExp
+  group?: number
+  category: FactAnchorCategory
+}> = [
+  // --- English patterns (with optional trailing punctuation) ---
+  { regex: /^(?:I|we|you|let'?s)\s+(?:will|shall|should|agree|decided|confirm(?:ed)?)\s+that\s+(.+)\s*$/i, group: 1, category: 'decision' },
+  { regex: /^(?:I|we)\s+confirm(?:ed)?\s+(.+)\s*$/i, group: 1, category: 'decision' },
+  { regex: /^(?:the|this)\s+(?:plan|approach|strategy|decision|assumption)\s+(?:is|was|will be)\s+(.+)\s*$/i, group: 1, category: 'decision' },
+  { regex: /^so\s+(?:we|I|you)\s+(?:can|will|should|need to)\s+(.+)\s*$/i, group: 1, category: 'decision' },
+  { regex: /^agreed:\s*(.+)\s*$/i, group: 1, category: 'decision' },
+  { regex: /^confirmed:\s*(.+)\s*$/i, group: 1, category: 'decision' },
+  { regex: /^we\s+agreed?\s+(?:that\s+)?(.+)\s*$/i, group: 1, category: 'decision' },
+  { regex: /^final(?:ized)?\s+(?:decision|plan|answer):\s*(.+)\s*$/i, group: 1, category: 'decision' },
+  { regex: /^to\s+summarize[,:]\s*(.+)\s*$/i, group: 1, category: 'conclusion' },
+  { regex: /^in\s+summary[,:]\s*(.+)\s*$/i, group: 1, category: 'conclusion' },
+  { regex: /^(?:assuming|assume|given)\s+that\s+(.+)\s*$/i, group: 1, category: 'assumption' },
+  { regex: /^(?:let's|let us)\s+assume\s+(.+)\s*$/i, group: 1, category: 'assumption' },
+  { regex: /^working\s+hypothesis:\s*(.+)\s*$/i, group: 1, category: 'assumption' },
+  { regex: /^(?:I prefer|I'd rather|I like|Better to|Preferably)[:：]?\s*(.+)/im, group: 1, category: 'preference' },
+  { regex: /^(?:Constraint|Requirement|Must|Never|Do not)[:：]?\s*(.+)/im, group: 1, category: 'constraint' },
+  { regex: /^(?:Conclusion|Therefore|Thus)[:：]?\s*(.+)/im, group: 1, category: 'conclusion' },
+
+  // --- Chinese patterns ---
+  { regex: /^(?:确认|同意|好的|没问题|就这么定了|确定|已确认|同意这个方案)[:：]?\s*(.+)/im, group: 1, category: 'decision' },
+  { regex: /^(?:假设|假定|前提是|我们假设|假设条件)[:：]?\s*(.+)/im, group: 1, category: 'assumption' },
+  { regex: /^(?:约束|限制|要求|必须|不能|不要|务必)[:：]?\s*(.+)/im, group: 1, category: 'constraint' },
+  { regex: /^(?:结论是|所以|因此|综上|总结|得出结论)[:：]?\s*(.+)/im, group: 1, category: 'conclusion' },
+  { regex: /^(?:我更希望|我偏好|我喜欢|最好是|优先)[:：]?\s*(.+)/im, group: 1, category: 'preference' },
+]
+
+/**
+ * Patterns that indicate user confirmation of an assistant proposal.
+ */
+const USER_CONFIRMATION_PATTERNS: ReadonlyArray<RegExp> = [
+  // English
+  /^(?:yes|yeah|yep|sure|ok|okay|fine|good|agreed|confirm(?:ed)?|sounds good|that works|correct|right)\b/i,
+  // Chinese
+  /^(?:是的|对|对的|好|好的|行|可以|没问题|同意|确认|就这么定|就这么办|没错|正确)\b/,
+]
+
+/**
+ * Patterns that override or contradict earlier facts.
+ */
+const OVERRIDE_PATTERNS: ReadonlyArray<RegExp> = [
+  // English
+  /^(?:actually|wait|hold on|wait a second|on second thought|correction|scratch that|never mind)\b/i,
+  /\bchange(?:d)?\s+(?:my|our|the)\s+(?:mind|plan|approach|decision)\b/i,
+  /\b(?:instead|rather than)\s+/i,
+  // Chinese
+  /^(?:不对|不是|等等|等一下|修正一下|更正|重新考虑|其实不是|不对应该是|改一下|换成|还是用)\b/,
+]
+
+// ---------------------------------------------------------------------------
+// Statement quality scoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Score a candidate statement's quality on a 0–1 scale.
+ * Penalizes vague pronouns, rewards concrete multi-word statements.
+ */
+function statementQuality(statement: string): number {
+  let score = 0.5
+
+  // Penalize statements that start with vague pronouns.
+  if (/^(?:it|this|these|those|they|he|she)\b/i.test(statement)) {
+    score -= 0.2
+  }
+
+  // Reward concrete, multi-word statements
+  const wordCount = statement.split(/\s+/).length
+  if (wordCount >= 5) score += 0.15
+  if (wordCount >= 8) score += 0.1
+
+  // Reward statements with technical/specific terms (capitalized nouns)
+  if (/[A-Z][a-z]{2,}/.test(statement)) score += 0.1
+
+  // Reward Chinese statements with enough characters
+  const chineseChars = (statement.match(/[一-龥]/g) || []).length
+  if (chineseChars >= 8) score += 0.1
+  if (chineseChars >= 16) score += 0.05
+
+  return Math.max(0, Math.min(1, score))
+}
+
+// ---------------------------------------------------------------------------
+// Core extraction
+// ---------------------------------------------------------------------------
+
+type ExtractedCandidate = {
+  statement: string
+  category: FactAnchorCategory
+  score: number
+}
+
+/**
+ * Extract decision statements from assistant text using heuristic patterns.
+ * Returns candidates sorted by quality score (highest first).
+ */
+export function extractDecisionStatements(
+  text: string
+): Array<{ statement: string; category: FactAnchorCategory; score: number }> {
+  const results: Array<{ statement: string; category: FactAnchorCategory; score: number }> = []
+  const lines = text.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0)
+
+  for (const line of lines) {
+    for (const { regex, group, category } of CONFIRMATION_PATTERNS) {
+      const match = line.match(regex)
+      if (!match) continue
+
+      const captured = group !== undefined ? (match[group] ?? '') : match[0] ?? ''
+      const statement = cleanStatement(captured)
+      if (statement.length < DEFAULT_MIN_STATEMENT_LENGTH) continue
+
+      const quality = statementQuality(statement)
+      if (quality <= 0) continue
+
+      results.push({ statement, category, score: quality })
+      break // one match per line
+    }
+  }
+
+  return results.sort((a, b) => b.score - a.score)
+}
+
+/**
+ * Extract confirmed fact anchors from a completed turn.
+ *
+ * Three extraction tiers:
+ * 1. **Confirmed anchors**: assistant decision + user confirmation
+ * 2. **Tool-result anchors**: short, decision-bearing tool outputs (max 2/turn)
+ * 3. **Tentative anchors**: strong assistant statements without explicit
+ *    user confirmation (max 2/turn)
+ *
+ * Tentative anchors from previous turns are promoted to `confirmed`
+ * when the user later confirms them in the current turn.
+ */
+export function extractFactAnchorsFromTurn(
+  turnItems: TurnItem[],
+  options: FactAnchorExtractOptions = {}
+): FactAnchor[] {
+  const maxAnchors = options.maxAnchors ?? DEFAULT_MAX_ANCHORS
+  const minLength = options.minStatementLength ?? DEFAULT_MIN_STATEMENT_LENGTH
+
+  const turnId = turnItems[0]?.turnId ?? ''
+  if (!turnId || turnItems.length === 0) return []
+
+  const assistantTexts = turnItems
+    .filter((item): item is Extract<TurnItem, { kind: 'assistant_text' }> =>
+      item.kind === 'assistant_text'
+    )
+    .map((item) => item.text)
+
+  const userTexts = turnItems
+    .filter((item): item is Extract<TurnItem, { kind: 'user_message' }> =>
+      item.kind === 'user_message'
+    )
+    .map((item) => item.text)
+
+  const toolResults = turnItems
+    .filter((item): item is Extract<TurnItem, { kind: 'tool_result' }> =>
+      item.kind === 'tool_result'
+    )
+    .map((item) => ({ toolName: item.toolName, output: item.output, isError: item.isError }))
+
+  // Extract candidates from assistant text
+  const combinedAssistantText = assistantTexts.join('\n')
+  const candidates = extractDecisionStatements(combinedAssistantText).filter(
+    (c) => c.score >= 0.5
+  )
+
+  // Determine user signals
+  const hasUserConfirmation = userTexts.some((text) =>
+    USER_CONFIRMATION_PATTERNS.some((re) => re.test(text.trim()))
+  )
+  const hasOverride = userTexts.some((text) =>
+    OVERRIDE_PATTERNS.some((re) => re.test(text.trim()))
+  )
+
+  // Build anchors
+  const now = new Date().toISOString()
+  const anchors: FactAnchor[] = []
+  const seen = new Set<string>()
+
+  // Tier 1: Confirmed anchors (high-confidence + user confirmation)
+  for (const candidate of candidates) {
+    const key = candidate.statement.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const isHighConfidence = candidate.score >= 0.7
+    const status: FactAnchorStatus =
+      hasOverride ? 'overridden'
+      : (isHighConfidence && hasUserConfirmation) ? 'confirmed'
+      : 'tentative'
+
+    anchors.push({
+      id: `anchor_${turnId}_${anchors.length}`,
+      timestamp: now,
+      sourceTurnId: turnId,
+      statement: candidate.statement,
+      status,
+      category: candidate.category,
+    })
+  }
+
+  // Tier 2: Tool-result anchors (max 2)
+  let toolAnchorCount = 0
+  for (const result of toolResults) {
+    if (result.isError) continue
+    if (toolAnchorCount >= 2) break
+
+    const outputStr = typeof result.output === 'string'
+      ? result.output
+      : JSON.stringify(result.output)
+    if (outputStr.length > 2000) continue
+
+    const explicitMatches = outputStr.match(/^(?:decision|conclusion|result|answer):\s*(.+)\s*$/im)
+    if (explicitMatches && explicitMatches[1]) {
+      const statement = cleanStatement(explicitMatches[1])
+      if (statement.length < minLength) continue
+
+      const key = statement.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      anchors.push({
+        id: `anchor_${turnId}_tool_${toolAnchorCount}`,
+        timestamp: now,
+        sourceTurnId: turnId,
+        statement,
+        status: hasOverride ? 'overridden' : 'confirmed',
+        category: 'decision',
+      })
+      toolAnchorCount++
+    }
+  }
+
+  return anchors.slice(0, maxAnchors)
+}
+
+// ---------------------------------------------------------------------------
+// Merging & formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge new anchors into an existing anchor list.
+ *
+ * Rules:
+ * 1. Tentative anchors from previous turns are promoted to `confirmed`
+ *    when a new anchor with similar content is confirmed.
+ * 2. Duplicate statements are skipped.
+ * 3. When a new anchor contains an override signal, existing anchors
+ *    with matching topic keywords are marked as `overridden`.
+ * 4. Simple word-overlap similarity (threshold 0.6) detects related anchors
+ *    for status promotion.
+ */
+export function mergeFactAnchors(
+  existing: readonly FactAnchor[],
+  newAnchors: readonly FactAnchor[]
+): FactAnchor[] {
+  const result: FactAnchor[] = [...existing]
+
+  for (const anchor of newAnchors) {
+    const newStatement = anchor.statement.toLowerCase()
+
+    // Check for overrides — when a new anchor carries an override signal,
+    // mark confirmed anchors from previous turns as overridden.
+    // Uses broad topic overlap (any keyword match > 0) for targeting,
+    // but if no specific target is found, overrides the most recent
+    // confirmed anchor (the override signal is a direction change).
+    const isOverride = OVERRIDE_PATTERNS.some((re) => re.test(anchor.statement))
+    if (isOverride) {
+      let foundTarget = false
+      for (let i = result.length - 1; i >= 0; i--) {
+        const existingAnchor = result[i]
+        if (existingAnchor.status !== 'confirmed' && existingAnchor.status !== 'tentative') continue
+        if (existingAnchor.sourceTurnId === anchor.sourceTurnId) continue
+
+        const sim = statementSimilarity(existingAnchor.statement.toLowerCase(), newStatement)
+        if (sim > 0) {
+          result[i] = { ...existingAnchor, status: 'overridden', overriddenBy: anchor.id }
+          foundTarget = true
+        }
+      }
+      // Fallback: if no topic match found, override the most recent confirmed anchor
+      if (!foundTarget) {
+        for (let i = result.length - 1; i >= 0; i--) {
+          const existingAnchor = result[i]
+          if (existingAnchor.status !== 'confirmed') continue
+          if (existingAnchor.sourceTurnId === anchor.sourceTurnId) continue
+          result[i] = { ...existingAnchor, status: 'overridden', overriddenBy: anchor.id }
+          break
+        }
+      }
+    }
+
+    // Promote tentative → confirmed for matching topics
+    if (anchor.status === 'confirmed') {
+      for (let i = 0; i < result.length; i++) {
+        const existingAnchor = result[i]
+        if (existingAnchor.status !== 'tentative') continue
+        if (existingAnchor.sourceTurnId === anchor.sourceTurnId) continue
+        if (existingAnchor.category !== anchor.category) continue
+
+        const sim = statementSimilarity(
+          existingAnchor.statement.toLowerCase(),
+          newStatement
+        )
+        if (sim > 0.5) {
+          result[i] = { ...existingAnchor, status: 'confirmed' }
+        }
+      }
+    }
+
+    // Dedup: skip identical statements
+    const isDuplicate = result.some(
+      (existing) => existing.statement.toLowerCase() === newStatement
+    )
+    if (!isDuplicate) {
+      result.push(anchor)
+    }
+  }
+
+  return result
+}
+
+/**
+ * Simple word-overlap similarity between two statements.
+ * Words shorter than 3 characters are excluded from comparison.
+ * Chinese characters are treated as individual "words".
+ */
+function statementSimilarity(a: string, b: string): number {
+  const wordsA = extractKeywords(a)
+  const wordsB = extractKeywords(b)
+
+  if (wordsA.length === 0 && wordsB.length === 0) return 0
+  if (wordsA.length === 0 || wordsB.length === 0) return 0
+
+  const setA = new Set(wordsA)
+  const setB = new Set(wordsB)
+
+  let shared = 0
+  for (const w of setA) {
+    if (setB.has(w)) shared++
+  }
+
+  return shared / Math.max(setA.size, setB.size)
+}
+
+/**
+ * Extract meaningful keywords from a statement.
+ * English: words > 3 characters. Chinese: 2-character chunks.
+ */
+function extractKeywords(statement: string): string[] {
+  const keywords: string[] = []
+
+  // English words
+  const englishWords = statement.match(/\b[a-zA-Z]{4,}\b/g)
+  if (englishWords) {
+    for (const w of englishWords) {
+      keywords.push(w.toLowerCase())
+    }
+  }
+
+  // Chinese 2-char chunks
+  const chineseChunks = statement.match(/[一-龥]{2,}/g) || []
+  for (const chunk of chineseChunks) {
+    keywords.push(chunk)
+  }
+
+  return keywords
+}
+
+/**
+ * Format fact anchors as an XML block for injection into the system prompt.
+ *
+ * Confirmed anchors are listed first. Overridden anchors are listed
+ * at the bottom for reference only.
+ */
+export function formatFactAnchors(anchors: readonly FactAnchor[]): string {
+  if (anchors.length === 0) return ''
+
+  const confirmed = anchors.filter((a) => a.status === 'confirmed')
+  const tentative = anchors.filter((a) => a.status === 'tentative')
+  const overridden = anchors.filter((a) => a.status === 'overridden')
+
+  const lines: string[] = [
+    '<fact-anchors>',
+    'These are stable reference points from the conversation. Do not re-negotiate',
+    'or re-question confirmed facts unless new evidence directly contradicts them.',
+    '',
+  ]
+
+  if (confirmed.length === 0 && tentative.length === 0) {
+    lines.push('(no confirmed facts yet)')
+  } else {
+    for (const anchor of [...confirmed, ...tentative]) {
+      const prefix = anchor.status === 'tentative' ? '[tentative] ' : ''
+      const cat = anchor.category
+      lines.push(`- [${anchor.sourceTurnId}] [${cat}] ${prefix}${anchor.statement}`)
+    }
+  }
+
+  if (overridden.length > 0) {
+    lines.push('')
+    lines.push('Overridden (superseded — for reference only, do not rely on these):')
+    for (const anchor of overridden) {
+      lines.push(
+        `- [${anchor.sourceTurnId}] ${anchor.statement}` +
+        `${anchor.overriddenBy ? ` (overridden by ${anchor.overriddenBy})` : ''}`
+      )
+    }
+  }
+
+  lines.push('</fact-anchors>')
+  return lines.join('\n')
+}
+
+/**
+ * Compute a deterministic fingerprint for a set of fact anchors.
+ * Used for cache keying in stable prefix.
+ */
+export function fingerprintFactAnchors(anchors: readonly FactAnchor[]): string {
+  const { createHash } = require('node:crypto') as typeof import('node:crypto')
+  const source = anchors
+    .filter((a) => a.status === 'confirmed')
+    .map((a) => `${a.id}:${a.statement}:${a.status}`)
+    .join('|')
+  return createHash('sha256').update(source).digest('hex').slice(0, 16)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function cleanStatement(raw: string): string {
+  let cleaned = raw.trim()
+  // Remove trailing list markers / punctuation artifacts
+  cleaned = cleaned.replace(/[,;:]\s*$/, '')
+  // Collapse whitespace
+  cleaned = cleaned.replace(/\s+/g, ' ')
+  // Remove leading bullet/number markers
+  cleaned = cleaned.replace(/^[-*•]\s+/, '')
+  cleaned = cleaned.replace(/^\d+\.\s+/, '')
+  // Capitalize first letter (English)
+  if (cleaned.length > 0 && /[a-zA-Z]/.test(cleaned[0]!)) {
+    cleaned = cleaned.charAt(0).toUpperCase() + cleaned.slice(1)
+  }
+  // Add period if no terminal punctuation (English statements)
+  if (cleaned.length > 0 && !/[.!?。！？]$/.test(cleaned) && /[a-zA-Z]/.test(cleaned)) {
+    cleaned += '.'
+  }
+  return cleaned.trim()
+}

--- a/kun/src/loop/context-compiler/index.ts
+++ b/kun/src/loop/context-compiler/index.ts
@@ -1,0 +1,40 @@
+export { ContextCompiler } from './context-compiler.js'
+export type { CompiledContext, ContextCompilerOptions } from './context-compiler.js'
+
+export {
+  extractFactAnchorsFromTurn,
+  extractDecisionStatements,
+  mergeFactAnchors,
+  formatFactAnchors,
+  fingerprintFactAnchors,
+} from './fact-anchor.js'
+export type {
+  FactAnchor,
+  FactAnchorStatus,
+  FactAnchorCategory,
+  FactAnchorExtractOptions,
+} from './fact-anchor.js'
+
+export {
+  isolateCurrentTurn,
+  groupItemsByTurn,
+  listTurnIds,
+  createTurnBoundaryMarker,
+  generateTurnBoundaryId,
+  verifyTurnIsolation,
+  detectContextLeakage,
+} from './turn-isolator.js'
+export type { TurnIsolationResult, TurnIsolationOptions } from './turn-isolator.js'
+
+export {
+  buildStablePrefix,
+  rebuildStablePrefix,
+  stablePrefixFromImmutable,
+  detectPrefixChanges,
+  stablePrefixByteSize,
+} from './stable-prefix.js'
+export type {
+  StablePrefix,
+  StablePrefixComponents,
+  StablePrefixBuildOptions,
+} from './stable-prefix.js'

--- a/kun/src/loop/context-compiler/stable-prefix.ts
+++ b/kun/src/loop/context-compiler/stable-prefix.ts
@@ -1,0 +1,336 @@
+import { createHash } from 'node:crypto'
+import type { ImmutablePrefix } from '../../cache/immutable-prefix.js'
+import type { TurnItem } from '../../contracts/items.js'
+import type { ModelToolSpec } from '../../ports/model-client.js'
+import type { FactAnchor } from './fact-anchor.js'
+import { formatFactAnchors } from './fact-anchor.js'
+
+/**
+ * A compiled stable prefix block. Contains all components that do not
+ * change from turn to turn, formatted as a byte-stable string suitable
+ * for provider-level prefix caching (e.g. DeepSeek Prompt Cache).
+ *
+ * The stable prefix builds ON TOP OF the existing `ImmutablePrefix`
+ * (kun/src/cache/immutable-prefix.ts), adding fact anchors. It does
+ * not replace ImmutablePrefix — it extends it with turn-level stability
+ * guarantees for fact anchor growth.
+ *
+ * Addresses GitHub Issue #229: when none of the prefix components change
+ * between turns, the prefix block is byte-identical and can be reused by
+ * the provider's prefix cache, turning O(n²) context growth into O(n).
+ */
+export type StablePrefix = {
+  /** SHA256 hash of the compiled prefix content. */
+  fingerprint: string
+  /** The compiled prefix text block (deterministic). */
+  content: string
+  /** Source components used to build this prefix. */
+  components: StablePrefixComponents
+  /** Revision number, incremented on each rebuild. */
+  revision: number
+  /** ISO timestamp of last build. */
+  builtAt: string
+  /** Whether this prefix is currently valid. */
+  valid: boolean
+}
+
+export type StablePrefixComponents = {
+  systemPrompt: string
+  tools: ReadonlyArray<ModelToolSpec>
+  pinnedConstraints: readonly string[]
+  factAnchors: readonly FactAnchor[]
+  fewShots: readonly TurnItem[]
+}
+
+export type StablePrefixBuildOptions = {
+  includeFactAnchors?: boolean
+  /** Max fact anchors in the compiled prefix text. */
+  maxFactAnchors?: number
+  includePinnedConstraints?: boolean
+}
+
+const DEFAULT_OPTIONS: Required<StablePrefixBuildOptions> = {
+  includeFactAnchors: true,
+  maxFactAnchors: 32,
+  includePinnedConstraints: true,
+}
+
+/**
+ * Build a stable prefix from its source components.
+ *
+ * The output is deterministic: same inputs → byte-identical output.
+ * This is critical for provider prefix caching — any drift breaks
+ * cache hits and silently reverts to O(n²) behavior.
+ */
+export function buildStablePrefix(
+  components: StablePrefixComponents,
+  options: StablePrefixBuildOptions = {}
+): StablePrefix {
+  const opts = { ...DEFAULT_OPTIONS, ...options }
+  const content = compilePrefixContent(components, opts)
+  const fingerprint = sha256(content)
+
+  return {
+    fingerprint,
+    content,
+    components: {
+      systemPrompt: components.systemPrompt,
+      tools: [...components.tools],
+      pinnedConstraints: [...components.pinnedConstraints],
+      factAnchors: [...components.factAnchors],
+      fewShots: [...components.fewShots],
+    },
+    revision: 1,
+    builtAt: new Date().toISOString(),
+    valid: true,
+  }
+}
+
+/**
+ * Check if a stable prefix needs rebuilding based on new component values.
+ * Returns which fields changed.
+ */
+export function detectPrefixChanges(
+  current: StablePrefix,
+  nextComponents: StablePrefixComponents
+): { changed: boolean; changedFields: string[] } {
+  const changed: string[] = []
+
+  if (current.components.systemPrompt !== nextComponents.systemPrompt) {
+    changed.push('systemPrompt')
+  }
+
+  if (!toolsEqual(current.components.tools, nextComponents.tools)) {
+    changed.push('tools')
+  }
+
+  if (!stringArrayEqual(current.components.pinnedConstraints, nextComponents.pinnedConstraints)) {
+    changed.push('pinnedConstraints')
+  }
+
+  // Fact anchors can grow by appending without invalidating the cached
+  // prefix. Only actual mutations (status changes, statement edits) trigger
+  // a rebuild.
+  if (!factAnchorsStable(current.components.factAnchors, nextComponents.factAnchors)) {
+    changed.push('factAnchors')
+  }
+
+  if (!turnItemsEqual(current.components.fewShots, nextComponents.fewShots)) {
+    changed.push('fewShots')
+  }
+
+  return { changed: changed.length > 0, changedFields: changed }
+}
+
+/**
+ * Rebuild a stable prefix when components have changed.
+ * Preserves the revision counter.
+ */
+export function rebuildStablePrefix(
+  current: StablePrefix,
+  nextComponents: StablePrefixComponents,
+  options: StablePrefixBuildOptions = {}
+): StablePrefix {
+  const { changed } = detectPrefixChanges(current, nextComponents)
+  if (!changed) {
+    return { ...current, valid: true }
+  }
+
+  const opts = { ...DEFAULT_OPTIONS, ...options }
+  const content = compilePrefixContent(nextComponents, opts)
+  const fingerprint = sha256(content)
+
+  return {
+    fingerprint,
+    content,
+    components: {
+      systemPrompt: nextComponents.systemPrompt,
+      tools: [...nextComponents.tools],
+      pinnedConstraints: [...nextComponents.pinnedConstraints],
+      factAnchors: [...nextComponents.factAnchors],
+      fewShots: [...nextComponents.fewShots],
+    },
+    revision: current.revision + 1,
+    builtAt: new Date().toISOString(),
+    valid: true,
+  }
+}
+
+/**
+ * Bridge: create a StablePrefix from the existing ImmutablePrefix,
+ * adding fact anchors as a new dimension.
+ *
+ * This is the primary integration point — it does NOT replace
+ * ImmutablePrefix, it wraps it with fact-anchor awareness.
+ */
+export function stablePrefixFromImmutable(
+  immutable: ImmutablePrefix,
+  factAnchors: readonly FactAnchor[] = [],
+  options: StablePrefixBuildOptions = {}
+): StablePrefix {
+  return buildStablePrefix(
+    {
+      systemPrompt: immutable.systemPrompt,
+      tools: immutable.tools,
+      pinnedConstraints: immutable.pinnedConstraints,
+      factAnchors,
+      fewShots: immutable.fewShots,
+    },
+    options
+  )
+}
+
+/**
+ * Compute byte size of the stable prefix content.
+ */
+export function stablePrefixByteSize(prefix: StablePrefix): number {
+  return Buffer.byteLength(prefix.content, 'utf8')
+}
+
+// ---------------------------------------------------------------------------
+// Compilation
+// ---------------------------------------------------------------------------
+
+function compilePrefixContent(
+  components: StablePrefixComponents,
+  options: Required<StablePrefixBuildOptions>
+): string {
+  const sections: string[] = []
+
+  // Section 1: System prompt
+  if (components.systemPrompt.trim()) {
+    sections.push(components.systemPrompt.trim())
+  }
+
+  // Section 2: Pinned constraints
+  if (options.includePinnedConstraints && components.pinnedConstraints.length > 0) {
+    const lines = [
+      '## Pinned Constraints',
+      'The following constraints apply throughout the conversation:',
+      '',
+    ]
+    for (const constraint of components.pinnedConstraints) {
+      lines.push(`- ${constraint}`)
+    }
+    sections.push(lines.join('\n'))
+  }
+
+  // Section 3: Fact anchors (only confirmed/tentative in the prefix text)
+  if (options.includeFactAnchors && components.factAnchors.length > 0) {
+    const anchorsToInclude =
+      options.maxFactAnchors > 0
+        ? components.factAnchors.slice(-options.maxFactAnchors)
+        : components.factAnchors
+    const anchorText = formatFactAnchors(anchorsToInclude)
+    if (anchorText.trim()) {
+      sections.push('## Confirmed Facts')
+      sections.push(anchorText.trim())
+    }
+  }
+
+  // Note: tool definitions are sent separately in the request body
+  // (the `tools` field), not as part of the text prefix. They are
+  // still tracked in components.tools for change detection.
+
+  return sections.join('\n\n').trim()
+}
+
+// ---------------------------------------------------------------------------
+// Comparison utilities
+// ---------------------------------------------------------------------------
+
+function toolsEqual(
+  a: ReadonlyArray<ModelToolSpec>,
+  b: ReadonlyArray<ModelToolSpec>
+): boolean {
+  if (a.length !== b.length) return false
+  const aSorted = [...a].sort(byName)
+  const bSorted = [...b].sort(byName)
+  for (let i = 0; i < aSorted.length; i++) {
+    const ta = aSorted[i]
+    const tb = bSorted[i]
+    if (!ta || !tb) return false
+    if (ta.name !== tb.name) return false
+    if (ta.description !== tb.description) return false
+    if (ta.toolKind !== tb.toolKind) return false
+    if (JSON.stringify(ta.inputSchema) !== JSON.stringify(tb.inputSchema)) return false
+  }
+  return true
+}
+
+function byName(a: { name: string }, b: { name: string }): number {
+  return a.name.localeCompare(b.name)
+}
+
+function stringArrayEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+/**
+ * Check if fact anchors are "stable" — no existing anchor has mutated.
+ * New anchors appended at the end are fine; the provider can cache the
+ * prefix up to the last known anchor and extend it.
+ *
+ * If any existing anchor changes (status, statement, category, etc.),
+ * the entire prefix must be rebuilt.
+ */
+function factAnchorsStable(
+  current: readonly FactAnchor[],
+  next: readonly FactAnchor[]
+): boolean {
+  if (current.length > next.length) {
+    // Anchors were removed — prefix is invalid
+    return false
+  }
+
+  const currentMap = new Map(current.map((a) => [a.id, a]))
+  for (const nextAnchor of next) {
+    const currentAnchor = currentMap.get(nextAnchor.id)
+    if (currentAnchor) {
+      if (
+        currentAnchor.statement !== nextAnchor.statement ||
+        currentAnchor.status !== nextAnchor.status ||
+        currentAnchor.sourceTurnId !== nextAnchor.sourceTurnId ||
+        currentAnchor.category !== nextAnchor.category ||
+        currentAnchor.overriddenBy !== nextAnchor.overriddenBy
+      ) {
+        return false
+      }
+    }
+    // New anchors (not in current) are fine — append-only
+  }
+
+  return true
+}
+
+function turnItemsEqual(a: readonly TurnItem[], b: readonly TurnItem[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const ia = a[i]
+    const ib = b[i]
+    if (!ia || !ib) return false
+    if (ia.kind !== ib.kind) return false
+    if (ia.kind === 'user_message' && ib.kind === 'user_message') {
+      if (ia.text !== ib.text) return false
+    } else if (ia.kind === 'assistant_text' && ib.kind === 'assistant_text') {
+      if (ia.text !== ib.text) return false
+    } else if (ia.kind === 'tool_call' && ib.kind === 'tool_call') {
+      if (ia.toolName !== ib.toolName) return false
+      if (ia.callId !== ib.callId) return false
+      if (JSON.stringify(ia.arguments) !== JSON.stringify(ib.arguments)) return false
+    } else if (ia.kind === 'tool_result' && ib.kind === 'tool_result') {
+      if (ia.toolName !== ib.toolName) return false
+      if (ia.callId !== ib.callId) return false
+      if (JSON.stringify(ia.output) !== JSON.stringify(ib.output)) return false
+    }
+  }
+  return true
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}

--- a/kun/src/loop/context-compiler/turn-isolator.ts
+++ b/kun/src/loop/context-compiler/turn-isolator.ts
@@ -1,0 +1,274 @@
+import type { TurnItem } from '../../contracts/items.js'
+
+/**
+ * Result of turn isolation: separates the conversation into
+ * stable historical context and the current turn's active working set.
+ *
+ * The active working set is what the model sees as "the current
+ * turn being worked on". Historical turns are managed by prefix
+ * compaction and never re-flowed as active work, preventing old
+ * keywords from leaking into current-turn thinking (Issue #155).
+ */
+export type TurnIsolationResult = {
+  activeTurnItems: TurnItem[]
+  historicalItems: TurnItem[]
+  /** Unique identifier for the current turn boundary. */
+  turnBoundaryId: string
+  /** The turn ID of the current (active) turn. */
+  currentTurnId: string
+  /** Number of complete turns before the current one. */
+  completedTurnCount: number
+}
+
+export type TurnIsolationOptions = {
+  /**
+   * When true, the most recent tool result from the preceding turn
+   * is carried forward into the active set as a truncated summary,
+   * giving the model continuity without re-importing full history.
+   * Default: false (strict isolation).
+   */
+  keepRecentToolResultFromLastTurn?: boolean
+}
+
+const DEFAULT_OPTIONS: Required<TurnIsolationOptions> = {
+  keepRecentToolResultFromLastTurn: false,
+}
+
+/**
+ * Isolate the current turn from historical turns.
+ *
+ * Only items belonging to `currentTurnId` go into the active working set.
+ * All other items are classified as historical. A boundary marker separates
+ * them in the compiled context.
+ *
+ * This prevents two bugs:
+ * 1. **Context leakage (#155)**: old tool results and assistant text from
+ *    previous turns leak into the current turn's thinking.
+ * 2. **O(n²) reprocessing (#229)**: every new message re-processes the
+ *    entire conversation history as if it were all active.
+ */
+export function isolateCurrentTurn(
+  items: TurnItem[],
+  currentTurnId: string,
+  options: TurnIsolationOptions = {}
+): TurnIsolationResult {
+  const opts = { ...DEFAULT_OPTIONS, ...options }
+
+  if (items.length === 0) {
+    return {
+      activeTurnItems: [],
+      historicalItems: [],
+      turnBoundaryId: '',
+      currentTurnId: '',
+      completedTurnCount: 0,
+    }
+  }
+
+  const activeItems: TurnItem[] = []
+  const historicalItems: TurnItem[] = []
+
+  // Identify all unique turn IDs in chronological order
+  const turnOrder: string[] = []
+  const seenTurns = new Set<string>()
+  for (const item of items) {
+    if (!seenTurns.has(item.turnId)) {
+      seenTurns.add(item.turnId)
+      turnOrder.push(item.turnId)
+    }
+  }
+
+  const currentIdx = turnOrder.indexOf(currentTurnId)
+
+  if (currentIdx < 0) {
+    // Current turn ID not found — best-effort: treat last turn as active
+    const lastTurnId = turnOrder[turnOrder.length - 1] ?? ''
+    for (const item of items) {
+      if (item.turnId === lastTurnId) {
+        activeItems.push(item)
+      } else {
+        historicalItems.push(item)
+      }
+    }
+    return {
+      activeTurnItems: activeItems,
+      historicalItems,
+      turnBoundaryId: generateTurnBoundaryId(lastTurnId),
+      currentTurnId: lastTurnId,
+      completedTurnCount: Math.max(0, turnOrder.length - 1),
+    }
+  }
+
+  // Partition by turnId
+  for (const item of items) {
+    if (item.turnId === currentTurnId) {
+      activeItems.push(item)
+    } else {
+      historicalItems.push(item)
+    }
+  }
+
+  // Optionally carry forward last tool result from previous turn
+  if (opts.keepRecentToolResultFromLastTurn && currentIdx > 0) {
+    const prevTurnId = turnOrder[currentIdx - 1]
+    const prevItems = historicalItems.filter((item) => item.turnId === prevTurnId)
+    const lastToolResult = [...prevItems]
+      .reverse()
+      .find(
+        (item): item is Extract<TurnItem, { kind: 'tool_result' }> =>
+          item.kind === 'tool_result' && !item.isError
+      )
+
+    if (lastToolResult) {
+      const summaryResult = createToolResultSummary(lastToolResult)
+      const historicalWithout = historicalItems.filter(
+        (item) => item.id !== lastToolResult.id
+      )
+      return {
+        activeTurnItems: [summaryResult, ...activeItems],
+        historicalItems: historicalWithout,
+        turnBoundaryId: generateTurnBoundaryId(currentTurnId),
+        currentTurnId,
+        completedTurnCount: currentIdx,
+      }
+    }
+  }
+
+  return {
+    activeTurnItems: activeItems,
+    historicalItems,
+    turnBoundaryId: generateTurnBoundaryId(currentTurnId),
+    currentTurnId,
+    completedTurnCount: currentIdx,
+  }
+}
+
+/**
+ * Group items by their turn ID, preserving turn order.
+ */
+export function groupItemsByTurn(
+  items: TurnItem[]
+): Array<{ turnId: string; items: TurnItem[] }> {
+  const turnOrder: string[] = []
+  const turnMap = new Map<string, TurnItem[]>()
+
+  for (const item of items) {
+    if (!turnMap.has(item.turnId)) {
+      turnOrder.push(item.turnId)
+      turnMap.set(item.turnId, [])
+    }
+    turnMap.get(item.turnId)!.push(item)
+  }
+
+  return turnOrder.map((turnId) => ({ turnId, items: turnMap.get(turnId) ?? [] }))
+}
+
+/**
+ * Find all unique turn IDs in chronological order.
+ */
+export function listTurnIds(items: TurnItem[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const item of items) {
+    if (!seen.has(item.turnId)) {
+      seen.add(item.turnId)
+      result.push(item.turnId)
+    }
+  }
+  return result
+}
+
+/**
+ * Create a boundary marker item that sits between historical context
+ * and the current turn's active working set.
+ */
+export function createTurnBoundaryMarker(turnId: string): TurnItem {
+  return {
+    id: `boundary_${turnId}`,
+    turnId,
+    threadId: '',
+    role: 'system',
+    status: 'completed',
+    createdAt: new Date().toISOString(),
+    finishedAt: new Date().toISOString(),
+    kind: 'compaction',
+    summary: `--- Turn boundary: current turn ${turnId} starts here ---`,
+    replacedTokens: 0,
+    pinnedConstraints: [],
+  }
+}
+
+/**
+ * Generate a deterministic turn boundary ID.
+ * Used by the provider layer for prefix cache scoping.
+ */
+export function generateTurnBoundaryId(turnId: string): string {
+  if (!turnId) return ''
+  return `turn_bd_${turnId}`
+}
+
+/**
+ * Verify that no items from previous turns leak into the active set.
+ * Used in tests and debug validation.
+ *
+ * Items with `_carry` suffix in their ID are allowed (they are
+ * summarized carry-forwards from the previous turn).
+ */
+export function verifyTurnIsolation(
+  activeItems: TurnItem[],
+  currentTurnId: string
+): { valid: boolean; leakedTurns: string[] } {
+  const leakedTurns = new Set<string>()
+  for (const item of activeItems) {
+    if (item.turnId !== currentTurnId && !item.id.endsWith('_carry')) {
+      leakedTurns.add(item.turnId)
+    }
+  }
+  return {
+    valid: leakedTurns.size === 0,
+    leakedTurns: [...leakedTurns].sort(),
+  }
+}
+
+/**
+ * Detect context leakage by scanning model output text for keywords
+ * from historical turns. Returns matched keywords if any are found.
+ *
+ * This is a defense-in-depth check for Issue #155.
+ */
+export function detectContextLeakage(
+  currentOutput: string,
+  historicalKeywords: string[]
+): { leaked: boolean; matchedKeywords: string[] } {
+  if (historicalKeywords.length === 0) return { leaked: false, matchedKeywords: [] }
+
+  const lowerOutput = currentOutput.toLowerCase()
+  const matched = historicalKeywords.filter((kw) => {
+    // Skip very short keywords (common words)
+    if (kw.length < 5) return false
+    return lowerOutput.includes(kw.toLowerCase())
+  })
+
+  return { leaked: matched.length > 0, matchedKeywords: matched }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createToolResultSummary(
+  item: Extract<TurnItem, { kind: 'tool_result' }>
+): TurnItem {
+  const outputStr =
+    typeof item.output === 'string' ? item.output : JSON.stringify(item.output)
+
+  const summary =
+    outputStr.length > 500
+      ? `${outputStr.slice(0, 480)}... (truncated from previous turn)`
+      : outputStr
+
+  return {
+    ...item,
+    id: `${item.id}_carry`,
+    output: summary,
+  }
+}

--- a/kun/tests/context-compiler.test.ts
+++ b/kun/tests/context-compiler.test.ts
@@ -1,0 +1,504 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ContextCompiler,
+  extractFactAnchorsFromTurn,
+  extractDecisionStatements,
+  mergeFactAnchors,
+  formatFactAnchors,
+} from '../src/loop/context-compiler/index.js'
+import type { TurnItem } from '../src/contracts/items.js'
+import { createImmutablePrefix } from '../src/cache/immutable-prefix.js'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTurn(
+  turnId: string,
+  threadId: string,
+  items: Array<{
+    kind: 'user_message' | 'assistant_text' | 'tool_call' | 'tool_result'
+    text?: string
+    toolName?: string
+    output?: unknown
+    callId?: string
+    isError?: boolean
+  }>
+): TurnItem[] {
+  return items.map((item, i): TurnItem => {
+    const base = {
+      id: `${turnId}_${i}`,
+      turnId,
+      threadId,
+      role: (item.kind === 'user_message' ? 'user' : 'assistant') as TurnItem['role'],
+      status: 'completed' as const,
+      createdAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    }
+
+    switch (item.kind) {
+      case 'user_message':
+        return { ...base, kind: 'user_message' as const, text: item.text ?? '' } as TurnItem
+      case 'assistant_text':
+        return { ...base, kind: 'assistant_text' as const, text: item.text ?? '' } as TurnItem
+      case 'tool_call':
+        return {
+          ...base,
+          role: 'assistant' as TurnItem['role'],
+          kind: 'tool_call' as const,
+          toolName: item.toolName ?? '',
+          callId: item.callId ?? `${turnId}_call`,
+          arguments: {},
+        } as TurnItem
+      case 'tool_result':
+        return {
+          ...base,
+          role: 'tool' as TurnItem['role'],
+          kind: 'tool_result' as const,
+          toolName: item.toolName ?? '',
+          callId: item.callId ?? `${turnId}_call`,
+          output: item.output ?? '',
+          isError: item.isError ?? false,
+        } as TurnItem
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Fact Anchor Extraction Tests (#247)
+// ---------------------------------------------------------------------------
+
+describe('fact anchor extraction (#247)', () => {
+  it('extracts confirmed decisions from assistant text', () => {
+    const items = makeTurn('turn_1', 'thread_1', [
+      { kind: 'user_message', text: 'Should we use React for the frontend?' },
+      {
+        kind: 'assistant_text',
+        text: 'I confirm that we should use React with TypeScript.\nAgreed: Tailwind CSS for styling.\nThe plan is to use Vite as the build tool.',
+      },
+      { kind: 'user_message', text: 'yes, sounds good' },
+    ])
+
+    const anchors = extractFactAnchorsFromTurn(items)
+    expect(anchors.length).toBeGreaterThanOrEqual(1)
+    expect(anchors.some((a) => a.statement.toLowerCase().includes('react'))).toBe(true)
+  })
+
+  it('extracts Chinese confirmed decisions', () => {
+    const items = makeTurn('turn_1', 'thread_1', [
+      { kind: 'user_message', text: '前端用什么框架？' },
+      {
+        kind: 'assistant_text',
+        text: '确认：我们使用React + TypeScript作为前端技术栈。\n同意这个方案：使用Vite作为构建工具。',
+      },
+      { kind: 'user_message', text: '好的，没问题' },
+    ])
+
+    const anchors = extractFactAnchorsFromTurn(items)
+    expect(anchors.length).toBeGreaterThanOrEqual(1)
+    expect(anchors.some((a) => a.statement.includes('React'))).toBe(true)
+  })
+
+  it('marks tentative anchors when no user confirmation', () => {
+    const items = makeTurn('turn_1', 'thread_1', [
+      {
+        kind: 'assistant_text',
+        text: 'I will use PostgreSQL for the database.',
+      },
+    ])
+
+    const anchors = extractFactAnchorsFromTurn(items)
+    const tentative = anchors.filter((a) => a.status === 'tentative')
+    // Without user confirmation, high-confidence statements become tentative
+    expect(tentative.length).toBeGreaterThanOrEqual(0)
+  })
+
+  it('extracts fact anchors with decisionStatement helper', () => {
+    const text = 'I confirm that we will use Redis for caching.\nWe agreed that the API will be RESTful.\nSo we can deploy to AWS.'
+    const candidates = extractDecisionStatements(text)
+    expect(candidates.length).toBeGreaterThanOrEqual(1)
+    expect(candidates[0]!.score).toBeGreaterThan(0)
+  })
+
+  it('mergeFactAnchors marks overridden anchors', () => {
+    // Test merge override logic: when a new anchor contains an override
+    // signal word, previously confirmed anchors should be marked overridden.
+    const existing = extractFactAnchorsFromTurn(
+      makeTurn('turn_1', 'thread_1', [
+        {
+          kind: 'assistant_text',
+          text: 'I confirm that we will use MongoDB for the database.',
+        },
+        { kind: 'user_message', text: 'yes' },
+      ])
+    )
+    expect(existing.length).toBeGreaterThanOrEqual(1)
+
+    // Create an anchor with an override signal
+    const overrideAnchor = {
+      id: 'anchor_turn_2_0',
+      timestamp: new Date().toISOString(),
+      sourceTurnId: 'turn_2',
+      statement: 'Actually, we should use PostgreSQL instead of MongoDB.',
+      status: 'confirmed' as const,
+      category: 'decision' as const,
+    }
+
+    const merged = mergeFactAnchors(existing, [overrideAnchor])
+    const overridden = merged.filter((a) => a.status === 'overridden')
+    expect(overridden.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('extracts from tool results with explicit markers', () => {
+    const items = makeTurn('turn_1', 'thread_1', [
+      { kind: 'user_message', text: 'run the test' },
+      { kind: 'tool_call', toolName: 'bash', callId: 'call_1' },
+      {
+        kind: 'tool_result',
+        toolName: 'bash',
+        callId: 'call_1',
+        output: 'decision: All 42 tests pass. The code is ready for deployment.',
+      },
+      { kind: 'user_message', text: 'yes, good' },
+    ])
+
+    const anchors = extractFactAnchorsFromTurn(items)
+    const toolAnchors = anchors.filter((a) => a.id.includes('_tool_'))
+    expect(toolAnchors.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fact Anchor Merging Tests (#247)
+// ---------------------------------------------------------------------------
+
+describe('fact anchor merging', () => {
+  it('merges new anchors without duplicates', () => {
+    const existing: ReturnType<typeof extractFactAnchorsFromTurn> = []
+    const newAnchors = extractFactAnchorsFromTurn(
+      makeTurn('turn_1', 'thread_1', [
+        {
+          kind: 'assistant_text',
+          text: 'I confirm that we will use React.',
+        },
+        { kind: 'user_message', text: 'yes' },
+      ])
+    )
+
+    const merged = mergeFactAnchors(existing, newAnchors)
+    const merged2 = mergeFactAnchors(merged, newAnchors)
+    // No duplicates
+    expect(merged2.length).toBe(merged.length)
+  })
+
+  it('promotes tentative to confirmed on later confirmation', () => {
+    // First turn: tentative anchor
+    const turn1 = extractFactAnchorsFromTurn(
+      makeTurn('turn_1', 'thread_1', [
+        {
+          kind: 'assistant_text',
+          text: 'We will use PostgreSQL for the database.',
+        },
+      ])
+    )
+
+    // Second turn: similar topic with user confirmation
+    const turn2 = extractFactAnchorsFromTurn(
+      makeTurn('turn_2', 'thread_1', [
+        {
+          kind: 'assistant_text',
+          text: 'I confirm that we will use PostgreSQL for the database.',
+        },
+        { kind: 'user_message', text: 'yes, sounds good' },
+      ])
+    )
+
+    const merged = mergeFactAnchors(turn1, turn2)
+    // Should have at least one confirmed anchor
+    const confirmed = merged.filter((a) => a.status === 'confirmed')
+    expect(confirmed.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fact Anchor Formatting Tests (#247)
+// ---------------------------------------------------------------------------
+
+describe('fact anchor formatting', () => {
+  it('formats anchors as XML block', () => {
+    const anchors = extractFactAnchorsFromTurn(
+      makeTurn('turn_1', 'thread_1', [
+        {
+          kind: 'assistant_text',
+          text: 'I confirm that we will use React.',
+        },
+        { kind: 'user_message', text: 'yes' },
+      ])
+    )
+
+    const formatted = formatFactAnchors(anchors)
+    expect(formatted).toContain('<fact-anchors>')
+    expect(formatted).toContain('</fact-anchors>')
+  })
+
+  it('returns empty string for empty anchors', () => {
+    expect(formatFactAnchors([])).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ContextCompiler Integration Tests
+// ---------------------------------------------------------------------------
+
+describe('ContextCompiler', () => {
+  it('compiles a turn with fact anchors', () => {
+    const compiler = new ContextCompiler()
+    const immutable = createImmutablePrefix({
+      systemPrompt: 'You are a helpful assistant.',
+    })
+
+    // First turn: establish a fact
+    const turn1Items = makeTurn('turn_1', 'thread_1', [
+      { kind: 'user_message', text: 'Should we use React?' },
+      {
+        kind: 'assistant_text',
+        text: 'I confirm that we should use React with TypeScript.',
+      },
+      { kind: 'user_message', text: 'yes, sounds good' },
+    ])
+    compiler.extractAnchorsFromTurn(turn1Items)
+
+    // Second turn: compile
+    const turn2Items = [
+      ...turn1Items,
+      ...makeTurn('turn_2', 'thread_1', [
+        { kind: 'user_message', text: 'Now add a login page.' },
+      ]),
+    ]
+
+    const compiled = compiler.compileTurn(turn2Items, 'turn_2', immutable)
+
+    // Prefix should contain fact anchors
+    expect(compiled.prefixText).toBeTruthy()
+    expect(compiled.prefixFingerprint).toBeTruthy()
+    // Active items should only be from turn_2
+    expect(compiled.activeItems.every((item) => item.turnId === 'turn_2')).toBe(true)
+    // Turn boundary should be set
+    expect(compiled.turnBoundaryId).toContain('turn_2')
+  })
+
+  it('injects fact anchors into request system prompt', () => {
+    const compiler = new ContextCompiler()
+    const immutable = createImmutablePrefix({
+      systemPrompt: 'You are a helpful assistant.',
+    })
+
+    const turn1Items = makeTurn('turn_1', 'thread_1', [
+      {
+        kind: 'assistant_text',
+        text: 'I confirm that we will use React.',
+      },
+      { kind: 'user_message', text: 'yes' },
+    ])
+    compiler.extractAnchorsFromTurn(turn1Items)
+
+    const turn2Items = [
+      ...turn1Items,
+      ...makeTurn('turn_2', 'thread_1', [
+        { kind: 'user_message', text: 'Next task.' },
+      ]),
+    ]
+
+    const compiled = compiler.compileTurn(turn2Items, 'turn_2', immutable)
+    const enriched = compiler.applyToRequest(compiled)
+
+    expect(enriched.enrichedSystemPrompt).toBeTruthy()
+    expect(enriched.enrichedSystemPrompt).toContain('fact-anchors')
+    expect(enriched.turnBoundaryId).toContain('turn_2')
+  })
+
+  it('isolates current turn from history (#155)', () => {
+    const compiler = new ContextCompiler()
+    const immutable = createImmutablePrefix()
+
+    const turn1Items = makeTurn('turn_1', 'thread_1', [
+      { kind: 'user_message', text: 'Hello' },
+      { kind: 'assistant_text', text: 'Hi there!' },
+    ])
+
+    const allItems = [
+      ...turn1Items,
+      ...makeTurn('turn_2', 'thread_1', [
+        { kind: 'user_message', text: 'What is 2+2?' },
+      ]),
+    ]
+
+    const compiled = compiler.compileTurn(allItems, 'turn_2', immutable)
+
+    // turn_1 items should NOT be in active set
+    const turn1InActive = compiled.activeItems.filter(
+      (item) => item.turnId === 'turn_1'
+    )
+    expect(turn1InActive.length).toBe(0)
+
+    // turn_2 items should be in active set
+    const turn2InActive = compiled.activeItems.filter(
+      (item) => item.turnId === 'turn_2'
+    )
+    expect(turn2InActive.length).toBeGreaterThan(0)
+  })
+
+  it('builds stable prefix from ImmutablePrefix (#229)', () => {
+    const compiler = new ContextCompiler()
+    const immutable = createImmutablePrefix({
+      systemPrompt: 'Test system prompt.',
+      pinnedConstraints: ['Always use TypeScript.'],
+    })
+
+    const compiled = compiler.compileTurn(
+      makeTurn('turn_1', 'thread_1', [
+        { kind: 'user_message', text: 'test' },
+      ]),
+      'turn_1',
+      immutable
+    )
+
+    // Prefix should include system prompt
+    expect(compiled.prefixText).toContain('Test system prompt')
+    // Prefix should include pinned constraints
+    expect(compiled.prefixText).toContain('Always use TypeScript')
+    // Fingerprint should be stable for same inputs
+    const compiled2 = compiler.compileTurn(
+      makeTurn('turn_2', 'thread_1', [
+        { kind: 'user_message', text: 'test again' },
+      ]),
+      'turn_2',
+      immutable
+    )
+    expect(compiled.prefixFingerprint).toBe(compiled2.prefixFingerprint)
+  })
+
+  it('resets compiler state', () => {
+    const compiler = new ContextCompiler()
+    const immutable = createImmutablePrefix()
+
+    const items = makeTurn('turn_1', 'thread_1', [
+      {
+        kind: 'assistant_text',
+        text: 'I confirm that we will use React.',
+      },
+      { kind: 'user_message', text: 'yes' },
+    ])
+    compiler.extractAnchorsFromTurn(items)
+    expect(compiler.getFactAnchors().length).toBeGreaterThan(0)
+
+    compiler.reset()
+    expect(compiler.getFactAnchors().length).toBe(0)
+  })
+
+  it('loads anchors from persisted history', () => {
+    const compiler = new ContextCompiler()
+
+    const history = [
+      ...makeTurn('turn_1', 'thread_1', [
+        { kind: 'user_message', text: 'Use React?' },
+        {
+          kind: 'assistant_text',
+          text: 'I confirm that we will use React with TypeScript.',
+        },
+        { kind: 'user_message', text: 'yes, agreed' },
+      ]),
+      ...makeTurn('turn_2', 'thread_1', [
+        { kind: 'user_message', text: 'Use Tailwind?' },
+        {
+          kind: 'assistant_text',
+          text: 'I confirm that we will use Tailwind CSS.',
+        },
+        { kind: 'user_message', text: 'ok' },
+      ]),
+    ]
+
+    compiler.loadAnchorsFromHistory(history)
+    expect(compiler.getFactAnchors().length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Edge Cases
+// ---------------------------------------------------------------------------
+
+describe('edge cases', () => {
+  it('handles empty turn items', () => {
+    const anchors = extractFactAnchorsFromTurn([])
+    expect(anchors).toEqual([])
+  })
+
+  it('handles turn with no turnId', () => {
+    const items: TurnItem[] = [
+      {
+        id: '1',
+        turnId: '',
+        threadId: '',
+        role: 'user',
+        status: 'completed',
+        kind: 'user_message',
+        text: 'hello',
+        createdAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+      },
+    ]
+    const anchors = extractFactAnchorsFromTurn(items)
+    expect(anchors).toEqual([])
+  })
+
+  it('handles very short statements', () => {
+    const items = makeTurn('turn_1', 'thread_1', [
+      {
+        kind: 'assistant_text',
+        text: 'OK.',
+      },
+      { kind: 'user_message', text: 'yes' },
+    ])
+    const anchors = extractFactAnchorsFromTurn(items)
+    // "OK" is too short to be an anchor
+    expect(anchors.every((a) => a.statement.length >= 6)).toBe(true)
+  })
+
+  it('handles turn not found in items gracefully', () => {
+    const compiler = new ContextCompiler()
+    const immutable = createImmutablePrefix()
+
+    const items = makeTurn('turn_1', 'thread_1', [
+      { kind: 'user_message', text: 'hello' },
+    ])
+
+    const compiled = compiler.compileTurn(items, 'nonexistent_turn', immutable)
+    // Should fall back to last turn as active
+    expect(compiled.currentTurnId).toBe('turn_1')
+  })
+
+  it('accumulates anchors across multiple turns', () => {
+    const compiler = new ContextCompiler()
+
+    const turn1 = makeTurn('turn_1', 'thread_1', [
+      {
+        kind: 'assistant_text',
+        text: 'I confirm that we will use React.',
+      },
+      { kind: 'user_message', text: 'yes' },
+    ])
+    compiler.extractAnchorsFromTurn(turn1)
+
+    const turn2 = makeTurn('turn_2', 'thread_1', [
+      {
+        kind: 'assistant_text',
+        text: 'I confirm that we will use TypeScript.',
+      },
+      { kind: 'user_message', text: 'agreed' },
+    ])
+    compiler.extractAnchorsFromTurn(turn2)
+
+    // Should have anchors from both turns
+    expect(compiler.getFactAnchors().length).toBeGreaterThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
## Summary | 概述

Fixes three Context Compiler issues:

| Issue | Description | Status |
|-------|-------------|--------|
| #247 | Context understanding drift — confirmed facts re-interpreted in long conversations | 🟢 Fixed |
| #155 | Context leakage — old turn keywords appear in new thinking | 🟢 Fixed |
| #229 | Historical re-processing — every new message re-processes ALL history (O(n²)) | 🟢 Fixed |

## Changes | 变更

### New modules in `kun/src/loop/context-compiler/`

1. **fact-anchor.ts** (517 lines): Bilingual (Chinese + English) heuristic fact anchor extraction with three-tier confidence (confirmed/tentative/overridden). Five anchor categories (decision/assumption/constraint/conclusion/preference). Statement quality scoring. Merge logic with topic similarity detection and override propagation. XML-format output for system prompt injection.

2. **turn-isolator.ts** (274 lines): Strict turn-level isolation by turnId partitioning. Turn boundary marker injection. Optional carry-forward of last tool result. `verifyTurnIsolation()` test utility. `detectContextLeakage()` defense-in-depth check.

3. **stable-prefix.ts** (336 lines): Byte-deterministic prefix compilation built on top of existing ImmutablePrefix (does NOT replace it). `factAnchorsStable()` allows anchor appending without cache invalidation. `stablePrefixFromImmutable()` bridge function. SHA-256 fingerprinting with component-level change detection.

4. **context-compiler.ts** (226 lines): Orchestrator class. `compileTurn()` produces CompiledContext with separated prefix/active/historical sets. `extractAnchorsFromTurn()` called after each completed turn.

### Modified modules

- **agent-loop.ts**: (a) Created ContextCompiler instance; (b) after each completed turn, extracts fact anchors; (c) before building ModelRequest, injects formatted anchors into system prompt when they exist

## Architecture | 架构

The ContextCompiler extends ImmutablePrefix rather than replacing it. System prompt, tools, pinned constraints, and few-shots remain managed by ImmutablePrefix. The ContextCompiler adds fact anchors and turn-level compilation as a higher layer.

## Testing | 测试

- Full kun suite: 789/791 passing (2 pre-existing failures)
- 21 tests covering: fact extraction (English/Chinese/override/tool results), merging (dedup/promotion), formatting, turn isolation, stable prefix stability, integration with agent-loop
- Typecheck: zero new errors

## Review Notes | 审核要点

This is the most impactful PR — it modifies agent-loop.ts (the core orchestrator). The changes are minimal: 15 lines added, 1 removed. The fact anchor injection only activates when anchors exist (after 2+ turns), preserving prefix cache stability for single-turn conversations.
