### PR TITLE
fix(composer): restore goal panel/floater background fill

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -1618,7 +1618,7 @@ export function FloatingComposer({
       <div className="relative">
         {showGoalFloater && activeThreadGoal && !pendingUserInputBlock ? (
           <div className="pointer-events-none absolute inset-x-3 bottom-full z-20 mb-2 flex justify-center">
-            <div className="pointer-events-auto flex min-h-11 w-full max-w-[46rem] items-center gap-2 rounded-full border border-ds-border bg-ds-card/95 px-3 py-1.5 text-ds-muted shadow-[0_12px_34px_rgba(20,47,95,0.10)] backdrop-blur-xl dark:bg-ds-card/90">
+            <div className="pointer-events-auto flex min-h-11 w-full max-w-[46rem] items-center gap-2 rounded-full border border-ds-border bg-white px-3 py-1.5 text-ds-muted shadow-[0_12px_34px_rgba(20,47,95,0.10)] backdrop-blur-xl dark:bg-ds-card">
               <Target className="h-3.5 w-3.5 shrink-0 text-ds-faint" strokeWidth={1.9} />
               <div className="flex min-w-0 flex-1 items-center gap-1.5 text-[13px] leading-5">
                 <span className="shrink-0 font-semibold text-ds-ink">
@@ -1924,7 +1924,7 @@ export function FloatingComposer({
         {goalPanelOpen && slashQuery == null && !pendingUserInputBlock ? (
           <div
             ref={goalPanelRef}
-            className="absolute inset-x-2 bottom-full z-30 mb-3 overflow-hidden rounded-[26px] border border-ds-border bg-ds-card/95 p-3 shadow-[0_18px_52px_rgba(20,47,95,0.14)] backdrop-blur-xl dark:bg-ds-card/90"
+            className="absolute inset-x-2 bottom-full z-30 mb-3 overflow-hidden rounded-[26px] border border-ds-border bg-white p-3 shadow-[0_18px_52px_rgba(20,47,95,0.14)] backdrop-blur-xl dark:bg-ds-card"
           >
             <div className="flex items-start gap-3">
               <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-ds-border-muted text-ds-muted">


### PR DESCRIPTION
## Bug
Clicking **追求目标 (Goal mode)** in the composer menu appeared to do nothing — the menu closed and no panel showed.

## Root cause
The goal popover ([FloatingComposer.tsx:1927](src/renderer/src/components/chat/FloatingComposer.tsx)) and the active-goal floater pill (:1621) used `bg-ds-card/95` / `dark:bg-ds-card/90`. The `ds-card` Tailwind token is `var(--ds-surface-card)` — a raw CSS var with **no `<alpha-value>` channel** — so Tailwind 3.4 **silently drops the entire `background-color` declaration** for the `/NN` opacity modifier. The panel rendered with no fill (just a faint blurred border over the chat), so it looked like nothing opened.

This is the known opacity-on-var-token failure mode; other modals were already migrated to no-opacity tokens.

## Fix
Switch both goal surfaces to the solid `bg-white dark:bg-ds-card` token already used by the adjacent (visible) composer menu popover.

## Verification
- Compiled Tailwind directly: `.bg-ds-card` and `.bg-white` emit a `background-color` rule; `.bg-ds-card/95` and `.bg-ds-card/90` emit **nothing** (confirming the drop).
- Web typecheck: clean.
- (Electron app — the goal panel requires the connected kun runtime to enable, so a plain browser preview can't exercise it; fix is a CSS-class swap to a proven-rendering token.)

Note: the same `bg-ds-card/NN` pattern still exists on smaller composer chips (attachment/usage/context, lines ~2024–2431); they sit inside the composer shell so they're not glaring. Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)