### PR TITLE
fix(skills): honor disabled skill sources in runtime

### DIFF
--- a/kun/src/contracts/capabilities.ts
+++ b/kun/src/contracts/capabilities.ts
@@ -182,6 +182,7 @@ export type WebCapabilityConfig = z.infer<typeof WebCapabilityConfig>
 
 export const SkillsCapabilityConfig = CapabilityToggleConfig.extend({
   roots: z.array(z.string().min(1)).default([]),
+  disabledIds: z.array(z.string().min(1)).default([]),
   legacySkillMd: z.boolean().default(true)
 }).strict()
 export type SkillsCapabilityConfig = z.infer<typeof SkillsCapabilityConfig>

--- a/kun/src/skills/skill-runtime.test.ts
+++ b/kun/src/skills/skill-runtime.test.ts
@@ -1,0 +1,58 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SkillRuntime } from './skill-runtime.js'
+
+describe('SkillRuntime', () => {
+  let tempRoot = ''
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), 'kun-skill-runtime-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true })
+  })
+
+  it('excludes disabled skill ids from catalog, diagnostics, matching, and load_skill', async () => {
+    const root = join(tempRoot, 'skills')
+    await writeSkill(root, 'gmail', 'Gmail')
+    await writeSkill(root, 'vercel-agent', 'Vercel Agent')
+
+    const runtime = await SkillRuntime.create({
+      enabled: true,
+      roots: [root],
+      disabledIds: ['gmail'],
+      legacySkillMd: true
+    })
+
+    const diagnostics = runtime.diagnostics()
+    expect(diagnostics.skills.map((skill) => skill.id)).toEqual(['vercel-agent'])
+    expect(runtime.catalogInstruction()).toContain('vercel-agent')
+    expect(runtime.catalogInstruction()).not.toContain('gmail')
+    expect(runtime.resolveTurn({ prompt: 'use /skill:gmail', workspace: tempRoot }).activeSkillIds)
+      .toEqual([])
+    expect(runtime.loadSkillById('gmail')).toMatchObject({
+      error: expect.stringContaining('unknown skill id')
+    })
+    expect(runtime.loadSkillById('vercel-agent')).toMatchObject({
+      skillId: 'vercel-agent',
+      name: 'Vercel Agent'
+    })
+  })
+})
+
+async function writeSkill(root: string, id: string, name: string): Promise<void> {
+  const skillRoot = join(root, id)
+  await mkdir(skillRoot, { recursive: true })
+  await writeFile(join(skillRoot, 'SKILL.md'), [
+    '---',
+    `id: ${id}`,
+    `name: ${name}`,
+    'description: Test skill.',
+    '---',
+    '',
+    'Follow the test instructions.'
+  ].join('\n'), 'utf8')
+}

--- a/kun/src/skills/skill-runtime.ts
+++ b/kun/src/skills/skill-runtime.ts
@@ -105,7 +105,7 @@ export class SkillRuntime {
     config: SkillsCapabilityConfig | undefined,
     options: SkillRuntimeOptions = {}
   ): Promise<SkillRuntime> {
-    const normalized = config ?? { enabled: false, roots: [], legacySkillMd: true }
+    const normalized = config ?? { enabled: false, roots: [], disabledIds: [], legacySkillMd: true }
     const resolvedOptions = {
       activeLimit: options.activeLimit ?? DEFAULT_ACTIVE_LIMIT,
       instructionBudgetBytes: options.instructionBudgetBytes ?? DEFAULT_INSTRUCTION_BUDGET_BYTES,
@@ -324,7 +324,9 @@ async function discoverSkills(config: SkillsCapabilityConfig): Promise<{
     if (!unique.has(skill.id)) unique.set(skill.id, skill)
     else validationErrors.push({ root: skill.root, message: `duplicate Skill id: ${skill.id}` })
   }
-  return { skills: [...unique.values()].sort((a, b) => a.id.localeCompare(b.id)), validationErrors }
+  const disabled = new Set(config.disabledIds.map((id) => slug(id)))
+  const enabledSkills = [...unique.values()].filter((skill) => !disabled.has(skill.id))
+  return { skills: enabledSkills.sort((a, b) => a.id.localeCompare(b.id)), validationErrors }
 }
 
 async function packageCandidates(root: string): Promise<string[]> {

--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -814,6 +814,38 @@ describe('syncGuiManagedKunConfig', () => {
     ]))
   })
 
