### PR TITLE
fix(settings): decouple memory and skill loading from current workspace

### DIFF
--- a/kun/src/memory/memory-store.ts
+++ b/kun/src/memory/memory-store.ts
@@ -13,7 +13,7 @@ export interface MemoryStore {
   create(input: MemoryCreateRequest): Promise<MemoryRecord>
   update(id: string, patch: MemoryUpdateRequest, access?: MemoryAccess): Promise<MemoryRecord>
   delete(id: string, access?: MemoryAccess): Promise<MemoryRecord>
-  list(filter?: { workspace?: string; includeDeleted?: boolean }): Promise<MemoryRecord[]>
+  list(filter?: { workspace?: string; includeDeleted?: boolean; all?: boolean }): Promise<MemoryRecord[]>
   retrieve(input: { query: string; workspace?: string; limit: number }): Promise<MemoryRecord[]>
   diagnostics(): Promise<MemoryDiagnostics>
   setLastInjected(ids: string[]): void
@@ -84,11 +84,11 @@ export class FileMemoryStore implements MemoryStore {
     return next
   }
 
-  async list(filter: { workspace?: string; includeDeleted?: boolean } = {}): Promise<MemoryRecord[]> {
+  async list(filter: { workspace?: string; includeDeleted?: boolean; all?: boolean } = {}): Promise<MemoryRecord[]> {
     const records = await this.readAll()
     return records
       .filter((record) => filter.includeDeleted || !record.deletedAt)
-      .filter((record) => inScope(record, filter.workspace))
+      .filter((record) => filter.all || inScope(record, filter.workspace))
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
   }
 

--- a/kun/src/server/routes/memory.ts
+++ b/kun/src/server/routes/memory.ts
@@ -10,7 +10,8 @@ export async function listMemories(store: MemoryStore | undefined, request: Requ
   return jsonResponse({
     memories: await store.list({
       workspace: url.searchParams.get('workspace') ?? undefined,
-      includeDeleted: url.searchParams.get('include_deleted') === 'true'
+      includeDeleted: url.searchParams.get('include_deleted') === 'true',
+      all: url.searchParams.get('all') === 'true'
     })
   })
 }

--- a/kun/tests/memory-store.test.ts
+++ b/kun/tests/memory-store.test.ts
@@ -236,6 +236,27 @@ describe('Memory store and recall', () => {
     expect(hits).toEqual([])
   })
 
+  it('lists every memory for settings management when all=true', async () => {
+    const store = createStore()
+    await store.create({
+      content: 'Project Alpha deploys with pnpm',
+      scope: 'project',
+      workspace: '/tmp/project-alpha'
+    })
+    await store.create({
+      content: 'Other workspace preference',
+      scope: 'workspace',
+      workspace: '/tmp/other'
+    })
+    await store.create({
+      content: 'User prefers concise answers',
+      scope: 'user'
+    })
+
+    expect(await store.list({ workspace: '/tmp/project-alpha' })).toHaveLength(2)
+    expect(await store.list({ all: true })).toHaveLength(3)
+  })
+
   it('isolates project memories and scope-protects mutations', async () => {
     const store = createStore()
     const memory = await store.create({

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -705,10 +705,11 @@ export class KunRuntimeProvider implements AgentProvider {
     )
   }
 
-  async listMemories(options: { workspace?: string; includeDeleted?: boolean } = {}): Promise<CoreMemoryRecordJson[]> {
+  async listMemories(options: { workspace?: string; includeDeleted?: boolean; all?: boolean } = {}): Promise<CoreMemoryRecordJson[]> {
     const query = buildQuery({
       workspace: options.workspace,
-      include_deleted: options.includeDeleted
+      include_deleted: options.includeDeleted,
+      all: options.all
     })
     const response = await rendererRuntimeClient.runtimeRequest(`${KUN_MEMORY_PATH}${query}`, 'GET')
     if (!response.ok) {

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -512,7 +512,7 @@ export interface AgentProvider {
     attachmentId: string,
     options?: { threadId?: string; workspace?: string }
   ): Promise<CoreAttachmentContentResponseJson>
-  listMemories?(options?: { workspace?: string; includeDeleted?: boolean }): Promise<CoreMemoryRecordJson[]>
+  listMemories?(options?: { workspace?: string; includeDeleted?: boolean; all?: boolean }): Promise<CoreMemoryRecordJson[]>
   createMemory?(input: {
     content: string
     scope?: 'user' | 'workspace' | 'project'

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -152,7 +152,6 @@ export function SettingsView(): ReactElement {
   const formTheme = form?.theme
   const formUiFontScale = form?.uiFontScale
   const writeTypography = form?.write?.typography
-  const formWorkspaceRoot = form?.workspaceRoot
   const formKun = form ? getKunRuntimeSettings(form) : null
   const formPort = formKun?.port
   const formGuiUpdateChannel = form?.guiUpdate?.channel
@@ -388,15 +387,16 @@ export function SettingsView(): ReactElement {
     if (typeof window.kunGui?.listSkillRoots !== 'function') return
     setSkillRootsLoading(true)
     try {
-      const workspaceRoot = normalizeWorkspaceRoot(expandHomePath(formWorkspaceRoot ?? ''))
-      const result = await window.kunGui.listSkillRoots(workspaceRoot || undefined)
+      // Settings is global: list every configured skill root from persisted
+      // settings, not the sidebar's currently selected project workspace.
+      const result = await window.kunGui.listSkillRoots()
       if (result.ok) setSkillRoots(result.roots)
     } catch {
       /* listing skill roots is best-effort; keep the last known list */
     } finally {
       setSkillRootsLoading(false)
     }
-  }, [expandHomePath, formWorkspaceRoot])
+  }, [])
 
   useEffect(() => {
     if (category !== 'agents') return
@@ -492,9 +492,7 @@ export function SettingsView(): ReactElement {
     setRuntimeDiagnosticsBusy(true)
     setRuntimeDiagnosticsNotice(null)
     try {
-      const loaded = await loadKunDiagnostics(provider, {
-        workspace: normalizeWorkspaceRoot(expandHomePath(formWorkspaceRoot ?? ''))
-      })
+      const loaded = await loadKunDiagnostics(provider, { listAllMemories: true })
       if (loaded.runtimeInfo !== undefined) setRuntimeInfo(loaded.runtimeInfo)
       if (loaded.toolDiagnostics !== undefined) setToolDiagnostics(loaded.toolDiagnostics)
       if (loaded.memoryRecords !== undefined) setMemoryRecords(loaded.memoryRecords)
@@ -512,7 +510,7 @@ export function SettingsView(): ReactElement {
     } finally {
       setRuntimeDiagnosticsBusy(false)
     }
-  }, [expandHomePath, formWorkspaceRoot])
+  }, [])
 
   useEffect(() => {
     if (category !== 'agents' && category !== 'memory') return
@@ -535,18 +533,31 @@ export function SettingsView(): ReactElement {
     void refreshMemoryDiagnostics()
   }, [category, memoryRecords])
 
+  const memoryMutationWorkspace = useCallback((memoryId: string): string | undefined => {
+    const record = memoryRecords.find((item) => item.id === memoryId)
+    if (!record || record.scope === 'user') return undefined
+    if (record.scope === 'project') {
+      return record.project ?? record.workspace
+    }
+    return record.workspace
+  }, [memoryRecords])
+
   const createMemoryRecord = async (input: {
     content: string
     scope?: 'user' | 'workspace' | 'project'
+    targetPath?: string
     tags?: string[]
     confidence?: number
   }): Promise<boolean> => {
     const provider = getProvider()
     if (typeof provider.createMemory !== 'function') return false
     try {
-      const workspace = normalizeWorkspaceRoot(formWorkspaceRoot)
+      const workspace = normalizeWorkspaceRoot(expandHomePath(input.targetPath ?? ''))
       const memory = await provider.createMemory({
-        ...input,
+        content: input.content,
+        scope: input.scope,
+        tags: input.tags,
+        confidence: input.confidence,
         ...(input.scope === 'user' ? {} : { workspace }),
         ...(input.scope === 'project' ? { project: workspace } : {})
       })
@@ -569,7 +580,7 @@ export function SettingsView(): ReactElement {
     if (typeof provider.updateMemory !== 'function') return false
     try {
       const memory = await provider.updateMemory(memoryId, patch, {
-        workspace: normalizeWorkspaceRoot(formWorkspaceRoot)
+        workspace: memoryMutationWorkspace(memoryId)
       })
       setMemoryRecords((records) => records.map((record) => (record.id === memoryId ? memory : record)))
       return true
@@ -587,7 +598,7 @@ export function SettingsView(): ReactElement {
     if (typeof provider.updateMemory !== 'function') return
     try {
       const memory = await provider.updateMemory(memoryId, { disabled: true }, {
-        workspace: normalizeWorkspaceRoot(formWorkspaceRoot)
+        workspace: memoryMutationWorkspace(memoryId)
       })
       setMemoryRecords((records) => records.map((record) => record.id === memoryId ? memory : record))
     } catch (error) {
@@ -603,7 +614,7 @@ export function SettingsView(): ReactElement {
     if (typeof provider.deleteMemory !== 'function') return
     try {
       await provider.deleteMemory(memoryId, {
-        workspace: normalizeWorkspaceRoot(formWorkspaceRoot)
+        workspace: memoryMutationWorkspace(memoryId)
       })
       setMemoryRecords((records) => records.filter((record) => record.id !== memoryId))
     } catch (error) {

--- a/src/renderer/src/components/settings-section-memory.test.ts
+++ b/src/renderer/src/components/settings-section-memory.test.ts
@@ -187,7 +187,7 @@ describe('isMemoryDraftDirty', () => {
   it('returns false in view mode regardless of draft', () => {
     const record = sampleRecord()
     const dialog: MemoryDialogState = { mode: 'view', memory: record }
-    const draft: MemoryDraft = { content: 'totally different', scope: 'user', tags: 'x', confidence: 0 }
+    const draft: MemoryDraft = { content: 'totally different', scope: 'user', targetPath: '', tags: 'x', confidence: 0 }
     expect(isMemoryDraftDirty(dialog, draft)).toBe(false)
   })
 
@@ -197,6 +197,7 @@ describe('isMemoryDraftDirty', () => {
     const draft: MemoryDraft = {
       content: record.content,
       scope: record.scope,
+      targetPath: record.workspace ?? '',
       tags: 'summary, kook-bot',
       confidence: record.confidence ?? 1
     }
@@ -209,6 +210,7 @@ describe('isMemoryDraftDirty', () => {
     const baseline: MemoryDraft = {
       content: record.content,
       scope: record.scope,
+      targetPath: record.workspace ?? '',
       tags: 'summary',
       confidence: 1
     }
@@ -219,15 +221,15 @@ describe('isMemoryDraftDirty', () => {
 
   it('returns false in create mode for an empty draft on the default scope', () => {
     const dialog: MemoryDialogState = { mode: 'create' }
-    const draft: MemoryDraft = { content: '   ', scope: 'workspace', tags: '   ', confidence: 1 }
+    const draft: MemoryDraft = { content: '   ', scope: 'workspace', targetPath: '', tags: '   ', confidence: 1 }
     expect(isMemoryDraftDirty(dialog, draft)).toBe(false)
   })
 
   it('returns true in create mode when any field changes from the empty default', () => {
     const dialog: MemoryDialogState = { mode: 'create' }
-    expect(isMemoryDraftDirty(dialog, { content: 'hello', scope: 'workspace', tags: '', confidence: 1 })).toBe(true)
-    expect(isMemoryDraftDirty(dialog, { content: '', scope: 'workspace', tags: 'tag', confidence: 1 })).toBe(true)
-    expect(isMemoryDraftDirty(dialog, { content: '', scope: 'user', tags: '', confidence: 1 })).toBe(true)
+    expect(isMemoryDraftDirty(dialog, { content: 'hello', scope: 'workspace', targetPath: '', tags: '', confidence: 1 })).toBe(true)
+    expect(isMemoryDraftDirty(dialog, { content: '', scope: 'workspace', targetPath: '', tags: 'tag', confidence: 1 })).toBe(true)
+    expect(isMemoryDraftDirty(dialog, { content: '', scope: 'user', targetPath: '', tags: '', confidence: 1 })).toBe(true)
   })
 })
 
@@ -238,6 +240,7 @@ describe('attemptCloseMemoryDialog', () => {
     const draft: MemoryDraft = {
       content: record.content,
       scope: record.scope,
+      targetPath: record.workspace ?? '',
       tags: 'summary',
       confidence: 1
     }
@@ -254,7 +257,7 @@ describe('attemptCloseMemoryDialog', () => {
     const close = vi.fn()
     const result = await attemptCloseMemoryDialog({
       dialog: null,
-      draft: { content: 'anything', scope: 'workspace', tags: '', confidence: 1 },
+      draft: { content: 'anything', scope: 'workspace', targetPath: '', tags: '', confidence: 1 },
       confirm,
       close
     })
@@ -269,6 +272,7 @@ describe('attemptCloseMemoryDialog', () => {
     const draft: MemoryDraft = {
       content: 'EDITED content',
       scope: record.scope,
+      targetPath: record.workspace ?? '',
       tags: 'summary',
       confidence: 1
     }
@@ -285,6 +289,7 @@ describe('attemptCloseMemoryDialog', () => {
     const draft: MemoryDraft = {
       content: 'half-typed thought',
       scope: 'workspace',
+      targetPath: '',
       tags: '',
       confidence: 1
     }

--- a/src/renderer/src/components/settings-section-memory.tsx
+++ b/src/renderer/src/components/settings-section-memory.tsx
@@ -10,6 +10,7 @@ type MemoryScope = 'user' | 'workspace' | 'project'
 export type MemoryDraft = {
   content: string
   scope: MemoryScope
+  targetPath: string
   tags: string
   confidence: number
 }
@@ -22,6 +23,7 @@ export type MemoryDialogState =
 const EMPTY_DRAFT: MemoryDraft = {
   content: '',
   scope: 'workspace',
+  targetPath: '',
   tags: '',
   confidence: 1
 }
@@ -64,6 +66,7 @@ export function isMemoryDraftDirty(
   return (
     draft.content.trim() !== '' ||
     draft.tags.trim() !== '' ||
+    draft.targetPath.trim() !== '' ||
     draft.scope !== DEFAULT_DRAFT_SCOPE
   )
 }
@@ -135,6 +138,7 @@ export function MemorySettingsSection({ ctx }: { ctx: Record<string, any> }): Re
     setDraft({
       content: record.content,
       scope: record.scope,
+      targetPath: projectForMemory(record) ?? '',
       tags: (record.tags ?? []).join(', '),
       confidence: record.confidence ?? 1
     })
@@ -164,11 +168,14 @@ export function MemorySettingsSection({ ctx }: { ctx: Record<string, any> }): Re
   const saveDraft = async (): Promise<void> => {
     const trimmed = draft.content.trim()
     if (!trimmed) return
+    const targetPath = draft.targetPath.trim()
+    if (dialog?.mode === 'create' && draft.scope !== 'user' && !targetPath) return
     let ok = false
     if (dialog?.mode === 'create') {
       ok = await createMemoryRecord({
         content: trimmed,
         scope: draft.scope,
+        ...(draft.scope === 'user' ? {} : { targetPath }),
         tags: parseTags(draft.tags),
         confidence: draft.confidence
       })
@@ -465,6 +472,15 @@ function MemoryRecordDialog({
                     <option value="project">{t('memoryScope_project')}</option>
                   </select>
                 ) : null}
+                {dialog.mode === 'create' && draft.scope !== 'user' ? (
+                  <input
+                    type="text"
+                    value={draft.targetPath}
+                    onChange={(e) => onDraftChange((prev) => ({ ...prev, targetPath: e.target.value }))}
+                    placeholder={t('memoryTargetPathPlaceholder')}
+                    className="min-w-[200px] flex-1 rounded-lg border border-ds-border-muted bg-ds-surface-subtle px-2 py-1 text-[12px] text-ds-ink outline-none"
+                  />
+                ) : null}
                 <input
                   type="text"
                   value={draft.tags}
@@ -508,7 +524,10 @@ function MemoryRecordDialog({
             <button
               type="button"
               onClick={onSave}
-              disabled={!draft.content.trim()}
+              disabled={
+                !draft.content.trim() ||
+                (dialog.mode === 'create' && draft.scope !== 'user' && !draft.targetPath.trim())
+              }
               className="rounded-lg bg-ds-ink px-3 py-1.5 text-[12px] font-semibold text-ds-main transition hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-45"
             >
               {t('memorySave')}

--- a/src/renderer/src/lib/load-kun-diagnostics.test.ts
+++ b/src/renderer/src/lib/load-kun-diagnostics.test.ts
@@ -9,13 +9,50 @@ describe('loadKunDiagnostics', () => {
     const provider = {
       getRuntimeInfo: async () => runtimeInfo,
       getToolDiagnostics: async () => toolDiagnostics,
-      listMemories: async () => memoryRecords
+      listMemories: async (options?: { all?: boolean; includeDeleted?: boolean }) => {
+        expect(options).toEqual({ all: true, includeDeleted: false })
+        return memoryRecords
+      }
     }
 
-    const loaded = await loadKunDiagnostics(provider, { workspace: '/tmp/project' })
+    const loaded = await loadKunDiagnostics(provider)
 
     expect(loaded.runtimeInfo).toBe(runtimeInfo)
     expect(loaded.toolDiagnostics).toBe(toolDiagnostics)
+    expect(loaded.memoryRecords).toBe(memoryRecords)
+    expect(loaded.errors).toEqual([])
+  })
+
+  it('loads all memories by default for global settings diagnostics', async () => {
+    const memoryRecords = [{ id: 'mem_1', content: 'remember this' }] as any
+    const provider = {
+      getRuntimeInfo: async () => null,
+      getToolDiagnostics: async () => null,
+      listMemories: async (options?: { all?: boolean }) => {
+        expect(options).toEqual({ all: true, includeDeleted: false })
+        return memoryRecords
+      }
+    }
+
+    const loaded = await loadKunDiagnostics(provider)
+
+    expect(loaded.memoryRecords).toBe(memoryRecords)
+    expect(loaded.errors).toEqual([])
+  })
+
+  it('can scope memory loading to the current workspace when explicitly requested', async () => {
+    const memoryRecords = [{ id: 'mem_ws', content: 'workspace only' }] as any
+    const provider = {
+      getRuntimeInfo: async () => null,
+      getToolDiagnostics: async () => null,
+      listMemories: async (options?: { all?: boolean }) => {
+        expect(options).toEqual({ includeDeleted: false })
+        return memoryRecords
+      }
+    }
+
+    const loaded = await loadKunDiagnostics(provider, { listAllMemories: false })
+
     expect(loaded.memoryRecords).toBe(memoryRecords)
     expect(loaded.errors).toEqual([])
   })
@@ -31,7 +68,7 @@ describe('loadKunDiagnostics', () => {
       }
     }
 
-    const loaded = await loadKunDiagnostics(provider, { workspace: '/tmp/project' })
+    const loaded = await loadKunDiagnostics(provider)
 
     expect(loaded.runtimeInfo).toBe(runtimeInfo)
     expect(loaded.toolDiagnostics).toBe(toolDiagnostics)

--- a/src/renderer/src/lib/load-kun-diagnostics.ts
+++ b/src/renderer/src/lib/load-kun-diagnostics.ts
@@ -17,13 +17,18 @@ export type LoadedKunDiagnostics = {
 
 export async function loadKunDiagnostics(
   provider: DiagnosticsProvider,
-  options: { workspace?: string } = {}
+  options: { listAllMemories?: boolean } = {}
 ): Promise<LoadedKunDiagnostics> {
+  const listAllMemories = options.listAllMemories !== false
   const [runtimeInfo, toolDiagnostics, memoryRecords] = await Promise.allSettled([
     provider.getRuntimeInfo ? provider.getRuntimeInfo() : Promise.resolve(null),
     provider.getToolDiagnostics ? provider.getToolDiagnostics() : Promise.resolve(null),
     provider.listMemories
-      ? provider.listMemories({ workspace: options.workspace, includeDeleted: false })
+      ? provider.listMemories(
+          listAllMemories
+            ? { all: true, includeDeleted: false }
+            : { includeDeleted: false }
+        )
       : Promise.resolve([])
   ])
 

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -1231,6 +1231,7 @@
   "memoryCancel": "Cancel",
   "memoryEmpty": "No memory records yet. The assistant will create them automatically as it learns your preferences, or add one manually.",
   "memoryContentPlaceholder": "What should the assistant remember? e.g. \"Prefer TypeScript with 2-space indentation.\"",
+  "memoryTargetPathPlaceholder": "Absolute path to the workspace or project directory",
   "memoryTagsPlaceholder": "Tags, comma-separated",
   "memoryConfidence": "Confidence",
   "memoryProject": "Project",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -1231,6 +1231,7 @@
   "memoryCancel": "取消",
   "memoryEmpty": "暂无记忆记录。助手会在了解你的偏好后自动创建,也可以手动添加。",
   "memoryContentPlaceholder": "想让助手记住什么?例如:「偏好 TypeScript,2 空格缩进」",
+  "memoryTargetPathPlaceholder": "工作区或项目目录的绝对路径",
   "memoryTagsPlaceholder": "标签,逗号分隔",
   "memoryConfidence": "置信度",
   "memoryProject": "所属项目",


### PR DESCRIPTION
## Summary

- Fix settings long-term memory list showing empty while the active count still reported global records, caused by workspace-scoped list filtering.
- Load all memories and all configured skill roots in settings instead of binding diagnostics to the sidebar's current project workspace.
- Require an explicit target directory when creating workspace/project memories from settings, and use each record's stored path for edit/disable/delete.

## Changes

- Add `all=true` support to the Kun memory list API and use it from settings diagnostics.
- Stop passing the current `workspaceRoot` override when listing skill roots in settings.
- Add a target path field to the memory create dialog for workspace/project scopes.

## Tests

- [x] `npm run test -- kun/tests/memory-store.test.ts`
- [x] `npm run test -- src/renderer/src/lib/load-kun-diagnostics.test.ts`
- [x] `npm run test -- src/renderer/src/components/settings-section-memory.test.ts`


Made with [Cursor](https://cursor.com)