### PR TITLE
refactor(main): split desktop behavior helpers

### DIFF
--- a/src/main/desktop-behavior.test.ts
+++ b/src/main/desktop-behavior.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppSettingsV1 } from '../shared/app-settings'
+
+const setLoginItemSettings = vi.fn()
+const logWarn = vi.fn()
+
+vi.mock('electron', () => ({
+  app: {
+    setLoginItemSettings
+  }
+}))
+
+vi.mock('./logger', () => ({
+  logWarn
+}))
+
+function settings(appBehavior: Partial<AppSettingsV1['appBehavior']>): AppSettingsV1 {
+  return {
+    appBehavior: {
+      openAtLogin: false,
+      startMinimized: false,
+      closeToTray: false,
+      ...appBehavior
+    }
+  } as AppSettingsV1
+}
+
+describe('desktop behavior', () => {
+  beforeEach(() => {
+    setLoginItemSettings.mockReset()
+    logWarn.mockReset()
+  })
+
+  it('starts hidden only for Windows login launch with the hidden arg', async () => {
+    const { HIDDEN_START_ARG, shouldStartHidden } = await import('./desktop-behavior')
+    const startupSettings = settings({ openAtLogin: true, startMinimized: true })
+
+    expect(shouldStartHidden(startupSettings, 'win32', ['kun', HIDDEN_START_ARG])).toBe(true)
+    expect(shouldStartHidden(startupSettings, 'win32', ['kun'])).toBe(false)
+    expect(shouldStartHidden(startupSettings, 'darwin', ['kun', HIDDEN_START_ARG])).toBe(false)
+    expect(shouldStartHidden(settings({ openAtLogin: true }), 'win32', ['kun', HIDDEN_START_ARG])).toBe(false)
+  })
+
+  it('syncs login item args on supported desktop platforms', async () => {
+    const { syncLoginItemSettings } = await import('./desktop-behavior')
+
+    syncLoginItemSettings(settings({ openAtLogin: true, startMinimized: true }), 'win32')
+    syncLoginItemSettings(settings({ openAtLogin: true, startMinimized: true }), 'darwin')
+    syncLoginItemSettings(settings({ openAtLogin: true, startMinimized: true }), 'linux')
+
+    expect(setLoginItemSettings).toHaveBeenCalledTimes(2)
+    expect(setLoginItemSettings).toHaveBeenNthCalledWith(1, {
+      openAtLogin: true,
+      args: ['--hidden']
+    })
+    expect(setLoginItemSettings).toHaveBeenNthCalledWith(2, {
+      openAtLogin: true,
+      args: []
+    })
+  })
+})

