### PR TITLE
fix(settings): move proxy below providers and refine font-scale control

### DIFF
--- a/src/renderer/src/components/settings-section-general.tsx
+++ b/src/renderer/src/components/settings-section-general.tsx
@@ -8,7 +8,6 @@ import {
   DEFAULT_WRITE_INLINE_COMPLETION_MODEL,
   DEFAULT_WRITE_INLINE_LONG_COMPLETION_MAX_TOKENS,
   DEFAULT_KUN_DATA_DIR,
-  LEGACY_UI_FONT_SCALE_FACTORS,
   UI_FONT_SCALE_MAX,
   UI_FONT_SCALE_MIN,
   WRITE_INLINE_COMPLETION_MODEL_IDS,
@@ -242,18 +241,6 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
   const fontScale = normalizeUiFontScale(form.uiFontScale)
   const fontScalePercent = Math.round(fontScale * 100)
   const setFontScale = (value: number): void => update({ uiFontScale: normalizeUiFontScale(value) })
-  const fontScalePresets: { value: number; label: string }[] = [
-    { value: LEGACY_UI_FONT_SCALE_FACTORS.small, label: t('fontScaleSmall') },
-    { value: LEGACY_UI_FONT_SCALE_FACTORS.medium, label: t('fontScaleMedium') },
-    { value: LEGACY_UI_FONT_SCALE_FACTORS.large, label: t('fontScaleLarge') }
-  ]
-  const fontScaleChipClass = (active: boolean): string =>
-    [
-      'inline-flex h-7 items-center rounded-full border px-3 text-[12px] font-medium transition',
-      active
-        ? 'border-accent/60 bg-accent/8 text-accent ring-1 ring-accent/30'
-        : 'border-ds-border bg-ds-card text-ds-muted hover:bg-ds-hover hover:text-ds-ink'
-    ].join(' ')
   const cursorSpotlightColor = normalizeHexColor(form.cursorSpotlightColor)
 
   return (
@@ -293,19 +280,6 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                   description={t('fontScaleDesc')}
                   control={
                     <div className="w-full min-w-0 space-y-2.5 md:max-w-md">
-                      <div className="flex flex-wrap items-center gap-1.5">
-                        {fontScalePresets.map((preset) => (
-                          <button
-                            key={preset.label}
-                            type="button"
-                            aria-pressed={fontScalePercent === Math.round(preset.value * 100)}
-                            className={fontScaleChipClass(fontScalePercent === Math.round(preset.value * 100))}
-                            onClick={() => setFontScale(preset.value)}
-                          >
-                            {preset.label}
-                          </button>
-                        ))}
-                      </div>
                       <div className="flex items-center gap-3">
                         <span className="shrink-0 text-[12px] leading-none text-ds-faint" aria-hidden="true">
                           A
@@ -332,7 +306,7 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                           >
                             −
                           </button>
-                          <div className="flex items-center border-x border-ds-border">
+                          <div className="flex h-7 w-[3.75rem] items-center justify-center border-x border-ds-border tabular-nums">
                             <input
                               type="number"
                               min={Math.round(UI_FONT_SCALE_MIN * 100)}
@@ -340,10 +314,10 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                               step={1}
                               value={fontScalePercent}
                               aria-label={t('fontScale')}
-                              className="w-10 border-0 bg-transparent py-1 text-center text-[13px] font-medium tabular-nums text-ds-ink outline-none"
+                              className="hide-number-spinner w-8 border-0 bg-transparent p-0 text-center text-[13px] font-medium text-ds-ink outline-none"
                               onChange={(e) => setFontScale(Number(e.target.value) / 100)}
                             />
-                            <span className="pr-1.5 text-[11px] text-ds-faint">%</span>
+                            <span className="text-[11px] text-ds-faint">%</span>
                           </div>
                           <button
                             type="button"

--- a/src/renderer/src/components/settings-section-providers.tsx
+++ b/src/renderer/src/components/settings-section-providers.tsx
@@ -1119,28 +1119,6 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
     <>
     <SettingsCard title={t('providers')}>
       <SettingRow
-        title={t('proxyUrl')}
-        description={t('proxyUrlDesc')}
-        control={
-          <div className="flex w-full min-w-0 flex-col gap-2 md:max-w-md">
-            <label className="flex items-center justify-between gap-3 rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[13px] text-ds-muted shadow-sm">
-              <span>{t('proxyEnabled')}</span>
-              <Toggle
-                checked={providerProxy.enabled === true}
-                onChange={(enabled) => updateProviderProxy({ enabled })}
-              />
-            </label>
-            <input
-              className={textInputClass}
-              placeholder={t('proxyUrlPlaceholder')}
-              value={providerProxy.url}
-              spellCheck={false}
-              onChange={(e) => updateProviderProxy({ url: e.target.value })}
-            />
-          </div>
-        }
-      />
-      <SettingRow
         title={t('providers')}
         description={t('providersDesc')}
         wideControl
@@ -1735,6 +1713,28 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
                 ) : null}
               </div>
             ) : null}
