### PR TITLE
fix(provider): diagnose stale proxy settings

### DIFF
--- a/kun/src/adapters/model/compat-model-client.ts
+++ b/kun/src/adapters/model/compat-model-client.ts
@@ -407,7 +407,10 @@ export class CompatModelClient implements ModelClient {
       return { kind: 'response', response }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      return { kind: 'error', message: `model request failed: ${message}` }
+      const proxyHint = this.config.modelProxyUrl?.trim()
+        ? '. Check the configured model-request proxy in Settings > Providers.'
+        : ''
+      return { kind: 'error', message: `model request failed: ${message}${proxyHint}` }
     }
   }
 

--- a/kun/src/adapters/model/compat-model-client.ts
+++ b/kun/src/adapters/model/compat-model-client.ts
@@ -407,7 +407,12 @@ export class CompatModelClient implements ModelClient {
       return { kind: 'response', response }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      const proxyHint = this.config.modelProxyUrl?.trim()
+      // Only blame the proxy for genuine transport failures. A user-initiated
+      // abort (turn cancelled, idle-timeout watchdog) also surfaces here as an
+      // AbortError but has nothing to do with the proxy — don't send the user
+      // chasing a proxy that is working fine.
+      const aborted = error instanceof Error && error.name === 'AbortError'
+      const proxyHint = !aborted && this.config.modelProxyUrl?.trim()
         ? '. Check the configured model-request proxy in Settings > Providers.'
         : ''
       return { kind: 'error', message: `model request failed: ${message}${proxyHint}` }

--- a/kun/tests/model-client.test.ts
+++ b/kun/tests/model-client.test.ts
@@ -2146,6 +2146,28 @@ describe('CompatModelClient', () => {
     })
   })
 
