### PR TITLE
chore: add .workbuddy/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,8 @@ rad.json
 #Test results file
 TestResults.xml
 
+### Tool data
+.workbuddy/
+
 ### Internal docs
 docs/R2_RELEASE.md


### PR DESCRIPTION
## Summary

Add `.workbuddy/` directory to `.gitignore` to prevent WorkBuddy tool metadata from being accidentally committed to the repository.

## Changes

- Added `.workbuddy/` under a new `### Tool data` section in `.gitignore`

## Tests

- Verified `git status` no longer shows `.workbuddy/` as untracked after the change