### PR TITLE
feat(agent-sdk): background binary download with a progress bar

### DIFF
--- a/src/main/agent-sdk-installer.ts
+++ b/src/main/agent-sdk-installer.ts
@@ -10,7 +10,7 @@
  */
 import { spawn } from 'node:child_process'
 import { createWriteStream, existsSync, mkdirSync, rmSync, chmodSync, statSync } from 'node:fs'
-import { Readable } from 'node:stream'
+import { Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -92,6 +92,7 @@ export async function installClaudeBinary(options: {
   userDataDir: string
   proxyUrl?: string
   version?: string
+  onProgress?: (receivedBytes: number, totalBytes: number) => void
 }): Promise<AgentSdkInstallResult> {
   const pkg = platformBinaryPackage()
   if (!pkg) return { ok: false, message: `unsupported platform: ${process.platform}/${process.arch}` }
@@ -108,11 +109,24 @@ export async function installClaudeBinary(options: {
     const tarball = meta.dist?.tarball
     if (!tarball) throw new Error(`no tarball for ${pkg}@${version}`)
 
-    // 2. stream the (~222MB) tarball to a temp file
+    // 2. stream the (~222MB) tarball to a temp file, reporting progress
     const res = await fetchWithOptionalProxy(tarball, {}, proxyUrl)
     if (!res.ok || !res.body) throw new Error(`download ${tarball}: ${res.status}`)
+    const totalBytes = Number(res.headers.get('content-length')) || 0
+    let receivedBytes = 0
+    const counter = new Transform({
+      transform(chunk, _enc, cb) {
+        receivedBytes += chunk.length
+        options.onProgress?.(receivedBytes, totalBytes)
+        cb(null, chunk)
+      }
+    })
     mkdirSync(destDir, { recursive: true })
-    await pipeline(Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(tgz))
+    await pipeline(
+      Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]),
+      counter,
+      createWriteStream(tgz)
+    )
 
     // 3. extract just the binary (tarball root is `package/`)
     await runTar(['-xzf', tgz, '-C', destDir, '--strip-components=1', `package/${claudeBinaryName()}`])
@@ -126,4 +140,55 @@ export async function installClaudeBinary(options: {
   } finally {
     rmSync(tgz, { force: true })
   }
+}
+
+// ---------------------------------------------------------------------------
+// Background download — a process-wide singleton so it keeps running even if the
+// user navigates away from the settings page; the UI re-reads its state on mount.
+// ---------------------------------------------------------------------------
+
+export type SdkDownloadState = {
+  status: 'downloading' | 'done' | 'error'
+  receivedBytes: number
+  totalBytes: number
+  message?: string
+}
+
+let activeState: SdkDownloadState | null = null
+let activePromise: Promise<AgentSdkInstallResult> | null = null
+
+/** Current background-download state, or null if none has run. */
+export function agentSdkDownloadState(): SdkDownloadState | null {
+  return activeState
+}
+
+/**
+ * Start (or resume) the background download. Idempotent while one is in flight —
+ * a second call returns the current state instead of starting another. Returns
+ * immediately with the live state; `onState` is called on every update.
+ */
+export function startAgentSdkInstall(
+  options: { userDataDir: string; proxyUrl?: string; version?: string },
+  onState?: (state: SdkDownloadState) => void
+): SdkDownloadState {
+  if (activeState?.status === 'downloading') return activeState
+  const emit = (state: SdkDownloadState): void => {
+    activeState = state
+    onState?.(state)
+  }
+  emit({ status: 'downloading', receivedBytes: 0, totalBytes: 0 })
+  activePromise = installClaudeBinary({
+    ...options,
+    onProgress: (receivedBytes, totalBytes) => emit({ status: 'downloading', receivedBytes, totalBytes })
+  }).then((result) => {
+    const received = activeState?.receivedBytes ?? 0
+    const total = activeState?.totalBytes ?? 0
+    emit(
+      result.ok
+        ? { status: 'done', receivedBytes: received, totalBytes: total }
+        : { status: 'error', receivedBytes: received, totalBytes: total, message: result.message }
+    )
+    return result
+  })
+  return activeState as SdkDownloadState
 }

--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -105,7 +105,12 @@ import {
 import { detectLegacySessions, importLegacySessions } from '../services/legacy-session-import-service'
 import { claudeSubscriptionStatus, runClaudeSetupToken } from '../claude-subscription-auth'
 import { fetchSdkModels } from '../claude-subscription-models'
-import { agentSdkStatus, installClaudeBinary, resolveClaudeBinary } from '../agent-sdk-installer'
+import {
+  agentSdkDownloadState,
+  agentSdkStatus,
+  resolveClaudeBinary,
+  startAgentSdkInstall
+} from '../agent-sdk-installer'
 import type { JsonSettingsStore } from '../settings-store'
 import { probeModelProvider } from '../provider-connection'
 import type { ClawRuntime } from '../claw-runtime'
@@ -516,14 +521,15 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
     ].map((root) => join(root, 'kun'))
   const claudeSubBinary = (): string | undefined =>
     resolveClaudeBinary(app.getPath('userData'), claudeSubKunDirs())
-  ipcMain.handle('claude-subscription:sdk-status', async () =>
-    agentSdkStatus(app.getPath('userData'), claudeSubKunDirs())
-  )
+  ipcMain.handle('claude-subscription:sdk-status', async () => ({
+    ...agentSdkStatus(app.getPath('userData'), claudeSubKunDirs()),
+    download: agentSdkDownloadState()
+  }))
   ipcMain.handle('claude-subscription:sdk-install', async () =>
-    installClaudeBinary({
-      userDataDir: app.getPath('userData'),
-      proxyUrl: resolveModelProviderProxyUrl(await store.load())
-    })
+    startAgentSdkInstall(
+      { userDataDir: app.getPath('userData'), proxyUrl: resolveModelProviderProxyUrl(await store.load()) },
+      (state) => getMainWindow()?.webContents.send('claude-subscription:sdk-progress', state)
+    )
   )
   ipcMain.handle('claude-subscription:login', async () =>
     runClaudeSetupToken({ binaryPath: claudeSubBinary() })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,14 @@ const api = {
   claudeSubscriptionModels: (token) => ipcRenderer.invoke('claude-subscription:models', token),
   claudeSubscriptionSdkStatus: () => ipcRenderer.invoke('claude-subscription:sdk-status'),
   claudeSubscriptionSdkInstall: () => ipcRenderer.invoke('claude-subscription:sdk-install'),
+  onClaudeSubscriptionSdkProgress: (handler) => {
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      payload: Parameters<typeof handler>[0]
+    ) => handler(payload)
+    ipcRenderer.on('claude-subscription:sdk-progress', wrapped)
+    return () => ipcRenderer.removeListener('claude-subscription:sdk-progress', wrapped)
+  },
   setSettings: (partial) =>
     ipcRenderer.invoke('settings:set', partial),
   saveSettingsSilent: (partial) =>

--- a/src/renderer/src/components/claude-subscription-section.tsx
+++ b/src/renderer/src/components/claude-subscription-section.tsx
@@ -7,6 +7,8 @@ type Translate = (key: string) => string
 
 const SETUP_TOKEN_COMMAND = 'claude setup-token'
 
+const formatMb = (bytes: number): string => (bytes / (1024 * 1024)).toFixed(1)
+
 function loginErrorText(message: string, t: Translate): string {
   if (message === 'claude-cli-not-found') return t('claudeSubLoginFailedCli')
   if (message === 'timeout') return t('claudeSubLoginFailedTimeout')
@@ -38,35 +40,59 @@ export function ClaudeSubscriptionSection({
   const [copied, setCopied] = useState(false)
   const [modelsBusy, setModelsBusy] = useState(false)
   const [modelsNote, setModelsNote] = useState<string | null>(null)
-  const [sdk, setSdk] = useState<'checking' | 'ready' | 'missing'>('checking')
-  const [sdkBusy, setSdkBusy] = useState(false)
+  const [sdk, setSdk] = useState<'checking' | 'ready' | 'missing' | 'downloading'>('checking')
+  const [progress, setProgress] = useState<{ received: number; total: number } | null>(null)
   const [sdkNote, setSdkNote] = useState<string | null>(null)
+
+  // Apply a background-download state (from status or a live progress event).
+  // Returns true if it represented an active/known download.
+  const applyDownload = (
+    d: { status: string; receivedBytes: number; totalBytes: number; message?: string } | null | undefined
+  ): boolean => {
+    if (!d) return false
+    if (d.status === 'downloading') {
+      setSdk('downloading')
+      setProgress({ received: d.receivedBytes, total: d.totalBytes })
+      return true
+    }
+    if (d.status === 'done') {
+      setSdk('ready')
+      setProgress(null)
+      return true
+    }
+    if (d.status === 'error') {
+      setSdk('missing')
+      setProgress(null)
+      setSdkNote(d.message ? `${t('claudeSubSdkFailed')}: ${d.message}` : t('claudeSubSdkFailed'))
+      return true
+    }
+    return false
+  }
 
   const checkSdk = async (): Promise<void> => {
     try {
       const s = await window.kunGui.claudeSubscriptionSdkStatus()
-      setSdk(s.installed ? 'ready' : 'missing')
+      if (s.installed) {
+        setSdk('ready')
+        return
+      }
+      if (!applyDownload(s.download)) setSdk('missing')
     } catch {
       setSdk('missing')
     }
   }
 
-  // Download the ~222MB Claude Code binary on demand (it isn't bundled).
+  // Start the ~222MB download in the background (main keeps it running even if the
+  // user navigates away); progress + completion arrive via the subscription below.
   const installSdk = async (): Promise<void> => {
-    setSdkBusy(true)
     setSdkNote(null)
+    setSdk('downloading')
+    setProgress({ received: 0, total: 0 })
     try {
-      const result = await window.kunGui.claudeSubscriptionSdkInstall()
-      if (result.ok) {
-        setSdk('ready')
-        setSdkNote(t('claudeSubSdkReady'))
-      } else {
-        setSdkNote(`${t('claudeSubSdkFailed')}: ${result.message}`)
-      }
+      applyDownload(await window.kunGui.claudeSubscriptionSdkInstall())
     } catch (err) {
+      setSdk('missing')
       setSdkNote(`${t('claudeSubSdkFailed')}: ${err instanceof Error ? err.message : ''}`)
-    } finally {
-      setSdkBusy(false)
     }
   }
 
@@ -103,6 +129,8 @@ export function ClaudeSubscriptionSection({
     void refreshStatus()
     void checkSdk()
   }, [])
+  // The download runs in main; subscribe so progress shows even after remounting.
+  useEffect(() => window.kunGui.onClaudeSubscriptionSdkProgress((state) => applyDownload(state)), [])
 
   const runLogin = async (): Promise<void> => {
     setBusy(true)
@@ -136,6 +164,10 @@ export function ClaudeSubscriptionSection({
   }
 
   const hasToken = provider.apiKey.trim().length > 0
+  const downloadPct =
+    progress && progress.total > 0
+      ? Math.min(100, Math.round((progress.received / progress.total) * 100))
+      : 0
 
   return (
     <div className="flex flex-col gap-3">
@@ -146,30 +178,47 @@ export function ClaudeSubscriptionSection({
       {sdk !== 'ready' ? (
         <div className="flex flex-col gap-2 rounded-lg border border-amber-300/50 bg-amber-50/40 px-3 py-2.5 dark:bg-amber-900/10">
           <div className="flex items-center gap-2 text-[13px]">
-            {sdk === 'checking' ? (
+            {sdk === 'checking' || sdk === 'downloading' ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin text-ds-muted" strokeWidth={1.9} />
             ) : (
               <AlertCircle className="h-3.5 w-3.5 text-amber-500" strokeWidth={1.9} />
             )}
             <span className="text-ds-ink">
-              {sdk === 'checking' ? t('claudeSubSdkChecking') : t('claudeSubSdkMissing')}
+              {sdk === 'checking'
+                ? t('claudeSubSdkChecking')
+                : sdk === 'downloading'
+                  ? t('claudeSubSdkDownloading')
+                  : t('claudeSubSdkMissing')}
             </span>
           </div>
+
+          {sdk === 'downloading' ? (
+            <div className="flex flex-col gap-1">
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-ds-border">
+                <div
+                  className="h-full rounded-full bg-accent transition-[width] duration-200"
+                  style={{ width: `${downloadPct}%` }}
+                />
+              </div>
+              <span className="text-[11px] text-ds-muted">
+                {progress && progress.total > 0
+                  ? `${formatMb(progress.received)} / ${formatMb(progress.total)} MB · ${downloadPct}%`
+                  : `${formatMb(progress?.received ?? 0)} MB`}
+              </span>
+            </div>
+          ) : null}
+
           {sdk === 'missing' ? (
             <button
               type="button"
-              disabled={sdkBusy}
               onClick={() => void installSdk()}
-              className="inline-flex h-9 items-center justify-center gap-2 self-start rounded-lg border border-accent/50 bg-ds-main/45 px-3 text-[13px] font-medium text-ds-ink transition hover:bg-ds-main/70 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex h-9 items-center justify-center gap-2 self-start rounded-lg border border-accent/50 bg-ds-main/45 px-3 text-[13px] font-medium text-ds-ink transition hover:bg-ds-main/70"
             >
-              {sdkBusy ? (
-                <Loader2 className="h-4 w-4 animate-spin" strokeWidth={1.9} />
-              ) : (
-                <Download className="h-4 w-4" strokeWidth={1.9} />
-              )}
-              {sdkBusy ? t('claudeSubSdkDownloading') : t('claudeSubSdkDownload')}
+              <Download className="h-4 w-4" strokeWidth={1.9} />
+              {t('claudeSubSdkDownload')}
             </button>
           ) : null}
+
           {sdkNote ? <span className="text-[12px] text-ds-muted">{sdkNote}</span> : null}
         </div>
       ) : null}

--- a/src/shared/kun-gui-api.ts
+++ b/src/shared/kun-gui-api.ts
@@ -294,6 +294,13 @@ export type ClaudeSubscriptionLoginResult =
   | { ok: true; token: string }
   | { ok: false; message: string }
 
+export type SdkDownloadState = {
+  status: 'downloading' | 'done' | 'error'
+  receivedBytes: number
+  totalBytes: number
+  message?: string
+}
+
 export type KunGuiApi = {
   platform: string
   homeDir: string
@@ -304,12 +311,16 @@ export type KunGuiApi = {
   claudeSubscriptionLogin: () => Promise<ClaudeSubscriptionLoginResult>
   /** List Claude models available to the subscription (via the SDK's supportedModels). */
   claudeSubscriptionModels: (token?: string) => Promise<string[]>
-  /** Whether the on-demand Claude Code binary is present (download not needed). */
-  claudeSubscriptionSdkStatus: () => Promise<{ installed: boolean; path?: string }>
-  /** Download + install the Claude Code binary into the user-data dir. */
-  claudeSubscriptionSdkInstall: () => Promise<
-    { ok: true; path: string } | { ok: false; message: string }
-  >
+  /** Whether the on-demand Claude Code binary is present + any in-flight download. */
+  claudeSubscriptionSdkStatus: () => Promise<{
+    installed: boolean
+    path?: string
+    download?: SdkDownloadState | null
+  }>
+  /** Start (or resume) the background download; returns the live state immediately. */
+  claudeSubscriptionSdkInstall: () => Promise<SdkDownloadState>
+  /** Subscribe to background-download progress; returns an unsubscribe fn. */
+  onClaudeSubscriptionSdkProgress: (handler: (state: SdkDownloadState) => void) => () => void
   setSettings: (partial: AppSettingsPatch) => Promise<AppSettingsV1>
   saveSettingsSilent: (partial: AppSettingsPatch) => Promise<AppSettingsV1>
   runtimeRequest: (path: string, method?: string, body?: string) => Promise<RuntimeRequestResult>


### PR DESCRIPTION
Follow-up to #611 (which is merged). That PR was merged before this last commit
was pushed, so the on-demand Claude Code binary download still blocked the UI and
had no progress. This adds the background + progress piece.

- The download now runs as a main-process singleton: it keeps going if the user
  navigates away from settings, and the component re-reads its state on mount.
- Progress (bytes) streams to the renderer over `claude-subscription:sdk-progress`
  (same pattern as the local-whisper download) and renders as a progress bar
  (% + MB).
- `sdk-install` starts/resumes the background download and returns the live state
  immediately (no await); `sdk-status` includes any in-flight download; repeated
  clicks are idempotent.

node + web typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)