### PR TITLE
fix: cross-turn edits (#640) + MCP-disconnect runtime stability (#639)

### DIFF
--- a/kun/src/adapters/tool/mcp-tool-provider.ts
+++ b/kun/src/adapters/tool/mcp-tool-provider.ts
@@ -459,6 +459,16 @@ function workspaceMatchesRoots(workspace: string, roots: readonly string[]): boo
 
 async function createSdkMcpClient(serverId: string, server: McpServerConfig): Promise<McpClientLike> {
   const client = new Client({ name: `kun-${serverId}`, version: '0.1.0' })
+  // Observe transport-level failures explicitly. The SDK routes a dropped SSE
+  // stream and exhausted background reconnects to `onerror`; with no handler
+  // they are silently swallowed, which hides real outages from the logs and (on
+  // some SDK/runtime versions) lets the rejection escape as unhandled. Handling
+  // it here keeps a streamable-http disconnect from destabilizing the runtime
+  // (#639) — the per-call reconnect in callMcpToolWithReconnect still recovers
+  // the connection on the next tool use.
+  client.onerror = (error) => {
+    process.stderr.write(`kun mcp[${serverId}]: transport error: ${redactSecretText(errorMessage(error))}\n`)
+  }
   const transport = createTransport(server)
   await client.connect(transport, { timeout: server.timeoutMs })
   return {

--- a/kun/src/adapters/tool/read-tracker.test.ts
+++ b/kun/src/adapters/tool/read-tracker.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { ReadTracker, normalizeReadTrackerOptions } from './read-tracker.js'
+import type { ToolHostContext, ToolCallLike } from '../../ports/tool-host.js'
+
+function context(turnId: string, overrides: Partial<ToolHostContext> = {}): ToolHostContext {
+  return {
+    threadId: 'thread_1',
+    turnId,
+    workspace: '/ws',
+    approvalPolicy: 'never',
+    abortSignal: new AbortController().signal,
+    awaitApproval: async () => 'allow' as const,
+    ...overrides
+  }
+}
+
+function readResult(turnId: string, path: string, content: string): {
+  context: ToolHostContext
+  call: ToolCallLike
+  output: unknown
+} {
+  return {
+    context: context(turnId),
+    call: { callId: `read_${turnId}`, toolName: 'read', arguments: { path } },
+    output: { path, relative_path: path, content, truncated: false }
+  }
+}
+
+function editCall(path: string, oldText: string): ToolCallLike {
+  return { callId: 'edit_1', toolName: 'edit', arguments: { path, oldText, newText: 'x' } }
+}
+
+describe('ReadTracker cross-turn edits (#640)', () => {
+  it('allows an edit in a later turn when the oldText is still present in the cached read', () => {
+    const tracker = new ReadTracker(normalizeReadTrackerOptions(true))
+    tracker.observeToolResult(readResult('turn_a', 'file.ts', 'const value = 42\n'))
+
+    // Edit arrives in a *different* turn than the read — the common case the
+    // turnId guard used to reject, forcing a fallback to sed/bash.
+    const verdict = tracker.validateBeforeTool({
+      context: context('turn_b'),
+      call: editCall('file.ts', 'const value = 42')
+    })
+
+    expect(verdict).toEqual({ ok: true })
+  })
+
+  it('still blocks an edit for a file that was never read', () => {
+    const tracker = new ReadTracker(normalizeReadTrackerOptions(true))
+    const verdict = tracker.validateBeforeTool({
+      context: context('turn_b'),
+      call: editCall('file.ts', 'const value = 42')
+    })
+
+    expect(verdict.ok).toBe(false)
+    if (!verdict.ok) expect(verdict.message).toContain('Read the current file contents')
+  })
+
+  it('still blocks a cross-turn edit when the oldText is not in the cached read', () => {
+    const tracker = new ReadTracker(normalizeReadTrackerOptions(true))
+    tracker.observeToolResult(readResult('turn_a', 'file.ts', 'const value = 42\n'))
+
+    const verdict = tracker.validateBeforeTool({
+      context: context('turn_b'),
+      call: editCall('file.ts', 'const other = 99')
+    })
+
+    expect(verdict.ok).toBe(false)
+    if (!verdict.ok) expect(verdict.message).toContain('was not present in the latest read output')
+  })
+
+  it('allows a cross-turn multi-edit when every oldText fragment is present', () => {
+    const tracker = new ReadTracker(normalizeReadTrackerOptions(true))
+    tracker.observeToolResult(readResult('turn_a', 'file.ts', 'alpha\nbeta\ngamma\n'))
+
+    const verdict = tracker.validateBeforeTool({
+      context: context('turn_b'),
+      call: {
+        callId: 'edit_2',
+        toolName: 'edit',
+        arguments: { path: 'file.ts', edits: [{ oldText: 'alpha' }, { oldText: 'gamma' }] }
+      }
+    })
+
+    expect(verdict).toEqual({ ok: true })
+  })
+
+  it('allows a cross-turn edit on a prior read when content checking is disabled', () => {
+    const tracker = new ReadTracker(normalizeReadTrackerOptions({ enabled: true, requireOldTextInRead: false }))
+    tracker.observeToolResult(readResult('turn_a', 'file.ts', 'const value = 42\n'))
+
+    const verdict = tracker.validateBeforeTool({
+      context: context('turn_b'),
+      call: editCall('file.ts', 'anything at all')
+    })
+
+    expect(verdict).toEqual({ ok: true })
+  })
+})

--- a/kun/src/adapters/tool/read-tracker.ts
+++ b/kun/src/adapters/tool/read-tracker.ts
@@ -57,14 +57,14 @@ export class ReadTracker {
           'Read the current file contents in this turn before editing so SEARCH text is based on fresh bytes.'
       }
     }
-    if (record.turnId !== input.context.turnId) {
-      return {
-        ok: false,
-        message:
-          `read-before-edit guard blocked edit for ${displayPath(rawPath, input.context.workspace)}. ` +
-          'The previous read is from an earlier turn; read the file again before editing.'
-      }
-    }
+    // A read from an earlier turn still counts: agent responses routinely span
+    // multiple turns (a long reply, or tool results arriving as separate turn
+    // items), so read-in-turn-A then edit-in-turn-B is a legitimate sequence.
+    // Hard-blocking it forced a fallback to sed/bash, which mangles code (#640).
+    // Freshness is still enforced below — `requireOldTextInRead` checks the
+    // oldText fragments against the cached read content, and the edit's own
+    // fuzzy matching runs against the current bytes on disk, so a stale SEARCH
+    // string fails there with a clear error instead of corrupting the file.
     if (!this.options.requireOldTextInRead) return { ok: true }
     const missing = oldTextFragments(input.call.arguments).filter((fragment) => {
       if (!fragment.trim()) return false

--- a/kun/src/cli/serve-crash-handlers.test.ts
+++ b/kun/src/cli/serve-crash-handlers.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import process from 'node:process'
+import { installServeCrashHandlers } from './serve-crash-handlers.js'
+
+type Listener = (...args: unknown[]) => void
+
+/**
+ * installServeCrashHandlers registers process-wide listeners. Snapshot the
+ * existing ones so we can invoke (and later remove) only the pair this call
+ * added, without disturbing vitest's own handlers.
+ */
+function install(getHandle: () => null = () => null): {
+  unhandled: Listener[]
+  uncaught: Listener[]
+  cleanup: () => void
+} {
+  const beforeRejection = new Set(process.listeners('unhandledRejection'))
+  const beforeException = new Set(process.listeners('uncaughtException'))
+  installServeCrashHandlers(getHandle)
+  const unhandled = process
+    .listeners('unhandledRejection')
+    .filter((l) => !beforeRejection.has(l)) as unknown as Listener[]
+  const uncaught = process
+    .listeners('uncaughtException')
+    .filter((l) => !beforeException.has(l)) as unknown as Listener[]
+  return {
+    unhandled,
+    uncaught,
+    cleanup: () => {
+      for (const l of unhandled) process.removeListener('unhandledRejection', l as never)
+      for (const l of uncaught) process.removeListener('uncaughtException', l as never)
+    }
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('serve crash handlers (#639)', () => {
+  it('keeps the runtime alive on an unhandledRejection (e.g. an MCP transport drop)', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const writes: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk))
+      return true
+    }) as never)
+
+    const handlers = install()
+    try {
+      expect(handlers.unhandled).toHaveLength(1)
+      handlers.unhandled[0](new Error('SSE stream disconnected: socket hang up'))
+
+      expect(exitSpy).not.toHaveBeenCalled()
+      expect(writes.join('')).toContain('unhandledRejection (non-fatal, runtime stays up)')
+      expect(writes.join('')).toContain('socket hang up')
+    } finally {
+      handlers.cleanup()
+    }
+  })
+
+  it('still exits non-zero on an uncaughtException so the supervisor restarts a clean process', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    vi.spyOn(process.stderr, 'write').mockImplementation((() => true) as never)
+
+    const handlers = install()
+    try {
+      expect(handlers.uncaught).toHaveLength(1)
+      handlers.uncaught[0](new Error('boom'))
+
+      // ServeExitCode.runtime === 70
+      expect(exitSpy).toHaveBeenCalledWith(70)
+    } finally {
+      handlers.cleanup()
+    }
+  })
+})

