### PR TITLE
feat(runtime): add automatic acceptance verification

### DIFF
--- a/kun/src/adapters/tool/builtin-tool-types.ts
+++ b/kun/src/adapters/tool/builtin-tool-types.ts
@@ -89,7 +89,16 @@ export type ReadClassification = {
 
 export const COMPACT_RESOURCE_FILE_NAMES = new Set(['AGENTS.md', 'AGENTS.MD', 'CLAUDE.md', 'CLAUDE.MD'])
 
-export type BuiltinToolName = 'read' | 'bash' | 'edit' | 'write' | 'grep' | 'find' | 'ls' | 'lsp'
+export type BuiltinToolName =
+  | 'read'
+  | 'bash'
+  | 'edit'
+  | 'write'
+  | 'grep'
+  | 'find'
+  | 'ls'
+  | 'lsp'
+  | 'verify_changes'
 export const allBuiltinToolNames: Set<BuiltinToolName> = new Set([
   'read',
   'bash',
@@ -98,7 +107,8 @@ export const allBuiltinToolNames: Set<BuiltinToolName> = new Set([
   'grep',
   'find',
   'ls',
-  'lsp'
+  'lsp',
+  'verify_changes'
 ])
 export type ToolName = BuiltinToolName
 export const allToolNames: Set<ToolName> = allBuiltinToolNames

--- a/kun/src/adapters/tool/builtin-tools.ts
+++ b/kun/src/adapters/tool/builtin-tools.ts
@@ -10,6 +10,7 @@ import { createEditLocalTool, createWriteLocalTool } from './builtin-file-tools.
 import { createLspLocalTool } from './builtin-lsp-tool.js'
 import { createReadLocalTool } from './builtin-read-tool.js'
 import { createFindLocalTool, createGrepLocalTool, createLsLocalTool } from './builtin-search-tools.js'
+import { createVerifyChangesLocalTool } from './builtin-verify-tool.js'
 
 export * from './builtin-tool-types.js'
 export * from './builtin-tool-operations.js'
@@ -17,6 +18,7 @@ export * from './builtin-read-tool.js'
 export * from './builtin-file-tools.js'
 export * from './builtin-search-tools.js'
 export * from './builtin-bash-tool.js'
+export * from './builtin-verify-tool.js'
 
 export function createBuiltinLocalTool(
   toolName: BuiltinToolName,
@@ -39,6 +41,8 @@ export function createBuiltinLocalTool(
       return createLsLocalTool(options.ls)
     case 'lsp':
       return createLspLocalTool()
+    case 'verify_changes':
+      return createVerifyChangesLocalTool()
   }
 }
 
@@ -59,7 +63,8 @@ export function buildBuiltinLocalTools(options: BuiltinLocalToolsOptions = {}): 
     createGrepLocalTool(options.grep),
     createFindLocalTool(options.find),
     createLsLocalTool(options.ls),
-    createLspLocalTool()
+    createLspLocalTool(),
+    createVerifyChangesLocalTool()
   ]
 }
 
@@ -104,7 +109,8 @@ export function buildBuiltinLocalToolRecord(
     grep: createGrepLocalTool(options.grep),
     find: createFindLocalTool(options.find),
     ls: createLsLocalTool(options.ls),
-    lsp: createLspLocalTool()
+    lsp: createLspLocalTool(),
+    verify_changes: createVerifyChangesLocalTool()
   }
 }
 

