### PR TITLE
feat(workbench): replace right-panel single mode with multi-tab ToolSidebar

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -39,7 +39,7 @@ import {
   extractLatestTurnDevPreviewUrls
 } from '../lib/dev-preview-detection'
 import { Sidebar } from './chat/Sidebar'
-import { WorkbenchTopBar, type RightPanelMode } from './chat/WorkbenchTopBar'
+import { WorkbenchTopBar } from './chat/WorkbenchTopBar'
 import { MessageTimeline } from './chat/MessageTimeline'
 import { IkunCameoLayer, KunCelebrationLayer } from './chat/AnimatedWorkLogo'
 import {
@@ -92,6 +92,13 @@ import { DevPreviewLaunchCard } from './DevPreviewLaunchCard'
 import { RuntimeBanner } from './RuntimeBanner'
 import { CODE_PANEL_PREFERRED, useWorkbenchLayout } from './workbench-layout'
 import { useWorkbenchPlanController } from './workbench-plan-controller'
+import { ToolSidebar } from './tool-sidebar/ToolSidebar'
+import {
+  useToolSidebarStore,
+  useActiveTabType,
+  useToolSidebarOpen,
+  type PanelTab
+} from './tool-sidebar/tool-sidebar-store'
 import { prepareImageAttachmentUpload } from '../lib/image-attachment-upload'
 import { isChatAttachmentUploadEnabled } from '../lib/attachment-upload-availability'
 import { normalizeWorkspaceRoot } from '../lib/workspace-path'
@@ -155,7 +162,6 @@ const COMPOSER_FILE_CONTEXT_MAX_TOTAL_CHARS = 180_000
 // Upper bound on how many files a single `@directory` mention expands into, so a
 // large folder cannot flood the prompt (the char budget above is the hard cap).
 const COMPOSER_DIRECTORY_CONTEXT_MAX_FILES = 60
-const FILE_TREE_SIDEBAR_WIDTH = 320
 const SDD_ASSISTANT_TITLE_SYNC_DELAY_MS = 900
 
 function workspaceFileTargetKey(target: WorkspaceFileTarget | null | undefined): string {
@@ -504,7 +510,6 @@ export function Workbench(): ReactElement {
   const [attachmentUploadBusy, setAttachmentUploadBusy] = useState(false)
   const [attachmentUploadError, setAttachmentUploadError] = useState<string | null>(null)
   const [connectPhoneSidebarOpen, setConnectPhoneSidebarOpen] = useState(false)
-  const [fileTreeSidePanelOpen, setFileTreeSidePanelOpen] = useState(false)
   const [openFilePreviewTargets, setOpenFilePreviewTargets] = useState<WorkspaceFileTarget[]>([])
   const initUiPlugins = useUiPluginStore((s) => s.initUiPlugins)
   const uiModeCameosEnabled = useUiModeCameosEnabled()
@@ -604,6 +609,17 @@ export function Workbench(): ReactElement {
   )
   const latestDevPreviewUrl = detectedDevPreviewUrls[0] ?? null
   const latestAutoOpenDevPreviewUrl = autoOpenDevPreviewUrls[0] ?? null
+  const autoOpenedPreviewUrlRef = useRef<string | null>(null)
+  const toolSidebarOpen = useToolSidebarOpen()
+  const activeTabType = useActiveTabType()
+  const openTab = useToolSidebarStore((s) => s.openTab)
+
+  useEffect(() => {
+    if (!latestAutoOpenDevPreviewUrl || route !== 'chat') return
+    if (autoOpenedPreviewUrlRef.current === latestAutoOpenDevPreviewUrl) return
+    autoOpenedPreviewUrlRef.current = latestAutoOpenDevPreviewUrl
+    openTab('browser')
+  }, [latestAutoOpenDevPreviewUrl, openTab, route])
   const currentSideConversations = useMemo(
     () =>
       Object.values(sideConversations)
@@ -615,33 +631,31 @@ export function Workbench(): ReactElement {
     (count, side) => count + (side.busy ? 1 : 0),
     0
   )
+  const closeToolSidebar = useToolSidebarStore((s) => s.close)
+  const closeTabsByType = useToolSidebarStore((s) => s.closeTabsByType)
+  const toggleTab = useToolSidebarStore((s) => s.toggleTab)
+  const toggleToolSidebar = useToolSidebarStore((s) => s.toggleOpen)
+  const planPanelInOverlay =
+    route === 'chat' &&
+    !activeSddDraft &&
+    activeTabType === 'plan' &&
+    planPanelOverlayPreferred
+  const rightPanelVisible =
+    route === 'write' ? writeAssistantOpen : toolSidebarOpen && !planPanelInOverlay
   const {
     beginLeftResize,
     beginRightResize,
-    beginTerminalResize,
     filePreviewTarget,
     leftSidebarCollapsed,
     leftSidebarWidth,
-    openDevPreview,
-    rightPanelMode,
-    rightPanelVisible,
     rightSidebarWidth,
     setFilePreviewTarget,
-    setRightPanelMode,
     setRightSidebarWidth,
     shellRef,
-    terminalHeight,
-    terminalOpen,
-    toggleLeftSidebar,
-    toggleRightPanelMode,
-    toggleTerminal,
+    toggleLeftSidebar
   } = useWorkbenchLayout({
     activeThreadId,
-    latestAutoOpenDevPreviewUrl,
-    latestDevPreviewUrl,
-    route,
-    workspaceRoot,
-    writeAssistantOpen
+    rightPanelVisible
   })
   const titleForSddDraft = useCallback((draft: SddDraft): string => {
     const snapshot = useSddDraftStore.getState()
@@ -685,7 +699,7 @@ export function Workbench(): ReactElement {
     sendMessage,
     setError,
     setComposerMode,
-    setRightPanelMode,
+    openTab,
     setRightSidebarWidth,
     t,
     workspaceRoot,
@@ -698,11 +712,6 @@ export function Workbench(): ReactElement {
       await useChatStore.getState().refreshThreads()
     }
   })
-  const planPanelInOverlay =
-    route === 'chat' &&
-    !activeSddDraft &&
-    rightPanelMode === 'plan' &&
-    planPanelOverlayPreferred
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
@@ -720,11 +729,11 @@ export function Workbench(): ReactElement {
   useEffect(() => {
     if (!planPanelInOverlay) return
     const onKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape') setRightPanelMode(null)
+      if (event.key === 'Escape') closeTabsByType('plan')
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [planPanelInOverlay, setRightPanelMode])
+  }, [planPanelInOverlay, closeTabsByType])
 
   useEffect(() => {
     const runDesktopShortcut = (command: DesktopCommand): void => {
@@ -760,7 +769,7 @@ export function Workbench(): ReactElement {
         return
       }
       if (commandId === 'toggle-terminal') {
-        toggleTerminal()
+        toggleTab('terminal')
         return
       }
       if (commandId === 'settings') {
@@ -782,7 +791,7 @@ export function Workbench(): ReactElement {
     composerMode,
     openSettings,
     setComposerMode,
-    toggleTerminal,
+    toggleTab,
     useWorktreePool,
     worktreeBranch
   ])
@@ -925,10 +934,10 @@ export function Workbench(): ReactElement {
   }, [input])
 
   useEffect(() => {
-    if (rightPanelMode === 'plan' && !activeGuiPlan) {
-      setRightPanelMode(null)
+    if (activeTabType === 'plan' && !activeGuiPlan) {
+      closeTabsByType('plan')
     }
-  }, [activeGuiPlan, rightPanelMode, setRightPanelMode])
+  }, [activeGuiPlan, activeTabType, closeTabsByType])
 
   useEffect(() => {
     if (
@@ -1001,10 +1010,10 @@ export function Workbench(): ReactElement {
 
   const selectedComposerModel = route === 'claw'
     ? activeClawChannel?.model ?? 'auto'
-    : route === 'write' || rightPanelMode === 'sdd-ai'
+    : route === 'write' || activeTabType === 'sdd-ai'
       ? writeAssistantModel
     : composerModel
-  const selectedComposerProviderId = route === 'write' || rightPanelMode === 'sdd-ai'
+  const selectedComposerProviderId = route === 'write' || activeTabType === 'sdd-ai'
     ? resolvedWriteAssistantProviderId
     : route === 'chat'
       ? composerProviderId
@@ -1047,7 +1056,7 @@ export function Workbench(): ReactElement {
 
   const activeComposerWorkspace = (): string | undefined => {
     const sddDraft = useSddDraftStore.getState().activeDraft
-    if (rightPanelMode === 'sdd-ai' && sddDraft?.workspaceRoot) return sddDraft.workspaceRoot
+    if (activeTabType === 'sdd-ai' && sddDraft?.workspaceRoot) return sddDraft.workspaceRoot
     const writeWorkspace = useWriteWorkspaceStore.getState().workspaceRoot
     if (route === 'write' && writeWorkspace.trim()) return writeWorkspace
     return threads.find((thread) => thread.id === activeThreadId)?.workspace || workspaceRoot || undefined
@@ -1088,7 +1097,7 @@ export function Workbench(): ReactElement {
     })
     setFilePreviewTarget(nextTarget)
     setRightSidebarWidth((width) => Math.max(width, CODE_PANEL_PREFERRED))
-    setRightPanelMode('file')
+    openTab('file')
   }
 
   const previewWorkspaceFileFromSidebar = (path: string): void => {
@@ -1106,7 +1115,7 @@ export function Workbench(): ReactElement {
       if (workspaceFileTargetKey(filePreviewTarget) === closingKey) {
         const fallback = next[Math.max(0, index - 1)] ?? next[0] ?? null
         setFilePreviewTarget(fallback)
-        if (!fallback) setRightPanelMode(null)
+        if (!fallback) closeTabsByType('file')
       }
       return next
     })
@@ -1116,18 +1125,14 @@ export function Workbench(): ReactElement {
     addComposerFileReference(reference)
   }
 
-  const toggleFileTreeSidePanel = (): void => {
-    setFileTreeSidePanelOpen((open) => !open)
-  }
-
   useEffect(() => {
-    if (rightPanelMode !== 'file' || !filePreviewTarget) return
+    if (activeTabType !== 'file' || !filePreviewTarget) return
     setOpenFilePreviewTargets((current) => {
       const key = workspaceFileTargetKey(filePreviewTarget)
       if (current.some((item) => workspaceFileTargetKey(item) === key)) return current
       return [...current, filePreviewTarget]
     })
-  }, [filePreviewTarget, rightPanelMode])
+  }, [filePreviewTarget, activeTabType])
 
   useEffect(() => {
     if (route !== 'chat') setComposerFileReferences([])
@@ -1422,12 +1427,12 @@ export function Workbench(): ReactElement {
       setRightSidebarWidth((width) => Math.max(width, 420))
       const sddThreadId = await ensureSddAssistantThreadForDraft(draft)
       if (sddThreadId) {
-        setRightPanelMode('sdd-ai')
+        openTab('sdd-ai')
       } else {
-        setRightPanelMode(null)
+        closeTabsByType('sdd-ai')
       }
     } else {
-      setRightPanelMode(null)
+      closeTabsByType('sdd-ai')
     }
     return true
   }
@@ -1438,7 +1443,7 @@ export function Workbench(): ReactElement {
       void saveActiveSddDraftToDisk()
       useSddDraftStore.getState().clearActiveDraft()
     }
-    if (options.closeAssistant && rightPanelMode === 'sdd-ai') setRightPanelMode(null)
+    if (options.closeAssistant && activeTabType === 'sdd-ai') closeTabsByType('sdd-ai')
   }
 
   const openSddAssistantPanel = async (): Promise<void> => {
@@ -1447,12 +1452,12 @@ export function Workbench(): ReactElement {
     setRightSidebarWidth((width) => Math.max(width, 420))
     const threadId = await ensureSddAssistantThreadForDraft(draft)
     if (!threadId) return
-    setRightPanelMode('sdd-ai')
+    openTab('sdd-ai')
   }
 
   const toggleSddAssistantPanel = async (): Promise<void> => {
-    if (rightPanelMode === 'sdd-ai') {
-      setRightPanelMode(null)
+    if (activeTabType === 'sdd-ai') {
+      closeTabsByType('sdd-ai')
       return
     }
     await openSddAssistantPanel()
@@ -2037,7 +2042,7 @@ export function Workbench(): ReactElement {
       }
     }
 
-    if (activeSddDraft && rightPanelMode === 'sdd-ai') {
+    if (activeSddDraft && activeTabType === 'sdd-ai') {
       void sendSddAssistantPrompt(v)
       return
     }
@@ -2250,8 +2255,8 @@ export function Workbench(): ReactElement {
       setWriteAssistantOpen(false)
       return
     }
-    if (rightPanelMode === 'file') setOpenFilePreviewTargets([])
-    setRightPanelMode(null)
+    if (activeTabType === 'file') setOpenFilePreviewTargets([])
+    closeToolSidebar()
     setFilePreviewTarget(null)
   }
 
@@ -2309,7 +2314,6 @@ export function Workbench(): ReactElement {
     runtimeActionNeedsConnection: t('runtimeActionNeedsConnection')
   })
   const rightPanelDockedVisible = rightPanelVisible && !planPanelInOverlay
-  const fileTreeSidePanelOffset = fileTreeSidePanelOpen ? FILE_TREE_SIDEBAR_WIDTH + 24 : 0
 
   const renderPlanPanel = (className: string): ReactElement => (
     <PlanPanel
@@ -2325,8 +2329,8 @@ export function Workbench(): ReactElement {
     />
   )
 
-  const renderRightPanel = (): ReactElement | null => {
-    if (!rightPanelDockedVisible) return null
+  const renderWriteAssistantPanel = (): ReactElement | null => {
+    if (!rightPanelDockedVisible || !(route === 'write' && writeAssistantOpen)) return null
     return (
       <>
         <div
@@ -2337,140 +2341,125 @@ export function Workbench(): ReactElement {
         />
         <div className="h-full min-h-0 shrink-0" style={{ width: rightSidebarWidth }}>
           <Suspense fallback={<div className="h-full w-full bg-ds-sidebar" />}>
-            {route === 'write' && writeAssistantOpen ? (
-              <WriteAssistantPanel
-                input={input}
-                setInput={setInput}
-                mode={composerMode}
-                setMode={setComposerMode}
-                busy={busy}
-                runtimeConnection={runtimeConnection}
-                activeThreadId={activeThreadId}
-                blocks={blocks}
-                liveReasoning={liveReasoning}
-                liveAssistant={liveAssistant}
-                composerModel={writeAssistantModel}
-                composerProviderId={resolvedWriteAssistantProviderId}
-                composerPickList={writeAssistantPickList}
-                composerModelGroups={composerModelGroups}
-                composerReasoningEffort={composerReasoningEffort}
-                setComposerModel={setWriteAssistantModel}
-                setComposerReasoningEffort={setComposerReasoningEffort}
-                queuedMessages={queuedMessages}
-                removeQueuedMessage={removeQueuedMessage}
-                attachments={composerAttachments}
-                attachmentUploadEnabled={attachmentUploadEnabled}
-                attachmentUploadBusy={attachmentUploadBusy}
-                attachmentUploadError={attachmentUploadError}
-                onPickAttachments={(files) => void handlePickAttachments(files)}
-                onPasteClipboardImage={(options) => void handlePasteClipboardImage(options)}
-                onRemoveAttachment={removeComposerAttachment}
-                onSend={handleSend}
-                onInterrupt={(options) => void interrupt(options)}
-                onRetryConnection={() => void probeRuntime('user', { restart: true })}
-                onOpenSettings={() => openSettings('agents')}
-                onConfigureProviders={() => openSettings('providers')}
-                onNewConversation={startNewWriteAssistantConversation}
-                onPickWorkspace={() => void pickWriteAssistantWorkspace()}
-                onCollapse={closeRightPanel}
-                className="h-full max-h-full w-full"
-              />
-            ) : rightPanelMode === 'sdd-ai' && activeSddDraft ? (
-              <SddAssistantPanel
-                draft={activeSddDraft}
-                input={input}
-                setInput={setInput}
-                mode={composerMode}
-                setMode={setComposerMode}
-                busy={busy}
-                runtimeConnection={runtimeConnection}
-                activeThreadId={activeThreadId}
-                blocks={blocks}
-                liveReasoning={liveReasoning}
-                liveAssistant={liveAssistant}
-                composerModel={writeAssistantModel}
-                composerProviderId={resolvedWriteAssistantProviderId}
-                composerPickList={writeAssistantPickList}
-                composerModelGroups={composerModelGroups}
-                composerReasoningEffort={composerReasoningEffort}
-                setComposerModel={setWriteAssistantModel}
-                setComposerReasoningEffort={setComposerReasoningEffort}
-                queuedMessages={queuedMessages}
-                removeQueuedMessage={removeQueuedMessage}
-                attachments={composerAttachments}
-                attachmentUploadEnabled={attachmentUploadEnabled}
-                attachmentUploadBusy={attachmentUploadBusy}
-                attachmentUploadError={attachmentUploadError}
-                onPickAttachments={(files) => void handlePickAttachments(files)}
-                onPasteClipboardImage={(options) => void handlePasteClipboardImage(options)}
-                onRemoveAttachment={removeComposerAttachment}
-                onSend={handleSend}
-                onInterrupt={(options) => void interrupt(options)}
-                onRetryConnection={() => void probeRuntime('user', { restart: true })}
-                onOpenSettings={() => openSettings('agents')}
-                onConfigureProviders={() => openSettings('providers')}
-                onApplyFramework={applySddFramework}
-                onNewConversation={() => {
-                  setInput('')
-                  pendingSddFrameworkRef.current = null
-                  pendingSddFrameworkPromptRef.current = null
-                  void createSddAssistantThreadForDraft(activeSddDraft)
-                }}
-                onCollapse={closeRightPanel}
-                className="h-full max-h-full w-full"
-              />
-            ) : rightPanelMode === 'changes' ? (
-              <ChangeInspector
-                blocks={blocks}
-                className="h-full max-h-full w-full flex-col"
-                onCollapse={closeRightPanel}
-              />
-            ) : rightPanelMode === 'todo' ? (
-              <TodoPanel
-                className="h-full max-h-full w-full"
-                onCollapse={closeRightPanel}
-                onOpenPlan={openGuiPlanPanel}
-              />
-            ) : rightPanelMode === 'browser' ? (
-              <DevBrowserPanel
-                blocks={devPreviewBlocks}
-                preferredUrl={latestDevPreviewUrl}
-                className="h-full max-h-full w-full flex-col"
-                onCollapse={closeRightPanel}
-              />
-            ) : rightPanelMode === 'plan' ? (
-              renderPlanPanel('h-full max-h-full w-full')
-            ) : (
-              <WorkspaceFilePreviewPanel
-                target={filePreviewTarget}
-                openTargets={openFilePreviewTargets}
-                workspaceRoot={workspaceRoot}
-                className="h-full max-h-full w-full"
-                onSelectTarget={openWorkspaceFilePreviewTarget}
-                onCloseTarget={closeWorkspaceFilePreviewTarget}
-                onClose={closeRightPanel}
-              />
-            )}
+            <WriteAssistantPanel
+              input={input}
+              setInput={setInput}
+              mode={composerMode}
+              setMode={setComposerMode}
+              busy={busy}
+              runtimeConnection={runtimeConnection}
+              activeThreadId={activeThreadId}
+              blocks={blocks}
+              liveReasoning={liveReasoning}
+              liveAssistant={liveAssistant}
+              composerModel={writeAssistantModel}
+              composerProviderId={resolvedWriteAssistantProviderId}
+              composerPickList={writeAssistantPickList}
+              composerModelGroups={composerModelGroups}
+              composerReasoningEffort={composerReasoningEffort}
+              setComposerModel={setWriteAssistantModel}
+              setComposerReasoningEffort={setComposerReasoningEffort}
+              queuedMessages={queuedMessages}
+              removeQueuedMessage={removeQueuedMessage}
+              attachments={composerAttachments}
+              attachmentUploadEnabled={attachmentUploadEnabled}
+              attachmentUploadBusy={attachmentUploadBusy}
+              attachmentUploadError={attachmentUploadError}
+              onPickAttachments={(files) => void handlePickAttachments(files)}
+              onPasteClipboardImage={(options) => void handlePasteClipboardImage(options)}
+              onRemoveAttachment={removeComposerAttachment}
+              onSend={handleSend}
+              onInterrupt={(options) => void interrupt(options)}
+              onRetryConnection={() => void probeRuntime('user', { restart: true })}
+              onOpenSettings={() => openSettings('agents')}
+              onConfigureProviders={() => openSettings('providers')}
+              onNewConversation={startNewWriteAssistantConversation}
+              onPickWorkspace={() => void pickWriteAssistantWorkspace()}
+              onCollapse={closeRightPanel}
+              className="h-full max-h-full w-full"
+            />
           </Suspense>
         </div>
       </>
     )
   }
 
-  const renderFileTreeSidePanel = (): ReactElement | null => {
-    if (!fileTreeSidePanelOpen) return null
+  const renderTab = (tab: PanelTab): ReactElement | null => {
     return (
-      <>
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          className="ds-workbench-divider ds-no-drag relative z-20 shrink-0"
-        />
-        <aside
-          className="ds-no-drag h-full min-h-0 shrink-0 border-l border-ds-border-muted bg-ds-sidebar"
-          style={{ width: FILE_TREE_SIDEBAR_WIDTH }}
-        >
-          {fileTreeWorkspaceRoot ? (
+      <Suspense fallback={<div className="h-full w-full bg-ds-sidebar" />}>
+        {tab.type === 'sdd-ai' && activeSddDraft ? (
+          <SddAssistantPanel
+            draft={activeSddDraft}
+            input={input}
+            setInput={setInput}
+            mode={composerMode}
+            setMode={setComposerMode}
+            busy={busy}
+            runtimeConnection={runtimeConnection}
+            activeThreadId={activeThreadId}
+            blocks={blocks}
+            liveReasoning={liveReasoning}
+            liveAssistant={liveAssistant}
+            composerModel={writeAssistantModel}
+            composerProviderId={resolvedWriteAssistantProviderId}
+            composerPickList={writeAssistantPickList}
+            composerModelGroups={composerModelGroups}
+            composerReasoningEffort={composerReasoningEffort}
+            setComposerModel={setWriteAssistantModel}
+            setComposerReasoningEffort={setComposerReasoningEffort}
+            queuedMessages={queuedMessages}
+            removeQueuedMessage={removeQueuedMessage}
+            attachments={composerAttachments}
+            attachmentUploadEnabled={attachmentUploadEnabled}
+            attachmentUploadBusy={attachmentUploadBusy}
+            attachmentUploadError={attachmentUploadError}
+              onPickAttachments={(files) => void handlePickAttachments(files)}
+              onPasteClipboardImage={(options) => void handlePasteClipboardImage(options)}
+              onRemoveAttachment={removeComposerAttachment}
+              onSend={handleSend}
+              onInterrupt={(options) => void interrupt(options)}
+              onRetryConnection={() => void probeRuntime('user', { restart: true })}
+              onOpenSettings={() => openSettings('agents')}
+              onConfigureProviders={() => openSettings('providers')}
+              onApplyFramework={applySddFramework}
+              onNewConversation={() => {
+                setInput('')
+                pendingSddFrameworkRef.current = null
+                pendingSddFrameworkPromptRef.current = null
+                void createSddAssistantThreadForDraft(activeSddDraft)
+              }}
+              onCollapse={closeRightPanel}
+              className="h-full max-h-full w-full"
+            />
+        ) : tab.type === 'changes' ? (
+          <ChangeInspector
+            blocks={blocks}
+            className="h-full max-h-full w-full flex-col"
+            onCollapse={closeRightPanel}
+          />
+        ) : tab.type === 'todo' ? (
+          <TodoPanel
+            className="h-full max-h-full w-full"
+            onCollapse={closeRightPanel}
+            onOpenPlan={openGuiPlanPanel}
+          />
+        ) : tab.type === 'browser' ? (
+          <DevBrowserPanel
+            blocks={devPreviewBlocks}
+            preferredUrl={latestDevPreviewUrl}
+            className="h-full max-h-full w-full flex-col"
+            onCollapse={closeRightPanel}
+          />
+        ) : tab.type === 'plan' ? (
+          renderPlanPanel('h-full max-h-full w-full')
+        ) : tab.type === 'terminal' ? (
+          <TerminalPanel
+            workspaceRoot={fileTreeWorkspaceRoot}
+            className="h-full w-full"
+            onCollapse={closeRightPanel}
+          />
+        ) : tab.type === 'files' ? (
+          fileTreeWorkspaceRoot ? (
             <ChatFileTreePanel
               workspaceRoot={fileTreeWorkspaceRoot}
               selectedPath={filePreviewTarget?.path}
@@ -2483,9 +2472,19 @@ export function Workbench(): ReactElement {
             <div className="px-4 py-3 text-[12px] leading-5 text-ds-muted">
               {t('workspaceRequiredToCreateThread')}
             </div>
-          )}
-        </aside>
-      </>
+          )
+        ) : (
+          <WorkspaceFilePreviewPanel
+            target={filePreviewTarget}
+            openTargets={openFilePreviewTargets}
+            workspaceRoot={workspaceRoot}
+            className="h-full max-h-full w-full"
+            onSelectTarget={openWorkspaceFilePreviewTarget}
+            onCloseTarget={closeWorkspaceFilePreviewTarget}
+            onClose={closeRightPanel}
+          />
+        )}
+      </Suspense>
     )
   }
 
@@ -2613,7 +2612,7 @@ export function Workbench(): ReactElement {
                 onSubmitPrompt={sendWritePrompt}
                 onOpenAgentSettings={() => openSettings('write')}
               />
-              {renderRightPanel()}
+              {renderWriteAssistantPanel()}
             </div>
           </>
         ) : (
@@ -2627,7 +2626,7 @@ export function Workbench(): ReactElement {
           {activeSddDraft ? (
             <SddDraftEditorView
               leftSidebarCollapsed={leftSidebarCollapsed}
-              assistantOpen={rightPanelMode === 'sdd-ai'}
+              assistantOpen={activeTabType === 'sdd-ai'}
               onToggleLeftSidebar={toggleLeftSidebar}
               onToggleAssistant={() => void toggleSddAssistantPanel()}
               onAssistantQuote={quoteToSddAssistant}
@@ -2660,18 +2659,12 @@ export function Workbench(): ReactElement {
                     </span>
                   ) : null}
                   <WorkbenchTopBar
-                    rightPanelMode={rightPanelMode}
-                    onToggleRightPanelMode={toggleRightPanelMode}
-                    planPanelEnabled={Boolean(activeGuiPlan)}
-                    terminalOpen={terminalOpen}
-                    onToggleTerminal={toggleTerminal}
                     sideChatCount={currentSideConversations.length}
                     sideChatRunningCount={currentSideRunningCount}
                     sideChatOpen={sidePanel.open}
                     sideChatEnabled={runtimeConnection === 'ready' && Boolean(activeThreadId)}
-                    fileTreeOpen={fileTreeSidePanelOpen}
-                    fileTreeEnabled={Boolean(fileTreeWorkspaceRoot)}
-                    onToggleFileTree={toggleFileTreeSidePanel}
+                    toolSidebarOpen={toolSidebarOpen}
+                    onToggleToolSidebar={toggleToolSidebar}
                     onOpenSideChat={openSideChat}
                   />
                 </div>
@@ -2696,8 +2689,8 @@ export function Workbench(): ReactElement {
                   showDevPreviewCard ? (
                     <DevPreviewLaunchCard
                       url={latestDevPreviewUrl}
-                      opened={rightPanelMode === 'browser'}
-                      onOpen={openDevPreview}
+                      opened={activeTabType === 'browser'}
+                      onOpen={() => openTab('browser')}
                     />
                   ) : null
                 }
@@ -2776,7 +2769,7 @@ export function Workbench(): ReactElement {
                 onNewCommand={() => void createThread({ workspaceRoot: activeSkillWorkspace, forceNew: true })}
                 onReviewCommand={(target) => void reviewActiveThread(target)}
                 onExecutionSettingsChange={updateComposerExecutionSettings}
-                onOpenChanges={() => setRightPanelMode('changes')}
+                onOpenChanges={() => openTab('changes')}
                 onReviewChanges={() => void reviewActiveThread({ kind: 'uncommittedChanges' })}
                 reviewChangesDisabled={busy || runtimeConnection !== 'ready'}
                 onBtwCommand={(seedText) => {
@@ -2789,36 +2782,23 @@ export function Workbench(): ReactElement {
               />
             </div>
             </div>
-            {terminalOpen ? (
-              <div className="ds-no-drag flex w-full shrink-0 flex-col px-0 pb-0">
-                <div
-                  role="separator"
-                  aria-orientation="horizontal"
-                  className="relative z-20 h-1 shrink-0 cursor-row-resize bg-transparent transition hover:bg-ds-border-muted"
-                  onPointerDown={beginTerminalResize}
-                />
-                <Suspense fallback={<div className="ds-surface-strong h-full w-full" />}>
-                  <TerminalPanel
-                    workspaceRoot={fileTreeWorkspaceRoot}
-                    height={terminalHeight}
-                    className="w-full"
-                    onCollapse={toggleTerminal}
-                  />
-                </Suspense>
-              </div>
-            ) : null}
           </section>
           )}
           </div>
 
           {route === 'chat' && !activeSddDraft ? (
             <SideConversationPanel
-              rightOffset={(rightPanelDockedVisible ? rightSidebarWidth + 24 : 24) + fileTreeSidePanelOffset}
+              rightOffset={rightPanelDockedVisible ? rightSidebarWidth + 24 : 24}
             />
           ) : null}
 
-          {renderRightPanel()}
-          {renderFileTreeSidePanel()}
+          {toolSidebarOpen ? (
+            <ToolSidebar
+              width={rightSidebarWidth}
+              onBeginResize={beginRightResize}
+              renderTab={renderTab}
+            />
+          ) : null}
         </div>
 
           </>

--- a/src/renderer/src/components/chat/WorkbenchTopBar.tsx
+++ b/src/renderer/src/components/chat/WorkbenchTopBar.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { EditorInfo } from '@shared/editor'
 import type { GuiUpdateState } from '@shared/gui-update'
 import {
@@ -7,16 +7,12 @@ import {
   Check,
   ChevronDown,
   Code2,
-  ClipboardList,
   Download,
   ExternalLink,
-  FileEdit,
-  Folders,
   FolderOpen,
-  Globe2,
-  ListTodo,
   Loader2,
   MessageCircleMore,
+  PanelRight,
   RefreshCw,
   Terminal
 } from 'lucide-react'
@@ -33,18 +29,12 @@ export type RightPanelMode =
   | null
 
 type Props = {
-  rightPanelMode: RightPanelMode
-  onToggleRightPanelMode: (mode: Exclude<RightPanelMode, null>) => void
-  planPanelEnabled?: boolean
-  terminalOpen?: boolean
-  onToggleTerminal?: () => void
   sideChatCount?: number
   sideChatRunningCount?: number
   sideChatOpen?: boolean
   sideChatEnabled?: boolean
-  fileTreeOpen?: boolean
-  fileTreeEnabled?: boolean
-  onToggleFileTree?: () => void
+  toolSidebarOpen?: boolean
+  onToggleToolSidebar?: () => void
   onOpenSideChat?: () => void
 }
 
@@ -60,18 +50,12 @@ function topbarIconButtonClass(active: boolean): string {
 }
 
 export function WorkbenchTopBar({
-  rightPanelMode,
-  onToggleRightPanelMode,
-  planPanelEnabled = false,
-  terminalOpen = false,
-  onToggleTerminal,
   sideChatCount = 0,
   sideChatRunningCount = 0,
   sideChatOpen = false,
   sideChatEnabled = true,
-  fileTreeOpen = false,
-  fileTreeEnabled = true,
-  onToggleFileTree,
+  toolSidebarOpen = false,
+  onToggleToolSidebar,
   onOpenSideChat
 }: Props): ReactElement {
   const { t } = useTranslation(['common', 'settings'])
@@ -82,12 +66,6 @@ export function WorkbenchTopBar({
   const [guiUpdateState, setGuiUpdateState] = useState<GuiUpdateState>({ status: 'idle' })
   const [applyingGuiUpdate, setApplyingGuiUpdate] = useState(false)
   const editorMenuRef = useRef<HTMLDivElement>(null)
-  const items = [
-    { mode: 'todo' as const, label: t('rightPanelTodo'), icon: ListTodo },
-    ...(planPanelEnabled ? [{ mode: 'plan' as const, label: t('rightPanelPlan'), icon: ClipboardList }] : []),
-    { mode: 'changes' as const, label: t('rightPanelChanges'), icon: FileEdit },
-    { mode: 'browser' as const, label: t('rightPanelBrowser'), icon: Globe2 }
-  ]
   const selectedEditor = useMemo(
     () => editors.find((editor) => editor.id === selectedEditorId) ?? editors[0],
     [editors, selectedEditorId]
@@ -363,49 +341,16 @@ export function WorkbenchTopBar({
         </button>
       ) : null}
 
-      {items.map((item) => {
-        const active = rightPanelMode === item.mode
-        const Icon = item.icon
-        const isChanges = item.mode === 'changes'
-        return (
-          <Fragment key={item.mode}>
-            <button
-              type="button"
-              onClick={() => onToggleRightPanelMode(item.mode)}
-              className={topbarIconButtonClass(active)}
-              aria-label={item.label}
-              aria-pressed={active}
-              title={item.label}
-            >
-              <Icon className={TOPBAR_ICON_CLASS} strokeWidth={1.75} />
-            </button>
-            {isChanges && onToggleTerminal ? (
-              <button
-                type="button"
-                onClick={onToggleTerminal}
-                className={topbarIconButtonClass(terminalOpen)}
-                aria-label={t('rightPanelTerminal')}
-                aria-pressed={terminalOpen}
-                title={t('rightPanelTerminal')}
-              >
-                <Terminal className={TOPBAR_ICON_CLASS} strokeWidth={1.75} />
-              </button>
-            ) : null}
-          </Fragment>
-        )
-      })}
-
-      {onToggleFileTree ? (
+      {onToggleToolSidebar ? (
         <button
           type="button"
-          onClick={onToggleFileTree}
-          disabled={!fileTreeEnabled}
-          className={`${topbarIconButtonClass(fileTreeOpen)} disabled:cursor-not-allowed disabled:opacity-45`}
-          aria-label={t('rightPanelFiles')}
-          aria-pressed={fileTreeOpen}
-          title={t('rightPanelFiles')}
+          onClick={onToggleToolSidebar}
+          className={topbarIconButtonClass(toolSidebarOpen)}
+          aria-label={t('toolSidebarToggle')}
+          aria-pressed={toolSidebarOpen}
+          title={t('toolSidebarToggle')}
         >
-          <Folders className={TOPBAR_ICON_CLASS} strokeWidth={1.75} />
+          <PanelRight className={TOPBAR_ICON_CLASS} strokeWidth={1.75} />
         </button>
       ) : null}
     </div>

--- a/src/renderer/src/components/tool-sidebar/ToolSidebar.tsx
+++ b/src/renderer/src/components/tool-sidebar/ToolSidebar.tsx
@@ -1,0 +1,163 @@
+import type { ReactElement, ReactNode } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Check, Plus, X } from 'lucide-react'
+import { useToolSidebarStore, type PanelTab } from './tool-sidebar-store'
+import { getAddMenuPanels, getPanelMeta } from './panel-registry'
+
+type ToolSidebarProps = {
+  width: number
+  onBeginResize: (event: ReactPointerEvent<HTMLDivElement>) => void
+  onCollapse?: () => void
+  renderTab: (tab: PanelTab) => ReactNode
+}
+
+export function ToolSidebar({
+  width,
+  onBeginResize,
+  renderTab
+}: ToolSidebarProps): ReactElement {
+  const { t } = useTranslation(['common'])
+  const tabs = useToolSidebarStore((s) => s.tabs)
+  const activeTabId = useToolSidebarStore((s) => s.activeTabId)
+  const setActiveTab = useToolSidebarStore((s) => s.setActiveTab)
+  const closeTab = useToolSidebarStore((s) => s.closeTab)
+  const openTab = useToolSidebarStore((s) => s.openTab)
+
+  const [addMenuOpen, setAddMenuOpen] = useState(false)
+  const addMenuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (tabs.length === 0) {
+      setAddMenuOpen(true)
+    }
+  }, [tabs.length])
+
+  useEffect(() => {
+    if (!addMenuOpen) return
+    const onPointerDown = (event: PointerEvent): void => {
+      const target = event.target
+      if (target instanceof Node && addMenuRef.current?.contains(target)) return
+      setAddMenuOpen(false)
+    }
+    window.addEventListener('pointerdown', onPointerDown)
+    return () => window.removeEventListener('pointerdown', onPointerDown)
+  }, [addMenuOpen])
+
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? null
+  const addMenuItems = getAddMenuPanels().filter(
+    (meta) => !tabs.some((tab) => tab.type === meta.type)
+  )
+
+  return (
+    <>
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        className="ds-workbench-divider ds-no-drag relative z-20 shrink-0 cursor-col-resize"
+        onPointerDown={onBeginResize}
+      />
+      <div
+        className="ds-tool-sidebar flex h-full min-h-0 shrink-0 flex-col bg-ds-sidebar"
+        style={{ width }}
+      >
+        <div className="ds-no-drag flex min-h-0 shrink-0 items-center gap-0.5 border-b border-ds-border-muted px-1.5 py-1">
+          <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">
+            {tabs.map((tab) => {
+              const meta = getPanelMeta(tab.type)
+              const Icon = meta.icon
+              const active = tab.id === activeTabId
+              return (
+                <div
+                  key={tab.id}
+                  className={`group/tab flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-[12px] font-medium transition ${
+                    active
+                      ? 'bg-ds-hover text-ds-ink'
+                      : 'text-ds-muted hover:bg-ds-hover/60 hover:text-ds-ink'
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="flex min-w-0 items-center gap-1.5"
+                    onClick={() => setActiveTab(tab.id)}
+                    title={t(meta.labelKey)}
+                  >
+                    <Icon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.85} />
+                    <span className="max-w-[8rem] truncate">{t(meta.labelKey)}</span>
+                  </button>
+                  {meta.closable ? (
+                    <button
+                      type="button"
+                      className="ml-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-ds-faint opacity-0 transition hover:bg-ds-border-muted hover:text-ds-ink group-hover/tab:opacity-100"
+                      onClick={() => closeTab(tab.id)}
+                      aria-label={t('toolSidebarCloseTab')}
+                      title={t('toolSidebarCloseTab')}
+                    >
+                      <X className="h-3 w-3" strokeWidth={2} />
+                    </button>
+                  ) : null}
+                </div>
+              )
+            })}
+          </div>
+
+          <div ref={addMenuRef} className="relative shrink-0">
+            <button
+              type="button"
+              onClick={() => setAddMenuOpen((value) => !value)}
+              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
+              aria-label={t('toolSidebarAddPanel')}
+              title={t('toolSidebarAddPanel')}
+            >
+              <Plus className="h-4 w-4" strokeWidth={1.85} />
+            </button>
+            {addMenuOpen && addMenuItems.length > 0 ? (
+              <div className="ds-card-strong absolute right-0 top-full z-50 mt-1.5 w-52 overflow-hidden rounded-[14px] border border-ds-border py-1.5 shadow-[0_18px_52px_rgba(20,47,95,0.18)] backdrop-blur-xl dark:shadow-[0_22px_58px_rgba(0,0,0,0.38)]">
+                <div className="border-b border-ds-border-muted px-3 pb-1.5 pt-1 text-[11px] font-semibold text-ds-faint">
+                  {t('toolSidebarAddPanel')}
+                </div>
+                {addMenuItems.map((meta) => {
+                  const Icon = meta.icon
+                  const isOpen = tabs.some((tab) => tab.type === meta.type)
+                  return (
+                    <button
+                      key={meta.type}
+                      type="button"
+                      onClick={() => {
+                        openTab(meta.type)
+                        setAddMenuOpen(false)
+                      }}
+                      className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-[13px] text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
+                    >
+                      <Icon className="h-4 w-4 shrink-0" strokeWidth={1.85} />
+                      <span className="min-w-0 flex-1 truncate">{t(meta.labelKey)}</span>
+                      {isOpen ? <Check className="h-3.5 w-3.5 shrink-0 text-accent" strokeWidth={2} /> : null}
+                    </button>
+                  )
+                })}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="relative min-h-0 flex-1">
+          {tabs.map((tab) => (
+            <div
+              key={tab.id}
+              className="absolute inset-0 min-h-0"
+              style={{ display: tab.id === activeTabId ? 'flex' : 'none' }}
+            >
+              <div className="h-full w-full min-h-0">{renderTab(tab)}</div>
+            </div>
+          ))}
+          {!activeTab ? (
+            <div className="flex h-full items-center justify-center text-[13px] text-ds-faint">
+              {t('toolSidebarEmpty')}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/renderer/src/components/tool-sidebar/panel-registry.ts
+++ b/src/renderer/src/components/tool-sidebar/panel-registry.ts
@@ -1,0 +1,86 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  ClipboardList,
+  FileEdit,
+  FolderOpen,
+  Folders,
+  Globe2,
+  ListTodo,
+  Terminal
+} from 'lucide-react'
+import type { PanelType } from './tool-sidebar-store'
+
+export type PanelMeta = {
+  type: PanelType
+  labelKey: string
+  icon: LucideIcon
+  closable: boolean
+  showInAddMenu: boolean
+}
+
+const PANEL_META: Record<PanelType, PanelMeta> = {
+  todo: {
+    type: 'todo',
+    labelKey: 'rightPanelTodo',
+    icon: ListTodo,
+    closable: true,
+    showInAddMenu: true
+  },
+  plan: {
+    type: 'plan',
+    labelKey: 'rightPanelPlan',
+    icon: ClipboardList,
+    closable: true,
+    showInAddMenu: false
+  },
+  changes: {
+    type: 'changes',
+    labelKey: 'rightPanelChanges',
+    icon: FileEdit,
+    closable: true,
+    showInAddMenu: true
+  },
+  browser: {
+    type: 'browser',
+    labelKey: 'rightPanelBrowser',
+    icon: Globe2,
+    closable: true,
+    showInAddMenu: true
+  },
+  file: {
+    type: 'file',
+    labelKey: 'rightPanelFiles',
+    icon: FolderOpen,
+    closable: true,
+    showInAddMenu: false
+  },
+  terminal: {
+    type: 'terminal',
+    labelKey: 'rightPanelTerminal',
+    icon: Terminal,
+    closable: true,
+    showInAddMenu: true
+  },
+  files: {
+    type: 'files',
+    labelKey: 'rightPanelFilesTree',
+    icon: Folders,
+    closable: true,
+    showInAddMenu: true
+  },
+  'sdd-ai': {
+    type: 'sdd-ai',
+    labelKey: 'rightPanelSddAssistant',
+    icon: FileEdit,
+    closable: true,
+    showInAddMenu: false
+  }
+}
+
+export function getPanelMeta(type: PanelType): PanelMeta {
+  return PANEL_META[type]
+}
+
+export function getAddMenuPanels(): PanelMeta[] {
+  return Object.values(PANEL_META).filter((meta) => meta.showInAddMenu)
+}

--- a/src/renderer/src/components/tool-sidebar/tool-sidebar-store.ts
+++ b/src/renderer/src/components/tool-sidebar/tool-sidebar-store.ts
@@ -1,0 +1,206 @@
+import { create } from 'zustand'
+import {
+  readBrowserStorageItem,
+  writeBrowserStorageItem
+} from '../../lib/browser-storage'
+
+export type PanelType =
+  | 'todo'
+  | 'plan'
+  | 'changes'
+  | 'browser'
+  | 'file'
+  | 'terminal'
+  | 'files'
+  | 'sdd-ai'
+
+export type PanelTab = {
+  id: string
+  type: PanelType
+  meta?: Record<string, unknown>
+}
+
+type ToolSidebarState = {
+  open: boolean
+  tabs: PanelTab[]
+  activeTabId: string | null
+  openTab: (type: PanelType, meta?: Record<string, unknown>) => void
+  closeTab: (id: string) => void
+  setActiveTab: (id: string) => void
+  toggleOpen: () => void
+  setOpen: (open: boolean) => void
+  close: () => void
+  closeTabsByType: (type: PanelType) => void
+  hasTab: (type: PanelType) => boolean
+  toggleTab: (type: PanelType, meta?: Record<string, unknown>) => void
+}
+
+const STORAGE_KEY = 'kun.layout.toolSidebar'
+const PERSISTABLE_TYPES: ReadonlySet<PanelType> = new Set([
+  'todo',
+  'changes',
+  'browser',
+  'terminal',
+  'files'
+])
+
+function tabIdForType(type: PanelType): string {
+  return type
+}
+
+function loadPersisted(): { tabs: PanelTab[]; activeTabId: string | null; open: boolean } {
+  const raw = readBrowserStorageItem(STORAGE_KEY)
+  if (!raw) return { tabs: [], activeTabId: null, open: false }
+  try {
+    const parsed = JSON.parse(raw) as {
+      tabs?: PanelTab[]
+      activeTabId?: string | null
+      open?: boolean
+    }
+    const tabs = (parsed.tabs ?? []).filter(
+      (tab) => PERSISTABLE_TYPES.has(tab.type) && typeof tab.id === 'string'
+    )
+    const activeTabId =
+      typeof parsed.activeTabId === 'string' &&
+      tabs.some((tab) => tab.id === parsed.activeTabId)
+        ? parsed.activeTabId
+        : (tabs[0]?.id ?? null)
+    return { tabs, activeTabId, open: parsed.open === true }
+  } catch {
+    return { tabs: [], activeTabId: null, open: false }
+  }
+}
+
+function persist(state: {
+  tabs: PanelTab[]
+  activeTabId: string | null
+  open: boolean
+}): void {
+  const persistable = state.tabs.filter((tab) => PERSISTABLE_TYPES.has(tab.type))
+  const activeTabId = persistable.some((tab) => tab.id === state.activeTabId)
+    ? state.activeTabId
+    : (persistable[0]?.id ?? null)
+  writeBrowserStorageItem(
+    STORAGE_KEY,
+    JSON.stringify({ tabs: persistable, activeTabId, open: state.open })
+  )
+}
+
+function removeTab(tabs: PanelTab[], id: string): {
+  tabs: PanelTab[]
+  activeTabId: string | null
+} {
+  const next = tabs.filter((tab) => tab.id !== id)
+  const closedIndex = tabs.findIndex((tab) => tab.id === id)
+  const fallback = next[Math.max(0, closedIndex - 1)]?.id ?? next[0]?.id ?? null
+  return { tabs: next, activeTabId: fallback }
+}
+
+const initial = loadPersisted()
+
+export const useToolSidebarStore = create<ToolSidebarState>((set, get) => ({
+  open: initial.open,
+  tabs: initial.tabs,
+  activeTabId: initial.activeTabId,
+
+  openTab: (type, meta) => {
+    set((state) => {
+      const id = tabIdForType(type)
+      const existing = state.tabs.find((tab) => tab.id === id)
+      const tabs = existing
+        ? state.tabs.map((tab) =>
+            tab.id === id ? { ...tab, meta: meta ?? tab.meta } : tab
+          )
+        : [...state.tabs, { id, type, ...(meta ? { meta } : {}) }]
+      const next = { tabs, activeTabId: id, open: true }
+      persist(next)
+      return next
+    })
+  },
+
+  closeTab: (id) => {
+    set((state) => {
+      const { tabs, activeTabId } = removeTab(state.tabs, id)
+      const open = tabs.length > 0 && state.open
+      const next = { tabs, activeTabId, open }
+      persist(next)
+      return next
+    })
+  },
+
+  setActiveTab: (id) => {
+    set((state) => {
+      if (!state.tabs.some((tab) => tab.id === id)) return state
+      const next = { tabs: state.tabs, activeTabId: id, open: true }
+      persist(next)
+      return next
+    })
+  },
+
+  toggleOpen: () => {
+    set((state) => {
+      const next = {
+        tabs: state.tabs,
+        activeTabId: state.activeTabId,
+        open: !state.open
+      }
+      persist(next)
+      return next
+    })
+  },
+
+  setOpen: (open) => {
+    set((state) => {
+      const next = {
+        tabs: state.tabs,
+        activeTabId: state.activeTabId,
+        open
+      }
+      persist(next)
+      return next
+    })
+  },
+
+  close: () => {
+    set((state) => {
+      const next = { tabs: state.tabs, activeTabId: state.activeTabId, open: false }
+      persist(next)
+      return next
+    })
+  },
+
+  closeTabsByType: (type) => {
+    set((state) => {
+      const id = tabIdForType(type)
+      if (!state.tabs.some((tab) => tab.id === id)) return state
+      const { tabs, activeTabId } = removeTab(state.tabs, id)
+      const open = tabs.length > 0 && state.open
+      const next = { tabs, activeTabId, open }
+      persist(next)
+      return next
+    })
+  },
+
+  hasTab: (type) => get().tabs.some((tab) => tab.type === type),
+
+  toggleTab: (type, meta) => {
+    const state = get()
+    const id = tabIdForType(type)
+    if (state.activeTabId === id && state.open) {
+      get().close()
+      return
+    }
+    get().openTab(type, meta)
+  }
+}))
+
+export function useActiveTabType(): PanelType | null {
+  return useToolSidebarStore((state) => {
+    if (!state.activeTabId) return null
+    return state.tabs.find((tab) => tab.id === state.activeTabId)?.type ?? null
+  })
+}
+
+export function useToolSidebarOpen(): boolean {
+  return useToolSidebarStore((state) => state.open)
+}

--- a/src/renderer/src/components/workbench-layout.ts
+++ b/src/renderer/src/components/workbench-layout.ts
@@ -1,21 +1,14 @@
 import type { PointerEvent as ReactPointerEvent } from 'react'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { WorkspaceFileTarget } from '@shared/workspace-file'
-import type { AppRoute } from '../store/chat-store-types'
 import {
   readBrowserStorageItem,
-  removeBrowserStorageItem,
   writeBrowserStorageItem
 } from '../lib/browser-storage'
-import { WORKSPACE_FILE_PREVIEW_EVENT, type WorkspaceFilePreviewDetail } from '../lib/workspace-file-preview'
-import type { RightPanelMode } from './chat/WorkbenchTopBar'
 
 const LEFT_PANEL_WIDTH_KEY = 'kun.layout.leftSidebarWidth'
 const LEFT_PANEL_COLLAPSED_KEY = 'kun.layout.leftSidebarCollapsed'
 const RIGHT_PANEL_WIDTH_KEY = 'kun.layout.rightInspectorWidth'
-const RIGHT_PANEL_MODE_KEY = 'kun.layout.rightPanelMode'
-const TERMINAL_OPEN_KEY = 'kun.layout.terminalOpen'
-const TERMINAL_HEIGHT_KEY = 'kun.layout.terminalHeight'
 const LEFT_PANEL_DEFAULT = 304
 const RIGHT_PANEL_DEFAULT = 360
 export const CODE_PANEL_PREFERRED = 560
@@ -26,11 +19,6 @@ const RIGHT_PANEL_MAX = 760
 const SIDEBAR_HARD_MIN = 180
 const MAIN_MIN_WIDTH = 560
 const PANEL_RESIZE_HANDLE_WIDTH = 5
-// Bottom terminal drawer sizing. The drawer lives below the chat stage and
-// resizes vertically, so it has its own clamps instead of the column widths.
-const TERMINAL_HEIGHT_DEFAULT = 360
-const TERMINAL_HEIGHT_MIN = 220
-const TERMINAL_HEIGHT_MAX = 760
 
 function clampWidth(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))
@@ -57,19 +45,6 @@ function readStoredBoolean(key: string, fallback: boolean): boolean {
 
 function persistBoolean(key: string, value: boolean): void {
   writeBrowserStorageItem(key, value ? '1' : '0')
-}
-
-function readStoredRightPanelMode(): RightPanelMode {
-  const raw = readBrowserStorageItem(RIGHT_PANEL_MODE_KEY)
-  return raw === 'todo' || raw === 'changes' || raw === 'browser' ? raw : null
-}
-
-function persistRightPanelMode(mode: RightPanelMode): void {
-  if (mode === 'todo' || mode === 'changes' || mode === 'browser') {
-    writeBrowserStorageItem(RIGHT_PANEL_MODE_KEY, mode)
-  } else {
-    removeBrowserStorageItem(RIGHT_PANEL_MODE_KEY)
-  }
 }
 
 function fitWorkbenchWidths(
@@ -152,20 +127,11 @@ function fitWorkbenchWidths(
 
 export function useWorkbenchLayout({
   activeThreadId,
-  latestAutoOpenDevPreviewUrl,
-  latestDevPreviewUrl,
-  route,
-  workspaceRoot,
-  writeAssistantOpen
+  rightPanelVisible
 }: {
   activeThreadId: string | null
-  latestAutoOpenDevPreviewUrl: string | null
-  latestDevPreviewUrl: string | null
-  route: AppRoute
-  workspaceRoot: string
-  writeAssistantOpen: boolean
+  rightPanelVisible: boolean
 }) {
-  const [rightPanelMode, setRightPanelMode] = useState<RightPanelMode>(readStoredRightPanelMode)
   const [filePreviewTarget, setFilePreviewTarget] = useState<WorkspaceFileTarget | null>(null)
   const [leftSidebarWidth, setLeftSidebarWidth] = useState(() =>
     readStoredWidth(LEFT_PANEL_WIDTH_KEY, LEFT_PANEL_DEFAULT)
@@ -176,14 +142,8 @@ export function useWorkbenchLayout({
   const [rightSidebarWidth, setRightSidebarWidth] = useState(() =>
     readStoredWidth(RIGHT_PANEL_WIDTH_KEY, RIGHT_PANEL_DEFAULT)
   )
-  const [terminalOpen, setTerminalOpen] = useState(false)
-  const [terminalHeight, setTerminalHeight] = useState(() =>
-    readStoredWidth(TERMINAL_HEIGHT_KEY, TERMINAL_HEIGHT_DEFAULT)
-  )
   const shellRef = useRef<HTMLDivElement | null>(null)
   const previewThreadId = useRef<string | null>(activeThreadId)
-  const autoOpenedPreviewUrlRef = useRef<string | null>(null)
-  const rightPanelVisible = route === 'write' ? writeAssistantOpen : rightPanelMode !== null
 
   useEffect(() => {
     persistWidth(LEFT_PANEL_WIDTH_KEY, leftSidebarWidth)
@@ -198,55 +158,9 @@ export function useWorkbenchLayout({
   }, [rightSidebarWidth])
 
   useEffect(() => {
-    persistRightPanelMode(rightPanelMode)
-  }, [rightPanelMode])
-
-  useEffect(() => {
-    removeBrowserStorageItem(TERMINAL_OPEN_KEY)
-  }, [])
-
-  useEffect(() => {
-    persistWidth(TERMINAL_HEIGHT_KEY, terminalHeight)
-  }, [terminalHeight])
-
-  useEffect(() => {
-    const onPreview = (event: Event): void => {
-      const detail = (event as CustomEvent<WorkspaceFilePreviewDetail>).detail
-      if (!detail?.path) return
-      setFilePreviewTarget({
-        ...detail,
-        workspaceRoot: detail.workspaceRoot ?? workspaceRoot
-      })
-      setRightSidebarWidth((width) => Math.max(width, CODE_PANEL_PREFERRED))
-      setRightPanelMode('file')
-    }
-
-    window.addEventListener(WORKSPACE_FILE_PREVIEW_EVENT, onPreview)
-    return () => window.removeEventListener(WORKSPACE_FILE_PREVIEW_EVENT, onPreview)
-  }, [workspaceRoot])
-
-  useEffect(() => {
     if (previewThreadId.current === activeThreadId) return
     previewThreadId.current = activeThreadId
-    autoOpenedPreviewUrlRef.current = null
-    if (rightPanelMode === 'browser') setRightPanelMode(null)
-    if (rightPanelMode === 'file') {
-      setRightPanelMode(null)
-      setFilePreviewTarget(null)
-    }
-  }, [activeThreadId, rightPanelMode])
-
-  useEffect(() => {
-    if (!latestAutoOpenDevPreviewUrl || route !== 'chat') return
-    if (autoOpenedPreviewUrlRef.current === latestAutoOpenDevPreviewUrl) return
-    autoOpenedPreviewUrlRef.current = latestAutoOpenDevPreviewUrl
-    setRightPanelMode('browser')
-  }, [latestAutoOpenDevPreviewUrl, route])
-
-  useEffect(() => {
-    if (route !== 'write') return
-    if (rightPanelMode !== null) setRightPanelMode(null)
-  }, [route, rightPanelMode])
+  }, [activeThreadId])
 
   useLayoutEffect(() => {
     const sync = (): void => {
@@ -268,19 +182,8 @@ export function useWorkbenchLayout({
     return () => window.removeEventListener('resize', sync)
   }, [leftSidebarCollapsed, leftSidebarWidth, rightPanelVisible, rightSidebarWidth])
 
-  const toggleRightPanelMode = (nextMode: Exclude<RightPanelMode, null>): void => {
-    setRightPanelMode((current) => (current === nextMode ? null : nextMode))
-  }
-
   const toggleLeftSidebar = (): void => {
     setLeftSidebarCollapsed((current) => !current)
-  }
-
-  const openDevPreview = (): void => {
-    if (latestDevPreviewUrl) {
-      autoOpenedPreviewUrlRef.current = latestDevPreviewUrl
-    }
-    setRightPanelMode('browser')
   }
 
   const beginLeftResize = (event: ReactPointerEvent<HTMLDivElement>): void => {
@@ -359,60 +262,16 @@ export function useWorkbenchLayout({
     window.addEventListener('pointerup', onUp)
   }
 
-  // Bottom terminal drawer: dragging the top edge up grows the panel. The
-  // clamps keep enough chat stage visible above it.
-  const beginTerminalResize = (event: ReactPointerEvent<HTMLDivElement>): void => {
-    if (event.button !== 0 || !terminalOpen) return
-    event.preventDefault()
-    const startY = event.clientY
-    const startHeight = terminalHeight
-    const prevCursor = document.body.style.cursor
-    const prevUserSelect = document.body.style.userSelect
-    document.body.style.cursor = 'row-resize'
-    document.body.style.userSelect = 'none'
-
-    const onMove = (moveEvent: PointerEvent): void => {
-      const containerHeight = shellRef.current?.clientHeight ?? window.innerHeight
-      const delta = startY - moveEvent.clientY
-      const maxHeight = Math.max(TERMINAL_HEIGHT_MIN, Math.min(TERMINAL_HEIGHT_MAX, containerHeight - 260))
-      const nextHeight = Math.min(Math.max(startHeight + delta, TERMINAL_HEIGHT_MIN), maxHeight)
-      setTerminalHeight(nextHeight)
-    }
-
-    const onUp = (): void => {
-      document.body.style.cursor = prevCursor
-      document.body.style.userSelect = prevUserSelect
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-    }
-
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
-  }
-
-  const toggleTerminal = (): void => {
-    setTerminalOpen((current) => !current)
-  }
-
   return {
     beginLeftResize,
     beginRightResize,
-    beginTerminalResize,
     filePreviewTarget,
     leftSidebarCollapsed,
     leftSidebarWidth,
-    openDevPreview,
-    rightPanelMode,
-    rightPanelVisible,
     rightSidebarWidth,
     setFilePreviewTarget,
-    setRightPanelMode,
     setRightSidebarWidth,
     shellRef,
-    terminalHeight,
-    terminalOpen,
-    toggleLeftSidebar,
-    toggleRightPanelMode,
-    toggleTerminal
+    toggleLeftSidebar
   }
 }

--- a/src/renderer/src/components/workbench-plan-controller.ts
+++ b/src/renderer/src/components/workbench-plan-controller.ts
@@ -22,7 +22,7 @@ import {
   planFeatureNameFromRequest
 } from '../plan/plan-path'
 import { extractPlanMetadataFromBlock } from '../plan/plan-tool'
-import type { RightPanelMode } from './chat/WorkbenchTopBar'
+import type { PanelType } from './tool-sidebar/tool-sidebar-store'
 import type { GuiPlanMessageContext, SendMessageOverrides } from '../store/chat-store-types'
 import { normalizeWorkspaceRoot } from '../lib/workspace-path'
 
@@ -46,7 +46,7 @@ type WorkbenchPlanControllerOptions = {
   sendMessage: ChatState['sendMessage']
   setError: ChatState['setError']
   setComposerMode: ChatState['setComposerMode']
-  setRightPanelMode: Dispatch<SetStateAction<RightPanelMode>>
+  openTab: (type: PanelType) => void
   setRightSidebarWidth: Dispatch<SetStateAction<number>>
   t: (key: string) => string
   workspaceRoot: string
@@ -145,7 +145,7 @@ export function useWorkbenchPlanController({
   sendMessage,
   setError,
   setComposerMode,
-  setRightPanelMode,
+  openTab,
   setRightSidebarWidth,
   t,
   workspaceRoot,
@@ -158,8 +158,8 @@ export function useWorkbenchPlanController({
 
   const openGuiPlanPanel = useCallback((): void => {
     setRightSidebarWidth((width) => Math.max(width, CODE_PANEL_PREFERRED))
-    setRightPanelMode('plan')
-  }, [setRightPanelMode, setRightSidebarWidth])
+    openTab('plan')
+  }, [openTab, setRightSidebarWidth])
 
   const savePlanContentToDisk = async (
     plan: GuiPlanArtifact,

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1307,6 +1307,13 @@
   "terminalExitMessage": "Process exited — click to restart",
   "terminalUnavailable": "Terminal unavailable",
   "rightPanelCollapse": "Collapse right sidebar",
+  "toolSidebarToggle": "Toggle tool sidebar",
+  "toolSidebarCloseTab": "Close tab",
+  "toolSidebarAddPanel": "Add panel",
+  "toolSidebarEmpty": "No panels open. Click + to add one.",
+  "rightPanelFilesTree": "File Tree",
+  "rightPanelSddAssistant": "Assistant",
+
   "editorPickerTitle": "Choose default editor",
   "editorPickerTitleWithEditor": "Default editor: {{editor}}",
   "editorPickerMenuTitle": "Open files with",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1307,6 +1307,13 @@
   "terminalExitMessage": "进程已退出 — 点击重启",
   "terminalUnavailable": "终端不可用",
   "rightPanelCollapse": "收起右侧栏",
+  "toolSidebarToggle": "切换工具侧栏",
+  "toolSidebarCloseTab": "关闭标签页",
+  "toolSidebarAddPanel": "添加面板",
+  "toolSidebarEmpty": "没有打开的面板,点击 + 添加。",
+  "rightPanelFilesTree": "文件树",
+  "rightPanelSddAssistant": "需求助手",
+
   "editorPickerTitle": "选择默认编辑器",
   "editorPickerTitleWithEditor": "默认编辑器：{{editor}}",
   "editorPickerMenuTitle": "打开文件使用",


### PR DESCRIPTION
## Summary

Replace the crowded right-panel icon buttons in WorkbenchTopBar with a single sidebar toggle that opens a tabbed ToolSidebar. Each feature (Todo, Plan, Changes, Browser, Terminal, Files) opens as a switchable tab, with a "+" button to add more panels. Terminal and file tree are now right-side tabs instead of a bottom drawer / side panel.

## Changes

- **tool-sidebar-store.ts** — Zustand store managing multi-tab state (`tabs[]`, `activeTabId`, `open`) with localStorage persistence for structural panels (todo, changes, browser, terminal, files)
- **panel-registry.ts** — Metadata registry mapping `PanelType` to icon, label, closable, and add-menu visibility
- **ToolSidebar.tsx** — Tabbed sidebar component with tab strip, "+" add menu, and content area (all tabs stay mounted, display-toggled)
- **Workbench.tsx** — Rewired to replace `rightPanelMode` (single value) with ToolSidebar (multi-tab); terminal and file tree now render as sidebar tabs
- **WorkbenchTopBar.tsx** — Removed 7 feature icon buttons (Todo/Plan/Changes/Browser/Terminal/Files); kept SideChat button and editor picker; added single `PanelRight` toggle
- **workbench-layout.ts** — Stripped `rightPanelMode`, `terminalOpen`, `terminalHeight`; hook now accepts `rightPanelVisible` as input
- **workbench-plan-controller.ts** — Replaced `setRightPanelMode('plan')` with `openTab('plan')`
- **locales/{en,zh}/common.json** — Added 6 i18n keys

## Tests

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors, 12 pre-existing warnings only
- Manual verification: toggle opens empty sidebar with "+" menu, clicking a panel type creates a tab, multiple tabs switchable, close works