--- a/kun/src/cli/serve-crash-handlers.ts
+++ b/kun/src/cli/serve-crash-handlers.ts
@@ -1,0 +1,45 @@
+import process from 'node:process'
+import { ServeExitCode } from './serve.js'
+import type { KunServeHandle } from '../server/runtime-factory.js'
+
+/**
+ * Serve mode runs unattended under the GUI. The two failure modes are
+ * deliberately handled differently:
+ *
+ * - `uncaughtException` left the stack unwound mid-operation, so the process
+ *   state is genuinely unsafe. Report it on stderr (the GUI captures the tail),
+ *   attempt a bounded graceful close, then exit non-zero so the GUI supervisor
+ *   can restart a fresh process.
+ * - `unhandledRejection` does NOT corrupt the process — Node keeps running. A
+ *   stray background rejection (e.g. a streamable-http MCP server dropping its
+ *   connection while a reconnect promise is in flight) is fully recoverable, so
+ *   tearing the whole runtime down and blanking the GUI for it is the wrong
+ *   trade (#639). Log it for the stderr tail and stay up; the MCP layer already
+ *   reports the server unavailable and reconnects on the next request.
+ */
+export function installServeCrashHandlers(getHandle: () => KunServeHandle | null): void {
+  let crashing = false
+  const crash = (kind: string, error: unknown): void => {
+    if (crashing) return
+    crashing = true
+    const detail = error instanceof Error ? (error.stack ?? error.message) : String(error)
+    process.stderr.write(`kun serve: ${kind}: ${detail}\n`)
+    const finish = (): void => process.exit(ServeExitCode.runtime)
+    const handle = getHandle()
+    if (!handle) {
+      finish()
+      return
+    }
+    const deadline = setTimeout(finish, 3000)
+    deadline.unref()
+    void handle
+      .close()
+      .catch(() => undefined)
+      .finally(finish)
+  }
+  process.on('uncaughtException', (error) => crash('uncaughtException', error))
+  process.on('unhandledRejection', (reason) => {
+    const detail = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason)
+    process.stderr.write(`kun serve: unhandledRejection (non-fatal, runtime stays up): ${detail}\n`)
+  })
+}