+          </div>
+        }
+      />
+      <SettingRow
+        title={t('proxyUrl')}
+        description={t('proxyUrlDesc')}
+        control={
+          <div className="flex w-full min-w-0 flex-col gap-2 md:max-w-md">
+            <label className="flex items-center justify-between gap-3 rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[13px] text-ds-muted shadow-sm">
+              <span>{t('proxyEnabled')}</span>
+              <Toggle
+                checked={providerProxy.enabled === true}
+                onChange={(enabled) => updateProviderProxy({ enabled })}
+              />
+            </label>
+            <input
+              className={textInputClass}
+              placeholder={t('proxyUrlPlaceholder')}
+              value={providerProxy.url}
+              spellCheck={false}
+              onChange={(e) => updateProviderProxy({ url: e.target.value })}
+            />
           </div>
         }
       />

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -3,3 +3,15 @@
 @tailwind utilities;
 
 /* Design tokens: light keeps the existing OpenBridge feel; dark follows the Codex-style theme-v1 palette. */
+
+/* Hide the native number-input spinner (up/down arrows). Used by the font-scale
+   control where the adjacent range slider already provides fine-grained control. */
+.hide-number-spinner::-webkit-outer-spin-button,
+.hide-number-spinner::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.hide-number-spinner {
+  -moz-appearance: textfield;
+}
+


### PR DESCRIPTION
## Summary

两处设置页体验调整：

1. 「模型供应商」卡片内，把「模型请求代理」配置项从供应商列表的上方移动到下方。
2. 字体大小控件优化：数字与 `%` 居中贴合、去掉悬停时原生上下箭头、删除「小/中/大」三个预设按钮。

## Changes

- `src/renderer/src/components/settings-section-providers.tsx`
  - 交换 `SettingsCard` 内两个 `SettingRow` 的顺序，使 `proxyUrl` 位于 `providers` 之后。仅调整渲染顺序，读写逻辑不变。
- `src/renderer/src/components/settings-section-general.tsx`
  - 删除「小/中/大」预设 chip（`fontScalePresets` / `fontScaleChipClass`）及其 JSX，移除不再使用的 `LEGACY_UI_FONT_SCALE_FACTORS` 导入。
  - 数字 input 与 `%` 收进同一固定宽度居中容器，数字不再与 `%` 分离。
  - number input 加 `hide-number-spinner` 类，去掉悬停原生上下箭头。
- `src/renderer/src/index.css`
  - 新增 `.hide-number-spinner` 规则，隐藏 webkit 的 `outer/inner-spin-button` 与 Firefox spinner。

## Tests

- `npm run typecheck` 通过。
- 本地打包 macOS arm64 覆盖安装，验证三个问题均已解决。
