### PR TITLE
fix(chat): narrow vision→text model lock to sessions with image attachments

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -31,7 +31,8 @@ import { useChatStore } from '../store/chat-store'
 import {
   isClawThread,
   providerIdForComposerModel,
-  resolveComposerContextWindowTokens
+  resolveComposerContextWindowTokens,
+  sessionHasImageAttachments
 } from '../store/chat-store-helpers'
 import { threadHasPendingRuntimeWork } from '../store/chat-store-runtime-helpers'
 import {
@@ -567,7 +568,7 @@ export function Workbench(): ReactElement {
   const sddTitleSyncTimerRef = useRef<number | null>(null)
   const lastSyncedSddTitleRef = useRef<Record<string, string>>({})
   const timelineBlocks = blocks
-  const lockVisionToTextModelSwitch = route === 'chat' && timelineBlocks.some((block) => block.kind === 'user')
+  const lockVisionToTextModelSwitch = route === 'chat' && sessionHasImageAttachments(timelineBlocks)
   const timelineLiveReasoning = liveReasoning
   const timelineLiveAssistant = liveAssistant
   const devPreviewBlocks = useMemo<ChatBlock[]>(() => {

--- a/src/renderer/src/store/chat-store-app-actions.test.ts
+++ b/src/renderer/src/store/chat-store-app-actions.test.ts
@@ -282,7 +282,7 @@ describe('chat-store app actions composer model loading', () => {
     expect(state.composerProviderId).toBe('')
   })
 
-  it('blocks switching an active chat with user messages from vision to text-only', () => {
+  it('blocks switching an active chat with image attachments from vision to text-only', () => {
     const { actions, state } = buildHarness({
       ok: true,
       modelIds: ['vision-model', 'text-model'],
@@ -290,7 +290,14 @@ describe('chat-store app actions composer model loading', () => {
       modelGroups: []
     })
     state.route = 'chat'
-    state.blocks = [{ kind: 'user', id: 'user-1', text: 'hello' }] as ChatState['blocks']
+    state.blocks = [{
+      kind: 'user',
+      id: 'user-1',
+      text: 'hello',
+      meta: {
+        attachments: [{ id: 'img-1', kind: 'image', name: 'photo.png', mimeType: 'image/png' }]
+      }
+    }] as ChatState['blocks']
     state.activeThreadId = 'thread-a'
     state.threads = [{
       id: 'thread-a',
@@ -408,6 +415,47 @@ describe('chat-store app actions composer model loading', () => {
     expect(state.composerModel).toBe('vision-model')
     expect(state.composerProviderId).toBe('test-provider')
     expect(localStorage.getItem(COMPOSER_MODEL_STORAGE_KEY)).toBe('vision-model')
+  })
+
+  it('allows switching an active chat with only text messages from vision to text-only', () => {
+    const { actions, state } = buildHarness({
+      ok: true,
+      modelIds: ['vision-model', 'text-model'],
+      defaultModelId: 'vision-model',
+      modelGroups: []
+    })
+    state.route = 'chat'
+    state.blocks = [{ kind: 'user', id: 'user-1', text: 'hello' }] as ChatState['blocks']
+    state.composerModel = 'vision-model'
+    state.composerProviderId = 'test-provider'
+    state.composerModelGroups = [{
+      providerId: 'test-provider',
+      label: 'Test',
+      modelIds: ['vision-model', 'text-model'],
+      modelProfiles: {
+        'vision-model': {
+          inputModalities: ['text', 'image'],
+          outputModalities: ['text'],
+          supportsToolCalling: true,
+          messageParts: ['text', 'image_url']
+        },
+        'text-model': {
+          inputModalities: ['text'],
+          outputModalities: ['text'],
+          supportsToolCalling: true,
+          messageParts: ['text']
+        }
+      }
+    }]
+
+    actions.setComposerModel('text-model', 'test-provider')
+
+    expect(state.composerModel).toBe('text-model')
+    expect(state.composerProviderId).toBe('test-provider')
+    expect(localStorage.getItem(COMPOSER_MODEL_STORAGE_KEY)).toBe('text-model')
+    expect(window.kunGui.saveSettingsSilent).toHaveBeenCalledWith({
+      agents: { kun: { model: 'text-model' } }
+    })
   })
 
   it('does not overwrite a stored custom model when only fallback models are available', async () => {

--- a/src/renderer/src/store/chat-store-app-actions.ts
+++ b/src/renderer/src/store/chat-store-app-actions.ts
@@ -15,6 +15,7 @@ import {
   readThreadComposerSelection,
   rememberThreadComposerMode,
   rememberThreadComposerSelection,
+  sessionHasImageAttachments,
   readStoredComposerProviderId
 } from './chat-store-helpers'
 
@@ -100,7 +101,7 @@ export function createAppActions(options: CreateAppActionsOptions): Pick<
       const lockVisionToTextSwitch =
         state.route === 'chat' &&
         Array.isArray(state.blocks) &&
-        state.blocks.some((block) => block.kind === 'user')
+        sessionHasImageAttachments(state.blocks)
       if (!canSwitchComposerModel(
         lockVisionToTextSwitch,
         state.composerModelGroups,

--- a/src/renderer/src/store/chat-store-helpers.ts
+++ b/src/renderer/src/store/chat-store-helpers.ts
@@ -203,6 +203,29 @@ export function canSwitchComposerModel(
   return modelSupportsImageInput(nextProfile)
 }
 
+/**
+ * Whether any user message in the timeline carried an image attachment.
+ *
+ * Only image attachments are uploaded to the runtime and assigned real
+ * attachment IDs; document/PDF attachments stay local and are excluded
+ * from `attachmentIds`. So a non-empty `attachmentIds` on a reloaded
+ * user block is a reliable proxy for "images were sent". On a live
+ * session the full `attachments` array with `kind` is still present.
+ */
+export function sessionHasImageAttachments(blocks: readonly ChatBlock[]): boolean {
+  return blocks.some((block) => {
+    if (block.kind !== 'user') return false
+    const meta = block.meta
+    if (!meta) return false
+    const attachments = meta.attachments
+    if (Array.isArray(attachments) && attachments.some((a) => a.kind === 'image')) {
+      return true
+    }
+    const attachmentIds = meta.attachmentIds
+    return Array.isArray(attachmentIds) && attachmentIds.length > 0
+  })
+}
+
 function modelProfileForComposerSelection(
   modelGroups: readonly ModelProviderModelGroup[],
   modelId: string,


### PR DESCRIPTION
## Summary

When a provider's model is set to support image recognition, the model switching menu in the chat session makes **all** text-only models unselectable (greyed out) — even from different providers. Users can only switch between models that all support images or all support text.

## Root Cause

PR #419 (`fix(chat): prevent unsafe vision model downgrades`) added a `lockVisionToTextModelSwitch` flag to prevent downgrading from a vision model to a text-only model mid-session. The original intent was to avoid losing image context when images were present. However, the implementation locked whenever **any user message** existed in the timeline (`blocks.some(b => b.kind === 'user')`), not just when images were actually present.

This meant sending a single text message would freeze model selection — all text-only models became unselectable.

## Changes

- **`chat-store-helpers.ts`**: New `sessionHasImageAttachments()` helper that checks user blocks for image attachments via two paths:
  - **Live session**: `meta.attachments` array with `kind === 'image'`
  - **Reloaded session**: `meta.attachmentIds` non-empty (only image attachments are uploaded to the runtime and receive real IDs; document/PDF attachments stay local and are excluded from `attachmentIds`)
- **`Workbench.tsx`**: Uses `sessionHasImageAttachments(timelineBlocks)` instead of `timelineBlocks.some(b => b.kind === 'user')`
- **`chat-store-app-actions.ts`**: Same change in the `setComposerModel` guard
- **`chat-store-app-actions.test.ts`**: Updated the "blocks switching" test to include image attachments; added a new test verifying text-only messages allow vision→text switching

## Tests

- `npx vitest run src/renderer/src/store/chat-store-app-actions.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts` — 73 passed
- `npm run typecheck` — clean

Fixes #579