--- a/kun/src/adapters/tool/builtin-verify-tool.test.ts
+++ b/kun/src/adapters/tool/builtin-verify-tool.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  createVerifyChangesLocalTool,
+  planVerificationCommands,
+  type VerificationCheck,
+  type VerificationCommand
+} from './builtin-verify-tool.js'
+import type { ToolHostContext } from '../../ports/tool-host.js'
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function fixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'kun-verify-'))
+  tempRoots.push(root)
+  await mkdir(join(root, 'src'))
+  await writeFile(join(root, 'package-lock.json'), '{}')
+  await writeFile(join(root, 'src', 'sample.ts'), 'export const sample = 1\n')
+  await writeFile(join(root, 'src', 'sample.test.ts'), 'export {}\n')
+  await writeFile(join(root, 'package.json'), JSON.stringify({
+    scripts: {
+      test: 'vitest run',
+      typecheck: 'tsc --noEmit',
+      lint: 'eslint .',
+      build: 'vite build'
+    },
+    devDependencies: { vitest: '^4.0.0' }
+  }))
+  return root
+}
+
+function context(root: string): ToolHostContext {
+  return {
+    threadId: 'thread_1',
+    turnId: 'turn_1',
+    workspace: root,
+    approvalPolicy: 'auto',
+    sandboxMode: 'danger-full-access',
+    abortSignal: new AbortController().signal,
+    awaitApproval: async () => 'allow'
+  }
+}
+
+function check(command: VerificationCommand, exitCode = 0, output = ''): VerificationCheck {
+  return { ...command, exitCode, output, durationMs: 1 }
+}
+
+describe('planVerificationCommands', () => {
+  it('selects adjacent Vitest coverage and typecheck for focused verification', async () => {
+    const root = await fixture()
+    const commands = await planVerificationCommands(root, ['src/sample.ts'], 'focused')
+
+    expect(commands.map((command) => command.label)).toEqual(['focused tests', 'typecheck'])
+    expect(commands[0]?.args).toContain('src/sample.test.ts')
+  })
+
+  it('adds lint and build only for full verification', async () => {
+    const root = await fixture()
+    const commands = await planVerificationCommands(root, ['src/sample.ts'], 'full')
+
+    expect(commands.map((command) => command.label)).toEqual([
+      'focused tests',
+      'typecheck',
+      'lint',
+      'build'
+    ])
+  })
+
+  it('assigns monorepo files only to their nearest package root', async () => {
+    const root = await fixture()
+    await mkdir(join(root, 'packages', 'child', 'src'), { recursive: true })
+    await writeFile(join(root, 'packages', 'child', 'src', 'child.ts'), 'export {}\n')
+    await writeFile(join(root, 'packages', 'child', 'package.json'), JSON.stringify({
+      scripts: { typecheck: 'tsc --noEmit' }
+    }))
+
+    const commands = await planVerificationCommands(
+      root,
+      ['packages/child/src/child.ts'],
+      'focused'
+    )
+
+    expect(commands).toHaveLength(1)
+    expect(commands[0]?.cwd).toBe(join(root, 'packages', 'child'))
+    expect(commands[0]?.label).toBe('typecheck')
+  })
+})
+
+describe('createVerifyChangesLocalTool', () => {
+  it('runs selected checks and returns structured evidence', async () => {
+    const root = await fixture()
+    const executed: string[] = []
+    const tool = createVerifyChangesLocalTool({
+      runCommand: async (command) => {
+        if (command.label === 'unstaged changes') return check(command, 0, 'src/sample.ts')
+        if (command.label === 'staged changes' || command.label === 'untracked files') {
+          return check(command)
+        }
+        executed.push(command.label)
+        return check(command, 0, `${command.label} passed`)
+      }
+    })
+
+    const result = await tool.execute({}, context(root))
+
+    expect(result.isError).not.toBe(true)
+    expect(executed).toEqual(['focused tests', 'typecheck'])
+    expect(result.output).toMatchObject({ status: 'passed', changed_files: ['src/sample.ts'] })
+  })
+
+  it('stops on the first failed check so the model can repair it', async () => {
+    const root = await fixture()
+    const executed: string[] = []
+    const tool = createVerifyChangesLocalTool({
+      runCommand: async (command) => {
+        if (command.label === 'unstaged changes') return check(command, 0, 'src/sample.ts')
+        if (command.label === 'staged changes' || command.label === 'untracked files') {
+          return check(command)
+        }
+        executed.push(command.label)
+        return check(command, command.label === 'focused tests' ? 1 : 0, 'test failed')
+      }
+    })
+
+    const result = await tool.execute({}, context(root))
+
+    expect(result.isError).toBe(true)
+    expect(executed).toEqual(['focused tests'])
+    expect(result.output).toMatchObject({ status: 'failed' })
+  })
+})

