### PR TITLE
feat(chat): add process tool icons

### DIFF
--- a/src/renderer/src/components/chat/message-timeline-process.tsx
+++ b/src/renderer/src/components/chat/message-timeline-process.tsx
@@ -1,7 +1,21 @@
 import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, ReactElement, RefObject } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronRight, Minimize2 } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import {
+  Brain,
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  FolderOpen,
+  ListTodo,
+  MessageSquareQuote,
+  Minimize2,
+  PencilLine,
+  Search,
+  Terminal,
+  Wrench
+} from 'lucide-react'
 import type { ChatBlock, ToolBlock } from '../../agent/types'
 import { extractUnifiedDiffText } from '../../lib/diff-stats'
 import { useDeferredRender } from '../../hooks/use-deferred-render'
@@ -176,6 +190,7 @@ export function ProcessSectionRow({
     reasoningDurationMs,
     singleReasoningSection
   })
+  const SectionIcon = processSectionIcon(section)
   const reasoningText = section.kind === 'reasoning' ? getReasoningSectionText(section) : ''
   const canToggleSection = hasDetails && !forceExpanded
   const showActiveError = active && hasError
@@ -226,6 +241,7 @@ export function ProcessSectionRow({
               <span className={`h-2 w-2 rounded-full ${processErrorDotClass(errorTone)}`} />
             </span>
           ) : null}
+          {SectionIcon ? <ProcessGlyph Icon={SectionIcon} /> : null}
           <span className={active && !hasError ? 'ds-shiny-text' : ''}>{title}</span>
           {expanded ? (
             <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-45" strokeWidth={1.8} />
@@ -244,6 +260,7 @@ export function ProcessSectionRow({
               <span className={`h-2 w-2 rounded-full ${processErrorDotClass(errorTone)}`} />
             </span>
           ) : null}
+          {SectionIcon ? <ProcessGlyph Icon={SectionIcon} /> : null}
           <span className={active && !hasError ? 'ds-shiny-text' : ''}>{title}</span>
         </div>
       )}
