### PR TITLE
fix: resolve five v0.2.18 bugs (proxy #600, provider-save #602, scroll #603, delete-dialog #605, user-input #606)

### DIFF
--- a/kun/src/server/routes/index.ts
+++ b/kun/src/server/routes/index.ts
@@ -166,7 +166,7 @@ export function buildRouter(runtime: ServerRuntime): Router {
   })
   router.add('GET', '/v1/threads/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
-    return getThread(runtime.threadService, ctx.params.id, runtime.sessionStore)
+    return getThread(runtime.threadService, ctx.params.id, runtime.sessionStore, runtime.userInputGate)
   })
   router.add('PATCH', '/v1/threads/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()

--- a/kun/src/server/routes/threads.test.ts
+++ b/kun/src/server/routes/threads.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { getThread } from './threads.js'
+import { createThreadRecord } from '../../domain/thread.js'
+import { InMemoryUserInputGate } from '../../adapters/in-memory-user-input-gate.js'
+import type { ThreadService } from '../../services/thread-service.js'
+
+function serviceWith(threadId: string): ThreadService {
+  const record = createThreadRecord({
+    id: threadId,
+    title: 'Demo',
+    workspace: '/tmp',
+    model: 'deepseek-chat',
+    status: 'running'
+  })
+  return {
+    get: async (id: string) => (id === threadId ? record : null)
+  } as unknown as ThreadService
+}
+
+describe('getThread pendingUserInputIds (#606)', () => {
+  it('reports request ids the user-input gate is still awaiting for the thread', async () => {
+    const gate = new InMemoryUserInputGate()
+    // request() returns a promise that stays pending until resolved; we only
+    // care that the request is now addressable in the gate.
+    void gate
+      .request({
+        id: 'in_live',
+        threadId: 'thr_1',
+        turnId: 'turn_1',
+        itemId: 'item_input',
+        prompt: 'north or south?',
+        questions: []
+      })
+      .catch(() => undefined)
+    // A request for a different thread must not leak into this thread's list.
+    void gate
+      .request({
+        id: 'in_other',
+        threadId: 'thr_2',
+        turnId: 'turn_x',
+        itemId: 'item_x',
+        prompt: 'unrelated',
+        questions: []
+      })
+      .catch(() => undefined)
+
+    const response = await getThread(serviceWith('thr_1'), 'thr_1', undefined, gate)
+    const body = JSON.parse(response.body)
+    expect(body.pendingUserInputIds).toEqual(['in_live'])
+  })
+
+  it('reports an empty list when nothing is awaiting (finished thread)', async () => {
+    const response = await getThread(serviceWith('thr_1'), 'thr_1', undefined, new InMemoryUserInputGate())
+    const body = JSON.parse(response.body)
+    expect(body.pendingUserInputIds).toEqual([])
+  })
+
+  it('omits no field when no gate is provided', async () => {
+    const response = await getThread(serviceWith('thr_1'), 'thr_1')
+    const body = JSON.parse(response.body)
+    expect(body.pendingUserInputIds).toEqual([])
+  })
+})

--- a/kun/src/server/routes/threads.ts
+++ b/kun/src/server/routes/threads.ts
@@ -19,6 +19,7 @@ import { readJsonBody } from '../read-json-body.js'
 import type { ForkThreadOptions, ListThreadsOptions, ThreadService } from '../../services/thread-service.js'
 import type { RuntimeError } from './runtime-error.js'
 import type { SessionStore } from '../../ports/session-store.js'
+import type { UserInputGate } from '../../ports/user-input-gate.js'
 import type { Turn } from '../../contracts/turns.js'
 import type { TurnItem } from '../../contracts/items.js'
 
@@ -79,7 +80,8 @@ export async function createThread(
 export async function getThread(
   service: ThreadService,
   threadId: string,
-  sessionStore?: SessionStore
+  sessionStore?: SessionStore,
+  userInputGate?: UserInputGate
 ): Promise<JsonResponse> {
   const thread = await service.get(threadId)
   if (!thread) {
@@ -98,9 +100,14 @@ export async function getThread(
     sessionItems = await healSessionItemsForFinishedTurns(thread, sessionItems, sessionStore)
   }
   const hydratedThread = hydrateThreadItemsFromSession(thread, sessionItems)
+  // Request ids the runtime is still actively awaiting. The renderer uses these
+  // to tell a live ask-user prompt (answerable across reconnects) apart from a
+  // stale `pending` item rehydrated from a finished thread (issue #606).
+  const pendingUserInputIds = userInputGate?.pending(threadId).map((request) => request.id) ?? []
   return jsonResponse({
     ...ThreadSchema.parse(hydratedThread),
-    latestSeq
+    latestSeq,
+    pendingUserInputIds
   })
 }
 

--- a/src/renderer/src/agent/kun-contract.ts
+++ b/src/renderer/src/agent/kun-contract.ts
@@ -46,6 +46,8 @@ export type CoreThreadSummaryJson = {
 export type CoreThreadJson = CoreThreadSummaryJson & {
   turns?: CoreTurnJson[]
   latestSeq?: number
+  /** Request ids the runtime is still actively awaiting (live ask-user gate). */
+  pendingUserInputIds?: string[]
 }
 
 export type CoreAttachmentMetadataJson = {

--- a/src/renderer/src/agent/kun-runtime.test.ts
+++ b/src/renderer/src/agent/kun-runtime.test.ts
@@ -151,6 +151,61 @@ describe('KunRuntimeProvider', () => {
     expect(detail.latestUserMessageId).toBe('item_user')
   })
 
+  it('flags user_input blocks live only when the runtime gate still awaits them (#606)', async () => {
+    const threadBody = (pendingUserInputIds: string[]): string =>
+      JSON.stringify({
+        id: 'thr_1',
+        title: 'Demo',
+        workspace: '/tmp',
+        model: 'deepseek-chat',
+        mode: 'agent',
+        status: 'running',
+        createdAt: 't0',
+        updatedAt: 't1',
+        latestSeq: 9,
+        pendingUserInputIds,
+        turns: [
+          {
+            id: 'turn_1',
+            threadId: 'thr_1',
+            status: 'running',
+            prompt: 'hi',
+            createdAt: 't0',
+            items: [
+              {
+                id: 'item_input',
+                turnId: 'turn_1',
+                threadId: 'thr_1',
+                role: 'assistant',
+                status: 'pending',
+                createdAt: 't1',
+                kind: 'user_input',
+                inputId: 'in_live',
+                prompt: 'north or south?'
+              }
+            ]
+          }
+        ]
+      })
+
+    // Gate still awaiting in_live -> the rehydrated prompt stays answerable.
+    installDsGui({
+      runtimeRequest: vi.fn(async () => ({ ok: true, status: 200, body: threadBody(['in_live']) }))
+    })
+    const liveDetail = await new KunRuntimeProvider().getThreadDetail('thr_1')
+    const liveBlock = liveDetail.blocks.find((block) => block.kind === 'user_input')
+    expect(liveBlock).toMatchObject({ requestId: 'in_live', status: 'pending', live: true })
+
+    // Gate empty (finished thread) -> the same pending item is NOT live.
+    resetProviderCacheForTests()
+    installDsGui({
+      runtimeRequest: vi.fn(async () => ({ ok: true, status: 200, body: threadBody([]) }))
+    })
+    const staleDetail = await new KunRuntimeProvider().getThreadDetail('thr_1')
+    const staleBlock = staleDetail.blocks.find((block) => block.kind === 'user_input')
+    expect(staleBlock?.kind === 'user_input' && staleBlock.live).toBeFalsy()
+  })
+
   it('coalesces tool_call and tool_result pairs into one tool block on thread load', async () => {
     installDsGui({
       runtimeRequest: vi.fn(async () => ({

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -225,6 +225,20 @@ export class KunRuntimeProvider implements AgentProvider {
       const block = chatBlockFromItem(item)
       return block ? [block] : []
     }))
+    // Re-derive the live ask-user flag from the runtime's pending gate so a
+    // request the agent is still awaiting stays answerable after a rehydration
+    // (thread switch, SSE recovery, restart) — and a stale `pending` item from a
+    // finished thread, whose gate entry is gone, stays a read-only record (#606).
+    const pendingUserInputIds = new Set(
+      Array.isArray(thread.pendingUserInputIds) ? thread.pendingUserInputIds : []
+    )
+    if (pendingUserInputIds.size > 0) {
+      for (const block of blocks) {
+        if (block.kind === 'user_input' && pendingUserInputIds.has(block.requestId)) {
+          block.live = true
+        }
+      }
+    }
     const latestTurn = turns.at(-1)
     const latestUserMessageId = [...items].reverse().find((item) => item.kind === 'user_message')?.id
     return {

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -300,6 +300,13 @@ export type ChatBlock =
       status: 'pending' | 'submitted' | 'cancelled' | 'error'
       answers?: UserInputAnswer[]
       errorMessage?: string
+      /**
+       * True only for a request the live runtime is currently awaiting (set by
+       * the `onUserInput` stream event). Historical blocks rehydrated from a
+       * finished thread never carry it, so a stale `pending` request reopened
+       * from history is not re-surfaced as an actionable prompt (issue #606).
+       */
+      live?: boolean
     }
 
 export type ApprovalRequestPayload = {

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -139,6 +139,11 @@ export function SettingsView(): ReactElement {
   const saveTimer = useRef<ReturnType<typeof window.setTimeout> | null>(null)
   const statusTimer = useRef<ReturnType<typeof window.setTimeout> | null>(null)
   const draftVersion = useRef(0)
+  // Snapshot of a debounced-but-not-yet-persisted edit, flushed on unmount so
+  // exits that bypass goBack() (Esc, route changes, closing settings) don't
+  // drop the last edit made within the 450ms debounce window (issue #602).
+  const pendingSnapshotRef = useRef<AppSettingsV1 | null>(null)
+  const flushOnUnmountRef = useRef<() => void>(() => {})
   const agentsSectionRef = useRef<HTMLDivElement | null>(null)
   const skillSectionRef = useRef<HTMLDivElement | null>(null)
   const mcpSectionRef = useRef<HTMLDivElement | null>(null)
@@ -367,6 +372,8 @@ export function SettingsView(): ReactElement {
     return () => {
       if (saveTimer.current) window.clearTimeout(saveTimer.current)
       if (statusTimer.current) window.clearTimeout(statusTimer.current)
+      // Persist any debounced edit that hasn't been flushed yet (issue #602).
+      flushOnUnmountRef.current()
     }
   }, [])
 
@@ -661,18 +668,22 @@ export function SettingsView(): ReactElement {
     setSaveError(null)
 
     if (!hasValidPort(next)) {
+      pendingSnapshotRef.current = null
       setSaveStatus('idle')
       return
     }
 
+    pendingSnapshotRef.current = next
     setSaveStatus('saving')
     saveTimer.current = window.setTimeout(() => {
       saveTimer.current = null
+      pendingSnapshotRef.current = null
       void persistSettings(next, version)
     }, 450)
   }
 
   const flushPendingSave = async (): Promise<void> => {
+    pendingSnapshotRef.current = null
     if (!form || !hasValidPort(form)) return
     draftVersion.current += 1
     const version = draftVersion.current
@@ -687,6 +698,32 @@ export function SettingsView(): ReactElement {
     }
 
     await persistSettings(form, version)
+  }
+
+  // Recomputed every render so the unmount cleanup always sees current values.
+  // Persists the pending snapshot directly over IPC (no React state writes,
+  // since the component is unmounting) and broadcasts the change so other
+  // surfaces stay in sync.
+  flushOnUnmountRef.current = (): void => {
+    const snapshot = pendingSnapshotRef.current
+    pendingSnapshotRef.current = null
+    if (!snapshot || !hasValidPort(snapshot)) return
+    void rendererRuntimeClient
+      .setSettings(expandSettingsHomePathsForUse(snapshot, settingsHomeDir, settingsPlatform))
+      .then((saved) => {
+        const next = coerceRendererSettings(saved)
+        emitRendererSettingsChanged(next)
+        // App-wide effects the normal save path runs, so a last-moment locale or
+        // UI-token edit still takes effect immediately rather than on next start.
+        void applyI18n(next.locale)
+        void reloadUiSettings()
+      })
+      .catch((e) => {
+        const message = e instanceof Error ? e.message : String(e)
+        void window.kunGui?.logError?.('settings', 'Failed to flush settings on unmount', { message }).catch(
+          () => undefined
+        )
+      })
   }
 
   const goBack = (): void => {

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -95,6 +95,7 @@ import {
 import { FloatingComposerAgentPicker } from './FloatingComposerAgentPicker'
 import { FloatingComposerUserInputPanel } from './FloatingComposerUserInputPanel'
 import { useComposerUserInput, type PendingUserInputBlock } from './use-composer-user-input'
+import { selectLivePendingUserInput } from './user-input-panel-logic'
 import {
   FloatingComposerQueuedMessages,
   type QueuedComposerMessage
@@ -541,11 +542,10 @@ export function FloatingComposer({
   // it. The timeline bubble remains the record in every surface.
   const pendingUserInputBlock = useMemo<PendingUserInputBlock | null>(() => {
     if (compact || route !== 'chat') return null
-    for (let i = blocks.length - 1; i >= 0; i -= 1) {
-      const block = blocks[i]
-      if (block.kind === 'user_input' && block.status === 'pending') return block
-    }
-    return null
+    // Only surface a request the live runtime is actively awaiting. A stale
+    // `pending` block rehydrated from a finished thread must not re-prompt the
+    // user (issue #606) — resolving it would hit a dead gate.
+    return selectLivePendingUserInput(blocks)
   }, [blocks, compact, route])
   const userInput = useComposerUserInput(pendingUserInputBlock, resolveUserInput)
   const fileInputRef = useRef<HTMLInputElement | null>(null)

--- a/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
+++ b/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
@@ -521,6 +521,8 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
       id: 'ui_freeform',
       requestId: 'input_freeform',
       status: 'pending',
+      // The live runtime is actively awaiting this request.
+      live: true,
       questions: [
         {
           header: 'Input',
@@ -546,6 +548,42 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
     expect(html).not.toContain('<textarea')
     expect(html).toContain('Answer below the input box')
     expect(html).toContain('Cancel')
+  })
+
+  it('renders a stale pending request_user_input from history as a non-actionable record (issue #606)', () => {
+    // A request rehydrated from a finished thread keeps `status: 'pending'` but
+    // is not `live`, so it must not offer Cancel (which would hit a dead gate).
+    const inputBlock: ChatBlock = {
+      kind: 'user_input',
+      id: 'ui_stale',
+      requestId: 'input_stale',
+      status: 'pending',
+      questions: [
+        {
+          header: 'Input',
+          id: 'direction',
+          question: '你更想去南方还是北方？',
+          options: []
+        }
+      ]
+    }
+
+    const html = renderToStaticMarkup(
+      createElement(ProcessSectionRow, {
+        section: { id: 'execution-input', kind: 'execution', blocks: [inputBlock] },
+        processing: true,
+        singleReasoningSection: false,
+        viewportRef: { current: null }
+      })
+    )
+
+    // The record still shows what was asked…
+    expect(html).toContain('你更想去南方还是北方？')
+    // …but offers no live affordances (the "answer below" hint and the Cancel
+    // button share one `pending` branch), so it can't fire a dead resolve.
+    expect(html).not.toContain('Answer below the input box')
+    // It reads as an ended record rather than an active prompt.
+    expect(html).toContain('Cancelled')
   })
 
   it('expands the live work timeline by default while keeping tool details collapsed', () => {

--- a/src/renderer/src/components/chat/SidebarProjectsSection.tsx
+++ b/src/renderer/src/components/chat/SidebarProjectsSection.tsx
@@ -1664,7 +1664,7 @@ function SidebarActionDialog({
     >
       <div
         onMouseDown={(event) => event.stopPropagation()}
-        className="w-full max-w-[520px] rounded-[26px] border border-ds-border bg-ds-card/96 p-6 shadow-[0_26px_82px_rgba(20,47,95,0.24)] backdrop-blur-xl dark:bg-ds-card"
+        className="w-full max-w-[520px] rounded-[26px] border border-ds-border bg-ds-elevated p-6 shadow-[0_26px_82px_rgba(20,47,95,0.24)] backdrop-blur-xl"
       >
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
@@ -1686,7 +1686,7 @@ function SidebarActionDialog({
             <X className="h-4 w-4" strokeWidth={1.9} />
           </button>
         </div>
-        <p className="mt-4 rounded-2xl border border-ds-border-muted bg-ds-main/55 px-3.5 py-3 text-[13px] leading-6 text-ds-muted">
+        <p className="mt-4 rounded-2xl border border-ds-border-muted bg-ds-main px-3.5 py-3 text-[13px] leading-6 text-ds-muted">
           {state.detail}
         </p>
         <div className="mt-5 flex justify-end gap-2">

--- a/src/renderer/src/components/chat/message-timeline-bubbles.tsx
+++ b/src/renderer/src/components/chat/message-timeline-bubbles.tsx
@@ -1006,7 +1006,12 @@ function UserInputBubble({
   const [answers, setAnswers] = useState<Record<string, UserInputAnswer>>(() =>
     answersByQuestionId(block.answers)
   )
-  const pending = block.status === 'pending'
+  // A `pending` block is only actionable while the live runtime is awaiting it.
+  // One rehydrated from a finished thread keeps its stored `pending` status but
+  // is not live, so it renders as a read-only ended record rather than a live
+  // prompt — and crucially never offers cancel, which would hit a dead gate and
+  // raise "user input not found" (issue #606).
+  const pending = block.status === 'pending' && block.live === true
   const done = block.status !== 'pending'
 
   useEffect(() => {
@@ -1028,7 +1033,9 @@ function UserInputBubble({
         ? t('userInputCancelled')
         : block.status === 'error'
           ? t('userInputFailed')
-          : t('userInputPending')
+          : pending
+            ? t('userInputPending')
+            : t('userInputCancelled')
   const tone =
     block.status === 'error'
       ? 'error'
@@ -1036,7 +1043,9 @@ function UserInputBubble({
         ? 'success'
         : block.status === 'cancelled'
           ? 'muted'
-          : 'active'
+          : pending
+            ? 'active'
+            : 'muted'
   const questionCount = block.questions.length
   const containerClass = nested
     ? `overflow-hidden rounded-[14px] border px-3.5 py-3 text-[13px] leading-5 shadow-[0_8px_22px_rgba(20,47,95,0.035)] ${

--- a/src/renderer/src/components/chat/use-timeline-scroll.ts
+++ b/src/renderer/src/components/chat/use-timeline-scroll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
 
 /** Threshold (px) from the top of the scroll container that triggers
  * auto-loading earlier turns. */
@@ -108,8 +108,9 @@ export function useTimelineScroll({
   }, [pageSize])
 
   // A freshly submitted user turn should become visible even if the user was
-  // reading older history before pressing Enter.
-  useEffect(() => {
+  // reading older history before pressing Enter. Runs as a layout effect so the
+  // stick-to-bottom intent is set before the snap effect below pins (issue #603).
+  useLayoutEffect(() => {
     if (!userTurnKey || lastUserTurnKeyRef.current === userTurnKey) return
     lastUserTurnKeyRef.current = userTurnKey
     stickToBottomRef.current = true
@@ -130,21 +131,28 @@ export function useTimelineScroll({
     return () => el.removeEventListener('scroll', onScroll)
   }, [containerRef, hiddenTurnCount, loadEarlierTurns])
 
-  // Snap to bottom when content changes, but only if the user was
-  // already at the bottom.
-  useEffect(() => {
+  // Snap to bottom when the content or the visible window changes, but only if
+  // the user was already at the bottom. Runs as a layout effect so a discrete
+  // change (e.g. sending a message, which slides the collapsed turn window and
+  // drops the oldest visible turn) pins *before* paint instead of flashing the
+  // viewport upward and then jumping back once the model streams (issue #603).
+  // Streaming deltas stay rAF-throttled to avoid a forced reflow per delta.
+  useLayoutEffect(() => {
     if (!stickToBottomRef.current) return
+    // A visibleTurnCount bump from loading earlier turns must not pull the
+    // viewport to the bottom — the prepend effect owns scroll position there.
+    if (prependInFlightRef.current) return
+    if (!streaming) {
+      endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
+    }
     if (scrollFrameRef.current !== null) {
       window.cancelAnimationFrame(scrollFrameRef.current)
     }
     scrollFrameRef.current = window.requestAnimationFrame(() => {
       scrollFrameRef.current = null
-      endRef.current?.scrollIntoView({
-        behavior: streaming ? 'auto' : 'smooth',
-        block: 'end'
-      })
+      endRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
     })
-  }, [contentKey, endRef, streaming])
+  }, [contentKey, visibleTurnCount, streaming, endRef])
 
   // Hard reset on thread switch.
   useEffect(() => {

--- a/src/renderer/src/components/chat/user-input-panel-logic.test.ts
+++ b/src/renderer/src/components/chat/user-input-panel-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { UserInputQuestion } from '../../agent/types'
+import type { ChatBlock, UserInputQuestion } from '../../agent/types'
 import {
   USER_INPUT_FREEFORM_LABEL,
   USER_INPUT_OTHER_LABEL,
@@ -7,10 +7,12 @@ import {
   answerFromOption,
   answerFromTypedText,
   answersByQuestionId,
+  isLivePendingUserInput,
   isQuestionAnswered,
   nextUnansweredIndex,
   optionsNeedRows,
   orderedAnswers,
+  selectLivePendingUserInput,
   shouldShowQuestionHeader
 } from './user-input-panel-logic'
 
@@ -30,6 +32,43 @@ const freeformQuestion: UserInputQuestion = {
   question: 'Service name?',
   options: []
 }
+
+function userInputBlock(overrides: Partial<Extract<ChatBlock, { kind: 'user_input' }>>): ChatBlock {
+  return {
+    kind: 'user_input',
+    id: overrides.id ?? 'ui_1',
+    requestId: overrides.requestId ?? 'in_1',
+    questions: overrides.questions ?? [optionQuestion],
+    status: overrides.status ?? 'pending',
+    ...overrides
+  }
+}
+
+describe('selectLivePendingUserInput', () => {
+  it('surfaces a live pending request', () => {
+    const block = userInputBlock({ status: 'pending', live: true })
+    expect(isLivePendingUserInput(block as Extract<ChatBlock, { kind: 'user_input' }>)).toBe(true)
+    expect(selectLivePendingUserInput([block])).toBe(block)
+  })
+
+  it('ignores a stale pending request rehydrated from history (issue #606)', () => {
+    // No `live` flag — this is exactly the block a finished thread replays.
+    const stale = userInputBlock({ status: 'pending' })
+    expect(isLivePendingUserInput(stale as Extract<ChatBlock, { kind: 'user_input' }>)).toBe(false)
+    expect(selectLivePendingUserInput([stale])).toBeNull()
+  })
+
+  it('ignores resolved requests even when marked live', () => {
+    const submitted = userInputBlock({ status: 'submitted', live: true })
+    expect(selectLivePendingUserInput([submitted])).toBeNull()
+  })
+
+  it('returns the latest live pending block when several exist', () => {
+    const older = userInputBlock({ id: 'ui_old', requestId: 'in_old', status: 'pending', live: true })
+    const newer = userInputBlock({ id: 'ui_new', requestId: 'in_new', status: 'pending', live: true })
+    expect(selectLivePendingUserInput([older, newer])).toBe(newer)
+  })
+})
 
 describe('answerFromOption', () => {
   it('uses the option label as both label and value', () => {

--- a/src/renderer/src/components/chat/user-input-panel-logic.ts
+++ b/src/renderer/src/components/chat/user-input-panel-logic.ts
@@ -1,4 +1,26 @@
-import type { UserInputAnswer, UserInputOption, UserInputQuestion } from '../../agent/types'
+import type { ChatBlock, UserInputAnswer, UserInputOption, UserInputQuestion } from '../../agent/types'
+
+type UserInputBlock = Extract<ChatBlock, { kind: 'user_input' }>
+
+/**
+ * A `user_input` request is actionable only while the live runtime is awaiting
+ * it (`block.live`). A block rehydrated from a finished thread keeps its stored
+ * `pending` status but is NOT live, so reopening that history must not re-prompt
+ * the user (issue #606) — answering it would hit a dead gate ("user input not
+ * found").
+ */
+export function isLivePendingUserInput(block: UserInputBlock): boolean {
+  return block.status === 'pending' && block.live === true
+}
+
+/** The live, awaited `user_input` block in a thread, if any (latest wins). */
+export function selectLivePendingUserInput(blocks: ChatBlock[]): UserInputBlock | null {
+  for (let i = blocks.length - 1; i >= 0; i -= 1) {
+    const block = blocks[i]
+    if (block.kind === 'user_input' && isLivePendingUserInput(block)) return block
+  }
+  return null
+}
 
 /**
  * Shared, framework-free helpers for the user_input / ask-user interaction.

--- a/src/renderer/src/store/chat-store-runtime.ts
+++ b/src/renderer/src/store/chat-store-runtime.ts
@@ -923,8 +923,21 @@ export function buildThreadEventSink(
       resetBusyRecoveryAttempts()
       clearBusyWatchdog()
       set((s) => {
-        if (s.blocks.some((b) => b.kind === 'user_input' && b.requestId === req.requestId)) {
-          return {}
+        const existing = s.blocks.find(
+          (b) => b.kind === 'user_input' && b.requestId === req.requestId
+        )
+        if (existing) {
+          // Already have the block (e.g. rehydrated from history): make sure it
+          // is flagged live so it stays answerable, rather than no-op'ing and
+          // leaving a stale-looking read-only record (#606).
+          if (existing.kind === 'user_input' && existing.live === true) return {}
+          return {
+            blocks: s.blocks.map((b) =>
+              b.kind === 'user_input' && b.requestId === req.requestId
+                ? { ...b, live: true, status: 'pending' as const }
+                : b
+            )
+          }
         }
         const flushed = flushLiveBlocks(s)
         const baseBlocks = flushed.blocks ?? s.blocks
@@ -938,7 +951,10 @@ export function buildThreadEventSink(
               createdAt: new Date().toISOString(),
               requestId: req.requestId,
               questions: req.questions,
-              status: 'pending' as const
+              status: 'pending' as const,
+              // Marks this as a request the live runtime is actively awaiting.
+              // Only live blocks are actionable; rehydrated history is not.
+              live: true
             }
           ],
           error: clearRuntimeStreamRecoveringError(s.error)

--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -113,7 +113,7 @@ describe('model provider settings', () => {
     expect(resolveModelProviderProxyUrl(state)).toBe('socks5://127.0.0.1:1080')
   })
 
-  it('disables invalid model request proxy URLs', () => {
+  it('keeps the raw proxy URL in storage but refuses to apply invalid protocols', () => {
     const provider = normalizeModelProviderSettings({
       proxy: {
         enabled: true,
@@ -121,10 +121,39 @@ describe('model provider settings', () => {
       }
     })
 
+    // Storage keeps exactly what the user typed (so editing is never destroyed)…
     expect(provider.proxy).toEqual({
-      enabled: false,
-      url: ''
+      enabled: true,
+      url: 'ftp://127.0.0.1:2121'
     })
+
+    // …but an unsupported proxy protocol is not applied to outbound requests.
+    const state = settings()
+    state.provider.proxy = provider.proxy
+    expect(resolveModelProviderProxyUrl(state)).toBe('')
+  })
+
+  it('does not blank partial proxy URLs while typing (regression for #600)', () => {
+    // Intermediate values as the user types "http://127.0.0.1:7890"; none of
+    // them may be wiped to '' by the per-keystroke normalizer.
+    for (const partial of ['h', 'http:', 'http://127.0.0.1', 'http://127.0.0.1:78']) {
+      const provider = normalizeModelProviderSettings({ proxy: { enabled: true, url: partial } })
+      expect(provider.proxy.url).toBe(partial)
+      expect(provider.proxy.enabled).toBe(true)
+    }
+
+    // A completed URL applies cleanly; a port is optional.
+    const withPort = settings()
+    withPort.provider.proxy = normalizeModelProviderSettings({
+      proxy: { enabled: true, url: 'http://127.0.0.1:7890' }
+    }).proxy
+    expect(resolveModelProviderProxyUrl(withPort)).toBe('http://127.0.0.1:7890/')
+
+    const noPort = settings()
+    noPort.provider.proxy = normalizeModelProviderSettings({
+      proxy: { enabled: true, url: 'http://proxy.lan' }
+    }).proxy
+    expect(resolveModelProviderProxyUrl(noPort)).toBe('http://proxy.lan/')
   })
 
   it('keeps legacy Kun runtime credential overrides only when no provider is selected', () => {

--- a/src/shared/app-settings-provider.ts
+++ b/src/shared/app-settings-provider.ts
@@ -159,7 +159,11 @@ export function resolveModelProviderBaseUrl(settings: AppSettingsV1): string {
 
 export function resolveModelProviderProxyUrl(settings: AppSettingsV1): string {
   const proxy = getModelProviderSettings(settings).proxy
-  return proxy.enabled ? proxy.url.trim() : ''
+  if (!proxy.enabled) return ''
+  // Validation happens here, at the apply boundary — not while the user types
+  // (see `normalizeNetworkProxySettings`). An invalid/incomplete URL simply
+  // means "no proxy" for outbound requests instead of wiping the saved value.
+  return normalizeProxyUrl(proxy.url)
 }
 
 export function getDefaultModelProviderProfile(settings: AppSettingsV1): ModelProviderProfileV1 {
@@ -1238,10 +1242,14 @@ export function defaultNetworkProxySettings(): NetworkProxySettingsV1 {
 export function normalizeNetworkProxySettings(
   input: Partial<NetworkProxySettingsV1> | undefined
 ): NetworkProxySettingsV1 {
-  const url = normalizeProxyUrl(input?.url)
+  // Keep the user's raw (only-trimmed) URL and the enable toggle exactly as
+  // given. This normalizer runs on every keystroke (renderer `mergeSettings`),
+  // so it must NOT validate/blank the URL here — doing so wiped each
+  // half-typed value and made the proxy impossible to set (issue #600).
+  // Validity is enforced lazily in `resolveModelProviderProxyUrl`.
   return {
-    enabled: input?.enabled === true && Boolean(url),
-    url
+    enabled: input?.enabled === true,
+    url: typeof input?.url === 'string' ? input.url.trim() : ''
   }
 }
 
@@ -1252,7 +1260,9 @@ export function normalizeProxyUrl(value: unknown): string {
     const parsed = new URL(raw)
     const protocol = parsed.protocol.replace(/:$/, '').toLowerCase()
     if (!NETWORK_PROXY_PROTOCOLS.includes(protocol as typeof NETWORK_PROXY_PROTOCOLS[number])) return ''
-    if (!parsed.hostname || !parsed.port) return ''
+    // A hostname is required; the port is optional (the proxy agent falls back
+    // to the protocol's default port) so URLs like `http://proxy.lan` work.
+    if (!parsed.hostname) return ''
     return parsed.toString()
   } catch {
     return ''


### PR DESCRIPTION
Fixes five reported bugs (v0.2.18). Each is one focused commit.

## Bugs & fixes

### [Bug] 模型请求代理设置后不生效，重启后会被重置 (#600)
The renderer normalizes settings on **every keystroke** (`mergeSettings → normalizeNetworkProxySettings`), and `normalizeProxyUrl` returned `''` for any incomplete URL (and required an explicit port). So the controlled proxy input was blanked as you typed — the proxy could only ever be *pasted* whole, otherwise it was never stored and looked like it "reset on restart".
**Fix:** keep the raw (trimmed) URL + the enable toggle in storage; validate only at the apply boundary (`resolveModelProviderProxyUrl`); allow a missing port.

### [Bug] AI模型供应商设置页面缺少保存按钮，修改后退出配置丢失 (#602)
Edits auto-save on a 450 ms debounce and `goBack()` flushes them, but exits that bypass `goBack()` (Esc, route change, closing settings) unmounted `SettingsView` and the cleanup just **cleared the debounce timer** — dropping the last edit.
**Fix:** track the pending snapshot and flush it (fire-and-forget over IPC) on unmount, re-running the locale/UI-token side effects.

### [Bug] 新消息发送后会话会往上翻页 (#603)
In a long (collapsed) thread, sending a message slides the visible-turn window and drops the oldest visible turn. The snap-to-bottom ran in a post-paint `useEffect` + rAF, so the layout shift painted first — the viewport jumped up a screen, then snapped back once streaming began.
**Fix:** pin in a `useLayoutEffect` (before paint) and re-pin on window recompute; streaming deltas stay rAF-throttled; the snap yields to the prepend position-restore when loading earlier turns.

### [Bug] 删除会话时显示有问题 (#605)
The confirmation card used `bg-ds-card/96`. **Tailwind v3.4 silently drops an opacity modifier on a `var()`-based color token** (it can't inject alpha into a full `rgba()` var), so in light mode the card had *no* background and relied entirely on `backdrop-blur`; where `backdrop-filter` is weak/disabled (Windows) the sidebar bled through and collided with the text.
**Fix:** opaque `bg-ds-elevated` card + solid `bg-ds-main` inset box (both immune to the dropped-opacity quirk).

### [Bug] 打开已完成的历史会话会弹窗 (#606)
A `user_input` block rehydrated from a finished thread kept its stored `pending` status, so reopening that history re-surfaced the ask-user panel and let the user "answer" a request whose runtime gate is gone → `user input not found: in_...`.
**Fix:** a request is actionable only while the **gate is actually awaiting it**. `getThread` now reports `pendingUserInputIds`, and `getThreadDetail` flags matching blocks `live` on every rehydration (thread switch, SSE recovery, restart); the live `onUserInput` event flags fresh requests. The panel and bubble treat a non-live `pending` block as a read-only ended record. Deriving `live` from the gate (not the SSE event alone) keeps a genuinely in-flight prompt answerable after a reconnect, since the `user_input_requested` event is the thread's latest seq and is never replayed.

> The first cut of #606 gated only on a renderer-side `live` flag set by the SSE event. An adversarial review caught that this would make a *genuinely in-flight* prompt un-answerable after a thread-switch / SSE blip / restart (the live event isn't replayed) — so the fix now derives `live` from the runtime gate, the ground truth.

## Testing
- `typecheck` clean (GUI **and** kun). `eslint` clean on changed files.
- Added/updated unit tests: proxy normalization & typing regression, `selectLivePendingUserInput`, live-vs-stale bubble rendering, `getThreadDetail` live derivation, and a `getThread` `pendingUserInputIds` backend test.
- Full suites: GUI **1776 passed**, kun **823 passed**. The remaining failures are pre-existing/environmental and unrelated to this branch: 4 `kun-process` tests (`EADDRINUSE 127.0.0.1:18899` — a running Kun app holds the port), 2 `MessageTimeline.tool-summary` tests (fail on clean `develop`), and 1 `memory-store` test (known-red on `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