--- a/kun/src/adapters/tool/builtin-verify-tool.ts
+++ b/kun/src/adapters/tool/builtin-verify-tool.ts
@@ -1,0 +1,346 @@
+import { access, readFile } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+import type { LocalTool } from './local-tool-host.js'
+import { terminateSpawnTree, workspaceRoot } from './builtin-tool-utils.js'
+
+export const VERIFY_CHANGES_TOOL_NAME = 'verify_changes'
+
+const DEFAULT_TIMEOUT_SECONDS = 180
+const MAX_TIMEOUT_SECONDS = 600
+const MAX_OUTPUT_CHARS = 24_000
+const SOURCE_EXTENSION = /\.[cm]?[jt]sx?$/i
+const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/i
+
+type PackageJson = {
+  scripts?: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+export type VerificationCommand = {
+  label: string
+  command: string
+  args: string[]
+  cwd: string
+}
+
+export type VerificationCheck = VerificationCommand & {
+  exitCode: number | null
+  output: string
+  durationMs: number
+}
+
+type VerifyToolOperations = {
+  runCommand?: (
+    command: VerificationCommand,
+    options: { signal: AbortSignal; timeoutSeconds: number }
+  ) => Promise<VerificationCheck>
+}
+
+export function createVerifyChangesLocalTool(
+  operations: VerifyToolOperations = {}
+): LocalTool {
+  return {
+    name: VERIFY_CHANGES_TOOL_NAME,
+    description:
+      'Run project-aware acceptance checks for files changed in the workspace. ' +
+      'The focused scope selects adjacent Vitest tests and typecheck scripts; full also runs lint and build scripts. ' +
+      'Use after code changes and fix failures before finishing.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        scope: { type: 'string', enum: ['focused', 'full'] },
+        timeout: { type: 'number', minimum: 1, maximum: MAX_TIMEOUT_SECONDS }
+      },
+      additionalProperties: false
+    },
+    policy: 'on-request',
+    toolKind: 'command_execution',
+    execute: async (args, context, onUpdate) => {
+      const root = workspaceRoot(context.workspace)
+      const scope = args.scope === 'full' ? 'full' : 'focused'
+      const timeoutSeconds = normalizeTimeout(args.timeout)
+      const changedFiles = await listChangedFiles(root, context.abortSignal, timeoutSeconds, operations)
+      if (changedFiles.length === 0) {
+        return {
+          output: {
+            status: 'skipped',
+            scope,
+            changed_files: [],
+            checks: [],
+            summary: 'No changed files were detected in the workspace.'
+          }
+        }
+      }
+
+      const commands = await planVerificationCommands(root, changedFiles, scope)
+      if (commands.length === 0) {
+        return {
+          output: {
+            status: 'skipped',
+            scope,
+            changed_files: changedFiles,
+            checks: [],
+            summary: 'No supported project verification scripts were found.'
+          },
+          isError: true
+        }
+      }
+
+      const checks: VerificationCheck[] = []
+      const runCommand = operations.runCommand ?? runVerificationCommand
+      for (const command of commands) {
+        const check = await runCommand(command, {
+          signal: context.abortSignal,
+          timeoutSeconds
+        })
+        if (context.abortSignal.aborted) throw new Error('verification aborted')
+        checks.push(check)
+        await onUpdate?.({
+          output: {
+            status: check.exitCode === 0 ? 'running' : 'failed',
+            scope,
+            changed_files: changedFiles,
+            checks,
+            summary: `${command.label} ${check.exitCode === 0 ? 'passed' : 'failed'}.`
+          },
+          isError: check.exitCode !== 0
+        })
+        if (check.exitCode !== 0) {
+          return {
+            output: {
+              status: 'failed',
+              scope,
+              changed_files: changedFiles,
+              checks,
+              summary: `${command.label} failed. Fix the reported error and run verification again.`
+            },
+            isError: true
+          }
+        }
+      }
+
+      return {
+        output: {
+          status: 'passed',
+          scope,
+          changed_files: changedFiles,
+          checks,
+          summary: `${checks.length} verification check(s) passed.`
+        }
+      }
+    }
+  }
+}
+
+export async function planVerificationCommands(
+  root: string,
+  changedFiles: readonly string[],
+  scope: 'focused' | 'full'
+): Promise<VerificationCommand[]> {
+  const packageRoots = await packageRootsForChangedFiles(root, changedFiles)
+  const filesByPackageRoot = new Map(packageRoots.map((packageRoot) => [packageRoot, [] as string[]]))
+  for (const file of changedFiles) {
+    const owner = packageRoots.find((packageRoot) => isInside(packageRoot, resolve(root, file)))
+    if (owner) filesByPackageRoot.get(owner)?.push(file)
+  }
+  const commands: VerificationCommand[] = []
+  for (const packageRoot of packageRoots) {
+    const packageJson = await readPackageJson(packageRoot)
+    if (!packageJson?.scripts) continue
+    const packageManager = await detectPackageManager(packageRoot)
+    const packageChangedFiles = filesByPackageRoot.get(packageRoot) ?? []
+    if (packageChangedFiles.length === 0) continue
+    const tests = await adjacentTests(packageRoot, root, packageChangedFiles)
+    if (tests.length > 0 && packageJson.scripts.test && usesVitest(packageJson)) {
+      commands.push(scriptCommand(packageManager, packageRoot, 'test', tests, 'focused tests'))
+    }
+    if (packageJson.scripts.typecheck && packageChangedFiles.some((file) => SOURCE_EXTENSION.test(file))) {
+      commands.push(scriptCommand(packageManager, packageRoot, 'typecheck', [], 'typecheck'))
+    }
+    if (scope === 'full' && packageJson.scripts.lint) {
+      commands.push(scriptCommand(packageManager, packageRoot, 'lint', [], 'lint'))
+    }
+    if (scope === 'full' && packageJson.scripts.build) {
+      commands.push(scriptCommand(packageManager, packageRoot, 'build', [], 'build'))
+    }
+  }
+  return dedupeCommands(commands)
+}
+
+async function listChangedFiles(
+  root: string,
+  signal: AbortSignal,
+  timeoutSeconds: number,
+  operations: VerifyToolOperations
+): Promise<string[]> {
+  const runCommand = operations.runCommand ?? runVerificationCommand
+  const commands: VerificationCommand[] = [
+    { label: 'unstaged changes', command: 'git', args: ['diff', '--name-only', '--diff-filter=ACMRTUXB'], cwd: root },
+    { label: 'staged changes', command: 'git', args: ['diff', '--cached', '--name-only', '--diff-filter=ACMRTUXB'], cwd: root },
+    { label: 'untracked files', command: 'git', args: ['ls-files', '--others', '--exclude-standard'], cwd: root }
+  ]
+  const files = new Set<string>()
+  for (const command of commands) {
+    const result = await runCommand(command, { signal, timeoutSeconds })
+    if (signal.aborted) throw new Error('verification aborted')
+    if (result.exitCode !== 0) continue
+    for (const line of result.output.split(/\r?\n/)) {
+      const file = line.trim().replaceAll('\\', '/')
+      if (file) files.add(file)
+    }
+  }
+  return [...files].sort()
+}
+
+async function packageRootsForChangedFiles(root: string, changedFiles: readonly string[]): Promise<string[]> {
+  const roots = new Set<string>()
+  if (await exists(join(root, 'package.json'))) roots.add(root)
+  for (const file of changedFiles) {
+    let current = dirname(resolve(root, file))
+    while (isInside(root, current)) {
+      if (await exists(join(current, 'package.json'))) {
+        roots.add(current)
+        break
+      }
+      if (current === root) break
+      current = dirname(current)
+    }
+  }
+  return [...roots].sort((left, right) => right.length - left.length)
+}
+
+async function adjacentTests(
+  packageRoot: string,
+  workspaceRoot: string,
+  changedFiles: readonly string[]
+): Promise<string[]> {
+  const tests = new Set<string>()
+  for (const file of changedFiles) {
+    const absolute = resolve(workspaceRoot, file)
+    if (!isInside(packageRoot, absolute) || !SOURCE_EXTENSION.test(file)) continue
+    const packageRelative = relative(packageRoot, absolute).replaceAll('\\', '/')
+    if (TEST_FILE.test(packageRelative)) {
+      tests.add(packageRelative)
+      continue
+    }
+    const extension = packageRelative.match(/(\.[cm]?[jt]sx?)$/i)?.[1]
+    if (!extension) continue
+    const stem = packageRelative.slice(0, -extension.length)
+    for (const candidate of [`${stem}.test${extension}`, `${stem}.spec${extension}`]) {
+      if (await exists(join(packageRoot, candidate))) tests.add(candidate)
+    }
+  }
+  return [...tests].sort()
+}
+
+async function readPackageJson(root: string): Promise<PackageJson | null> {
+  try {
+    return JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as PackageJson
+  } catch {
+    return null
+  }
+}
+
+function usesVitest(packageJson: PackageJson): boolean {
+  const deps = { ...packageJson.dependencies, ...packageJson.devDependencies }
+  return Boolean(deps.vitest) || /\bvitest\b/.test(packageJson.scripts?.test ?? '')
+}
+
+async function detectPackageManager(root: string): Promise<'npm' | 'pnpm' | 'yarn' | 'bun'> {
+  if (await exists(join(root, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (await exists(join(root, 'yarn.lock'))) return 'yarn'
+  if (await exists(join(root, 'bun.lockb')) || await exists(join(root, 'bun.lock'))) return 'bun'
+  return 'npm'
+}
+
+function scriptCommand(
+  packageManager: 'npm' | 'pnpm' | 'yarn' | 'bun',
+  cwd: string,
+  script: string,
+  extraArgs: string[],
+  label: string
+): VerificationCommand {
+  const command = process.platform === 'win32' && packageManager === 'npm' ? 'npm.cmd' : packageManager
+  if (packageManager === 'yarn') {
+    return { label, command, args: [script, ...extraArgs], cwd }
+  }
+  return {
+    label,
+    command,
+    args: ['run', script, ...(extraArgs.length > 0 ? ['--', ...extraArgs] : [])],
+    cwd
+  }
+}
+
+async function runVerificationCommand(
+  command: VerificationCommand,
+  options: { signal: AbortSignal; timeoutSeconds: number }
+): Promise<VerificationCheck> {
+  const startedAt = Date.now()
+  return await new Promise((resolvePromise) => {
+    const child = spawn(command.command, command.args, {
+      cwd: command.cwd,
+      env: process.env,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    let output = ''
+    let timedOut = false
+    const append = (chunk: Buffer | string) => {
+      output += chunk.toString()
+      if (output.length > MAX_OUTPUT_CHARS) output = output.slice(-MAX_OUTPUT_CHARS)
+    }
+    child.stdout?.on('data', append)
+    child.stderr?.on('data', append)
+    const stop = () => terminateSpawnTree(child)
+    const timer = setTimeout(() => {
+      timedOut = true
+      stop()
+    }, options.timeoutSeconds * 1000)
+    options.signal.addEventListener('abort', stop, { once: true })
+    child.once('error', (error) => {
+      append(error.message)
+    })
+    child.once('close', (code) => {
+      clearTimeout(timer)
+      options.signal.removeEventListener('abort', stop)
+      resolvePromise({
+        ...command,
+        exitCode: timedOut || options.signal.aborted ? null : code,
+        output: timedOut ? `${output}\nCommand timed out.`.trim() : output.trim(),
+        durationMs: Date.now() - startedAt
+      })
+    })
+  })
+}
+
+function dedupeCommands(commands: readonly VerificationCommand[]): VerificationCommand[] {
+  const seen = new Set<string>()
+  return commands.filter((command) => {
+    const key = `${command.cwd}\0${command.command}\0${command.args.join('\0')}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function normalizeTimeout(value: unknown): number {
+  const parsed = typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : DEFAULT_TIMEOUT_SECONDS
+  return Math.max(1, Math.min(MAX_TIMEOUT_SECONDS, parsed))
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = relative(resolve(root), resolve(candidate))
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`))
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/kun/src/adapters/tool/index.ts
+++ b/kun/src/adapters/tool/index.ts
@@ -1,4 +1,5 @@
 export * from './bash.js'
+export * from './builtin-verify-tool.js'
 export * from './capability-registry.js'
 export * from './create-plan-tool.js'
 export * from './delegation-tool-provider.js'

--- a/kun/src/loop/agent-loop.test.ts
+++ b/kun/src/loop/agent-loop.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+  automaticVerificationState,
   buildRuntimeContextInstruction,
   isStalePlanContext,
   resolvePlanModeToolSpecs,
@@ -18,6 +19,78 @@ function spec(name: string): ModelToolSpec {
     inputSchema: { type: 'object', properties: {} }
   }
 }
+
+function result(input: {
+  id: string
+  toolName: string
+  toolKind: 'file_change' | 'command_execution'
+  isError?: boolean
+}) {
+  return {
+    id: input.id,
+    threadId: 'thread_1',
+    turnId: 'turn_1',
+    role: 'tool' as const,
+    kind: 'tool_result' as const,
+    toolName: input.toolName,
+    callId: `call_${input.id}`,
+    toolKind: input.toolKind,
+    output: {},
+    isError: input.isError ?? false,
+    status: 'completed' as const,
+    createdAt: '2000-01-02T03:04:05.000Z'
+  }
+}
+
+describe('automaticVerificationState', () => {
+  it('requires verification after a successful file mutation', () => {
+    expect(automaticVerificationState([
+      result({ id: 'write', toolName: 'write', toolKind: 'file_change' })
+    ], 'turn_1')).toMatchObject({ hasFileChanges: true, pending: true, exhausted: false })
+  })
+
+  it('does not trigger for a failed edit or create_plan artifact', () => {
+    const state = automaticVerificationState([
+      result({ id: 'failed', toolName: 'edit', toolKind: 'file_change', isError: true }),
+      result({ id: 'plan', toolName: 'create_plan', toolKind: 'file_change' })
+    ], 'turn_1')
+
+    expect(state.hasFileChanges).toBe(false)
+    expect(state.pending).toBe(false)
+  })
+
+  it('requires another run when a repair follows a failed verification', () => {
+    const state = automaticVerificationState([
+      result({ id: 'write', toolName: 'write', toolKind: 'file_change' }),
+      result({ id: 'verify_1', toolName: 'verify_changes', toolKind: 'command_execution', isError: true }),
+      result({ id: 'repair', toolName: 'edit', toolKind: 'file_change' })
+    ], 'turn_1')
+
+    expect(state).toMatchObject({ pending: true, latestVerificationFailed: true, consecutiveFailures: 1 })
+  })
+
+  it('bounds repeated failed repair cycles and resets after a pass', () => {
+    const failedCycles = [1, 2, 3].flatMap((attempt) => [
+      result({ id: `edit_${attempt}`, toolName: 'edit', toolKind: 'file_change' }),
+      result({
+        id: `verify_${attempt}`,
+        toolName: 'verify_changes',
+        toolKind: 'command_execution',
+        isError: true
+      })
+    ])
+    expect(automaticVerificationState([
+      ...failedCycles,
+      result({ id: 'last_repair', toolName: 'edit', toolKind: 'file_change' })
+    ], 'turn_1')).toMatchObject({ pending: true, exhausted: true, consecutiveFailures: 3 })
+
+    expect(automaticVerificationState([
+      ...failedCycles,
+      result({ id: 'pass', toolName: 'verify_changes', toolKind: 'command_execution' }),
+      result({ id: 'next_edit', toolName: 'edit', toolKind: 'file_change' })
+    ], 'turn_1')).toMatchObject({ pending: true, exhausted: false, consecutiveFailures: 0 })
+  })
+})
 
 const ALL_TOOLS: ModelToolSpec[] = [
   spec('read'),

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -89,6 +89,7 @@ import { guiPlanWorkspaceMatches } from '../shared/gui-plan.js'
 import { GET_GOAL_TOOL_NAME, UPDATE_GOAL_TOOL_NAME } from '../adapters/tool/goal-tools.js'
 import { TODO_LIST_TOOL_NAME, TODO_WRITE_TOOL_NAME } from '../adapters/tool/todo-tools.js'
 import { shellRuntimeInstruction } from '../adapters/tool/builtin-tool-utils.js'
+import { VERIFY_CHANGES_TOOL_NAME } from '../adapters/tool/builtin-verify-tool.js'
 import {
   GoalResumeCoordinator,
   DEFAULT_MAX_GOAL_RESUME_NO_PROGRESS_ATTEMPTS,
@@ -103,6 +104,7 @@ const MAX_PARALLEL_TOOL_CALLS = 3
 // N images"), bounding context growth for long computer-use sessions.
 const MAX_FORWARDED_TOOL_IMAGES = 3
 const MAX_TURN_MODEL_STEPS = 64
+const MAX_CONSECUTIVE_VERIFICATION_FAILURES = 3
 
 /**
  * Tools that, on their own, do not count as "progress" toward a goal when
@@ -283,6 +285,89 @@ export function resolvePlanModeToolSpecs(
         (tool) => tool.name === planTool || readOnly.has(tool.name) || interactive.has(tool.name)
       )
     : toolSpecs.filter((tool) => tool.name === planTool)
+}
+
+export type AutomaticVerificationState = {
+  hasFileChanges: boolean
+  pending: boolean
+  exhausted: boolean
+  latestVerificationFailed: boolean
+  consecutiveFailures: number
+}
+
+/**
+ * Determine whether the current turn changed files after its most recent
+ * acceptance run. Only successful file-change results count, so a denied or
+ * failed edit never triggers a pointless verification cycle.
+ */
+export function automaticVerificationState(
+  items: readonly TurnItem[],
+  turnId: string,
+  maxFailures = MAX_CONSECUTIVE_VERIFICATION_FAILURES
+): AutomaticVerificationState {
+  let lastFileChangeIndex = -1
+  let lastVerificationIndex = -1
+  let latestVerificationFailed = false
+  let consecutiveFailures = 0
+
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index]
+    if (!item || item.turnId !== turnId || item.kind !== 'tool_result') continue
+    if (
+      item.toolKind === 'file_change' &&
+      item.toolName !== CREATE_PLAN_TOOL_NAME &&
+      item.isError !== true
+    ) {
+      lastFileChangeIndex = index
+      continue
+    }
+    if (item.toolName !== VERIFY_CHANGES_TOOL_NAME) continue
+    lastVerificationIndex = index
+    latestVerificationFailed = item.isError === true
+    consecutiveFailures = latestVerificationFailed ? consecutiveFailures + 1 : 0
+  }
+
+  const hasFileChanges = lastFileChangeIndex >= 0
+  const pending = hasFileChanges && lastFileChangeIndex > lastVerificationIndex
+  return {
+    hasFileChanges,
+    pending,
+    exhausted: pending && consecutiveFailures >= maxFailures,
+    latestVerificationFailed,
+    consecutiveFailures
+  }
+}
+
+function automaticVerificationInstruction(input: {
+  state: AutomaticVerificationState
+  toolAvailable: boolean
+}): string | null {
+  if (input.state.exhausted) {
+    return [
+      'Automatic acceptance reached its retry limit after repeated failures.',
+      'Do not claim verification passed. Report the remaining failure and its evidence in the final answer.'
+    ].join(' ')
+  }
+  if (input.state.pending && !input.toolAvailable) {
+    return [
+      'Files changed in this turn, but automatic command verification is unavailable under the current tool or sandbox policy.',
+      'Use an available validation path or state clearly that validation could not run.'
+    ].join(' ')
+  }
+  if (input.state.pending) {
+    return [
+      'Files changed in this turn and have not been verified yet.',
+      `Continue the implementation as needed, but call ${VERIFY_CHANGES_TOOL_NAME} before giving the final answer.`
+    ].join(' ')
+  }
+  if (input.state.latestVerificationFailed && !input.state.pending) {
+    return [
+      'The latest automatic acceptance check failed.',
+      'Inspect its exact output, fix the cause, and modify the affected files; verification will run again after the fix.',
+      'If it cannot be fixed, report the failing check and reason explicitly.'
+    ].join(' ')
+  }
+  return null
 }
 
 /**
@@ -708,6 +793,7 @@ export class AgentLoop {
   private readonly lastNoToolTextByTurn = new Map<string, string>()
   private readonly goalNoToolRecoveryStepsByTurn = new Map<string, number>()
   private readonly emptyPostToolRecoveryStepsByTurn = new Map<string, number>()
+  private readonly verificationRequiredByTurn = new Set<string>()
   private readonly turnFailures = new Map<string, TurnFailure>()
   /** Turns that executed at least one real (non-goal-status) tool call. */
   private readonly turnMadeProgress = new Set<string>()
@@ -862,6 +948,7 @@ export class AgentLoop {
       this.goalNoToolRecoveryStepsByTurn.delete(turnId)
       this.turnMadeProgress.delete(turnId)
       this.emptyPostToolRecoveryStepsByTurn.delete(turnId)
+      this.verificationRequiredByTurn.delete(turnId)
       this.turnFailures.delete(turnId)
       await this.runTurnEndHooks(threadId, turnId, finalStatus ?? 'failed', finalError)
     }
@@ -1434,12 +1521,26 @@ export class AgentLoop {
     const createPlanSatisfied = planTurnActive
       ? hasSuccessfulCreatePlanResult(historyItems, turnId)
       : false
-    const requiredToolName =
+    const verificationState = automaticVerificationState(historyItems, turnId)
+    const verificationToolAvailable = toolSpecs.some(
+      (tool) => tool.name === VERIFY_CHANGES_TOOL_NAME
+    )
+    const planRequiredToolName =
       planTurnActive &&
       !createPlanSatisfied &&
       toolSpecs.some((tool) => tool.name === CREATE_PLAN_TOOL_NAME)
         ? CREATE_PLAN_TOOL_NAME
         : undefined
+    const verificationRequiredToolName =
+      !planTurnActive &&
+      this.verificationRequiredByTurn.has(turnId) &&
+      verificationState.pending &&
+      !verificationState.exhausted &&
+      verificationToolAvailable
+        ? VERIFY_CHANGES_TOOL_NAME
+        : undefined
+    const requiredToolName = planRequiredToolName ?? verificationRequiredToolName
+    if (!verificationState.pending) this.verificationRequiredByTurn.delete(turnId)
     const effectiveToolSpecs = resolvePlanModeToolSpecs(toolSpecs, {
       planTurnActive,
       createPlanSatisfied,
@@ -1465,6 +1566,10 @@ export class AgentLoop {
           nowIso: this.opts.nowIso()
         })
       : null
+    const verificationInstruction = automaticVerificationInstruction({
+      state: verificationState,
+      toolAvailable: verificationToolAvailable
+    })
     const contextInstructions = [
       ...(runtimeContextInstruction ? [runtimeContextInstruction] : []),
       ...(activeGoalInstruction ? [activeGoalInstruction] : []),
@@ -1486,6 +1591,7 @@ export class AgentLoop {
       ...skillResolution.instructions,
       ...(userInputDisabled ? [userInputUnavailableInstruction()] : []),
       ...(effectiveToolSpecs.some((tool) => tool.name === 'bash') ? [shellRuntimeInstruction()] : []),
+      ...(verificationInstruction ? [verificationInstruction] : []),
       ...(toolCatalogDriftMessage ? [toolCatalogDriftMessage] : [])
     ]
     await this.recordPipelineStage(threadId, turnId, 'input_remembered', {
@@ -1813,7 +1919,7 @@ export class AgentLoop {
           if (dispatched === 'all_suppressed') return 'stop'
           return 'continue'
         }
-        const message = `Model did not call the required \`${request.requiredToolName}\` tool for this GUI plan turn.`
+        const message = `Model did not call the required \`${request.requiredToolName}\` tool for this turn.`
         await this.opts.events.record({
           kind: 'error',
           threadId,
@@ -1833,17 +1939,19 @@ export class AgentLoop {
         )
         return 'failed'
       }
-      const hasCurrentTurnFileChange = historyItems.some(
-        (item) =>
-          item.turnId === turnId &&
-          item.kind === 'tool_call' &&
-          item.toolKind === 'file_change' &&
-          item.toolName !== CREATE_PLAN_TOOL_NAME
-      )
+      if (
+        stopReason === 'stop' &&
+        verificationState.pending &&
+        !verificationState.exhausted &&
+        verificationToolAvailable
+      ) {
+        this.verificationRequiredByTurn.add(turnId)
+        return 'continue'
+      }
       if (
         stopReason === 'stop' &&
         !textAccumulator.value.trim() &&
-        hasCurrentTurnFileChange
+        verificationState.hasFileChanges
       ) {
         const recoverySteps = (this.emptyPostToolRecoveryStepsByTurn.get(turnId) ?? 0) + 1
         if (recoverySteps <= EMPTY_POST_TOOL_MAX_RECOVERY_STEPS) {


### PR DESCRIPTION
## Summary

Adds a bounded automatic acceptance loop for code-changing turns.

## Changes

- adds a project-aware `verify_changes` builtin tool that discovers changed files and runs adjacent Vitest tests plus package typechecks
- supports npm, pnpm, yarn, and bun package roots without duplicate monorepo ownership
- runs lint/build only when the model requests full verification
- requires verification when a model tries to finish with unverified file changes, while allowing uninterrupted multi-file edits
- feeds failures back into the same turn and caps consecutive failed repair cycles at three
- preserves existing approval and sandbox enforcement for all verification commands

## Tests

- `npm.cmd --prefix kun test -- src/adapters/tool/builtin-verify-tool.test.ts src/adapters/tool/builtin-tool-types.test.ts src/loop/agent-loop.test.ts` (27 passed)
- `npm.cmd run typecheck`
- `npm.cmd run build`
- ESLint passes for all changed files
- Full-repo `npm.cmd run lint` still fails on the pre-existing conditional Hook in `src/renderer/src/components/chat/message-timeline-process.tsx:241` (plus 14 existing warnings); this PR does not touch those files.