+  it('passes disabled skill ids and drops stale Codex plugin cache roots from runtime capabilities', async () => {
+    if (!tempRoot) throw new Error('temp root not initialized')
+    const configPath = join(tempRoot, 'config.json')
+    const stalePluginRoot = join(homedir(), '.codex', 'plugins', 'cache', 'github', '0.1.0', 'skills')
+    const manualRoot = join(tempRoot, 'manual-skills')
+    writeFileSync(configPath, JSON.stringify({
+      capabilities: {
+        skills: {
+          enabled: true,
+          roots: [stalePluginRoot, manualRoot],
+          disabledIds: ['old-disabled'],
+          legacySkillMd: true
+        }
+      }
+    }), 'utf8')
+    const module = await import('./kun-process')
+    const settings = createSettings('/tmp/fake-kun-child.js')
+    settings.disabledSkillIds = ['gmail', '/skill:vercel-agent', '']
+
+    await module.syncGuiManagedKunConfig(tempRoot, defaultKunRuntimeSettings(), {
+      scheduleMcp: {
+        settings,
+        launch: { appPath: '/tmp/deepseek-gui-test-app', execPath: '/tmp/electron', isPackaged: false }
+      }
+    })
+
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as any
+    expect(parsed.capabilities.skills.roots).toContain(manualRoot)
+    expect(parsed.capabilities.skills.roots).not.toContain(stalePluginRoot)
+    expect(parsed.capabilities.skills.disabledIds).toEqual(['gmail', 'vercel-agent'])
+  })
+
   it('re-enables skills when roots are discovered despite a persisted enabled:false', async () => {
     if (!tempRoot) throw new Error('temp root not initialized')
     const configPath = join(tempRoot, 'config.json')

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -59,6 +59,7 @@ import {
   comparableSkillRootPath,
   guiSkillManagedComparablePaths,
   guiSkillRootsForRuntime,
+  isCodexPluginCacheSkillRoot,
   normalizeSkillRootPath
 } from './services/skill-service'
 
@@ -599,11 +600,16 @@ async function skillCapabilityConfigForRuntime(
   const managed = guiSkillManagedComparablePaths(settings)
   const manualExisting = stringArrayValue(existing.roots)
     .map(normalizeSkillRootPath)
-    .filter((path) => path.length > 0 && !managed.has(comparableSkillRootPath(path)))
+    .filter((path) =>
+      path.length > 0 &&
+      !managed.has(comparableSkillRootPath(path)) &&
+      !isCodexPluginCacheSkillRoot(path)
+    )
   const roots = uniqueStrings([
     ...manualExisting,
     ...(await guiSkillRootsForRuntime(settings)).map((root) => root.path)
   ])
+  const disabledIds = normalizeDisabledSkillIds(settings?.disabledSkillIds)
   return {
     ...existing,
     // Auto-enable once we discover skill roots. There is no user-facing skills
@@ -612,8 +618,15 @@ async function skillCapabilityConfigForRuntime(
     // skills. An explicit `true` still forces on even with no roots.
     enabled: roots.length > 0 || existing.enabled === true,
     roots,
+    disabledIds,
     legacySkillMd: existing.legacySkillMd === false ? false : true
   }
+}
+
+function normalizeDisabledSkillIds(value: unknown): string[] {
+  return uniqueStrings(stringArrayValue(value)
+    .map((item) => item.trim().replace(/^\/?skill:/i, '').trim())
+    .filter(Boolean))
 }
 
 function stringArrayValue(value: unknown): string[] {

--- a/src/main/services/skill-service.test.ts
+++ b/src/main/services/skill-service.test.ts
@@ -210,6 +210,19 @@ describe('skill-service', () => {
       .not.toContain(comparable(pluginRoot))
   })
 
+  it('omits Codex plugin roots when global Codex skills are disabled', async () => {
+    const workspaceRoot = join(tempRoot, 'ws-plugin-global-toggle')
+    const pluginRoot = join(tempRoot, '.codex', 'plugins', 'cache', 'github', '1.0', 'skills')
+    await mkdir(join(pluginRoot, 'review'), { recursive: true })
+    await writeFile(join(pluginRoot, 'review', 'SKILL.md'), ['---', 'name: review', '---'].join('\n'), 'utf8')
+
+    const settings = createSettings(workspaceRoot)
+    settings.claw.skills.disabledDirs = ['global-codex']
+
+    expect((await guiSkillRootsForRuntime(settings, workspaceRoot)).map((root) => comparable(root.path)))
+      .not.toContain(comparable(pluginRoot))
+  })
+
   it('rejects a skill.json whose entry escapes the package directory (path traversal)', async () => {
     const workspaceRoot = join(tempRoot, 'ws-traversal')
     const skillRoot = join(workspaceRoot, '.claude', 'skills', 'evil')

--- a/src/main/services/skill-service.ts
+++ b/src/main/services/skill-service.ts
@@ -31,7 +31,7 @@ export type GuiSkillRoot = {
   scope: GuiSkillScope
 }
 
-export type GuiSkillRootSource = 'common' | 'extra'
+export type GuiSkillRootSource = 'common' | 'codex-plugin' | 'extra'
 
 export type GuiSkillRootListItem = {
   /** Stable id: a common-directory id (e.g. `global-codex`) or the path for custom dirs. */
@@ -65,8 +65,10 @@ type SkillRootCandidate = {
  * Enabled, on-disk skill roots passed to the Kun runtime. Builds the common
  * directory conventions (.agents/.claude/.codex/skills + global equivalents)
  * plus configured extra dirs, drops any the user toggled off, and appends
- * enabled Codex plugin caches. Precedence (earlier wins on duplicate skill
- * id): project commons → global commons → plugin caches → extra dirs.
+ * enabled Codex plugin caches. Disabling `global-codex` also disables the
+ * plugin cache roots because they are Codex-owned global skill sources.
+ * Precedence (earlier wins on duplicate skill id): project commons → global
+ * commons → plugin caches → extra dirs.
  */
 export async function guiSkillRootsForRuntime(
   settings: AppSettingsV1 | undefined,
@@ -84,10 +86,12 @@ export async function guiSkillRootsForRuntime(
   const projectCommon = candidates.filter((c) => c.source === 'common' && c.scope === 'project')
   const globalCommon = candidates.filter((c) => c.source === 'common' && c.scope === 'global')
   const extra = candidates.filter((c) => c.source === 'extra')
-  const pluginRoots = (await discoverCodexPluginSkillRoots())
-    .filter((root) => existsSync(root))
-    .filter((root) => !disabled.has(comparablePath(root)))
-    .map((path) => ({ path, scope: 'global' as const }))
+  const pluginRoots = isCodexPluginSkillSourceDisabled(disabled)
+    ? []
+    : (await discoverCodexPluginSkillRoots())
+        .filter((root) => existsSync(root))
+        .filter((root) => !disabled.has(comparablePath(root)))
+        .map((path) => ({ path, scope: 'global' as const }))
 
   return uniqueSkillRoots([
     ...projectCommon.map(toGuiSkillRoot),
@@ -100,8 +104,9 @@ export async function guiSkillRootsForRuntime(
 /**
  * Full list of detected common skill directories + configured extra dirs for
  * the settings UI, including ones the user disabled or that do not exist yet,
- * annotated with skill counts and enabled state. Codex plugin caches are
- * always-on and intentionally excluded from this user-toggleable list.
+ * annotated with skill counts and enabled state. Codex plugin caches follow
+ * the global Codex switch and are intentionally excluded from the list until
+ * the UI has a dedicated aggregate row for them.
  */
 export async function listGuiSkillRoots(
   settings: AppSettingsV1,
@@ -139,7 +144,8 @@ export async function listGuiSkillRoots(
  * Comparable paths of every GUI-managed candidate (common dirs + extra dirs),
  * regardless of enabled state. Lets the runtime config builder tell apart
  * roots it manages (and may need to drop when toggled off) from roots a user
- * added by hand to the Kun config file.
+ * added by hand to the Kun config file. Codex plugin cache roots are managed
+ * by prefix so deleted old plugin versions do not stick around forever.
  */
 export function guiSkillManagedComparablePaths(
   settings: AppSettingsV1 | undefined,
@@ -149,6 +155,12 @@ export function guiSkillManagedComparablePaths(
     .map((candidate) => comparablePath(candidate.path))
     .filter(Boolean)
   return new Set(paths)
+}
+
+export function isCodexPluginCacheSkillRoot(path: string): boolean {
+  const comparable = comparablePath(normalizeSkillRootPath(path))
+  const prefix = comparablePath(join(homedir(), '.codex', 'plugins', 'cache'))
+  return comparable === prefix || comparable.startsWith(`${prefix}/`)
 }
 
 function buildSkillRootCandidates(
@@ -218,6 +230,10 @@ function buildDisabledKeySet(settings: AppSettingsV1 | undefined): Set<string> {
 
 function isCandidateDisabled(candidate: SkillRootCandidate, disabled: Set<string>): boolean {
   return disabled.has(candidate.id) || disabled.has(comparablePath(candidate.path))
+}
+
+function isCodexPluginSkillSourceDisabled(disabled: Set<string>): boolean {
+  return disabled.has('global-codex')
 }
 
 function toGuiSkillRoot(candidate: SkillRootCandidate): GuiSkillRoot {


### PR DESCRIPTION
Summary
- Treat Codex plugin cache skill roots as controlled by the global Codex skill toggle.
- Pass GUI disabled skill IDs into the Kun runtime config and filter them during skill discovery.
- Drop stale Codex plugin cache roots while preserving manual runtime roots.

Changes
- Added skills.disabledIds to the runtime capability contract.
- Filtered disabled skills before diagnostics, catalog rendering, auto matching, and load_skill access.
- Added regression coverage for plugin-root disabling, stale root cleanup, config propagation, and runtime filtering.

Tests
- npm run test -- src/main/services/skill-service.test.ts kun/src/skills/skill-runtime.test.ts
- npm run test -- src/main/kun-process.test.ts -t "passes disabled skill ids"
- npm --prefix kun run test -- src/skills/skill-runtime.test.ts
- npm run typecheck
- npm run build:kun
- git diff --check

Fixes #566