--- a/src/main/desktop-behavior.ts
+++ b/src/main/desktop-behavior.ts
@@ -1,0 +1,39 @@
+import { app } from 'electron'
+import type { AppSettingsV1 } from '../shared/app-settings'
+import { logWarn } from './logger'
+
+export const HIDDEN_START_ARG = '--hidden'
+
+export function shouldStartHidden(
+  settings: AppSettingsV1,
+  platform = process.platform,
+  argv: readonly string[] = process.argv
+): boolean {
+  return (
+    platform === 'win32' &&
+    settings.appBehavior.openAtLogin &&
+    settings.appBehavior.startMinimized &&
+    argv.includes(HIDDEN_START_ARG)
+  )
+}
+
+export function syncLoginItemSettings(
+  settings: AppSettingsV1,
+  platform = process.platform
+): void {
+  if (platform !== 'win32' && platform !== 'darwin') return
+  const behavior = settings.appBehavior
+  try {
+    app.setLoginItemSettings({
+      openAtLogin: behavior.openAtLogin,
+      args:
+        platform === 'win32' && behavior.openAtLogin && behavior.startMinimized
+          ? [HIDDEN_START_ARG]
+          : []
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn('[kun-gui] failed to update login item settings:', error)
+    logWarn('desktop-behavior', 'Failed to update login item settings.', { message })
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,7 @@ import { createAppIcon, pickTrayIcon, prepareTrayIcon } from './app-icon'
 import { buildTrayMenuTemplate, parseTrayThreads, type TrayThreadSummary } from './tray-session-menu'
 import { configureLinuxWaylandImeSwitches } from './app-command-line'
 import { configureAppIdentity } from './app-identity'
+import { shouldStartHidden, syncLoginItemSettings } from './desktop-behavior'
 import { runLegacyKunDataMigration } from './legacy-data-migration'
 import {
   applyKunRuntimePatch,
@@ -98,7 +99,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 // 的 appId 一致才能让 Windows 通知 / 任务栏分组在升级前后连续,而
 // appId 因为 NSIS 升级 GUID 与 macOS 更新签名校验的原因永远不改。
 const APP_USER_MODEL_ID = 'com.xingyuzhong.deepseekgui'
-const HIDDEN_START_ARG = '--hidden'
 const startupTraceEnabled =
   process.env.KUN_STARTUP_TRACE === '1' || process.env.DEEPSEEK_GUI_STARTUP_TRACE === '1'
 const startupTraceStart = Date.now()
@@ -410,33 +410,6 @@ function windowCloseLabels(locale: AppSettingsV1['locale']): {
     quit: 'Quit app',
     cancel: 'Cancel',
     remember: 'Remember my choice and do not ask again'
-  }
-}
-
-function shouldStartHidden(settings: AppSettingsV1): boolean {
-  return (
-    process.platform === 'win32' &&
-    settings.appBehavior.openAtLogin &&
-    settings.appBehavior.startMinimized &&
-    process.argv.includes(HIDDEN_START_ARG)
-  )
-}
-
-function syncLoginItemSettings(settings: AppSettingsV1): void {
-  if (process.platform !== 'win32' && process.platform !== 'darwin') return
-  const behavior = settings.appBehavior
-  try {
-    app.setLoginItemSettings({
-      openAtLogin: behavior.openAtLogin,
-      args:
-        process.platform === 'win32' && behavior.openAtLogin && behavior.startMinimized
-          ? [HIDDEN_START_ARG]
-          : []
-    })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.warn('[kun-gui] failed to update login item settings:', error)
-    logWarn('desktop-behavior', 'Failed to update login item settings.', { message })
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,4 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, Notification, powerSaveBlocker, Tray } from 'electron'
-import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -15,6 +14,7 @@ import { buildTrayMenuTemplate, parseTrayThreads, type TrayThreadSummary } from 
 import { configureLinuxWaylandImeSwitches } from './app-command-line'
 import { configureAppIdentity } from './app-identity'
 import { shouldStartHidden, syncLoginItemSettings } from './desktop-behavior'
+import { resolveLogDirectory, resolvePreloadPath } from './main-paths'
 import { runLegacyKunDataMigration } from './legacy-data-migration'
 import {
   applyKunRuntimePatch,
@@ -130,16 +130,6 @@ function syncWeixinBridgeRuntime(settings: AppSettingsV1): void {
 
 const runningClawScheduleMcpServer =
   process.argv.includes('--gui-schedule-mcp-server') || process.argv.includes('--claw-schedule-mcp-server')
-
-function resolveLogDirectory(): string {
-  return join(app.getPath('userData'), 'logs')
-}
-
-function resolvePreloadPath(): string {
-  const cjsPath = join(__dirname, '../preload/index.cjs')
-  if (existsSync(cjsPath)) return cjsPath
-  return join(__dirname, '../preload/index.mjs')
-}
 
 function getClawScheduleMcpLaunchConfig(): ClawScheduleMcpLaunchConfig {
   return {
@@ -1121,7 +1111,7 @@ async function restartRuntimeOnce(settings: AppSettingsV1): Promise<void> {
 
 function createWindow(options: { suppressInitialShow?: boolean } = {}): void {
   traceStartup('createWindow:start')
-  const preloadPath = resolvePreloadPath()
+  const preloadPath = resolvePreloadPath(__dirname)
   const usesDesktopTitleBar = process.platform === 'win32' || process.platform === 'linux'
   mainWindow = new BrowserWindow({
     width: 1280,
@@ -1471,7 +1461,7 @@ app.whenReady().then(async () => {
     console.error('[claw-schedule-mcp] failed to sync config on startup:', error)
   })
 
-  logDir = resolveLogDirectory()
+  logDir = resolveLogDirectory(app)
   configureLogger({
     dir: logDir,
     enabled: initial.log.enabled,
@@ -1618,7 +1608,7 @@ app.whenReady().then(async () => {
     getAppVersion: () => app.getVersion(),
     readGuiUpdateState,
     loadGuiUpdaterModule,
-    resolveLogDirectory,
+    resolveLogDirectory: () => resolveLogDirectory(app),
     logError
   })
 

--- a/src/main/main-paths.test.ts
+++ b/src/main/main-paths.test.ts
@@ -1,0 +1,27 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveLogDirectory, resolvePreloadPath } from './main-paths'
+
+describe('main paths', () => {
+  it('resolves the log directory under Electron userData', () => {
+    expect(resolveLogDirectory({ getPath: () => 'C:\\Users\\test\\AppData\\Kun' })).toBe(
+      join('C:\\Users\\test\\AppData\\Kun', 'logs')
+    )
+  })
+
+  it('prefers the CommonJS preload build when present', () => {
+    const distDir = 'C:\\app\\out\\main'
+
+    expect(resolvePreloadPath(distDir, (path) => path.endsWith('index.cjs'))).toBe(
+      join(distDir, '../preload/index.cjs')
+    )
+  })
+
+  it('falls back to the ESM preload build', () => {
+    const distDir = 'C:\\app\\out\\main'
+
+    expect(resolvePreloadPath(distDir, () => false)).toBe(
+      join(distDir, '../preload/index.mjs')
+    )
+  })
+})

--- a/src/main/main-paths.ts
+++ b/src/main/main-paths.ts
@@ -1,0 +1,19 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+type UserDataPathResolver = {
+  getPath(name: 'userData'): string
+}
+
+export function resolveLogDirectory(app: UserDataPathResolver): string {
+  return join(app.getPath('userData'), 'logs')
+}
+
+export function resolvePreloadPath(
+  distDir: string,
+  fileExists: (path: string) => boolean = existsSync
+): string {
+  const cjsPath = join(distDir, '../preload/index.cjs')
+  if (fileExists(cjsPath)) return cjsPath
+  return join(distDir, '../preload/index.mjs')
+}


### PR DESCRIPTION
﻿## Summary

- Split login-item/start-hidden desktop behavior helpers out of `src/main/index.ts`.
- Keep `index.ts` behavior unchanged while moving the low-coupling desktop helpers into `src/main/desktop-behavior.ts`.
- Add focused tests for Windows hidden startup and login item args.

## Tests

- `git diff --check`
- `npm.cmd test -- src/main/desktop-behavior.test.ts`
- `npm.cmd run typecheck`
