### PR TITLE
fix(ui): remove left border and dim thinking process text

### DIFF
--- a/src/renderer/src/components/chat/message-timeline-process.tsx
+++ b/src/renderer/src/components/chat/message-timeline-process.tsx
@@ -312,12 +312,12 @@ export function ProcessSectionRow({
       {expanded ? (
         <div
           ref={deferredDetailRef}
-          className="mt-1 border-l-2 border-ds-border-muted/35 pl-3"
+          className="mt-1"
           style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 220px' }}
         >
           {shouldRenderDetail ? (
             section.kind === 'reasoning' ? (
-            <div className="ds-markdown text-[13.5px] leading-6 text-ds-muted">
+            <div className="ds-markdown text-[13.5px] leading-6 text-ds-faint">
               <AssistantMarkdown text={reasoningText} streaming={active && processing} />
             </div>
           ) : (


### PR DESCRIPTION
## Summary

Remove the left border line from thinking process and tool call sections, and make the thinking process text darker to match tool calls.

## Changes

- Remove `border-l-2`, `border-ds-border-muted/35`, and `pl-3` from the thinking process expanded section container
- Change thinking process text color from `text-ds-muted` to `text-ds-faint` (darker) to match tool call styling

## Visual Impact

- Thinking process and tool calls no longer have a left white border line
- Thinking process text is now displayed in a darker color, consistent with tool calls

## Testing

- Verified UI rendering of thinking process sections
- Confirmed tool call sections remain unaffected
- Checked that text colors are consistent across both components
