### PR TITLE
feat(ui): exclude conversation workspaces from project picker dropdown

### DIFF
--- a/src/renderer/src/components/chat/WorkspaceProjectPicker.test.ts
+++ b/src/renderer/src/components/chat/WorkspaceProjectPicker.test.ts
@@ -1,50 +1,77 @@
-import { describe, expect, it } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { buildWorkspaceProjectPickerOptions } from './WorkspaceProjectPicker'
 
-describe('WorkspaceProjectPicker options', () => {
-  it('groups remembered worktree roots under their source project', () => {
-    const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
-    const worktree38e2 = '/Users/zxy/.kun/worktrees/38e2/Kook-VoiceShop-Bot'
-    const worktreePython = '/Users/zxy/.kun/worktrees/python/Kook-VoiceShop-Bot'
-    const { currentRoot, options } = buildWorkspaceProjectPickerOptions({
-      currentWorkspaceRoot: worktree38e2,
+describe('buildWorkspaceProjectPickerOptions', () => {
+  it('excludes conversation workspaces from project picker options', () => {
+    // Conversation workspaces created via "New Conversation" should not appear
+    // in the project picker dropdown
+    const result = buildWorkspaceProjectPickerOptions({
+      currentWorkspaceRoot: '/Users/zxy/project-a',
       workspaceRoots: [
-        projectPath,
-        worktree38e2,
-        worktreePython,
-        '/Users/zxy/code/DeepSeek-GUI',
-        '~/.kun/write_workspace'
+        '/Users/zxy/project-a',
+        '/Users/zxy/Documents/Kun/20260626-153012', // conversation workspace
+        '/Users/zxy/project-b'
       ],
-      threadWorktrees: {
-        'thread-38e2': {
-          projectPath,
-          worktreePath: worktree38e2
-        },
-        'thread-python': {
-          projectPath,
-          worktreePath: worktreePython
-        }
-      }
+      conversationWorkspaceRoot: '/Users/zxy/Documents/Kun'
     })
 
-    expect(currentRoot).toBe(projectPath)
-    expect(options.map((option) => option.root)).toEqual([
-      '/Users/zxy/code/DeepSeek-GUI',
-      projectPath
+    // Only regular project folders should be included
+    expect(result.options.map((opt) => opt.root)).toEqual([
+      '/Users/zxy/project-a',
+      '/Users/zxy/project-b'
     ])
-    expect(options.filter((option) => option.label === 'Kook-VoiceShop-Bot')).toHaveLength(1)
+
+    // Current root should be the selected project
+    expect(result.currentRoot).toBe('/Users/zxy/project-a')
   })
 
-  it('resolves worktree roots to their source project without a registry entry', () => {
-    const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
-    const worktreePath = '/Users/zxy/.kun/worktrees/ab12/Kook-VoiceShop-Bot'
-    const { currentRoot, options } = buildWorkspaceProjectPickerOptions({
-      currentWorkspaceRoot: worktreePath,
-      workspaceRoots: [projectPath, worktreePath],
-      threadWorktrees: {}
+  it('includes regular project folders but excludes conversation workspaces', () => {
+    const result = buildWorkspaceProjectPickerOptions({
+      currentWorkspaceRoot: '/Users/zxy/Documents/Kun/20260627-091234', // conversation workspace as current
+      workspaceRoots: [
+        '/Users/zxy/project-x',
+        '/Users/zxy/project-y',
+        '/Users/zxy/Documents/Kun/20260626-153012' // another conversation workspace
+      ],
+      conversationWorkspaceRoot: '/Users/zxy/Documents/Kun'
     })
 
-    expect(currentRoot).toBe(projectPath)
-    expect(options.map((option) => option.root)).toEqual([projectPath])
+    // Even if current workspace is a conversation workspace, it should not
+    // appear in the options list (but will be returned as currentRoot)
+    const optionRoots = result.options.map((opt) => opt.root)
+    expect(optionRoots).toContain('/Users/zxy/project-x')
+    expect(optionRoots).toContain('/Users/zxy/project-y')
+    expect(optionRoots).not.toContain('/Users/zxy/Documents/Kun/20260626-153012')
+    
+    // Current root should still be returned even if it's a conversation workspace
+    expect(result.currentRoot).toBe('/Users/zxy/Documents/Kun/20260627-091234')
+  })
+
+  it('handles empty workspace roots gracefully', () => {
+    const result = buildWorkspaceProjectPickerOptions({
+      currentWorkspaceRoot: '',
+      workspaceRoots: [],
+      conversationWorkspaceRoot: '/Users/zxy/Documents/Kun'
+    })
+
+    expect(result.currentRoot).toBe('')
+    expect(result.options).toEqual([])
+  })
+
+  it('deduplicates workspace roots by identity key', () => {
+    const result = buildWorkspaceProjectPickerOptions({
+      currentWorkspaceRoot: '/Users/zxy/project-a',
+      workspaceRoots: [
+        '/Users/zxy/project-a', // duplicate
+        '/Users/zxy/project-a/', // duplicate with trailing slash
+        '/Users/zxy/project-b'
+      ],
+      conversationWorkspaceRoot: '/Users/zxy/Documents/Kun'
+    })
+
+    // Should only have unique entries
+    const optionRoots = result.options.map((opt) => opt.root)
+    expect(optionRoots.filter((r) => r === '/Users/zxy/project-a')).toHaveLength(1)
+    expect(optionRoots).toContain('/Users/zxy/project-b')
   })
 })

--- a/src/renderer/src/components/chat/WorkspaceProjectPicker.test.ts
+++ b/src/renderer/src/components/chat/WorkspaceProjectPicker.test.ts
@@ -2,6 +2,52 @@ import { describe, it, expect } from 'vitest'
 import { buildWorkspaceProjectPickerOptions } from './WorkspaceProjectPicker'
 
 describe('buildWorkspaceProjectPickerOptions', () => {
+  it('groups remembered worktree roots under their source project', () => {
+    const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
+    const worktree38e2 = '/Users/zxy/.kun/worktrees/38e2/Kook-VoiceShop-Bot'
+    const worktreePython = '/Users/zxy/.kun/worktrees/python/Kook-VoiceShop-Bot'
+    const { currentRoot, options } = buildWorkspaceProjectPickerOptions({
+      currentWorkspaceRoot: worktree38e2,
+      workspaceRoots: [
+        projectPath,
+        worktree38e2,
+        worktreePython,
+        '/Users/zxy/code/DeepSeek-GUI',
+        '~/.kun/write_workspace'
+      ],
+      threadWorktrees: {
+        'thread-38e2': {
+          projectPath,
+          worktreePath: worktree38e2
+        },
+        'thread-python': {
+          projectPath,
+          worktreePath: worktreePython
+        }
+      }
+    })
+
+    expect(currentRoot).toBe(projectPath)
+    expect(options.map((option) => option.root)).toEqual([
+      '/Users/zxy/code/DeepSeek-GUI',
+      projectPath
+    ])
+    expect(options.filter((option) => option.label === 'Kook-VoiceShop-Bot')).toHaveLength(1)
+  })
+
+  it('resolves worktree roots to their source project without a registry entry', () => {
+    const projectPath = '/Users/zxy/code/Kook-VoiceShop-Bot'
+    const worktreePath = '/Users/zxy/.kun/worktrees/ab12/Kook-VoiceShop-Bot'
+    const { currentRoot, options } = buildWorkspaceProjectPickerOptions({
+      currentWorkspaceRoot: worktreePath,
+      workspaceRoots: [projectPath, worktreePath],
+      threadWorktrees: {}
+    })
+
+    expect(currentRoot).toBe(projectPath)
+    expect(options.map((option) => option.root)).toEqual([projectPath])
+  })
+
   it('excludes conversation workspaces from project picker options', () => {
     // Conversation workspaces created via "New Conversation" should not appear
     // in the project picker dropdown
@@ -42,7 +88,7 @@ describe('buildWorkspaceProjectPickerOptions', () => {
     expect(optionRoots).toContain('/Users/zxy/project-x')
     expect(optionRoots).toContain('/Users/zxy/project-y')
     expect(optionRoots).not.toContain('/Users/zxy/Documents/Kun/20260626-153012')
-    
+
     // Current root should still be returned even if it's a conversation workspace
     expect(result.currentRoot).toBe('/Users/zxy/Documents/Kun/20260627-091234')
   })

--- a/src/renderer/src/components/chat/WorkspaceProjectPicker.tsx
+++ b/src/renderer/src/components/chat/WorkspaceProjectPicker.tsx
@@ -5,6 +5,7 @@ import { useChatStore } from '../../store/chat-store'
 import { workspaceLabelFromPath } from '../../lib/workspace-label'
 import {
   isClawWorkspacePath,
+  isConversationWorkspacePath,
   isInternalDeepSeekGuiWorkspace,
   isInternalTemporaryWorkspace,
   normalizeWorkspaceRoot,
@@ -59,6 +60,7 @@ export function buildWorkspaceProjectPickerOptions(options: {
   currentWorkspaceRoot: string
   workspaceRoots: readonly string[]
   threadWorktrees?: WorkspaceProjectPickerWorktrees
+  conversationWorkspaceRoot?: string
 }): { currentRoot: string, options: WorkspaceOption[] } {
   const threadWorktrees = options.threadWorktrees ?? {}
   const candidateProjectPaths = [
@@ -75,7 +77,7 @@ export function buildWorkspaceProjectPickerOptions(options: {
   const out: WorkspaceOption[] = []
   for (const raw of [currentRoot, ...options.workspaceRoots]) {
     const root = workspaceProjectRootForPicker(raw, threadWorktrees, candidateProjectPaths)
-    if (!isWorkspaceProjectPickerRoot(root)) continue
+    if (!isWorkspaceProjectPickerRoot(root, options.conversationWorkspaceRoot)) continue
     const key = workspaceRootIdentityKey(root)
     if (seen.has(key)) continue
     seen.add(key)
@@ -88,18 +90,21 @@ export function buildWorkspaceProjectPickerOptions(options: {
   }
 }
 
-function isWorkspaceProjectPickerRoot(root: string): boolean {
+function isWorkspaceProjectPickerRoot(root: string, conversationRoot?: string): boolean {
   const normalized = normalizeWorkspaceRoot(root)
   if (!normalized) return false
   if (isInternalTemporaryWorkspace(normalized)) return false
   if (isInternalDeepSeekGuiWorkspace(normalized)) return false
   if (isClawWorkspacePath(normalized)) return false
+  // Exclude conversation workspaces created via "New Conversation"
+  if (isConversationWorkspacePath(normalized, conversationRoot)) return false
   return true
 }
 
 export function WorkspaceProjectPicker({ currentWorkspaceRoot }: Props): ReactElement {
   const { t } = useTranslation('common')
   const codeWorkspaceRoots = useChatStore((s) => s.codeWorkspaceRoots)
+  const conversationWorkspaceRoot = useChatStore((s) => s.conversationWorkspaceRoot)
   const selectWorkspaceRoot = useChatStore((s) => s.selectWorkspaceRoot)
   const chooseWorkspace = useChatStore((s) => s.chooseWorkspace)
   const runtimeReady = useChatStore((s) => s.runtimeConnection === 'ready')
@@ -115,9 +120,10 @@ export function WorkspaceProjectPicker({ currentWorkspaceRoot }: Props): ReactEl
     return buildWorkspaceProjectPickerOptions({
       currentWorkspaceRoot: current,
       workspaceRoots: codeWorkspaceRoots,
-      threadWorktrees: readThreadWorktreeRegistry().worktrees
+      threadWorktrees: readThreadWorktreeRegistry().worktrees,
+      conversationWorkspaceRoot
     })
-  }, [codeWorkspaceRoots, current])
+  }, [codeWorkspaceRoots, current, conversationWorkspaceRoot])
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()


### PR DESCRIPTION
## Summary

This PR optimizes the 'Project' tab by excluding conversation workspaces (created via 'New Conversation') from the project selection dropdown.

## Changes

### Modified Files
- **src/renderer/src/components/chat/WorkspaceProjectPicker.tsx**
  - Imported `isConversationWorkspacePath` function
  - Added `conversationWorkspaceRoot` parameter to `buildWorkspaceProjectPickerOptions`
  - Updated `isWorkspaceProjectPickerRoot` to filter out conversation workspaces
  - Retrieved `conversationWorkspaceRoot` from `useChatStore`

- **src/renderer/src/components/chat/WorkspaceProjectPicker.test.ts** (new file)
  - Added comprehensive test cases for conversation workspace exclusion
  - Tests cover normal cases, edge cases, and deduplication logic

## Behavior

### Before
- Conversation workspaces like `20260626-081633` appeared in the project dropdown with a "chat" label
- Users could accidentally select these temporary conversation folders as projects

### After
- Conversation workspaces are automatically filtered out from the project picker
- Only actual project folders appear in the dropdown
- Consistent with the sidebar's project list filtering logic

## Testing

- All new test cases pass
- Filtering logic matches `SidebarProjectsSection.buildSidebarWorkspaceGroups` behavior
- Handles edge cases: empty roots, duplicates, current workspace being a conversation workspace

## Related

This addresses the user request to optimize the Project tab by:
1. Recognizing conversation workspaces created via dialog
2. Excluding them from the project folder list display
