### PR TITLE
fix(chat): show chrome for plain text code blocks

### DIFF
--- a/src/renderer/src/components/chat/StreamdownCode.test.ts
+++ b/src/renderer/src/components/chat/StreamdownCode.test.ts
@@ -4,7 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { StreamdownCode } from './StreamdownCode'
 
 describe('StreamdownCode plain text fences', () => {
-  it('renders text fenced blocks without code block chrome', () => {
+  it('renders text fenced blocks with plain text code block chrome', () => {
     const html = renderToStaticMarkup(
       createElement(
         StreamdownCode,
@@ -13,13 +13,27 @@ describe('StreamdownCode plain text fences', () => {
       )
     )
 
-    expect(html).toContain('ds-plain-text-block')
-    expect(html).toContain('ds-plain-code-block')
+    expect(html).toContain('ds-code-block-header')
+    expect(html).toContain('plain text')
     expect(html).toContain('refactor(chat): simplify composer')
     expect(html).toContain('- Keep only Stop')
-    expect(html).not.toContain('ds-code-block-header')
-    expect(html).not.toContain('Download code')
-    expect(html).not.toContain('Copy code')
+    expect(html).toContain('Download code')
+    expect(html).toContain('Copy code')
+  })
+
+  it('renders language-less fenced blocks with plain text code block chrome', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        StreamdownCode,
+        { 'data-block': true },
+        'echo hello\n'
+      )
+    )
+
+    expect(html).toContain('data-language="plain text"')
+    expect(html).toContain('plain text')
+    expect(html).toContain('echo hello')
+    expect(html).toContain('Copy code')
   })
 
   it('hides empty plain text fenced blocks', () => {

--- a/src/renderer/src/components/chat/StreamdownCode.tsx
+++ b/src/renderer/src/components/chat/StreamdownCode.tsx
@@ -95,15 +95,8 @@ function isPlainTextLanguage(language: string): boolean {
   return PLAIN_TEXT_LANGUAGES.has(language.trim().toLowerCase())
 }
 
-function PlainTextBlock({ code }: { code: string }): ReactNode {
-  const trimmedCode = code.replace(TRAILING_NEWLINES_REGEX, '')
-  if (!trimmedCode.trim()) return null
-
-  return (
-    <div className="ds-plain-text-block ds-plain-code-block" data-streamdown="plain-text-block">
-      {trimmedCode}
-    </div>
-  )
+function displayCodeLanguage(language: string): string {
+  return isPlainTextLanguage(language) ? 'plain text' : language
 }
 
 function inlineFileReference(text: string): { text: string; target: FileReferenceTarget } | null {
@@ -184,6 +177,7 @@ function CodeBlock({
   const [expanded, setExpanded] = useState(false)
   const bodyRef = useRef<HTMLDivElement>(null)
   const copyResetRef = useRef<number | null>(null)
+  const displayLanguage = displayCodeLanguage(language)
 
   useEffect(() => {
     let cancelled = false
@@ -240,7 +234,7 @@ function CodeBlock({
   return (
     <div
       className="ds-code-block"
-      data-language={language}
+      data-language={displayLanguage}
       data-streamdown="code-block"
       style={{
         contentVisibility: 'auto',
@@ -248,7 +242,7 @@ function CodeBlock({
       }}
     >
       <div className="ds-code-block-header" data-streamdown="code-block-header">
-        <span className="ds-code-block-language">{language || 'text'}</span>
+        <span className="ds-code-block-language">{displayLanguage}</span>
         <div className="ds-code-block-actions">
           <button
             type="button"
@@ -352,8 +346,8 @@ function CodeComponent({ node, className, children, ...props }: CodeProps) {
   const match = className?.match(LANGUAGE_REGEX)
   const language = match?.[1] ?? ''
 
-  if (isPlainTextLanguage(language)) {
-    return <PlainTextBlock code={text} />
+  if (isPlainTextLanguage(language) && !text.replace(TRAILING_NEWLINES_REGEX, '').trim()) {
+    return null
   }
 
   return <CodeBlock code={text} language={language} />


### PR DESCRIPTION
Summary
- Show full code block chrome for language-less and plain text fenced code blocks.
- Display the header language as `plain text` so copy/download controls remain available.

Changes
- Normalize empty, text, plaintext, plain, and txt code fences to the `plain text` header label.
- Keep empty plain text fenced blocks hidden.
- Update StreamdownCode coverage for text and language-less fences.

Tests
- npm run test -- StreamdownCode
- npm run typecheck
