### PR TITLE
perf(renderer): lazy-load write and SDD workspaces

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -56,11 +56,6 @@ import {
 } from './chat/FloatingComposerModelPicker'
 import { SideConversationPanel } from './chat/SideConversationPanel'
 import { SessionHeader } from './SessionHeader'
-import { WriteWorkspaceView } from './write/WriteWorkspaceView'
-import { WriteAssistantPanel } from './write/WriteAssistantPanel'
-import { WriteSidebar } from './write/WriteSidebar'
-import { SddAssistantPanel } from './sdd/SddAssistantPanel'
-import { SddDraftEditorView } from './sdd/SddDraftEditorView'
 import { SidebarTitlebarToggleButton } from './sidebar/SidebarPrimitives'
 import { composeWritePrompt } from '../write/quoted-selection'
 import { resolveWriteAgentPreset } from '../write/agent-presets'
@@ -148,6 +143,25 @@ const SubagentDetailPanel = lazy(() =>
 const WorkflowRunPanel = lazy(() =>
   import('./workflow/WorkflowRunPanel').then((module) => ({ default: module.WorkflowRunPanel }))
 )
+const WriteWorkspaceView = lazy(() =>
+  import('./write/WriteWorkspaceView').then((module) => ({ default: module.WriteWorkspaceView }))
+)
+const WriteAssistantPanel = lazy(() =>
+  import('./write/WriteAssistantPanel').then((module) => ({ default: module.WriteAssistantPanel }))
+)
+const WriteSidebar = lazy(() =>
+  import('./write/WriteSidebar').then((module) => ({ default: module.WriteSidebar }))
+)
+const SddAssistantPanel = lazy(() =>
+  import('./sdd/SddAssistantPanel').then((module) => ({ default: module.SddAssistantPanel }))
+)
+const SddDraftEditorView = lazy(() =>
+  import('./sdd/SddDraftEditorView').then((module) => ({ default: module.SddDraftEditorView }))
+)
+
+function WorkbenchPaneFallback(): ReactElement {
+  return <div className="h-full min-h-0 w-full bg-ds-main" aria-hidden />
+}
 
 type PendingSddPlanTarget = {
   planId: string
@@ -2549,14 +2563,16 @@ export function Workbench(): ReactElement {
         <>
           <div className="min-h-0 shrink-0" style={{ width: leftSidebarWidth }}>
             {route === 'write' ? (
-              <WriteSidebar
-                activeView="write"
-                connectPhoneSidebarOpen={connectPhoneSidebarOpen}
-                onCodeOpen={openCodeMode}
-                onWriteOpen={openWriteMode}
-                onOpenSettings={(section) => openSettings(section)}
-                onToggleConnectPhone={toggleConnectPhone}
-              />
+              <Suspense fallback={<WorkbenchPaneFallback />}>
+                <WriteSidebar
+                  activeView="write"
+                  connectPhoneSidebarOpen={connectPhoneSidebarOpen}
+                  onCodeOpen={openCodeMode}
+                  onWriteOpen={openWriteMode}
+                  onOpenSettings={(section) => openSettings(section)}
+                  onToggleConnectPhone={toggleConnectPhone}
+                />
+              </Suspense>
             ) : (
             <Sidebar
               threads={codeThreads}
@@ -2630,7 +2646,7 @@ export function Workbench(): ReactElement {
             />
           </Suspense>
         ) : route === 'write' ? (
-          <>
+          <Suspense fallback={<WorkbenchPaneFallback />}>
             {writeRuntimeBannerMessage ? renderRuntimeBanner(writeRuntimeBannerMessage, visibleRuntimeErrorDetail) : null}
             <div className="flex min-h-0 flex-1">
               <WriteWorkspaceView
@@ -2643,7 +2659,7 @@ export function Workbench(): ReactElement {
               />
               {renderRightPanel()}
             </div>
-          </>
+          </Suspense>
         ) : (
           <>
         {visibleRuntimeError && !(runtimeConnection !== 'ready' && !activeThreadId)
@@ -2653,17 +2669,19 @@ export function Workbench(): ReactElement {
         <div className="flex min-h-0 flex-1">
           <div className="flex min-h-0 min-w-0 flex-1">
           {activeSddDraft ? (
-            <SddDraftEditorView
-              leftSidebarCollapsed={leftSidebarCollapsed}
-              assistantOpen={rightPanelMode === 'sdd-ai'}
-              onToggleLeftSidebar={toggleLeftSidebar}
-              onToggleAssistant={() => void toggleSddAssistantPanel()}
-              onAssistantQuote={quoteToSddAssistant}
-              onPrototypeTurn={sendSddPrototypeTurn}
-              onNext={() => void handleSddNextStep()}
-              onClose={() => dismissActiveSddDraft({ closeAssistant: true })}
-              nextDisabled={busy || runtimeConnection !== 'ready' || sddDraftOperationStatus === 'upgrading'}
-            />
+            <Suspense fallback={<WorkbenchPaneFallback />}>
+              <SddDraftEditorView
+                leftSidebarCollapsed={leftSidebarCollapsed}
+                assistantOpen={rightPanelMode === 'sdd-ai'}
+                onToggleLeftSidebar={toggleLeftSidebar}
+                onToggleAssistant={() => void toggleSddAssistantPanel()}
+                onAssistantQuote={quoteToSddAssistant}
+                onPrototypeTurn={sendSddPrototypeTurn}
+                onNext={() => void handleSddNextStep()}
+                onClose={() => dismissActiveSddDraft({ closeAssistant: true })}
+                nextDisabled={busy || runtimeConnection !== 'ready' || sddDraftOperationStatus === 'upgrading'}
+              />
+            </Suspense>
           ) : (
             <section className="ds-chat-stage ds-drag flex min-h-0 min-w-0 flex-1 flex-col">
             <div className={`${stageInsetClass} flex min-h-0 min-w-0 flex-1 flex-col`}>


### PR DESCRIPTION
## Summary
- lazy-load Write workspace, Write sidebar/assistant, and SDD editor/assistant surfaces
- keep local Suspense boundaries so mode loading does not blank the whole application
- preserve the existing route and state ownership in Workbench

## Performance
Production build comparison on the same checkout:
- Workbench before: 4,753.3 KB
- Workbench after: 1,450.8 KB
- reduction: 3,302.5 KB (69.5%) from the default workbench chunk

Write/Tiptap/CodeMirror and SDD UI now load only when those modes are opened.

## Tests
- `npm.cmd run typecheck`
- `npm.cmd run build`