### PR TITLE
fix(build): add missing @emnapi install records to kun lockfile

### DIFF
--- a/kun/package-lock.json
+++ b/kun/package-lock.json
@@ -443,6 +443,31 @@
         "regenerator-runtime": "^0.13.3"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",


### PR DESCRIPTION
The root postinstall runs `npm --prefix kun ci`, which failed in CI with:
  Missing: @emnapi/core@1.11.1 from lock file
  Missing: @emnapi/runtime@1.11.1 from lock file

kun/package-lock.json was missing the install records for these optional
peer deps of @napi-rs/wasm-runtime (pulled transitively via vitest's
rolldown wasm fallback), so `npm ci` refused to install. Add the two
records so the lockfile is back in sync with package.json and the
macOS/Windows/Linux release builds can install dependencies again.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BuDt5m3agtnihau5MYt2Gd