@@ -323,6 +340,7 @@ function ProcessStackRows({
         const open = canExpand && (forceOpen || userOpened || (defaultOpen && !userClosed))
         const rowActive = processBlockIsActive(block, processing)
         const canToggle = canExpand && !forceOpen
+        const RowIcon = processBlockIcon(block)
         const handleToggle = (): void => {
           if (!canToggle) return
           if (open) {
@@ -369,6 +387,7 @@ function ProcessStackRows({
                   : 'text-ds-faint hover:text-ds-muted'
               } ${canToggle ? 'cursor-pointer hover:bg-ds-hover/45' : 'cursor-default'}`}
             >
+              {RowIcon ? <ProcessGlyph Icon={RowIcon} /> : null}
               <span className={`min-w-0 flex-1 truncate ${rowActive && !isError ? 'ds-shiny-text' : ''}`}>
                 <ProcessSummaryText block={block} summary={summary} />
               </span>
@@ -438,6 +457,7 @@ function ProcessEntryRow({
   const rowActive = isRunningTool || isAutoOpenPending || isStreamingAssistant
   const wrapSummary = (block.kind === 'system' && !canExpand) || isAssistantProcessText
   const canToggle = canExpand && !forceOpen
+  const RowIcon = processBlockIcon(block)
   const handleToggle = (): void => {
     if (!canToggle) return
     setUserOpen(!open)
@@ -471,9 +491,7 @@ function ProcessEntryRow({
             : 'cursor-default'
         }`}
       >
-        {!rowActive && block.kind === 'compaction' ? (
-          <Minimize2 className="mt-1 h-3 w-3 shrink-0 opacity-70" strokeWidth={2} />
-        ) : null}
+        {RowIcon ? <ProcessGlyph Icon={RowIcon} className="mt-1" /> : null}
         <span
           className={`min-w-0 flex-1 ${wrapSummary ? 'whitespace-pre-wrap break-words' : 'truncate'} ${
             rowActive && !isError ? 'ds-shiny-text' : ''
@@ -523,6 +541,16 @@ function ProcessEntryRow({
       ) : null}
     </div>
   )
+}
+
+function ProcessGlyph({
+  Icon,
+  className = 'mt-0.5'
+}: {
+  Icon: LucideIcon
+  className?: string
+}): ReactElement {
+  return <Icon className={`${className} h-3.5 w-3.5 shrink-0 opacity-75`} strokeWidth={1.9} />
 }
 
 function describeProcessSection(
@@ -609,6 +637,74 @@ function summarizeExecutionSection(
 
   if (parts.length > 0) return parts.join(' · ')
   return t('processSteps', { count: blocks.length })
+}
+
+function processSectionIcon(section: ProcessSection): LucideIcon | null {
+  if (section.kind === 'reasoning') return Brain
+  if (section.kind === 'output') return MessageSquareQuote
+
+  const toolIcons = section.blocks
+    .map(processBlockIcon)
+    .filter((icon): icon is LucideIcon => icon !== null)
+  if (toolIcons.length === 0) return null
+  const [first] = toolIcons
+  return toolIcons.every((icon) => icon === first) ? first : Wrench
+}
+
+function processBlockIcon(block: ChatBlock): LucideIcon | null {
+  if (block.kind === 'reasoning') return Brain
+  if (block.kind === 'assistant') return MessageSquareQuote
+  if (block.kind === 'compaction') return Minimize2
+  if (block.kind === 'approval') return Wrench
+  if (block.kind === 'user_input') return MessageSquareQuote
+  if (block.kind !== 'tool') return null
+  return toolBlockIcon(block)
+}
+
+function toolBlockIcon(block: ToolBlock): LucideIcon {
+  const toolName = toolNameForBlock(block)
+  switch (toolName) {
+    case 'bash':
+    case 'shell':
+    case 'terminal':
+    case 'run_command':
+    case 'exec':
+      return Terminal
+    case 'read':
+    case 'read_file':
+      return BookOpen
+    case 'write':
+    case 'write_file':
+    case 'edit':
+    case 'edit_file':
+    case 'apply_patch':
+    case 'create_file':
+      return PencilLine
+    case 'grep':
+    case 'grep_files':
+    case 'search':
+    case 'search_files':
+    case 'find':
+      return Search
+    case 'ls':
+    case 'list':
+    case 'list_dir':
+      return FolderOpen
+    case 'create_plan':
+    case 'update_plan':
+      return ListTodo
+    default:
+      break
+  }
+
+  if (block.toolKind === 'command_execution') return Terminal
+  if (block.toolKind === 'file_change') return PencilLine
+  return Wrench
+}
+
+function toolNameForBlock(block: ToolBlock): string {
+  const rawSummary = block.summary?.trim() ?? ''
+  return (extractToolName(rawSummary) || readMetaString(block.meta, 'toolName') || '').toLowerCase()
 }
 
 function splitVerb(summary: string): { verb: string; rest: string } {
@@ -872,8 +968,7 @@ export function summarizeToolBlock(
   t: (key: string, opts?: Record<string, unknown>) => string
 ): string {
   const rawSummary = block.summary?.trim() ?? ''
-  const metaToolName = readMetaString(block.meta, 'toolName')
-  const toolName = extractToolName(rawSummary) || metaToolName || ''
+  const toolName = toolNameForBlock(block)
   const label = builtInToolLabel(toolName, t) || humanizeToolName(toolName) || formatToolTitle(block, t)
   const sourceText = [rawSummary, block.detail ?? ''].filter(Boolean).join('\n')
   const filePath = toolFilePath(block)


### PR DESCRIPTION
## Summary

Adds small Lucide icons to Kun process timeline rows so reasoning and tool calls are easier to distinguish at a glance.

## Changes

- Shows a brain icon for reasoning sections.
- Maps common tools to recognizable icons, including terminal for bash/shell, book for read, pencil for write/edit, search for grep/find, folder for ls, and checklist for plan tools.
- Adds matching icons to single execution rows, grouped execution rows, and grouped section headers without changing runtime data contracts.

## Tests

- `npx eslint src/renderer/src/components/chat/message-timeline-process.tsx`
- `npm run typecheck`
- `git diff --check`
- `npm run dist:mac:arm64`

## Package

- `dist/Kun-0.1.0-mac-arm64.dmg`
- `dist/Kun-0.1.0-mac-arm64.zip`
