### PR TITLE
fix(settings): wrap long test-connection error messages (#617)

### DIFF
--- a/src/renderer/src/components/settings-controls.tsx
+++ b/src/renderer/src/components/settings-controls.tsx
@@ -89,7 +89,13 @@ export function InlineNoticeView({
         : 'border-ds-border bg-ds-main/50 text-ds-muted'
 
   return (
-    <div className={`rounded-xl border px-3 py-2 text-[12.5px] leading-5 ${className}`}>
+    // `min-w-0 break-words` keeps long messages (a failed-probe error can carry
+    // a full URL or a 300-char response body) wrapping inside the container
+    // instead of forcing horizontal overflow that stretches the settings panel
+    // — the success notice is short so the bug only ever showed on failure (#617).
+    <div
+      className={`min-w-0 break-words rounded-xl border px-3 py-2 text-[12.5px] leading-5 ${className}`}
+    >
       {notice.message}
     </div>
   )


### PR DESCRIPTION
## Summary
- The provider **test connection** notice (`InlineNoticeView`) had no word-breaking. On a *failed* probe the full error — a URL, up to 300 chars of response body, or the new proxy-diagnosis text — is embedded into the notice and overflowed horizontally, stretching the settings panel. The *success* notice is short, so the breakage only ever showed on failure (matches #617, on both macOS and Windows).
- Fix: add `min-w-0 break-words` to the notice container so long messages wrap inside it.

## Root cause
`src/renderer/src/components/settings-controls.tsx` — `InlineNoticeView` rendered `{notice.message}` with `overflow-wrap: normal`. A long unbreakable token (a base URL or a no-space JSON body) has no break opportunity and overflows its grid cell (min-width: auto), pushing the panel wider.

## Validation
- `tsc --noEmit -p tsconfig.web.json` (renderer typecheck) — clean
- Before/after wrapping verified at the real panel width (long 404-body error: overflows before, wraps after)

Fixes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)