### PR TITLE
feat(chat): show memory summary on injected memory chip hover

### DIFF
--- a/kun/src/adapters/hybrid/hybrid-thread-store.ts
+++ b/kun/src/adapters/hybrid/hybrid-thread-store.ts
@@ -932,6 +932,10 @@ function mergeTurnMetadata(previous: Turn, next: Turn): Turn {
     attachmentIds: mergeStringArrays(previous.attachmentIds, next.attachmentIds),
     activeSkillIds: mergeStringArrays(previous.activeSkillIds, next.activeSkillIds),
     injectedMemoryIds: mergeStringArrays(previous.injectedMemoryIds, next.injectedMemoryIds),
+    injectedMemorySummaries:
+      next.injectedMemorySummaries.length > 0
+        ? next.injectedMemorySummaries
+        : previous.injectedMemorySummaries,
     items: mergeTurnItems(previous.items, next.items)
   }
 }
@@ -971,6 +975,7 @@ function turnFromItems(threadId: string, turnId: string, items: TurnItem[], fall
     attachmentIds: attachmentIdsFromItems(items),
     activeSkillIds: [],
     injectedMemoryIds: [],
+    injectedMemorySummaries: [],
     createdAt,
     finishedAt: hasOpenItem ? undefined : items[items.length - 1]?.finishedAt ?? fallbackTime,
     items

--- a/kun/src/contracts/turns.ts
+++ b/kun/src/contracts/turns.ts
@@ -50,6 +50,12 @@ export const TurnStatus = z.enum([
 ])
 export type TurnStatus = z.infer<typeof TurnStatus>
 
+export const InjectedMemorySummarySchema = z.object({
+  id: z.string().min(1),
+  content: z.string()
+})
+export type InjectedMemorySummary = z.infer<typeof InjectedMemorySummarySchema>
+
 export const TurnSchema = z.object({
   id: z.string().min(1),
   threadId: z.string().min(1),
@@ -66,6 +72,7 @@ export const TurnSchema = z.object({
   attachmentIds: z.array(z.string().min(1)).default([]),
   activeSkillIds: z.array(z.string().min(1)).default([]),
   injectedMemoryIds: z.array(z.string().min(1)).default([]),
+  injectedMemorySummaries: z.array(InjectedMemorySummarySchema).default([]),
   skillInjectionBytes: z.number().int().nonnegative().optional(),
   workspaceCheckpointId: z.string().min(1).optional(),
   toolCatalogFingerprint: z.string().optional(),

--- a/kun/src/domain/turn.ts
+++ b/kun/src/domain/turn.ts
@@ -30,6 +30,7 @@ export function createTurnRecord(input: {
     attachmentIds: [...(input.attachmentIds ?? [])],
     activeSkillIds: [],
     injectedMemoryIds: [],
+    injectedMemorySummaries: [],
     ...(model ? { model } : {}),
     ...(reasoningEffort ? { reasoningEffort } : {}),
     ...(input.guiPlan ? { guiPlan: input.guiPlan } : {}),

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -54,6 +54,7 @@ import {
   makeErrorItem
 } from '../domain/item.js'
 import { touchThread } from '../domain/thread.js'
+import { memoryPreview } from '../shared/memory-preview.js'
 import { repairModelHistoryItems } from '../domain/model-history-repair.js'
 import type { TurnItem } from '../contracts/items.js'
 import type { ThreadGoal, ThreadTodoList } from '../contracts/threads.js'
@@ -1509,6 +1510,10 @@ export class AgentLoop {
         activeSkillIds: skillResolution.activeSkillIds,
         skillInjectionBytes: skillResolution.injectedBytes,
         injectedMemoryIds: memories.map((memory) => memory.id),
+        injectedMemorySummaries: memories.map((memory) => ({
+          id: memory.id,
+          content: memoryPreview(memory.content)
+        })),
         toolCatalogFingerprint: toolCatalog.fingerprint,
         toolCatalogToolCount: toolCatalog.toolCount,
         toolCatalogDrift: toolCatalogDrift.kind !== 'none'

--- a/kun/src/services/thread-service.ts
+++ b/kun/src/services/thread-service.ts
@@ -749,6 +749,7 @@ function rebuildTurnsFromItems(input: {
       attachmentIds: [],
       activeSkillIds: [],
       injectedMemoryIds: [],
+      injectedMemorySummaries: [],
       createdAt: input.now,
       finishedAt: input.now,
       items: []
@@ -767,6 +768,7 @@ function rebuildTurnsFromItems(input: {
       attachmentIds: attachmentIdsFromItems(items),
       activeSkillIds: [],
       injectedMemoryIds: [],
+      injectedMemorySummaries: [],
       createdAt: items[0]?.createdAt ?? input.now,
       finishedAt: input.now,
       items

--- a/kun/src/services/turn-service.ts
+++ b/kun/src/services/turn-service.ts
@@ -446,6 +446,7 @@ export class TurnService {
       Partial<Turn>,
       | 'activeSkillIds'
       | 'injectedMemoryIds'
+      | 'injectedMemorySummaries'
       | 'skillInjectionBytes'
       | 'toolCatalogFingerprint'
       | 'toolCatalogToolCount'
@@ -460,6 +461,9 @@ export class TurnService {
               ...turn,
               ...(patch.activeSkillIds ? { activeSkillIds: [...patch.activeSkillIds] } : {}),
               ...(patch.injectedMemoryIds ? { injectedMemoryIds: [...patch.injectedMemoryIds] } : {}),
+              ...(patch.injectedMemorySummaries
+                ? { injectedMemorySummaries: [...patch.injectedMemorySummaries] }
+                : {}),
               ...(patch.skillInjectionBytes !== undefined ? { skillInjectionBytes: patch.skillInjectionBytes } : {}),
               ...(patch.toolCatalogFingerprint ? { toolCatalogFingerprint: patch.toolCatalogFingerprint } : {}),
               ...(patch.toolCatalogToolCount !== undefined ? { toolCatalogToolCount: patch.toolCatalogToolCount } : {}),

--- a/kun/src/shared/memory-preview.ts
+++ b/kun/src/shared/memory-preview.ts
@@ -1,0 +1,5 @@
+export function memoryPreview(content: string, maxLength = 200): string {
+  const compact = content.replace(/\s+/g, ' ').trim()
+  if (compact.length <= maxLength) return compact
+  return `${compact.slice(0, maxLength).trimEnd()}...`
+}

--- a/src/renderer/src/agent/kun-contract.ts
+++ b/src/renderer/src/agent/kun-contract.ts
@@ -362,6 +362,7 @@ export type CoreTurnJson = {
   attachmentIds?: string[]
   activeSkillIds?: string[]
   injectedMemoryIds?: string[]
+  injectedMemorySummaries?: Array<{ id: string; content: string }>
   skillInjectionBytes?: number
   workspaceCheckpointId?: string
   error?: string
@@ -409,6 +410,7 @@ export type CoreTurnItemJson = {
   workspaceCheckpointId?: string
   activeSkillIds?: string[]
   injectedMemoryIds?: string[]
+  injectedMemorySummaries?: Array<{ id: string; content: string }>
   skillInjectionBytes?: number
   target?: CoreReviewTargetJson
   title?: string

--- a/src/renderer/src/agent/kun-mapper.ts
+++ b/src/renderer/src/agent/kun-mapper.ts
@@ -278,6 +278,22 @@ function normalizeUserFileReferences(value: unknown): Array<{
   return references.length > 0 ? references : undefined
 }
 
+function normalizeInjectedMemorySummaries(
+  value: unknown
+): Array<{ id: string; content: string }> | undefined {
+  if (!Array.isArray(value)) return undefined
+  const summaries = value
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null
+      const raw = entry as Record<string, unknown>
+      const id = typeof raw.id === 'string' && raw.id.trim() ? raw.id.trim() : ''
+      const content = typeof raw.content === 'string' && raw.content.trim() ? raw.content.trim() : ''
+      return id && content ? { id, content } : null
+    })
+    .filter((entry): entry is { id: string; content: string } => entry !== null)
+  return summaries.length > 0 ? summaries : undefined
+}
+
 function applyRuntimeDisclosureMeta(
   meta: Record<string, unknown>,
   item: CoreTurnItemJson,
@@ -290,6 +306,7 @@ function applyRuntimeDisclosureMeta(
   const attachmentIds = stringArray(item.attachmentIds)
   const activeSkillIds = stringArray(item.activeSkillIds)
   const injectedMemoryIds = stringArray(item.injectedMemoryIds)
+  const injectedMemorySummaries = normalizeInjectedMemorySummaries(item.injectedMemorySummaries)
   const fileReferences = normalizeUserFileReferences(item.fileReferences)
   const normalizedChild = normalizeChildMetadata(child)
   const displayText = typeof item.displayText === 'string' ? item.displayText.trim() : ''
@@ -300,6 +317,7 @@ function applyRuntimeDisclosureMeta(
   if (fileReferences) meta.fileReferences = fileReferences
   if (activeSkillIds) meta.activeSkillIds = activeSkillIds
   if (injectedMemoryIds) meta.injectedMemoryIds = injectedMemoryIds
+  if (injectedMemorySummaries) meta.injectedMemorySummaries = injectedMemorySummaries
   if (typeof item.skillInjectionBytes === 'number') {
     meta.skillInjectionBytes = item.skillInjectionBytes
   }

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -217,6 +217,7 @@ export class KunRuntimeProvider implements AgentProvider {
         attachmentIds: turn.attachmentIds,
         activeSkillIds: turn.activeSkillIds,
         injectedMemoryIds: turn.injectedMemoryIds,
+        injectedMemorySummaries: turn.injectedMemorySummaries,
         skillInjectionBytes: turn.skillInjectionBytes,
         workspaceCheckpointId: item.workspaceCheckpointId ?? turn.workspaceCheckpointId
       }))

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -80,6 +80,7 @@ export type RuntimeDisclosureMetadata = {
   generatedFiles?: GeneratedFileReference[]
   activeSkillIds?: string[]
   injectedMemoryIds?: string[]
+  injectedMemorySummaries?: Array<{ id: string; content: string }>
   skillInjectionBytes?: number
   child?: RuntimeChildMetadata
   sources?: WebCitationSource[]

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -28,6 +28,7 @@ import {
   type Turn
 } from './message-timeline-turns'
 import { extractPlanMetadataFromBlock } from '../../plan/plan-tool'
+import { InjectedMemoryLookupProvider } from './injected-memory-lookup'
 import { planDisplayNameFromRelativePath } from '../../plan/plan-path'
 
 export { summarizeToolBlock } from './message-timeline-process'
@@ -255,6 +256,7 @@ export function MessageTimeline({
   }
 
   return (
+    <InjectedMemoryLookupProvider workspaceRoot={workspaceRoot}>
     <div ref={containerRef} className="ds-no-drag relative flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden">
       {visibleTurnAnchors.length > 2 ? (
         <nav
@@ -409,6 +411,7 @@ export function MessageTimeline({
         <div ref={endRef} aria-hidden className="h-px w-full shrink-0" />
       </div>
     </div>
+    </InjectedMemoryLookupProvider>
   )
 }
 

--- a/src/renderer/src/components/chat/injected-memory-lookup.test.ts
+++ b/src/renderer/src/components/chat/injected-memory-lookup.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { resolveInjectedMemoryTooltipLines } from './injected-memory-lookup'
+
+describe('resolveInjectedMemoryTooltipLines', () => {
+  it('prefers turn metadata summaries over live lookup', () => {
+    const lines = resolveInjectedMemoryTooltipLines(
+      {
+        injectedMemorySummaries: [{ id: 'mem_1', content: 'User prefers dark mode.' }]
+      },
+      ['mem_1'],
+      new Map([['mem_1', 'Stale lookup value']])
+    )
+
+    expect(lines).toEqual(['User prefers dark mode.'])
+  })
+
+  it('falls back to live lookup and numbers multiple memories', () => {
+    const lines = resolveInjectedMemoryTooltipLines(
+      undefined,
+      ['mem_1', 'mem_2'],
+      new Map([
+        ['mem_1', 'First memory'],
+        ['mem_2', 'Second memory']
+      ])
+    )
+
+    expect(lines).toEqual(['1. First memory', '2. Second memory'])
+  })
+})

--- a/src/renderer/src/components/chat/injected-memory-lookup.tsx
+++ b/src/renderer/src/components/chat/injected-memory-lookup.tsx
@@ -1,0 +1,86 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react'
+import { getProvider } from '../../agent/registry'
+import { memoryPreview } from '../../lib/memory-preview'
+
+const InjectedMemoryLookupContext = createContext<Map<string, string>>(new Map())
+
+export function InjectedMemoryLookupProvider({
+  workspaceRoot,
+  children
+}: {
+  workspaceRoot?: string
+  children: ReactNode
+}): ReactElement {
+  const [lookup, setLookup] = useState<Map<string, string>>(() => new Map())
+
+  useEffect(() => {
+    const provider = getProvider()
+    if (typeof provider.listMemories !== 'function') {
+      setLookup(new Map())
+      return
+    }
+    let cancelled = false
+    void provider
+      .listMemories({ workspace: workspaceRoot, includeDeleted: true })
+      .then((records) => {
+        if (cancelled) return
+        setLookup(new Map(records.map((record) => [record.id, memoryPreview(record.content)])))
+      })
+      .catch(() => {
+        if (!cancelled) setLookup(new Map())
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceRoot])
+
+  return (
+    <InjectedMemoryLookupContext.Provider value={lookup}>
+      {children}
+    </InjectedMemoryLookupContext.Provider>
+  )
+}
+
+export function useInjectedMemoryLookup(): Map<string, string> {
+  return useContext(InjectedMemoryLookupContext)
+}
+
+export function metaInjectedMemorySummaries(
+  meta: Record<string, unknown> | undefined
+): Array<{ id: string; content: string }> {
+  const value = meta?.injectedMemorySummaries
+  if (!Array.isArray(value)) return []
+  return value
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null
+      const raw = entry as Record<string, unknown>
+      const id = typeof raw.id === 'string' && raw.id.trim() ? raw.id.trim() : ''
+      const content = typeof raw.content === 'string' && raw.content.trim() ? raw.content.trim() : ''
+      return id && content ? { id, content } : null
+    })
+    .filter((entry): entry is { id: string; content: string } => entry !== null)
+}
+
+export function resolveInjectedMemoryTooltipLines(
+  meta: Record<string, unknown> | undefined,
+  memoryIds: string[],
+  lookup: Map<string, string>
+): string[] {
+  const summariesById = new Map(metaInjectedMemorySummaries(meta).map((entry) => [entry.id, entry.content]))
+  return memoryIds.map((id, index) => {
+    const content = summariesById.get(id) ?? lookup.get(id)
+    if (!content) return memoryIds.length > 1 ? `${index + 1}. ${id}` : id
+    return memoryIds.length > 1 ? `${index + 1}. ${content}` : content
+  })
+}
+
+export function useInjectedMemoryTooltipText(
+  meta: Record<string, unknown> | undefined,
+  memoryIds: string[]
+): string {
+  const lookup = useInjectedMemoryLookup()
+  return useMemo(
+    () => resolveInjectedMemoryTooltipLines(meta, memoryIds, lookup).join('\n\n'),
+    [lookup, memoryIds, meta]
+  )
+}

--- a/src/renderer/src/components/chat/injected-memory-meta-chip.tsx
+++ b/src/renderer/src/components/chat/injected-memory-meta-chip.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from 'react'
+import { createPortal } from 'react-dom'
+import { useCallback, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useInjectedMemoryTooltipText } from './injected-memory-lookup'
+
+type TooltipState = {
+  text: string
+  x: number
+  y: number
+}
+
+function chipTooltipPosition(clientX: number, anchorRect: DOMRect): { x: number; y: number } {
+  const maxWidth = Math.min(320, window.innerWidth - 24)
+  const x = Math.max(12, Math.min(clientX - maxWidth / 2, window.innerWidth - maxWidth - 12))
+  const y = Math.max(12, anchorRect.top - 8)
+  return { x, y }
+}
+
+export function InjectedMemoryMetaChip({
+  meta,
+  memoryIds,
+  chipClass
+}: {
+  meta?: Record<string, unknown>
+  memoryIds: string[]
+  chipClass: string
+}): ReactElement | null {
+  const { t } = useTranslation('common')
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const tooltipText = useInjectedMemoryTooltipText(meta, memoryIds)
+
+  const showTooltip = useCallback(
+    (clientX: number): void => {
+      if (!tooltipText.trim()) return
+      const anchorRect = anchorRef.current?.getBoundingClientRect()
+      if (!anchorRect) return
+      setTooltip({ text: tooltipText, ...chipTooltipPosition(clientX, anchorRect) })
+    },
+    [tooltipText]
+  )
+
+  const moveTooltip = useCallback((clientX: number): void => {
+    setTooltip((current) => {
+      if (!current) return current
+      const anchorRect = anchorRef.current?.getBoundingClientRect()
+      if (!anchorRect) return current
+      return { ...current, ...chipTooltipPosition(clientX, anchorRect) }
+    })
+  }, [])
+
+  const hideTooltip = useCallback((): void => {
+    setTooltip(null)
+  }, [])
+
+  if (memoryIds.length === 0) return null
+
+  return (
+    <>
+      <span
+        ref={anchorRef}
+        className={`${chipClass} cursor-default`}
+        onPointerEnter={(event) => showTooltip(event.clientX)}
+        onPointerMove={(event) => moveTooltip(event.clientX)}
+        onPointerLeave={hideTooltip}
+        onPointerCancel={hideTooltip}
+      >
+        {t('toolInjectedMemories')} {memoryIds.length}
+      </span>
+      {tooltip
+        ? createPortal(
+            <div
+              className="pointer-events-none fixed z-[9999] max-w-[min(20rem,calc(100vw-1.5rem))] whitespace-pre-wrap break-words rounded-lg border border-ds-border bg-ds-elevated px-2.5 py-1.5 text-[12px] font-normal leading-5 text-ds-ink shadow-[0_14px_36px_rgba(15,23,42,0.22)]"
+              style={{ left: tooltip.x, top: tooltip.y, transform: 'translateY(-100%)' }}
+            >
+              {tooltip.text}
+            </div>,
+            document.body
+          )
+        : null}
+    </>
+  )
+}

--- a/src/renderer/src/components/chat/message-timeline-bubbles.tsx
+++ b/src/renderer/src/components/chat/message-timeline-bubbles.tsx
@@ -17,6 +17,7 @@ import { ImagePreviewLightbox } from './ImagePreviewLightbox'
 import { ModelMetaTag, WritePromptMetaDisclosure } from './message-timeline-cards'
 import { readNumber, formatDuration, formatToolTitle } from './message-timeline-tools'
 import { answersByQuestionId, shouldShowQuestionHeader } from './user-input-panel-logic'
+import { InjectedMemoryMetaChip } from './injected-memory-meta-chip'
 
 const COPY_FEEDBACK_RESET_MS = 1600
 
@@ -893,9 +894,7 @@ function RuntimeMetaChips({
         </span>
       ) : null}
       {injectedMemoryIds.length > 0 ? (
-        <span className={chipClass} title={injectedMemoryIds.join(', ')}>
-          {t('toolInjectedMemories')} {injectedMemoryIds.length}
-        </span>
+        <InjectedMemoryMetaChip meta={meta} memoryIds={injectedMemoryIds} chipClass={chipClass} />
       ) : null}
       {childLabel ? (
         <span className={chipClass} title={childLabel}>

--- a/src/renderer/src/components/chat/message-timeline-process.tsx
+++ b/src/renderer/src/components/chat/message-timeline-process.tsx
@@ -28,6 +28,7 @@ import { MessageBubble } from './message-timeline-bubbles'
 import { blockHasPendingRuntimeWork, splitThink } from './message-timeline-turns'
 import { formatDuration, formatToolTitle } from './message-timeline-tools'
 import { SubagentGroup } from './SubagentCallCard'
+import { InjectedMemoryMetaChip } from './injected-memory-meta-chip'
 
 export type ProcessSection = {
   id: string
@@ -983,9 +984,7 @@ function RuntimeMetaBadges({
         </span>
       ) : null}
       {injectedMemoryIds.length > 0 ? (
-        <span className={chipClass} title={injectedMemoryIds.join(', ')}>
-          {t('toolInjectedMemories')} {injectedMemoryIds.length}
-        </span>
+        <InjectedMemoryMetaChip meta={meta} memoryIds={injectedMemoryIds} chipClass={chipClass} />
       ) : null}
       {attachmentIds.length > 0 ? (
         <span className={chipClass} title={attachmentIds.join(', ')}>

--- a/src/renderer/src/lib/memory-preview.ts
+++ b/src/renderer/src/lib/memory-preview.ts
@@ -1,0 +1,5 @@
+export function memoryPreview(content: string, maxLength = 200): string {
+  const compact = content.replace(/\s+/g, ' ').trim()
+  if (compact.length <= maxLength) return compact
+  return `${compact.slice(0, maxLength).trimEnd()}...`
+}


### PR DESCRIPTION
## Summary
- Persist injected memory previews on each turn as `injectedMemorySummaries` so historical messages retain the context that was applied.
- Show a hover tooltip on the timeline "记忆 N" chip with the memory summary in user bubbles, tool bubbles, and process rows.
- Fall back to live memory lookup for older turns that only stored memory IDs.

## Changes
- Runtime: store memory preview text when the agent loop injects memories into a turn.
- Renderer: add `InjectedMemoryMetaChip` tooltip UI and lookup provider in `MessageTimeline`.
- Mapper/runtime contracts: propagate summaries into block metadata for disclosure chips.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build:kun`
- [x] `npm run test -- src/renderer/src/components/chat/injected-memory-lookup.test.ts`
- [ ] Hover the "记忆 1" chip on a user message and confirm the summary tooltip appears
- [ ] Send a new message with injected memories and verify the tooltip matches the injected content
- [ ] Open an older thread without stored summaries and confirm lookup fallback still shows content when the memory exists


Made with [Cursor](https://cursor.com)