### PR TITLE
feat(attachments): add local files to conversations

### DIFF
--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -782,6 +782,27 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
     }
   })
 
+  ipcMain.handle('file:pick-local-files', async (_, defaultPath: unknown) => {
+    const normalizedDefaultPath = parseIpcPayload(
+      'file:pick-local-files',
+      z.object({ defaultPath: defaultPathSchema }).strict(),
+      { defaultPath }
+    ).defaultPath
+    const options: Electron.OpenDialogOptions = {
+      title: 'Add files to conversation',
+      defaultPath: normalizedDefaultPath,
+      properties: ['openFile', 'multiSelections', 'dontAddToRecent']
+    }
+    const mainWindow = getMainWindow()
+    const result = mainWindow
+      ? await dialog.showOpenDialog(mainWindow, options)
+      : await dialog.showOpenDialog(options)
+    return {
+      canceled: result.canceled,
+      paths: result.canceled ? [] : result.filePaths
+    }
+  })
+
   // 在对话工作目录根下创建一个 YYYYMMDD-HHmmss 时间戳子目录作为新对话的工作目录。
   ipcMain.handle(
     'conversation:create-workspace',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -58,6 +58,8 @@ const api = {
     ipcRenderer.invoke('claw:im-install:telegram-token', { botToken, allowedChatIds }),
   pickWorkspaceDirectory: (defaultPath) =>
     ipcRenderer.invoke('workspace:pick-directory', defaultPath),
+  pickLocalFiles: (defaultPath) =>
+    ipcRenderer.invoke('file:pick-local-files', defaultPath),
   createConversationWorkspace: (root) =>
     ipcRenderer.invoke('conversation:create-workspace', { root }),
   confirmDialog: (options) =>

--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -104,6 +104,7 @@ import { useUiModeCameosEnabled, useUiPluginStore } from '../store/ui-plugin-sto
 import { readFocusModePreference, writeFocusModePreference } from '../lib/focus-mode'
 import {
   buildComposerFileContextPrompt,
+  composerFileReferenceFromPath,
   isComposerDirectoryReference,
   mergeComposerFileReferences,
   relativeWorkspacePath,
@@ -1077,6 +1078,14 @@ export function Workbench(): ReactElement {
     setComposerFileReferences((current) => mergeComposerFileReferences(current, reference))
   }
 
+  const pickComposerFileReferences = async (): Promise<void> => {
+    const result = await window.kunGui.pickLocalFiles(activeSkillWorkspace || undefined)
+    if (result.canceled) return
+    for (const path of result.paths) {
+      addComposerFileReference(composerFileReferenceFromPath(path, activeSkillWorkspace))
+    }
+  }
+
   const removeComposerFileReference = (relativePath: string): void => {
     const key = relativePath.trim().replaceAll('\\', '/').replace(/\/+/g, '/').toLowerCase()
     setComposerFileReferences((current) =>
@@ -1952,8 +1961,12 @@ export function Workbench(): ReactElement {
       const key = contextKey(reference.relativePath || reference.path)
       if (seen.has(key)) return
       const result = await window.kunGui.readWorkspaceFile({
-        workspaceRoot: workspace,
-        path: reference.relativePath || reference.path
+        ...(reference.workspaceRoot === null
+          ? {}
+          : { workspaceRoot: reference.workspaceRoot || workspace }),
+        path: reference.workspaceRoot === null
+          ? reference.path
+          : (reference.relativePath || reference.path)
       })
       if (!result.ok) {
         if (!strict) return
@@ -2802,6 +2815,7 @@ export function Workbench(): ReactElement {
                 onPasteClipboardImage={(options) => void handlePasteClipboardImage(options)}
                 onRemoveAttachment={removeComposerAttachment}
                 onAddFileReference={addComposerFileReference}
+                onPickFileReferences={() => void pickComposerFileReferences()}
                 onOpenFileReferencePicker={openFileTreeSidePanel}
                 onRemoveFileReference={removeComposerFileReference}
                 queuedMessages={queuedMessages}

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -45,6 +45,7 @@ import type { AttachmentReference, ChatBlock, ReviewTarget } from '../../agent/t
 import { useChatStore } from '../../store/chat-store'
 import { normalizeWorkspaceRoot } from '../../lib/workspace-path'
 import {
+  composerFileReferenceFromPath,
   filterWorkspaceFileMentionSuggestions,
   formatComposerFileMentionToken,
   getFileMentionAtCursor,
@@ -182,6 +183,7 @@ type Props = {
   onPasteClipboardImage?: (options?: { silentNoImage?: boolean }) => void | Promise<void>
   onRemoveAttachment?: (id: string) => void
   onAddFileReference?: (reference: ComposerFileReference) => void
+  onPickFileReferences?: () => void
   onOpenFileReferencePicker?: () => void
   onRemoveFileReference?: (relativePath: string) => void
   onSend: () => void
@@ -496,6 +498,7 @@ export function FloatingComposer({
   onPasteClipboardImage,
   onRemoveAttachment,
   onAddFileReference,
+  onPickFileReferences,
   onOpenFileReferencePicker,
   onRemoveFileReference,
   onSend,
@@ -618,6 +621,7 @@ export function FloatingComposer({
   )
   const canPickAttachment = canCompose && attachmentUploadEnabled && !attachmentUploadBusy
   const canPickFileReference = canCompose && fileReferenceEnabled && Boolean(effectiveWorkspaceRoot) && Boolean(onOpenFileReferencePicker)
+  const canPickLocalFileReference = canCompose && fileReferenceEnabled && Boolean(onPickFileReferences)
   const showIntentToolbar = !compact && route === 'chat'
   const showComposerMenuButton = showIntentToolbar
   const canTogglePlanMode = canCompose && Boolean(onPlanCommand)
@@ -626,7 +630,7 @@ export function FloatingComposer({
   const canRunReview = canCompose && route !== 'claw' && Boolean(onReviewCommand)
   const canToggleWorktreeMode = canCompose && route !== 'claw' && Boolean(onToggleWorktreeMode)
   const canOpenComposerMenu = showComposerMenuButton
-    && (canPickFileReference || canTogglePlanMode || canCreateNewThread || canOpenGoalPanel || canRunReview || canToggleWorktreeMode)
+    && (canPickFileReference || canPickLocalFileReference || canTogglePlanMode || canCreateNewThread || canOpenGoalPanel || canRunReview || canToggleWorktreeMode)
   const showToolbarStartControls = showComposerMenuButton
   const showExecutionSettingsPicker = showIntentToolbar
     && Boolean(executionSettings)
@@ -1281,6 +1285,13 @@ export function FloatingComposer({
     draft.focusComposer()
   }
 
+  const handleLocalFileReferenceMenuClick = (): void => {
+    if (!canPickLocalFileReference) return
+    setComposerMenuOpen(false)
+    onPickFileReferences?.()
+    draft.focusComposer()
+  }
+
   const handlePlanToolbarClick = (): void => {
     if (!canTogglePlanMode) return
     setComposerMenuOpen(false)
@@ -1561,36 +1572,15 @@ export function FloatingComposer({
     event.dataTransfer.dropEffect = 'copy'
   }
 
-  const insertTextAtComposerCursor = (text: string): void => {
-    if (!text) return
-    const textarea = draft.textareaRef.current
-    const currentValue = input
-    const selectionStart = textarea?.selectionStart ?? composerCursor ?? currentValue.length
-    const selectionEnd = textarea?.selectionEnd ?? selectionStart
-    const before = currentValue.slice(0, selectionStart)
-    const after = currentValue.slice(selectionEnd)
-    const leadingPad = before.length > 0 && !/\s$/.test(before) ? ' ' : ''
-    const trailingPad = after.length > 0 && !/^\s/.test(after) ? ' ' : ''
-    const insertion = `${leadingPad}${text}${trailingPad}`
-    const nextInput = `${before}${insertion}${after}`
-    const nextCursor = before.length + insertion.length - trailingPad.length
-    setInput(nextInput)
-    window.requestAnimationFrame(() => {
-      const el = draft.textareaRef.current
-      if (!el) return
-      el.focus()
-      el.setSelectionRange(nextCursor, nextCursor)
-      setComposerCursor(nextCursor)
-    })
-  }
-
   const handleComposerDrop = (event: ReactDragEvent<HTMLDivElement>): void => {
     const imageFiles = canPickAttachment ? imageFilesFromTransfer(event.dataTransfer) : []
     const rawFiles = Array.from(event.dataTransfer.files ?? [])
     const isImageLike = (file: File): boolean =>
       isImageMimeType(file.type) || Boolean(imageMimeTypeFromFileName(file.name))
     const pdfFiles = canPickAttachment ? rawFiles.filter(isPdfFile) : []
-    const pathFiles = rawFiles.filter((file) => !isImageLike(file) && !isPdfFile(file))
+    const pathFiles = canPickLocalFileReference && onAddFileReference
+      ? rawFiles.filter((file) => !isImageLike(file) && !isPdfFile(file))
+      : []
     if (imageFiles.length === 0 && pdfFiles.length === 0 && pathFiles.length === 0) return
     event.preventDefault()
     if ((imageFiles.length > 0 || pdfFiles.length > 0) && onPickAttachments) {
@@ -1606,7 +1596,9 @@ export function FloatingComposer({
           // ignore files we cannot resolve a filesystem path for
         }
       }
-      if (paths.length > 0) insertTextAtComposerCursor(paths.join(' '))
+      for (const path of paths) {
+        onAddFileReference?.(composerFileReferenceFromPath(path, effectiveWorkspaceRoot))
+      }
     }
     draft.focusComposer()
   }
@@ -1691,12 +1683,23 @@ export function FloatingComposer({
             {fileReferenceEnabled ? (
               <button
                 type="button"
+                disabled={!canPickLocalFileReference}
+                onClick={handleLocalFileReferenceMenuClick}
+                className="ds-no-drag flex h-8 w-full items-center gap-2 px-3 text-left transition hover:bg-ds-hover hover:text-ds-ink disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent disabled:hover:text-ds-muted"
+              >
+                <FileText className="h-3.5 w-3.5 shrink-0" strokeWidth={1.9} />
+                <span className="min-w-0 flex-1 truncate">{t('composerAddLocalFiles')}</span>
+              </button>
+            ) : null}
+            {fileReferenceEnabled ? (
+              <button
+                type="button"
                 disabled={!canPickFileReference}
                 onClick={handleFileReferenceMenuClick}
                 className="ds-no-drag flex h-8 w-full items-center gap-2 px-3 text-left transition hover:bg-ds-hover hover:text-ds-ink disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent disabled:hover:text-ds-muted"
               >
                 <Paperclip className="h-3.5 w-3.5 shrink-0" strokeWidth={1.9} />
-                <span className="min-w-0 flex-1 truncate">{t('composerAddFilesAndFolders')}</span>
+                <span className="min-w-0 flex-1 truncate">{t('composerBrowseWorkspaceFiles')}</span>
               </button>
             ) : null}
             {attachmentUploadEnabled ? (

--- a/src/renderer/src/lib/composer-file-references.ts
+++ b/src/renderer/src/lib/composer-file-references.ts
@@ -5,6 +5,8 @@ export type ComposerFileReference = {
   relativePath: string
   name: string
   type?: ComposerFileReferenceKind
+  /** null explicitly allows a user-picked file outside the active workspace. */
+  workspaceRoot?: string | null
 }
 
 export type ComposerFileMention = {
@@ -46,6 +48,22 @@ export function relativeWorkspacePath(path: string, workspaceRoot: string): stri
     return normalizedPath.slice(normalizedRoot.length + 1)
   }
   return normalizedPath
+}
+
+export function composerFileReferenceFromPath(
+  path: string,
+  workspaceRoot: string
+): ComposerFileReference {
+  const normalizedPath = normalizeSlashes(path)
+  const relativePath = relativeWorkspacePath(normalizedPath, workspaceRoot)
+  const insideWorkspace = normalizeForCompare(relativePath) !== normalizeForCompare(normalizedPath)
+  return {
+    path: normalizedPath,
+    relativePath,
+    name: normalizedPath.split('/').filter(Boolean).pop() || normalizedPath,
+    type: 'file',
+    ...(insideWorkspace ? {} : { workspaceRoot: null })
+  }
 }
 
 export function composerFileReferenceKey(reference: Pick<ComposerFileReference, 'relativePath'>): string {

--- a/src/renderer/src/lib/workspace-file-index.test.ts
+++ b/src/renderer/src/lib/workspace-file-index.test.ts
@@ -4,7 +4,11 @@ import {
   mentionQueryDirectory,
   mergeMentionCandidates
 } from './workspace-file-index'
-import { filterWorkspaceFileMentionSuggestions, type ComposerFileReference } from './composer-file-references'
+import {
+  composerFileReferenceFromPath,
+  filterWorkspaceFileMentionSuggestions,
+  type ComposerFileReference
+} from './composer-file-references'
 
 function entry(path: string, type: 'file' | 'directory'): {
   name: string
@@ -27,6 +31,24 @@ function installListDirectory(
 
 afterEach(() => {
   vi.unstubAllGlobals()
+})
+
+describe('composerFileReferenceFromPath', () => {
+  it('keeps workspace files relative and external user-picked files explicit', () => {
+    expect(composerFileReferenceFromPath('C:\\repo\\src\\app.ts', 'C:\\repo')).toEqual({
+      path: 'C:/repo/src/app.ts',
+      relativePath: 'src/app.ts',
+      name: 'app.ts',
+      type: 'file'
+    })
+    expect(composerFileReferenceFromPath('D:\\notes\\context.md', 'C:\\repo')).toEqual({
+      path: 'D:/notes/context.md',
+      relativePath: 'D:/notes/context.md',
+      name: 'context.md',
+      type: 'file',
+      workspaceRoot: null
+    })
+  })
 })
 
 describe('mentionQueryDirectory', () => {

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1012,6 +1012,8 @@
   "composerWorkspaceHint": "Choose a working directory before starting or continuing a thread.",
   "composerAddImage": "Attach image",
   "composerAddFilesAndFolders": "Files and folders",
+  "composerAddLocalFiles": "Add files",
+  "composerBrowseWorkspaceFiles": "Browse workspace",
   "composerVoiceStart": "Voice input",
   "composerVoiceStop": "Stop recording",
   "composerVoiceSend": "Stop and send",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1012,6 +1012,8 @@
   "composerWorkspaceHint": "先选择一个工作目录，然后再开始或继续会话。",
   "composerAddImage": "添加图片",
   "composerAddFilesAndFolders": "文件和文件夹",
+  "composerAddLocalFiles": "添加文件",
+  "composerBrowseWorkspaceFiles": "浏览工作区",
   "composerVoiceStart": "语音输入",
   "composerVoiceStop": "停止录音",
   "composerVoiceSend": "停止并发送",

--- a/src/shared/kun-gui-api.ts
+++ b/src/shared/kun-gui-api.ts
@@ -121,6 +121,7 @@ export type KunRuntimeStatusPayload = {
 
 export type RuntimeRequestResult = { ok: boolean; status: number; body: string }
 export type WorkspacePickResult = { canceled: boolean; path: string | null }
+export type LocalFilesPickResult = { canceled: boolean; paths: string[] }
 export type ConversationWorkspaceCreateResult = { ok: boolean; path: string; error?: string }
 export type PathOpenResult = { ok: boolean; message?: string }
 export const DESKTOP_COMMANDS = [
@@ -351,6 +352,7 @@ export type KunGuiApi = {
     allowedChatIds?: string
   ) => Promise<ClawImTelegramConnectResult>
   pickWorkspaceDirectory: (defaultPath?: string) => Promise<WorkspacePickResult>
+  pickLocalFiles: (defaultPath?: string) => Promise<LocalFilesPickResult>
   /** 在对话工作目录根下创建一个时间戳子目录作为新对话的工作目录。 */
   createConversationWorkspace: (root?: string) => Promise<ConversationWorkspaceCreateResult>
   confirmDialog: (options: ConfirmDialogOptions) => Promise<boolean>


### PR DESCRIPTION
## Summary
- add a native multi-file picker to the composer menu
- turn selected and dropped non-image files into structured conversation references instead of plain path text
- support explicitly selected files outside the active workspace while keeping workspace files relative
- retain existing per-file and total context budgets when file contents are injected
- keep the workspace browser for directory references and indexed project files

## Security and performance
External files are only added through an explicit user picker or drag/drop. File reads still use the existing bounded preview path (60k chars per file, 180k chars total in the composer context), and binary files return a clear read error.

## Tests
- `npm.cmd test -- src/renderer/src/lib/workspace-file-index.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run build`