+  it('omits the proxy hint when a proxied request is aborted (cancel/idle-timeout)', async () => {
+    const fetchImpl: typeof fetch = async () => {
+      const abort = new Error('The operation was aborted')
+      abort.name = 'AbortError'
+      throw abort
+    }
+    const client = new CompatModelClient({
+      baseUrl: 'https://api.deepseek.com',
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+      modelProxyUrl: 'http://127.0.0.1:7890',
+      fetchImpl
+    })
+    const chunks: ModelStreamChunk[] = []
+    for await (const chunk of client.stream(buildRequest(new AbortController().signal))) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks[0]).toMatchObject({ kind: 'error' })
+    expect(JSON.stringify(chunks[0])).not.toContain('model-request proxy')
+  })
+
   it('adds a provider configuration hint and logs request context for HTTP 404', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const fetchImpl: typeof fetch = async () => new Response('', { status: 404 })

--- a/kun/tests/model-client.test.ts
+++ b/kun/tests/model-client.test.ts
@@ -2124,6 +2124,28 @@ describe('CompatModelClient', () => {
     expect(JSON.stringify(chunks[0])).toContain(providerMessage)
   })
 
+  it('adds a proxy hint when a proxied model request fails before receiving a response', async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw new Error('connect ETIMEDOUT')
+    }
+    const client = new CompatModelClient({
+      baseUrl: 'https://api.deepseek.com',
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+      modelProxyUrl: 'http://127.0.0.1:7890',
+      fetchImpl
+    })
+    const chunks: ModelStreamChunk[] = []
+    for await (const chunk of client.stream(buildRequest(new AbortController().signal))) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks[0]).toMatchObject({
+      kind: 'error',
+      message: 'model request failed: connect ETIMEDOUT. Check the configured model-request proxy in Settings > Providers.'
+    })
+  })
+
   it('adds a provider configuration hint and logs request context for HTTP 404', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const fetchImpl: typeof fetch = async () => new Response('', { status: 404 })

--- a/src/main/provider-connection.test.ts
+++ b/src/main/provider-connection.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AppSettingsV1 } from '../shared/app-settings'
 import { probeModelProvider, providerProbeHeaders } from './provider-connection'
 
 afterEach(() => {
@@ -99,6 +100,37 @@ describe('probeModelProvider', () => {
     })
 
     expect(result).toEqual({ ok: false, message: 'socket hang up' })
+  })
+
+  it('identifies a broken configured proxy when direct connectivity works', async () => {
+    const timeout = new Error('timed out')
+    timeout.name = 'TimeoutError'
+    const fetcher = vi.fn(async (_url: string | URL, _init: RequestInit | undefined, proxyUrl: string) => {
+      if (proxyUrl) throw timeout
+      return new Response('unauthorized', { status: 401 })
+    })
+    const settings = {
+      provider: {
+        proxy: { enabled: true, url: 'http://127.0.0.1:7890' }
+      }
+    } as unknown as AppSettingsV1
+
+    const result = await probeModelProvider({
+      baseUrl: 'https://api.deepseek.com',
+      apiKey: 'sk-test',
+      endpointFormat: 'chat_completions'
+    }, settings, fetcher)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toContain('timed out after 10s')
+      expect(result.message).toContain('configured model-request proxy failed')
+      expect(result.message).toContain('direct connection reached the provider')
+    }
+    expect(fetcher.mock.calls.map((call) => call[2])).toEqual([
+      'http://127.0.0.1:7890/',
+      ''
+    ])
   })
 
   it('does not probe /models for custom full endpoint providers', async () => {

--- a/src/main/provider-connection.ts
+++ b/src/main/provider-connection.ts
@@ -10,6 +10,11 @@ import { upstreamOpenAiModelsUrl } from '../shared/openai-compat-url'
 import { fetchWithOptionalProxy } from './proxy-fetch'
 
 const PROBE_TIMEOUT_MS = 10_000
+// The proxy-vs-direct diagnosis runs only after the proxied probe already
+// failed, so it gets a shorter budget — we just need to learn whether the
+// provider is reachable at all, not wait out another full timeout (which would
+// make a failed test connection take up to 20s).
+const DIRECT_PROBE_TIMEOUT_MS = 5_000
 const ANTHROPIC_VERSION = '2023-06-01'
 
 type ProviderProbeFetch = typeof fetchWithOptionalProxy
@@ -95,7 +100,7 @@ async function directProviderReachable(
     const response = await fetcher(url, {
       method: 'GET',
       headers: providerProbeHeaders(endpointFormat, apiKey),
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS)
+      signal: AbortSignal.timeout(DIRECT_PROBE_TIMEOUT_MS)
     }, '')
     await response.body?.cancel().catch(() => undefined)
     return true

--- a/src/main/provider-connection.ts
+++ b/src/main/provider-connection.ts
@@ -12,6 +12,8 @@ import { fetchWithOptionalProxy } from './proxy-fetch'
 const PROBE_TIMEOUT_MS = 10_000
 const ANTHROPIC_VERSION = '2023-06-01'
 
+type ProviderProbeFetch = typeof fetchWithOptionalProxy
+
 export function providerProbeHeaders(
   endpointFormat: ModelEndpointFormat,
   apiKey: string
@@ -33,7 +35,8 @@ export function providerProbeHeaders(
  */
 export async function probeModelProvider(
   request: ModelProviderProbeRequest,
-  settings?: AppSettingsV1
+  settings?: AppSettingsV1,
+  fetcher: ProviderProbeFetch = fetchWithOptionalProxy
 ): Promise<ModelProviderProbeResult> {
   const baseUrl = request.baseUrl.trim()
   if (!/^https?:\/\//i.test(baseUrl)) {
@@ -48,19 +51,24 @@ export async function probeModelProvider(
   }
   const url = upstreamOpenAiModelsUrl(baseUrl)
   const startedAt = Date.now()
+  const proxyUrl = settings ? resolveModelProviderProxyUrl(settings) : ''
   let res: Response
   let text: string
   try {
-    res = await fetchWithOptionalProxy(url, {
+    res = await fetcher(url, {
       method: 'GET',
       headers: providerProbeHeaders(endpointFormat, request.apiKey),
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS)
-    }, settings ? resolveModelProviderProxyUrl(settings) : '')
+    }, proxyUrl)
     text = await res.text()
   } catch (e) {
-    const message = e instanceof Error && e.name === 'TimeoutError'
-      ? `Request to ${url} timed out after ${PROBE_TIMEOUT_MS / 1_000}s.`
-      : e instanceof Error ? e.message : String(e)
+    const message = providerProbeFailureMessage(e, url)
+    if (proxyUrl && await directProviderReachable(url, endpointFormat, request.apiKey, fetcher)) {
+      return {
+        ok: false,
+        message: `${message} The configured model-request proxy failed, but a direct connection reached the provider. Disable or update the proxy in Settings > Providers.`
+      }
+    }
     return { ok: false, message }
   }
   const latencyMs = Date.now() - startedAt
@@ -68,6 +76,32 @@ export async function probeModelProvider(
     return { ok: false, message: `${url} responded ${res.status}: ${text.slice(0, 300)}` }
   }
   return { ok: true, latencyMs, modelIds: parseModelIds(text) }
+}
+
+function providerProbeFailureMessage(error: unknown, url: string): string {
+  if (error instanceof Error && error.name === 'TimeoutError') {
+    return `Request to ${url} timed out after ${PROBE_TIMEOUT_MS / 1_000}s.`
+  }
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function directProviderReachable(
+  url: string,
+  endpointFormat: ModelEndpointFormat,
+  apiKey: string,
+  fetcher: ProviderProbeFetch
+): Promise<boolean> {
+  try {
+    const response = await fetcher(url, {
+      method: 'GET',
+      headers: providerProbeHeaders(endpointFormat, apiKey),
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS)
+    }, '')
+    await response.body?.cancel().catch(() => undefined)
+    return true
+  } catch {
+    return false
+  }
 }
 
 function parseModelIds(body: string): string[] {

--- a/src/shared/app-settings-kun.ts
+++ b/src/shared/app-settings-kun.ts
@@ -1118,6 +1118,7 @@ export function migrateLegacyAppSettings(parsed: LegacyAppSettingsShape): Partia
     baseUrl: hasProviderSettings
       ? parsed.provider?.baseUrl
       : nonEmptyStringOrFallback(explicitKun.baseUrl, legacySeed.baseUrl),
+    proxy: parsed.provider?.proxy,
     providers: parsed.provider?.providers
   })
   const kun = {

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -987,6 +987,10 @@ describe('legacy Kun defaults migration', () => {
       provider: {
         apiKey: 'sk-default',
         baseUrl: 'https://api.deepseek.com',
+        proxy: {
+          enabled: true,
+          url: 'http://127.0.0.1:7890'
+        },
         providers: [
           ...defaultModelProviderSettings().providers,
           {
@@ -1021,6 +1025,10 @@ describe('legacy Kun defaults migration', () => {
       ])
     )
     expect(migrated.agents.kun.providerId).toBe('custom-provider-2')
+    expect(migrated.provider.proxy).toEqual({
+      enabled: true,
+      url: 'http://127.0.0.1:7890'
+    })
     expect(resolveKunRuntimeSettings(migrated)).toEqual(
       expect.objectContaining({
         apiKey: 'sk-custom',


### PR DESCRIPTION
## Summary
- preserve `provider.proxy` when `kun-settings.json` is migrated and normalized
- distinguish a broken configured model proxy from an unreachable provider during connection tests
- add an actionable proxy hint to runtime model network errors without silently bypassing the configured proxy

## Root cause
Issue #614 was reported against v0.2.18 and disappears after deleting `kun-settings.json`. The latest `develop` already contains #607, which fixes partial proxy input and pending provider edits, but the settings migration still rebuilt the provider object without carrying `provider.proxy`. In addition, a proxy timeout was reported as a generic DeepSeek endpoint timeout, so users could not tell whether the provider or their saved proxy was responsible.

The connection probe now retries directly only for diagnosis. A direct response does not turn the test into a success; it returns a precise message telling the user to disable or update the configured proxy.

## Validation
- `npm.cmd test -- src/main/provider-connection.test.ts src/shared/app-settings.test.ts`
- `npm.cmd --prefix kun test -- tests/model-client.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `git diff --check`

Fixes #614
