### PR TITLE
feat(composer): add files and folders entry

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -1129,6 +1129,10 @@ export function Workbench(): ReactElement {
     setFileTreeSidePanelOpen((open) => !open)
   }
 
+  const openFileTreeSidePanel = (): void => {
+    setFileTreeSidePanelOpen(true)
+  }
+
   useEffect(() => {
     if (rightPanelMode !== 'file' || !filePreviewTarget) return
     setOpenFilePreviewTargets((current) => {
@@ -2788,6 +2792,7 @@ export function Workbench(): ReactElement {
                 onPasteClipboardImage={(options) => void handlePasteClipboardImage(options)}
                 onRemoveAttachment={removeComposerAttachment}
                 onAddFileReference={addComposerFileReference}
+                onOpenFileReferencePicker={openFileTreeSidePanel}
                 onRemoveFileReference={removeComposerFileReference}
                 queuedMessages={queuedMessages}
                 onRemoveQueuedMessage={removeQueuedMessage}

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -24,6 +24,7 @@ import {
   MessageCircleMore,
   Mic,
   Minimize2,
+  Paperclip,
   PauseCircle,
   Pencil,
   Plus,
@@ -180,6 +181,7 @@ type Props = {
   onPasteClipboardImage?: (options?: { silentNoImage?: boolean }) => void | Promise<void>
   onRemoveAttachment?: (id: string) => void
   onAddFileReference?: (reference: ComposerFileReference) => void
+  onOpenFileReferencePicker?: () => void
   onRemoveFileReference?: (relativePath: string) => void
   onSend: () => void
   onInterrupt: (options?: { discard?: boolean }) => void
@@ -493,6 +495,7 @@ export function FloatingComposer({
   onPasteClipboardImage,
   onRemoveAttachment,
   onAddFileReference,
+  onOpenFileReferencePicker,
   onRemoveFileReference,
   onSend,
   onInterrupt,
@@ -614,6 +617,7 @@ export function FloatingComposer({
     (fileReferenceEnabled && fileReferences.length > 0)
   )
   const canPickAttachment = canCompose && attachmentUploadEnabled && !attachmentUploadBusy
+  const canPickFileReference = canCompose && fileReferenceEnabled && Boolean(effectiveWorkspaceRoot) && Boolean(onOpenFileReferencePicker)
   const showIntentToolbar = !compact && route === 'chat'
   const showComposerMenuButton = showIntentToolbar
   const canTogglePlanMode = canCompose && Boolean(onPlanCommand)
@@ -622,7 +626,7 @@ export function FloatingComposer({
   const canRunReview = canCompose && route !== 'claw' && Boolean(onReviewCommand)
   const canToggleWorktreeMode = canCompose && route !== 'claw' && Boolean(onToggleWorktreeMode)
   const canOpenComposerMenu = showComposerMenuButton
-    && (canTogglePlanMode || canCreateNewThread || canOpenGoalPanel || canRunReview || canToggleWorktreeMode)
+    && (canPickFileReference || canTogglePlanMode || canCreateNewThread || canOpenGoalPanel || canRunReview || canToggleWorktreeMode)
   const showToolbarStartControls = showComposerMenuButton
   const showExecutionSettingsPicker = showIntentToolbar
     && Boolean(executionSettings)
@@ -1270,6 +1274,13 @@ export function FloatingComposer({
     draft.focusComposer()
   }
 
+  const handleFileReferenceMenuClick = (): void => {
+    if (!canPickFileReference) return
+    setComposerMenuOpen(false)
+    onOpenFileReferencePicker?.()
+    draft.focusComposer()
+  }
+
   const handlePlanToolbarClick = (): void => {
     if (!canTogglePlanMode) return
     setComposerMenuOpen(false)
@@ -1677,8 +1688,20 @@ export function FloatingComposer({
             ref={composerMenuPanelRef}
             className="absolute bottom-12 left-1 z-40 w-48 overflow-hidden rounded-[18px] border border-ds-border bg-white py-1.5 text-[13px] text-ds-muted shadow-[0_18px_48px_rgba(20,47,95,0.16)] dark:bg-ds-card"
           >
+            {fileReferenceEnabled ? (
+              <button
+                type="button"
+                disabled={!canPickFileReference}
+                onClick={handleFileReferenceMenuClick}
+                className="ds-no-drag flex h-8 w-full items-center gap-2 px-3 text-left transition hover:bg-ds-hover hover:text-ds-ink disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent disabled:hover:text-ds-muted"
+              >
+                <Paperclip className="h-3.5 w-3.5 shrink-0" strokeWidth={1.9} />
+                <span className="min-w-0 flex-1 truncate">{t('composerAddFilesAndFolders')}</span>
+              </button>
+            ) : null}
             {attachmentUploadEnabled ? (
               <>
+                {fileReferenceEnabled ? <div className="my-1 h-px bg-ds-border-muted/70" /> : null}
                 <button
                   type="button"
                   disabled={!canPickAttachment || !onPickAttachments}

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1011,6 +1011,7 @@
   "composerOfflineHint": "Reconnect the runtime before sending another message.",
   "composerWorkspaceHint": "Choose a working directory before starting or continuing a thread.",
   "composerAddImage": "Attach image",
+  "composerAddFilesAndFolders": "Files and folders",
   "composerVoiceStart": "Voice input",
   "composerVoiceStop": "Stop recording",
   "composerVoiceSend": "Stop and send",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1011,6 +1011,7 @@
   "composerOfflineHint": "运行时恢复连接后，才可以继续发送消息。",
   "composerWorkspaceHint": "先选择一个工作目录，然后再开始或继续会话。",
   "composerAddImage": "添加图片",
+  "composerAddFilesAndFolders": "文件和文件夹",
   "composerVoiceStart": "语音输入",
   "composerVoiceStop": "停止录音",
   "composerVoiceSend": "停止并发送",


### PR DESCRIPTION
﻿## Summary

- Add a Codex-style `Files and folders` entry to the composer plus menu.
- Reuse the existing workspace file tree picker so users can add both files and folders as composer context references.
- Keep the existing `@file` reference and send path unchanged; this only adds a discoverable UI entry.

## Tests

- `git diff --check`
- `npm.cmd test -- src/renderer/src/components/chat/FloatingComposer.test.ts`
- `npm.cmd run typecheck`