--- a/kun/src/cli/serve-entry.ts
+++ b/kun/src/cli/serve-entry.ts
@@ -11,38 +11,9 @@ import {
   resolveEventLoopStallThresholdMs,
   startEventLoopMonitor
 } from '../server/event-loop-monitor.js'
+import { installServeCrashHandlers } from './serve-crash-handlers.js'
 
 export const KUN_READY_PREFIX = 'KUN_READY '
-
-/**
- * Serve mode runs unattended under the GUI. An uncaught error must not
- * leave a half-dead process: report it on stderr (the GUI captures the
- * tail), attempt a bounded graceful close, then exit non-zero so the
- * GUI supervisor can restart us.
- */
-function installServeCrashHandlers(getHandle: () => KunServeHandle | null): void {
-  let crashing = false
-  const crash = (kind: string, error: unknown): void => {
-    if (crashing) return
-    crashing = true
-    const detail = error instanceof Error ? (error.stack ?? error.message) : String(error)
-    process.stderr.write(`kun serve: ${kind}: ${detail}\n`)
-    const finish = (): void => process.exit(ServeExitCode.runtime)
-    const handle = getHandle()
-    if (!handle) {
-      finish()
-      return
-    }
-    const deadline = setTimeout(finish, 3000)
-    deadline.unref()
-    void handle
-      .close()
-      .catch(() => undefined)
-      .finally(finish)
-  }
-  process.on('uncaughtException', (error) => crash('uncaughtException', error))
-  process.on('unhandledRejection', (reason) => crash('unhandledRejection', reason))
-}
 
 /**
  * Serve-mode command. Kept separate from the dispatcher so GUI startup


### PR DESCRIPTION
Fixes two runtime bugs reported against the official release. Both changes are scoped to `kun/`.

## #640 — ReadTracker blocked legitimate cross-turn edits
`read-tracker.ts` rejected an `edit` whenever the preceding `read` happened in an **earlier turn**. Agent responses routinely span multiple turns (long replies, or tool results arriving as separate turn items), so `read` in turn A → `edit` in turn B is a normal sequence. The guard forced a fallback to `bash`/`sed`, which corrupts whitespace/indentation in code.

**Fix:** remove the `turnId` guard. Freshness is still enforced two ways:
- `requireOldTextInRead` (on by default) checks every `oldText` fragment against the cached read content, so hallucinated SEARCH text is still rejected.
- the edit's own fuzzy matching runs against the **current bytes on disk**, so a stale SEARCH string fails there with a clear error instead of silently corrupting the file.

## #639 — streamable-http MCP disconnect restarted the runtime / blanked the GUI
When a streamable-http MCP server dropped unexpectedly (e.g. network cable unplugged), the runtime process exited and the GUI supervisor restarted it (blank window).

Root cause: serve mode treated **every** `unhandledRejection` as fatal (`process.exit`), via `installServeCrashHandlers`. A stray background rejection from MCP transport churn (dropped SSE stream / reconnect) took the whole runtime down — even though an unhandled rejection does **not** corrupt the Node process.

**Fix:**
- Split the serve crash handlers. `uncaughtException` keeps the old behavior (bounded graceful close + non-zero exit — the process state is genuinely unsafe). `unhandledRejection` is now **logged and non-fatal**; the runtime stays up. Extracted into `serve-crash-handlers.ts` so it is unit-testable without triggering `serve-entry`'s top-level `main()`.
- Attach an `onerror` handler when creating the SDK MCP client so a dropped SSE stream / exhausted reconnects are logged (and surfaced as unavailable) instead of silently swallowed or escaping as unhandled.

The existing per-call reconnect in `callMcpToolWithReconnect` already recovers the connection on the next tool use, so a disconnected server reconnects on the next request.

## Tests / verification
- New `read-tracker.test.ts` (5 cases): cross-turn edit allowed when `oldText` matches; still blocked with no prior read; still blocked when `oldText` missing; multi-edit; content-check-disabled path.
- New `serve-crash-handlers.test.ts` (2 cases): `unhandledRejection` does not exit; `uncaughtException` still exits non-zero.
- `tsc --noEmit` clean, `eslint` clean on changed files.
- Full kun suite: 949 passing; the 3 remaining failures (`builtin-tools`, `memory-store`) are pre-existing on `develop` — verified by re-running them with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)