### PR TITLE
fix(worktree): allow repeat branch checkout and hide worktree projects

### DIFF
--- a/src/main/services/git-service.test.ts
+++ b/src/main/services/git-service.test.ts
@@ -198,6 +198,30 @@ describe('worktree branch checkout — integration with real git', () => {
     })
   })
 
+  it('creates multiple derived worktrees from the same source branch', async () => {
+    const sub = join(repoRoot, 'src', 'components')
+    const worktreeRoot = join(sandbox, 'kun-worktrees')
+    await mkdir(sub, { recursive: true })
+
+    const first = await checkoutGitBranchWorktree(sub, 'main', worktreeRoot)
+    const second = await checkoutGitBranchWorktree(sub, 'main', worktreeRoot)
+
+    expect(first.ok).toBe(true)
+    expect(second.ok).toBe(true)
+    if (!first.ok || !second.ok) throw new Error('unreachable')
+    expect(first.worktreePath).not.toBe(second.worktreePath)
+    expect(first.currentBranch).toMatch(/^kun\/worktree-[0-9a-f]{6}$/)
+    expect(second.currentBranch).toMatch(/^kun\/worktree-[0-9a-f]{6}$/)
+    expect(first.currentBranch).not.toBe(second.currentBranch)
+
+    const listed = await listGitBranchWorktrees(repoRoot, worktreeRoot)
+    expect(listed.ok).toBe(true)
+    if (!listed.ok) throw new Error('unreachable')
+    expect(listed.worktrees.map((item) => item.path)).toEqual(
+      expect.arrayContaining([first.worktreePath, second.worktreePath])
+    )
+  })
+
   it('creates a derived worktree branch when the selected branch is checked out in the main repo', async () => {
     const sub = join(repoRoot, 'src', 'components')
     const worktreeRoot = join(sandbox, 'kun-worktrees')

--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -266,7 +266,9 @@ export async function checkoutGitBranchWorktree(
     const wtPath = await allocateBranchWorktreePath(sourceRepositoryRoot, worktreeRoot)
     const worktreeBranch = await allocateDerivedWorktreeBranch(cwd)
     await mkdir(join(wtPath, '..'), { recursive: true })
-    await runGit(cwd, ['worktree', 'add', '-b', worktreeBranch, wtPath, branch], 30_000)
+    // Always add from the primary checkout so multiple derived worktrees can be
+    // created from the same source branch regardless of the caller's cwd.
+    await runGit(sourceRepositoryRoot, ['worktree', 'add', '-b', worktreeBranch, wtPath, branch], 30_000)
     return worktreeCheckoutResult(wtPath, sourceRepositoryRoot)
   } catch (error) {
     return gitWorktreeFailure(error)
@@ -288,7 +290,7 @@ export async function createGitBranchWorktree(
     const sourceRepositoryRoot = await getPrimaryWorktreeRoot(cwd, currentRepositoryRoot)
     const wtPath = await allocateBranchWorktreePath(sourceRepositoryRoot, worktreeRoot)
     await mkdir(join(wtPath, '..'), { recursive: true })
-    await runGit(cwd, ['worktree', 'add', '-b', branch, wtPath, 'HEAD'], 30_000)
+    await runGit(sourceRepositoryRoot, ['worktree', 'add', '-b', branch, wtPath, 'HEAD'], 30_000)
     return worktreeCheckoutResult(wtPath, sourceRepositoryRoot)
   } catch (error) {
     return gitWorktreeFailure(error)

--- a/src/renderer/src/components/chat/GitBranchPicker.tsx
+++ b/src/renderer/src/components/chat/GitBranchPicker.tsx
@@ -107,10 +107,11 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
 
   const trimmedQuery = query.trim()
   const exactBranchExists = branches.some((branch) => branch.name === trimmedQuery)
-  const canCreate = trimmedQuery.length > 0 && !exactBranchExists
   const switchTargetRow = exactBranchExists
     ? branches.find((branch) => branch.name === trimmedQuery) ?? null
     : null
+  const canCreate = trimmedQuery.length > 0 && !exactBranchExists
+  const canCreateWorktree = trimmedQuery.length > 0 && (canCreate || Boolean(switchTargetRow))
   const currentBranch = result?.ok ? result.currentBranch : null
   const label = currentBranch || (result?.ok ? t('gitDetached') : t('gitBranchUnavailable'))
   const footerBranchLabel = middleEllipsize(trimmedQuery, BRANCH_FOOTER_LABEL_MAX_LENGTH)
@@ -148,7 +149,7 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
       })
     )
     useChatStore.setState((state) => ({
-      codeWorkspaceRoots: rememberCodeWorkspaceRoots(state.codeWorkspaceRoots, [record.worktreePath]),
+      codeWorkspaceRoots: rememberCodeWorkspaceRoots(state.codeWorkspaceRoots, [record.projectPath]),
       threads: state.threads.map((thread) =>
         thread.id === activeThreadId ? { ...thread, workspace: record.worktreePath } : thread
       )
@@ -205,7 +206,7 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
             )
       )
       useChatStore.setState((state) => ({
-        codeWorkspaceRoots: rememberCodeWorkspaceRoots(state.codeWorkspaceRoots, [worktreePath]),
+        codeWorkspaceRoots: rememberCodeWorkspaceRoots(state.codeWorkspaceRoots, [projectPath]),
         threads: state.threads.map((thread) =>
           thread.id === activeThreadId ? { ...thread, workspace: worktreePath } : thread
         )
@@ -451,29 +452,35 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
             ) : null}
           </div>
 
-          {canCreate ? (
+          {canCreateWorktree ? (
             <div className="flex items-center gap-1 border-t border-ds-border-muted px-3 py-3">
-              <button
-                type="button"
-                disabled={actingBranch != null}
-                className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-1 py-2 text-left text-[14px] font-medium text-ds-ink transition hover:bg-ds-hover disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent"
-                aria-label={footerCreateTitle}
-                onPointerEnter={(event) => showTooltip(footerCreateTitle, event.clientX, event.clientY)}
-                onPointerMove={(event) => moveTooltip(event.clientX, event.clientY)}
-                onPointerLeave={hideTooltip}
-                onPointerCancel={hideTooltip}
-                onClick={() => {
-                  hideTooltip()
-                  void createAndSwitchBranch()
-                }}
-              >
-                {actingBranch === trimmedQuery && actingKind === 'switch' ? (
-                  <Loader2 className="h-4 w-4 shrink-0 animate-spin text-ds-muted" strokeWidth={2} />
-                ) : (
-                  <Plus className="h-4 w-4 shrink-0 text-ds-muted" strokeWidth={1.9} />
-                )}
-                <span className="min-w-0 truncate">{footerCreateLabel}</span>
-              </button>
+              {canCreate ? (
+                <button
+                  type="button"
+                  disabled={actingBranch != null}
+                  className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-1 py-2 text-left text-[14px] font-medium text-ds-ink transition hover:bg-ds-hover disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent"
+                  aria-label={footerCreateTitle}
+                  onPointerEnter={(event) => showTooltip(footerCreateTitle, event.clientX, event.clientY)}
+                  onPointerMove={(event) => moveTooltip(event.clientX, event.clientY)}
+                  onPointerLeave={hideTooltip}
+                  onPointerCancel={hideTooltip}
+                  onClick={() => {
+                    hideTooltip()
+                    void createAndSwitchBranch()
+                  }}
+                >
+                  {actingBranch === trimmedQuery && actingKind === 'switch' ? (
+                    <Loader2 className="h-4 w-4 shrink-0 animate-spin text-ds-muted" strokeWidth={2} />
+                  ) : (
+                    <Plus className="h-4 w-4 shrink-0 text-ds-muted" strokeWidth={1.9} />
+                  )}
+                  <span className="min-w-0 truncate">{footerCreateLabel}</span>
+                </button>
+              ) : (
+                <div className="min-w-0 flex-1 truncate px-1 py-2 text-[14px] font-medium text-ds-muted">
+                  {middleEllipsize(trimmedQuery, BRANCH_FOOTER_LABEL_MAX_LENGTH)}
+                </div>
+              )}
               <button
                 type="button"
                 disabled={actingBranch != null}
@@ -485,7 +492,11 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
                 onPointerCancel={hideTooltip}
                 onClick={() => {
                   hideTooltip()
-                  void createBranchWorktree()
+                  if (canCreate) {
+                    void createBranchWorktree()
+                  } else {
+                    void checkoutBranchWorktree(trimmedQuery)
+                  }
                 }}
               >
                 {actingBranch === trimmedQuery && actingKind === 'worktree' ? (

--- a/src/renderer/src/components/chat/SidebarProjectsSection.test.ts
+++ b/src/renderer/src/components/chat/SidebarProjectsSection.test.ts
@@ -145,6 +145,21 @@ describe('SidebarProjectsSection groups', () => {
     expect(groups[0]?.[1].map((item) => item.id)).toEqual(['default-short', 'default-absolute'])
   })
 
+  it('maps remembered worktree roots to their source project without a registry entry', () => {
+    const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
+    const worktreePath = '/Users/zxy/.kun/worktrees/ab12/Kook-VoiceShop-Bot'
+    const groups = buildSidebarWorkspaceGroups({
+      threads: [thread({ id: 'thread-worktree', workspace: worktreePath })],
+      searchQuery: '',
+      showArchived: false,
+      workspaceRoot: projectPath,
+      workspaceRoots: [projectPath, worktreePath]
+    })
+
+    expect(groups.map(([workspace]) => workspace)).toEqual([projectPath])
+    expect(groups[0]?.[1].map((item) => item.id)).toEqual(['thread-worktree'])
+  })
+
   it('shows worktree threads under their source project instead of a separate worktree project', () => {
     const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
     const worktreePath = '/Users/zxy/.kun/worktrees/0ff7/Kook-VoiceShop-Bot'

--- a/src/renderer/src/components/chat/SidebarProjectsSection.tsx
+++ b/src/renderer/src/components/chat/SidebarProjectsSection.tsx
@@ -43,6 +43,11 @@ import {
   SidebarSearchField,
   SidebarTreeRow
 } from '../sidebar/SidebarPrimitives'
+import {
+  projectPathForWorktreeRecord,
+  resolveProjectWorkspacePath,
+  shouldOmitFromCodeWorkspaceRoots
+} from '../../lib/worktree-project-path'
 import { readThreadWorktreeRegistry, type ThreadWorktreeRecord } from '../../lib/thread-worktree-registry'
 
 type SidebarProjectsSectionProps = {
@@ -137,18 +142,55 @@ function sortWorkspacePathsByActive(workspacePaths: string[], selectedWorkspace:
   return [...workspacePaths].sort((a, b) => compareWorkspacePathsByActive(a, b, selectedWorkspace))
 }
 
+function sidebarWorkspaceResolutionCandidates(options: {
+  workspaceRoot: string
+  workspaceRoots: string[]
+  threadWorktrees?: SidebarThreadWorktrees
+  threads?: NormalizedThread[]
+}): string[] {
+  const candidates = new Set<string>()
+  const selectedWorkspace = normalizeWorkspaceRoot(options.workspaceRoot)
+  if (selectedWorkspace) candidates.add(selectedWorkspace)
+  for (const workspacePath of options.workspaceRoots) {
+    const normalized = normalizeWorkspaceRoot(workspacePath)
+    if (normalized) candidates.add(normalized)
+  }
+  for (const record of Object.values(options.threadWorktrees ?? {})) {
+    const projectPath = projectPathForWorktreeRecord(record)
+    if (projectPath) candidates.add(projectPath)
+  }
+  for (const thread of options.threads ?? []) {
+    const normalized = normalizeWorkspaceRoot(thread.workspace)
+    if (normalized) candidates.add(normalized)
+  }
+  return [...candidates]
+}
+
 function workspacePathForWorktreeRecord(record: Pick<ThreadWorktreeRecord, 'projectPath' | 'worktreePath'> | undefined): string {
-  const projectPath = normalizeWorkspaceRoot(record?.projectPath ?? '')
-  const worktreePath = normalizeWorkspaceRoot(record?.worktreePath ?? '')
-  return projectPath && worktreePath ? projectPath : ''
+  return projectPathForWorktreeRecord(record)
 }
 
-function sidebarWorkspacePathForThread(thread: NormalizedThread, worktrees: SidebarThreadWorktrees = {}): string {
+function sidebarWorkspacePathForThread(
+  thread: NormalizedThread,
+  worktrees: SidebarThreadWorktrees = {},
+  candidateProjectPaths: readonly string[] = []
+): string {
   const worktreeProjectPath = workspacePathForWorktreeRecord(worktrees[thread.id])
-  return worktreeProjectPath || normalizeWorkspaceRoot(thread.workspace)
+  if (worktreeProjectPath) return worktreeProjectPath
+  const resolved = resolveProjectWorkspacePath(thread.workspace, {
+    threadWorktrees: worktrees,
+    candidateProjectPaths
+  })
+  if (resolved) return resolved
+  if (shouldOmitFromCodeWorkspaceRoots(thread.workspace)) return ''
+  return normalizeWorkspaceRoot(thread.workspace)
 }
 
-function sidebarWorkspacePathForRememberedRoot(workspacePath: string, worktrees: SidebarThreadWorktrees = {}): string {
+function sidebarWorkspacePathForRememberedRoot(
+  workspacePath: string,
+  worktrees: SidebarThreadWorktrees = {},
+  candidateProjectPaths: readonly string[] = []
+): string {
   const normalized = normalizeWorkspaceRoot(workspacePath)
   const key = workspaceRootIdentityKey(normalized)
   if (!key) return ''
@@ -158,6 +200,12 @@ function sidebarWorkspacePathForRememberedRoot(workspacePath: string, worktrees:
       return workspacePathForWorktreeRecord(record) || normalized
     }
   }
+  const resolved = resolveProjectWorkspacePath(normalized, {
+    threadWorktrees: worktrees,
+    candidateProjectPaths
+  })
+  if (resolved) return resolved
+  if (shouldOmitFromCodeWorkspaceRoots(normalized)) return ''
   return normalized
 }
 
@@ -186,6 +234,7 @@ export function buildSidebarWorkspaceGroups(options: {
   const selectedWorkspace = normalizeWorkspaceRoot(options.workspaceRoot)
   const selectedWorkspaceKey = workspaceRootIdentityKey(selectedWorkspace)
   const query = options.searchQuery.trim().toLowerCase()
+  const candidateProjectPaths = sidebarWorkspaceResolutionCandidates(options)
 
   const upsertWorkspace = (workspacePath: string, threads: NormalizedThread[] = []): void => {
     const normalized = normalizeWorkspaceRoot(workspacePath)
@@ -207,7 +256,7 @@ export function buildSidebarWorkspaceGroups(options: {
     if (isInternalDeepSeekGuiWorkspace(th.workspace)) continue
     if (isClawWorkspacePath(th.workspace)) continue
     if ((th.archived === true) !== options.showArchived) continue
-    const key = sidebarWorkspacePathForThread(th, options.threadWorktrees)
+    const key = sidebarWorkspacePathForThread(th, options.threadWorktrees, candidateProjectPaths)
     if (!key) continue
     if (query) {
       const haystack = [th.title, th.preview, key, workspaceLabelFromPath(key), th.workspace]
@@ -224,7 +273,11 @@ export function buildSidebarWorkspaceGroups(options: {
   }
   if (!query && !options.showArchived) {
     for (const workspacePath of options.workspaceRoots) {
-      const key = sidebarWorkspacePathForRememberedRoot(workspacePath, options.threadWorktrees)
+      const key = sidebarWorkspacePathForRememberedRoot(
+        workspacePath,
+        options.threadWorktrees,
+        candidateProjectPaths
+      )
       if (!key || map.has(workspaceRootIdentityKey(key))) continue
       if (isInternalTemporaryWorkspace(key)) continue
       if (isInternalDeepSeekGuiWorkspace(key)) continue
@@ -250,6 +303,7 @@ export function buildSidebarDraftWorkspacePaths(options: {
 }): string[] {
   const map = new Map<string, string>()
   const selectedWorkspace = normalizeWorkspaceRoot(options.workspaceRoot)
+  const candidateProjectPaths = sidebarWorkspaceResolutionCandidates(options)
 
   const upsertWorkspace = (workspacePath: string): void => {
     const normalized = normalizeWorkspaceRoot(workspacePath)
@@ -264,10 +318,16 @@ export function buildSidebarDraftWorkspacePaths(options: {
 
   upsertWorkspace(selectedWorkspace)
   for (const workspacePath of options.workspaceRoots) {
-    upsertWorkspace(sidebarWorkspacePathForRememberedRoot(workspacePath, options.threadWorktrees))
+    upsertWorkspace(
+      sidebarWorkspacePathForRememberedRoot(
+        workspacePath,
+        options.threadWorktrees,
+        candidateProjectPaths
+      )
+    )
   }
   for (const thread of options.threads) {
-    upsertWorkspace(sidebarWorkspacePathForThread(thread, options.threadWorktrees))
+    upsertWorkspace(sidebarWorkspacePathForThread(thread, options.threadWorktrees, candidateProjectPaths))
   }
 
   return sortWorkspacePathsByActive([...map.values()], selectedWorkspace)

--- a/src/renderer/src/components/chat/SidebarProjectsSection.tsx
+++ b/src/renderer/src/components/chat/SidebarProjectsSection.tsx
@@ -177,13 +177,14 @@ function sidebarWorkspacePathForThread(
 ): string {
   const worktreeProjectPath = workspacePathForWorktreeRecord(worktrees[thread.id])
   if (worktreeProjectPath) return worktreeProjectPath
-  const resolved = resolveProjectWorkspacePath(thread.workspace, {
+  const workspace = thread.workspace ?? ''
+  const resolved = resolveProjectWorkspacePath(workspace, {
     threadWorktrees: worktrees,
     candidateProjectPaths
   })
   if (resolved) return resolved
-  if (shouldOmitFromCodeWorkspaceRoots(thread.workspace)) return ''
-  return normalizeWorkspaceRoot(thread.workspace)
+  if (shouldOmitFromCodeWorkspaceRoots(workspace)) return ''
+  return normalizeWorkspaceRoot(workspace)
 }
 
 function sidebarWorkspacePathForRememberedRoot(

--- a/src/renderer/src/components/chat/WorkspaceProjectPicker.test.ts
+++ b/src/renderer/src/components/chat/WorkspaceProjectPicker.test.ts
@@ -34,4 +34,17 @@ describe('WorkspaceProjectPicker options', () => {
     ])
     expect(options.filter((option) => option.label === 'Kook-VoiceShop-Bot')).toHaveLength(1)
   })
+
+  it('resolves worktree roots to their source project without a registry entry', () => {
+    const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
+    const worktreePath = '/Users/zxy/.kun/worktrees/ab12/Kook-VoiceShop-Bot'
+    const { currentRoot, options } = buildWorkspaceProjectPickerOptions({
+      currentWorkspaceRoot: worktreePath,
+      workspaceRoots: [projectPath, worktreePath],
+      threadWorktrees: {}
+    })
+
+    expect(currentRoot).toBe(projectPath)
+    expect(options.map((option) => option.root)).toEqual([projectPath])
+  })
 })

--- a/src/renderer/src/components/chat/WorkspaceProjectPicker.tsx
+++ b/src/renderer/src/components/chat/WorkspaceProjectPicker.tsx
@@ -10,6 +10,7 @@ import {
   normalizeWorkspaceRoot,
   workspaceRootIdentityKey
 } from '../../lib/workspace-path'
+import { resolveProjectWorkspacePath } from '../../lib/worktree-project-path'
 import { readThreadWorktreeRegistry, type ThreadWorktreeRecord } from '../../lib/thread-worktree-registry'
 
 type Props = {
@@ -36,7 +37,8 @@ function workspaceContext(root: string, label: string): string {
 
 function workspaceProjectRootForPicker(
   workspacePath: string,
-  threadWorktrees: WorkspaceProjectPickerWorktrees = {}
+  threadWorktrees: WorkspaceProjectPickerWorktrees = {},
+  candidateProjectPaths: readonly string[] = []
 ): string {
   const normalized = normalizeWorkspaceRoot(workspacePath)
   const key = workspaceRootIdentityKey(normalized)
@@ -47,16 +49,10 @@ function workspaceProjectRootForPicker(
       return normalizeWorkspaceRoot(record.projectPath) || normalized
     }
   }
-  return normalized
-}
-
-function isWorkspaceProjectPickerRoot(root: string): boolean {
-  const normalized = normalizeWorkspaceRoot(root)
-  if (!normalized) return false
-  if (isInternalTemporaryWorkspace(normalized)) return false
-  if (isInternalDeepSeekGuiWorkspace(normalized)) return false
-  if (isClawWorkspacePath(normalized)) return false
-  return true
+  return resolveProjectWorkspacePath(normalized, {
+    threadWorktrees,
+    candidateProjectPaths
+  })
 }
 
 export function buildWorkspaceProjectPickerOptions(options: {
@@ -65,11 +61,20 @@ export function buildWorkspaceProjectPickerOptions(options: {
   threadWorktrees?: WorkspaceProjectPickerWorktrees
 }): { currentRoot: string, options: WorkspaceOption[] } {
   const threadWorktrees = options.threadWorktrees ?? {}
-  const currentRoot = workspaceProjectRootForPicker(options.currentWorkspaceRoot, threadWorktrees)
+  const candidateProjectPaths = [
+    options.currentWorkspaceRoot,
+    ...options.workspaceRoots,
+    ...Object.values(threadWorktrees).map((record) => record.projectPath)
+  ]
+  const currentRoot = workspaceProjectRootForPicker(
+    options.currentWorkspaceRoot,
+    threadWorktrees,
+    candidateProjectPaths
+  )
   const seen = new Set<string>()
   const out: WorkspaceOption[] = []
   for (const raw of [currentRoot, ...options.workspaceRoots]) {
-    const root = workspaceProjectRootForPicker(raw, threadWorktrees)
+    const root = workspaceProjectRootForPicker(raw, threadWorktrees, candidateProjectPaths)
     if (!isWorkspaceProjectPickerRoot(root)) continue
     const key = workspaceRootIdentityKey(root)
     if (seen.has(key)) continue
@@ -81,6 +86,15 @@ export function buildWorkspaceProjectPickerOptions(options: {
     currentRoot,
     options: out.sort((a, b) => a.label.localeCompare(b.label))
   }
+}
+
+function isWorkspaceProjectPickerRoot(root: string): boolean {
+  const normalized = normalizeWorkspaceRoot(root)
+  if (!normalized) return false
+  if (isInternalTemporaryWorkspace(normalized)) return false
+  if (isInternalDeepSeekGuiWorkspace(normalized)) return false
+  if (isClawWorkspacePath(normalized)) return false
+  return true
 }
 
 export function WorkspaceProjectPicker({ currentWorkspaceRoot }: Props): ReactElement {

--- a/src/renderer/src/lib/worktree-project-path.test.ts
+++ b/src/renderer/src/lib/worktree-project-path.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { resolveProjectWorkspacePath } from './worktree-project-path'
+
+describe('worktree-project-path', () => {
+  it('maps a Kun worktree path back to a known project root', () => {
+    const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
+    const worktreePath = '/Users/zxy/.kun/worktrees/ab12/Kook-VoiceShop-Bot'
+    expect(
+      resolveProjectWorkspacePath(worktreePath, {
+        candidateProjectPaths: [projectPath, worktreePath]
+      })
+    ).toBe(projectPath)
+  })
+})

--- a/src/renderer/src/lib/worktree-project-path.ts
+++ b/src/renderer/src/lib/worktree-project-path.ts
@@ -1,0 +1,46 @@
+import {
+  isKunBranchWorktreePath,
+  resolveKunBranchWorktreeProjectPath
+} from '@shared/kun-worktree-path'
+import type { ThreadWorktreeRecord } from './thread-worktree-registry'
+import { normalizeWorkspaceRoot, workspaceRootIdentityKey } from './workspace-path'
+
+export function projectPathForWorktreeRecord(
+  record: Pick<ThreadWorktreeRecord, 'projectPath' | 'worktreePath'> | undefined
+): string {
+  const projectPath = normalizeWorkspaceRoot(record?.projectPath ?? '')
+  const worktreePath = normalizeWorkspaceRoot(record?.worktreePath ?? '')
+  return projectPath && worktreePath ? projectPath : ''
+}
+
+export function resolveProjectWorkspacePath(
+  workspacePath: string,
+  options: {
+    threadWorktrees?: Record<string, Pick<ThreadWorktreeRecord, 'projectPath' | 'worktreePath'>>
+    candidateProjectPaths?: readonly string[]
+  } = {}
+): string {
+  const normalized = normalizeWorkspaceRoot(workspacePath)
+  if (!normalized) return ''
+  if (!isKunBranchWorktreePath(normalized)) return normalized
+
+  const key = workspaceRootIdentityKey(normalized)
+  for (const record of Object.values(options.threadWorktrees ?? {})) {
+    const worktreePath = normalizeWorkspaceRoot(record.worktreePath)
+    if (workspaceRootIdentityKey(worktreePath) === key) {
+      const projectPath = projectPathForWorktreeRecord(record)
+      if (projectPath) return projectPath
+    }
+  }
+
+  const resolved = resolveKunBranchWorktreeProjectPath(
+    normalized,
+    options.candidateProjectPaths ?? []
+  )
+  return resolved ? normalizeWorkspaceRoot(resolved) : ''
+}
+
+export function shouldOmitFromCodeWorkspaceRoots(workspacePath: string): boolean {
+  const normalized = normalizeWorkspaceRoot(workspacePath)
+  return Boolean(normalized) && isKunBranchWorktreePath(normalized)
+}

--- a/src/renderer/src/store/chat-store-helpers.test.ts
+++ b/src/renderer/src/store/chat-store-helpers.test.ts
@@ -142,6 +142,15 @@ describe('chat-store Claw helpers', () => {
     expect(compacted).not.toContain(`/Users/zxy/project-${MAX_CODE_WORKSPACE_ROOTS}`)
   })
 
+  it('drops Kun branch worktree paths from remembered code workspaces', () => {
+    expect(
+      compactCodeWorkspaceRoots([
+        '/Users/zxy/code/project-a',
+        '/Users/zxy/.kun/worktrees/ab12/project-a'
+      ])
+    ).toEqual(['/Users/zxy/code/project-a'])
+  })
+
   it('drops remembered write-only workspaces from the code workspace list', () => {
     expect(
       reconcileCodeWorkspaceRoots({

--- a/src/renderer/src/store/chat-store-helpers.ts
+++ b/src/renderer/src/store/chat-store-helpers.ts
@@ -20,6 +20,7 @@ import {
   normalizeWorkspaceRoot,
   workspaceRootIdentityKey
 } from '../lib/workspace-path'
+import { shouldOmitFromCodeWorkspaceRoots } from '../lib/worktree-project-path'
 import { readBrowserStorageItem, writeBrowserStorageItem } from '../lib/browser-storage'
 
 const COMPOSER_MODEL_STORAGE_KEY = 'kun.composerModel'
@@ -314,6 +315,7 @@ export function compactCodeWorkspaceRoots(workspaceRoots: readonly (string | und
     if (isInternalTemporaryWorkspace(normalized)) continue
     if (isInternalDeepSeekGuiWorkspace(normalized)) continue
     if (isClawWorkspacePath(normalized)) continue
+    if (shouldOmitFromCodeWorkspaceRoots(normalized)) continue
     const key = workspaceRootIdentityKey(normalized)
     if (seen.has(key)) continue
     seen.add(key)

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -27,6 +27,8 @@ import {
 } from '../lib/thread-fork-registry'
 import { workspaceLabelFromPath } from '../lib/workspace-label'
 import { isInternalTemporaryWorkspace, normalizeWorkspaceRoot } from '../lib/workspace-path'
+import { resolveProjectWorkspacePath } from '../lib/worktree-project-path'
+import { readThreadWorktreeRegistry } from '../lib/thread-worktree-registry'
 import { buildClawRuntimePrompt, getActiveAgentApiKey } from '@shared/app-settings'
 import type { ChatState, ChatStoreGet, ChatStoreSet } from './chat-store-types'
 import {
@@ -733,12 +735,27 @@ export function createNavigationActions(
         const writeWorkspace = writeWorkspaceForThreadId(thread.id, writeRegistry)
         return writeWorkspace ? { ...thread, workspace: writeWorkspace } : thread
       })
+      const threadWorktreeRegistry = readThreadWorktreeRegistry().worktrees
+      const workspaceCandidates = [
+        get().workspaceRoot,
+        ...get().codeWorkspaceRoots,
+        ...threads.map((thread) => thread.workspace),
+        ...displayThreads.map((thread) => thread.workspace)
+      ]
       const codeThreadWorkspaceRoots = [
         ...threads,
         ...displayThreads
       ]
         .filter((thread) => isCodeThread(thread, get().clawChannels, writeRegistry))
-        .map((thread) => thread.workspace)
+        .map((thread) => {
+          const record = threadWorktreeRegistry[thread.id]
+          if (record?.projectPath?.trim()) return record.projectPath.trim()
+          return resolveProjectWorkspacePath(thread.workspace, {
+            threadWorktrees: threadWorktreeRegistry,
+            candidateProjectPaths: workspaceCandidates
+          })
+        })
+        .filter(Boolean)
       const codeWorkspaceRoots = reconcileCodeWorkspaceRoots({
         currentRoots: get().codeWorkspaceRoots,
         codeThreadWorkspaceRoots,

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -741,7 +741,7 @@ export function createNavigationActions(
         ...get().codeWorkspaceRoots,
         ...threads.map((thread) => thread.workspace),
         ...displayThreads.map((thread) => thread.workspace)
-      ]
+      ].filter((path): path is string => Boolean(path))
       const codeThreadWorkspaceRoots = [
         ...threads,
         ...displayThreads
@@ -750,7 +750,7 @@ export function createNavigationActions(
         .map((thread) => {
           const record = threadWorktreeRegistry[thread.id]
           if (record?.projectPath?.trim()) return record.projectPath.trim()
-          return resolveProjectWorkspacePath(thread.workspace, {
+          return resolveProjectWorkspacePath(thread.workspace ?? '', {
             threadWorktrees: threadWorktreeRegistry,
             candidateProjectPaths: workspaceCandidates
           })

--- a/src/renderer/src/store/chat-store-thread-actions.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.ts
@@ -287,7 +287,10 @@ export function createThreadActions(
       // Setting it active first lets refreshThreads preserve it in the sidebar.
       set((s) => ({
         activeThreadId: t.id,
-        codeWorkspaceRoots: rememberCodeWorkspaceRoots(s.codeWorkspaceRoots, [workspaceRoot, t.workspace]),
+        codeWorkspaceRoots: rememberCodeWorkspaceRoots(
+          s.codeWorkspaceRoots,
+          [acquiredWorktree?.projectPath ?? workspaceRoot]
+        ),
         threads: s.threads.some((thread) => thread.id === t.id) ? s.threads : [t, ...s.threads]
       }))
       await get().selectThread(t.id)

--- a/src/shared/kun-worktree-path.test.ts
+++ b/src/shared/kun-worktree-path.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isKunBranchWorktreePath,
+  parseKunBranchWorktreeLayout,
+  resolveKunBranchWorktreeProjectPath
+} from './kun-worktree-path'
+
+describe('kun-worktree-path', () => {
+  it('recognizes default Kun branch worktree paths', () => {
+    const path = '/Users/zxy/.kun/worktrees/0ff7/Kook-VoiceShop-Bot'
+    expect(isKunBranchWorktreePath(path)).toBe(true)
+    expect(parseKunBranchWorktreeLayout(path)).toEqual({
+      poolId: '0ff7',
+      repoName: 'Kook-VoiceShop-Bot'
+    })
+    expect(
+      resolveKunBranchWorktreeProjectPath(path, ['/Users/zxy/code/Kook-VoiceShop-Bot'])
+    ).toBe('/Users/zxy/code/Kook-VoiceShop-Bot')
+  })
+
+  it('recognizes custom worktree roots that still use the worktrees layout', () => {
+    const path = '/data/worktrees/ab12/my-repo'
+    expect(isKunBranchWorktreePath(path)).toBe(true)
+  })
+
+  it('rejects regular project directories', () => {
+    expect(isKunBranchWorktreePath('/Users/zxy/code/Kook-VoiceShop-Bot')).toBe(false)
+    expect(isKunBranchWorktreePath('/Users/zxy/.kun/default_workspace')).toBe(false)
+  })
+
+  it('resolves a worktree path back to a known project root by repo basename', () => {
+    const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
+    const worktreePath = '/Users/zxy/.kun/worktrees/38e2/Kook-VoiceShop-Bot'
+    expect(
+      resolveKunBranchWorktreeProjectPath(worktreePath, [projectPath, '/Users/zxy/code/DeepSeek-GUI'])
+    ).toBe(projectPath)
+  })
+
+  it('ignores worktree paths when matching project roots by repo basename', () => {
+    expect(
+      resolveKunBranchWorktreeProjectPath(
+        '/Users/zxy/.kun/worktrees/ab12/Kook-VoiceShop-Bot',
+        [
+          '/Users/zxy/.kun/worktrees/ab12/Kook-VoiceShop-Bot',
+          '/Users/zxy/code/Kook-VoiceShop-Bot'
+        ]
+      )
+    ).toBe('/Users/zxy/code/Kook-VoiceShop-Bot')
+  })
+})

--- a/src/shared/kun-worktree-path.test.ts
+++ b/src/shared/kun-worktree-path.test.ts
@@ -18,9 +18,13 @@ describe('kun-worktree-path', () => {
     ).toBe('/Users/zxy/code/Kook-VoiceShop-Bot')
   })
 
-  it('recognizes custom worktree roots that still use the worktrees layout', () => {
-    const path = '/data/worktrees/ab12/my-repo'
-    expect(isKunBranchWorktreePath(path)).toBe(true)
+  it('only treats paths under the Kun worktree root (.kun/worktrees) as worktrees', () => {
+    // A user project that merely sits under some other `worktrees/<hex>/<name>`
+    // directory must NOT be misclassified as a Kun-managed worktree — otherwise
+    // it would be hidden from the sidebar project list.
+    expect(isKunBranchWorktreePath('/data/worktrees/ab12/my-repo')).toBe(false)
+    expect(isKunBranchWorktreePath('/Users/zxy/projects/worktrees/2024/app')).toBe(false)
+    expect(isKunBranchWorktreePath('/Users/zxy/.kun/worktrees/ab12/my-repo')).toBe(true)
   })
 
   it('rejects regular project directories', () => {

--- a/src/shared/kun-worktree-path.ts
+++ b/src/shared/kun-worktree-path.ts
@@ -1,0 +1,50 @@
+/**
+ * Path helpers for Kun-managed conversation worktrees created by git-service
+ * under `<worktreeRoot>/<4-hex-id>/<repo-basename>`.
+ */
+
+export type KunBranchWorktreeLayout = {
+  poolId: string
+  repoName: string
+}
+
+function normalizePathForMatch(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+export function parseKunBranchWorktreeLayout(path: string): KunBranchWorktreeLayout | null {
+  const normalized = normalizePathForMatch(path.trim())
+  if (!normalized) return null
+  const match = normalized.match(/\/([0-9a-f]{4})\/([^/]+)$/i)
+  if (!match) return null
+  const poolId = match[1] ?? ''
+  const repoName = match[2] ?? ''
+  if (!poolId || !repoName) return null
+  const prefix = normalized.slice(0, -(poolId.length + repoName.length + 2))
+  // Kun conversation worktrees always live under a ".../worktrees/..." root.
+  // Scheduled-agent pool slots use ".../.kun/wt-N" instead and are excluded.
+  if (!/\/worktrees(?:\/|$)/i.test(prefix)) return null
+  if (/\/\.kun\/wt-\d+(?:\/|$)/i.test(prefix)) return null
+  return { poolId, repoName }
+}
+
+export function isKunBranchWorktreePath(path: string): boolean {
+  return parseKunBranchWorktreeLayout(path) != null
+}
+
+export function resolveKunBranchWorktreeProjectPath(
+  worktreePath: string,
+  candidateProjectPaths: readonly string[]
+): string {
+  const layout = parseKunBranchWorktreeLayout(worktreePath)
+  if (!layout) return ''
+  for (const candidate of candidateProjectPaths) {
+    const trimmed = candidate.trim()
+    if (!trimmed || isKunBranchWorktreePath(trimmed)) continue
+    const normalized = normalizePathForMatch(trimmed)
+    if (!normalized) continue
+    const parts = normalized.split('/').filter(Boolean)
+    if (parts[parts.length - 1] === layout.repoName) return trimmed
+  }
+  return ''
+}

--- a/src/shared/kun-worktree-path.ts
+++ b/src/shared/kun-worktree-path.ts
@@ -21,10 +21,15 @@ export function parseKunBranchWorktreeLayout(path: string): KunBranchWorktreeLay
   const repoName = match[2] ?? ''
   if (!poolId || !repoName) return null
   const prefix = normalized.slice(0, -(poolId.length + repoName.length + 2))
-  // Kun conversation worktrees always live under a ".../worktrees/..." root.
-  // Scheduled-agent pool slots use ".../.kun/wt-N" instead and are excluded.
-  if (!/\/worktrees(?:\/|$)/i.test(prefix)) return null
-  if (/\/\.kun\/wt-\d+(?:\/|$)/i.test(prefix)) return null
+  // Branch worktrees are created by git-service's resolveBranchWorktreeRoot under
+  // the default Kun worktree root `~/.kun/worktrees`, i.e.
+  // `<home>/.kun/worktrees/<4-hex-id>/<repo-basename>`. Anchor on that exact
+  // `.kun/worktrees` root so an unrelated user project that merely happens to sit
+  // under some other `worktrees/<hex>/<name>` directory (e.g.
+  // `/work/worktrees/2024/app`) is not misclassified and hidden as a Kun
+  // worktree. The scheduled-agent pool uses a different layout
+  // (`<root>/<basename>/pool-N`) and is intentionally not matched here.
+  if (!/(?:^|\/)\.kun\/worktrees$/i.test(prefix)) return null
   return { poolId, repoName }
 }
 


### PR DESCRIPTION
## Summary / 概要

- Allow creating multiple conversation worktrees from the same source branch.
- Keep Kun-managed worktree directories grouped under their source project in the sidebar and project picker.

## Why / 背景

- After creating one worktree for a branch, users could not easily create another worktree for the same branch because the branch picker footer hid the worktree action for existing branch names.
- Worktree paths were sometimes remembered in `codeWorkspaceRoots`, which caused duplicate project entries in the left sidebar.

## Changes / 变更

- Run `git worktree add` from the primary repository root so repeated checkouts from the same branch succeed reliably.
- Show the branch-picker worktree action for existing branch names; existing branches fork via `checkoutGitBranchWorktree`, new names still use `createGitBranchWorktree`.
- Remember source project paths instead of worktree paths when binding a thread to a worktree.
- Add shared Kun worktree path detection and map worktree paths back to their source project in sidebar, picker, and workspace-root reconciliation.

## Media / 截图或录屏

- N/A (logic-only UI behavior change)

## Tests / 测试

- `src/shared/kun-worktree-path.test.ts`
- `src/renderer/src/lib/worktree-project-path.test.ts`
- `src/main/services/git-service.test.ts` (multiple worktrees from same branch)
- `src/renderer/src/components/chat/SidebarProjectsSection.test.ts`
- `src/renderer/src/components/chat/WorkspaceProjectPicker.test.ts`
- `src/renderer/src/store/chat-store-helpers.test.ts`

## Validation / 验证

- [x] I agree that this contribution is submitted under the [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md).
- [x] `npm run test` (worktree-related suites)
- [ ] `npm run typecheck`
- [ ] `npm run build`
- [x] Logic change: unit tests added or updated

## Notes / 备注

- Focused on conversation worktrees under `.../worktrees/{4hex}/{repo}`; scheduled-agent pool paths are excluded from sidebar project grouping heuristics.

Made with [Cursor](https://cursor.com)