### PR TITLE
fix(model): merge parallel tool_results into one Anthropic user message

### DIFF
--- a/kun/src/adapters/model/compat-model-client.tool-images.test.ts
+++ b/kun/src/adapters/model/compat-model-client.tool-images.test.ts
@@ -62,6 +62,56 @@ function screenshotHistory(): TurnItem[] {
   return [toolCall, toolResult]
 }
 
+// Two parallel tool calls in a single assistant turn, each with its own
+// tool_result — the shape that triggered issue #574 (each tool_result must
+// land in the SAME user message under the Anthropic Messages protocol).
+function parallelToolHistory(): TurnItem[] {
+  const base = { turnId: 'u2', threadId: 't1', status: 'completed' as const, createdAt: '2026-01-01T00:00:00.000Z' }
+  const callA: TurnItem = {
+    ...base,
+    id: 'pc1',
+    role: 'assistant',
+    kind: 'tool_call',
+    toolName: 'read_file',
+    callId: 'call_a',
+    toolKind: 'command_execution',
+    arguments: { path: 'a.txt' }
+  }
+  const callB: TurnItem = {
+    ...base,
+    id: 'pc2',
+    role: 'assistant',
+    kind: 'tool_call',
+    toolName: 'read_file',
+    callId: 'call_b',
+    toolKind: 'command_execution',
+    arguments: { path: 'b.txt' }
+  }
+  const resultA: TurnItem = {
+    ...base,
+    id: 'pr1',
+    role: 'tool',
+    kind: 'tool_result',
+    toolName: 'read_file',
+    callId: 'call_a',
+    toolKind: 'command_execution',
+    isError: false,
+    output: { kind: 'text', text: 'contents-a' }
+  }
+  const resultB: TurnItem = {
+    ...base,
+    id: 'pr2',
+    role: 'tool',
+    kind: 'tool_result',
+    toolName: 'read_file',
+    callId: 'call_b',
+    toolKind: 'command_execution',
+    isError: false,
+    output: { kind: 'text', text: 'contents-b' }
+  }
+  return [callA, callB, resultA, resultB]
+}
+
 function request(model: string): ModelRequest {
   return {
     threadId: 't1',
@@ -72,6 +122,13 @@ function request(model: string): ModelRequest {
     history: screenshotHistory(),
     tools: [],
     abortSignal: new AbortController().signal
+  }
+}
+
+function parallelRequest(model: string): ModelRequest {
+  return {
+    ...request(model),
+    history: parallelToolHistory()
   }
 }
 
@@ -159,5 +216,42 @@ describe('CompatModelClient tool-result image forwarding', () => {
     expect(body).not.toContain(SHOT)
     // Metadata (the screen size) still reaches the model as text.
     expect(body).toContain('computer_screenshot')
+  })
+
+  it('merges parallel tool_results into one user message (anthropic messages)', async () => {
+    // Regression for issue #574: parallel tool calls must answer with a
+    // single user message holding both tool_result blocks, not two separate
+    // user messages (which trips Anthropic's tool_result-immediately-after
+    // rule and yields HTTP 400 on compat providers).
+    const calls: CapturedCall[] = []
+    const client = new CompatModelClient({
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'sk',
+      model: 'claude-parallel',
+      endpointFormat: 'messages',
+      nonStreaming: true,
+      fetchImpl: fakeFetch(calls),
+      modelCapabilities: caps(false, 'messages')
+    })
+    await drain(client.stream(parallelRequest('claude-parallel')))
+    expect(calls[0].url).toMatch(/\/messages$/)
+    const messages = calls[0].body.messages as Array<{
+      role: string
+      content: Array<{ type: string; tool_use_id?: string }>
+    }>
+    const toolResultUserMessages = messages.filter(
+      (m) =>
+        m.role === 'user' &&
+        Array.isArray(m.content) &&
+        m.content.some((b) => b.type === 'tool_result')
+    )
+    // Exactly ONE user message carries the tool_result blocks.
+    expect(toolResultUserMessages).toHaveLength(1)
+    const merged = toolResultUserMessages[0]!
+    const toolResultIds = merged.content
+      .filter((b) => b.type === 'tool_result')
+      .map((b) => b.tool_use_id)
+      .sort()
+    expect(toolResultIds).toEqual(['call_a', 'call_b'])
   })
 })

--- a/kun/src/adapters/model/compat-model-client.ts
+++ b/kun/src/adapters/model/compat-model-client.ts
@@ -1614,7 +1614,24 @@ function messagesToAnthropic(
           if (image) blocks.push({ type: 'image', source: image })
         }
       }
-      out.push({ role: 'user', content: blocks })
+      // Parallel tool calls arrive as N consecutive `role: 'tool'` messages.
+      // Anthropic requires every tool_use from a single assistant turn to be
+      // answered by tool_result blocks inside ONE user message — emitting N
+      // separate user messages trips "tool_use ids were found without
+      // tool_result blocks immediately after" on compat providers. Real user
+      // turns never carry a tool_result block, so its presence marks the run
+      // we are still folding into.
+      const last = out[out.length - 1]
+      if (
+        last &&
+        last.role === 'user' &&
+        Array.isArray(last.content) &&
+        (last.content as AnthropicContentBlock[]).some((b) => b.type === 'tool_result')
+      ) {
+        last.content.push(...blocks)
+      } else {
+        out.push({ role: 'user', content: blocks })
+      }
       continue
     }
     const content = chatContentToAnthropicContent(message.content)


### PR DESCRIPTION
## Summary

When Kun talks to a third-party Anthropic-compatible API via `endpointFormat: 'messages'`, parallel tool calls (multiple `tool_use` blocks in one assistant turn) caused the follow-up request to return **HTTP 400 `tool_use ids were found without tool_result blocks immediately after`**.

Anthropic requires that every `tool_use` from a single assistant turn be answered by `tool_result` blocks inside **one** user message. Kun's `messagesToAnthropic()` instead emitted one separate `role: 'user'` message per tool result — N parallel calls produced N consecutive user messages, each with a single `tool_result`, violating that rule.

The agent loop was already correct: it waits for all parallel results (`Promise.allSettled`) before the next turn. The bug was confined to the Anthropic conversion layer, which split the correctly-collected consecutive `role: 'tool'` messages back into separate user messages.

Fixes #574

## Changes

- `kun/src/adapters/model/compat-model-client.ts` — in `messagesToAnthropic()`, the `role === 'tool'` branch now merges consecutive `tool_result` blocks into the same user message instead of pushing a new one each time. Sibling `image` blocks are preserved and stay paired with their tool_result. The chat_completions and responses paths are unaffected.
- `kun/src/adapters/model/compat-model-client.tool-images.test.ts` — added `merges parallel tool_results into one user message (anthropic messages)`, which builds two parallel `tool_call` + two `tool_result` items and asserts a single user message carries both `tool_result` blocks.

## Tests

- `npm --prefix kun run build:kun` — passes
- `npm --prefix kun run typecheck` — passes
- New regression test passes with the fix; verified it fails without the fix (it observes the two separate user messages that trigger the 400).
- Existing `compat-model-client` suites (`tool-images`, `endpoint-format`, `model-client`) — all green, no regressions on the messages path.
- Full kun suite: 778/779 pass. The single failure (`tests/memory-store.test.ts > injects relevant memories...`) is a pre-existing baseline failure caused by a `better-sqlite3` native-module version mismatch in this environment; it fails identically on clean `develop` and is unrelated to this change.
