### PR TITLE
fix(runtime): stabilize endpoint health recovery

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -694,26 +694,51 @@ async function waitForKunHealth(settings: AppSettingsV1, timeoutMs: number): Pro
   let lastError = ''
 
   while (Date.now() <= deadline) {
-    try {
-      const remaining = Math.max(1, deadline - Date.now())
-      const res = await fetch(`${base}/health`, {
-        headers: runtimeAuthHeaders(settings),
-        signal: AbortSignal.timeout(Math.max(250, Math.min(1_000, remaining)))
-      })
-      if (res.ok && isKunHealthResponseBody(await res.text())) return true
-      lastError = `unexpected status ${res.status}`
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
-      if (msg !== lastError) {
-        lastError = msg
-        logWarn('health-probe', `${base}/health: ${msg}`)
-      }
+    const remaining = Math.max(1, deadline - Date.now())
+    const result = await probeKunHealthOnce(settings, base, remaining)
+    if (result.healthy) return true
+    if (result.error !== lastError) {
+      lastError = result.error
+      logWarn('health-probe', `${base}/health: ${result.error}`)
     }
     await sleep(150)
   }
 
   logWarn('health-probe', `gave up after ${timeoutMs}ms, last error: ${lastError}`)
   return false
+}
+
+type KunHealthProbeResult = { healthy: boolean; error: string }
+const kunHealthProbeInFlight = new Map<string, Promise<KunHealthProbeResult>>()
+
+function probeKunHealthOnce(
+  settings: AppSettingsV1,
+  base: string,
+  remainingMs: number
+): Promise<KunHealthProbeResult> {
+  const existing = kunHealthProbeInFlight.get(base)
+  if (existing) return existing
+
+  let task: Promise<KunHealthProbeResult>
+  task = (async () => {
+    try {
+      const res = await fetch(`${base}/health`, {
+        headers: runtimeAuthHeaders(settings),
+        signal: AbortSignal.timeout(Math.max(250, Math.min(1_000, remainingMs)))
+      })
+      const healthy = res.ok && isKunHealthResponseBody(await res.text())
+      return { healthy, error: healthy ? '' : `unexpected status ${res.status}` }
+    } catch (error) {
+      return {
+        healthy: false,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  })().finally(() => {
+    if (kunHealthProbeInFlight.get(base) === task) kunHealthProbeInFlight.delete(base)
+  })
+  kunHealthProbeInFlight.set(base, task)
+  return task
 }
 
 async function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {

--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -410,7 +410,7 @@ describe('reclaimKunPort', () => {
     }
   })
 
-  it('does not kill the currently managed Kun child while resolving an occupied port', async () => {
+  it('keeps the configured endpoint when the currently managed Kun child owns it', async () => {
     const probe = createServer()
     await new Promise<void>((resolve, reject) => {
       probe.once('error', reject)
@@ -441,8 +441,7 @@ describe('reclaimKunPort', () => {
     await module.startKunChild(settings)
     const resolved = await module.resolveAvailableKunPort(preferredPort)
 
-    expect(resolved.changed).toBe(true)
-    expect(resolved.port).not.toBe(preferredPort)
+    expect(resolved).toEqual({ port: preferredPort, changed: false })
     expect(module.isKunChildRunning()).toBe(true)
     expect(await readKunLog()).not.toContain(`killing stale kun process holding port ${preferredPort}`)
   })

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -68,6 +68,7 @@ import {
 } from './services/skill-service'
 
 let child: ChildProcess | null = null
+let childPort: number | null = null
 let childLogCapture: KunChildLogCapture | null = null
 let lastResolvedBinary: string | null = null
 let kunStartPromise: Promise<void> | null = null
@@ -405,6 +406,7 @@ async function startKunChildOnce(
     detached: false
   })
   const startedChild = child
+  childPort = runtime.port
   const startedLogCapture = createKunChildLogCapture(startedChild.pid)
   childLogCapture = startedLogCapture
   childStderrTail = ''
@@ -421,7 +423,10 @@ async function startKunChildOnce(
         : `exited with code ${code ?? 'unknown'}`
     )
     void startedLogCapture.close()
-    if (child === startedChild) child = null
+    if (child === startedChild) {
+      child = null
+      childPort = null
+    }
     if (readyChildren.has(startedChild) && !intentionalStops.has(startedChild)) {
       onUnexpectedKunExit?.({
         code: code ?? null,
@@ -1327,7 +1332,10 @@ export async function stopKunChildAndWait(): Promise<void> {
     }
     await waitForChildExit(stoppingChild, KUN_STOP_FORCE_MS)
   }
-  if (child === stoppingChild) child = null
+  if (child === stoppingChild) {
+    child = null
+    childPort = null
+  }
   if (capture) {
     childLogCapture = null
     await capture.close()
@@ -1369,6 +1377,12 @@ export async function resolveAvailableKunPort(
   preferredPort: number
 ): Promise<{ port: number; changed: boolean; message?: string }> {
   if (preferredPort > 0) {
+    // A temporarily unresponsive managed child still owns its configured
+    // endpoint. Moving settings to another port here strands the live child
+    // and makes every concurrent request launch/probe a port with no server.
+    if (isKunChildRunning() && childPort === preferredPort) {
+      return { port: preferredPort, changed: false }
+    }
     if (await canBindTcpPort(preferredPort, '127.0.0.1')) {
       return { port: preferredPort, changed: false }
     }


### PR DESCRIPTION
## Summary
- keep the configured Kun endpoint when the currently managed child owns that port
- coalesce concurrent `/health` requests per runtime endpoint
- complement the upstream #621 hung-runtime recovery without duplicating its orphan cleanup

## Root cause
Concurrent callers could treat the live managed child's own listening port as unavailable after a temporary health stall, persist a different port, and then probe an endpoint with no server. Independent health loops amplified the failure into a request storm.

## Tests
- `npm.cmd test -- src/main/kun-process.test.ts src/main/runtime/kun-adapter.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run build:kun`

Related to #621.