### PR TITLE
fix(runtime): distinguish upstream model fetch_failed from local runtime failure

### DIFF
--- a/src/renderer/src/lib/format-runtime-error.test.ts
+++ b/src/renderer/src/lib/format-runtime-error.test.ts
@@ -36,6 +36,17 @@ describe('format runtime error', () => {
     expect(formatRuntimeError(error)).toBe(i18n.t('common:runtimeFetchFailed'))
   })
 
+  it('classifies upstream model request failures separately from local runtime fetch failures', () => {
+    const error = new Error(JSON.stringify({
+      message: 'model request failed: fetch failed',
+      severity: 'error'
+    }))
+
+    expect(getRuntimeErrorCode(error)).toBe('model_request_failed')
+    expect(formatRuntimeError(error)).toBe(i18n.t('common:runtimeModelRequestFailed'))
+    expect(formatRuntimeError(error)).not.toBe(i18n.t('common:runtimeFetchFailed'))
+  })
+
   it('keeps raw provider messages visible in details even when the summary is the same text', () => {
     const message = `model request failed with status 400: ${JSON.stringify({
       error: {

--- a/src/renderer/src/lib/format-runtime-error.ts
+++ b/src/renderer/src/lib/format-runtime-error.ts
@@ -43,6 +43,7 @@ function runtimeErrorCode(payload: RuntimeErrorPayload | null, raw: string): str
   const fromError = typeof payload?.error === 'string' ? payload.error.trim() : ''
   if (fromError) return fromError.toLowerCase()
   const lowered = stripIpcPrefix(payloadMessage(payload) || raw).toLowerCase()
+  if (lowered.includes('model request failed:')) return 'model_request_failed'
   if (lowered.includes('fetch failed')) return 'fetch_failed'
   if (lowered.includes('runtime unhealthy')) return 'runtime_unhealthy'
   if (lowered.includes('active turn')) return 'turn_in_progress'
@@ -79,6 +80,10 @@ function detailString(value: unknown): string {
 
 function localizedRuntimeSummary(code: string | null, text: string): string | null {
   const lowered = text.toLowerCase()
+
+  if (code === 'model_request_failed' || lowered.includes('model request failed:')) {
+    return i18n.t('common:runtimeModelRequestFailed')
+  }
 
   if (code === 'fetch_failed' || lowered.includes('fetch failed')) {
     return i18n.t('common:runtimeFetchFailed')

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1422,6 +1422,7 @@
   "busyTimeout": "No response from the runtime after waiting {{minutes}} minutes. Deep-thinking tasks may take longer. If it stays stuck, you can cancel and retry.",
   "runtimeActionNeedsConnection": "Connect to the runtime before using AI actions.",
   "runtimeFetchFailed": "Could not reach Kun. Make sure `kun serve` is running, or enable auto-start in Settings.",
+  "runtimeModelRequestFailed": "Kun could not reach the model provider. Check your network, proxy settings, and provider configuration (Base URL, Endpoint format).",
   "runtimeBinaryNotInstalled": "The Kun CLI was not found. Run `npm install` in the project folder to fetch it, or set the binary path in Settings.",
   "runtimeMissingApiKey": "DeepSeek API Key is missing. Open Settings and add it before the GUI can start the local runtime.",
   "runtimeAutoStartDisabled": "Kun is offline. Enable automatic startup in Settings, or start `kun serve` manually.",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1422,6 +1422,7 @@
   "busyTimeout": "已等待 {{minutes}} 分钟仍未收到运行时完成事件。深度思考任务可能需要更长时间,如果仍然卡住可中断后重试。",
   "runtimeActionNeedsConnection": "请先连接运行时后再使用 AI。",
   "runtimeFetchFailed": "无法连接到 Kun。请确认 `kun serve` 已启动，或在设置中开启自动启动。",
+  "runtimeModelRequestFailed": "Kun 无法连接到模型供应商。请检查网络、代理设置以及供应商配置（Base URL、Endpoint format）。",
   "runtimeBinaryNotInstalled": "未找到 Kun 可执行文件。请在项目目录运行 npm install 以下载 CLI，或在设置中填写 Kun 二进制路径。",
   "runtimeMissingApiKey": "尚未配置 DeepSeek API Key。请先打开设置填写，然后 GUI 才能自动启动本地运行时。",
   "runtimeAutoStartDisabled": "Kun 当前未启动。请在设置中开启自动启动，或手动执行 `kun serve`。",


### PR DESCRIPTION
## Summary

When running commands in Kun GUI, it fails with `fetch_failed` and shows "Cannot connect to Kun. Make sure `kun serve` is running, or enable auto-start in Settings." But the actual error is `model request failed: fetch failed` — the local runtime is healthy, but the runtime's own fetch to the **upstream model provider** failed (network/proxy/DNS issue). The GUI conflates two different failure origins into one misleading message.

## Root Cause

`format-runtime-error.ts` mapped **any** `"fetch failed"` substring to `fetch_failed` → "Could not reach Kun, make sure `kun serve` is running". But `fetch failed` has two distinct origins:

- **Origin A**: GUI → local `kun serve` connection failure (runtime is down) — genuine `fetch_failed`
- **Origin B**: runtime → upstream model provider connection failure (runtime is healthy) — `model request failed: fetch failed` from `compat-model-client.ts`

For Origin B, the local runtime is running fine, yet the GUI tells the user to "start `kun serve`" — an irrelevant and misleading remedy.

## Changes

- **`format-runtime-error.ts`**: Added `model_request_failed` error code, matched **before** `fetch_failed` via the `model request failed:` pattern (with colon). The colon precisely isolates connection errors from HTTP-status errors like `model request failed with status 400:` (where the colon comes after the status code).
- **`format-runtime-error.test.ts`**: New test verifying `model request failed: fetch failed` is classified as `model_request_failed`, not `fetch_failed`
- **`locales/en/common.json`** + **`locales/zh/common.json`**: New `runtimeModelRequestFailed` locale string — "Kun could not reach the model provider. Check your network, proxy settings, and provider configuration (Base URL, Endpoint format)."

## Tests

- `npx vitest run src/renderer/src/lib/format-runtime-error.test.ts` — 4 passed (including existing `http_400` test, which still works because `fromCode` short-circuits before text matching)
- `npm run typecheck` — clean

Fixes #573
