### PR TITLE
fix(mcp): harden runtime reconnect lifecycle

### DIFF
--- a/kun/src/adapters/tool/mcp-tool-provider.test.ts
+++ b/kun/src/adapters/tool/mcp-tool-provider.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest'
+import { McpCapabilityConfig, type McpServerConfig } from '../../contracts/capabilities.js'
+import type { ToolHostContext } from '../../ports/tool-host.js'
+import {
+  buildMcpToolProviders,
+  type McpClientLifecycleHandlers,
+  type McpClientLike,
+  type McpToolDescriptor
+} from './mcp-tool-provider.js'
+
+class MockMcpClient implements McpClientLike {
+  lifecycle: McpClientLifecycleHandlers = {}
+  close = vi.fn(async () => undefined)
+
+  constructor(
+    private readonly tools: McpToolDescriptor[],
+    readonly callTool: McpClientLike['callTool']
+  ) {}
+
+  async listTools(): Promise<{ tools: McpToolDescriptor[] }> {
+    return { tools: this.tools }
+  }
+
+  setLifecycleHandlers(handlers: McpClientLifecycleHandlers): void {
+    this.lifecycle = handlers
+  }
+}
+
+const server: McpServerConfig = {
+  enabled: true,
+  transport: 'streamable-http',
+  url: 'http://127.0.0.1:39999/mcp',
+  headers: {},
+  args: [],
+  env: {},
+  workspaceRoots: [],
+  trustScope: 'user',
+  trustedWorkspaceRoots: [],
+  timeoutMs: 1_000
+}
+
+const config = McpCapabilityConfig.parse({
+  enabled: true,
+  servers: { docs: server },
+  search: { enabled: false }
+})
+
+const context: ToolHostContext = {
+  threadId: 'thread_test',
+  turnId: 'turn_test',
+  workspace: '/workspace',
+  approvalPolicy: 'auto',
+  abortSignal: new AbortController().signal,
+  awaitApproval: vi.fn()
+}
+
+const descriptor: McpToolDescriptor = {
+  name: 'lookup',
+  description: 'Lookup docs',
+  inputSchema: { type: 'object', properties: {} },
+  annotations: { readOnlyHint: true }
+}
+
+describe('mcp tool provider reliability', () => {
+  it('shares one reconnect across concurrent tool calls after a transport failure', async () => {
+    const first = new MockMcpClient([descriptor], vi.fn(async () => {
+      throw new Error('socket connection reset')
+    }))
+    const second = new MockMcpClient([descriptor], vi.fn(async () => ({ ok: true })))
+    const clientFactory = vi.fn()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+
+    const built = await buildMcpToolProviders(config, {
+      clientFactory,
+      nowIso: () => '2026-06-29T00:00:00.000Z'
+    })
+    const tool = built.providers[0]?.tools[0]
+    expect(tool?.name).toBe('mcp_docs_lookup')
+
+    const [one, two] = await Promise.all([
+      tool!.execute({}, context),
+      tool!.execute({}, context)
+    ])
+
+    expect(clientFactory).toHaveBeenCalledTimes(2)
+    expect(first.close).toHaveBeenCalledTimes(1)
+    expect(second.callTool).toHaveBeenCalledTimes(2)
+    expect(one).toMatchObject({ output: { result: { ok: true } } })
+    expect(two).toMatchObject({ output: { result: { ok: true } } })
+    expect(built.diagnostics[0]).toMatchObject({
+      id: 'docs',
+      status: 'connected',
+      available: true,
+      reconnectAttempts: 1
+    })
+  })
+
+  it('marks lifecycle transport close as offline and reconnects on the next call', async () => {
+    const first = new MockMcpClient([descriptor], vi.fn(async () => ({ stale: true })))
+    const second = new MockMcpClient([descriptor], vi.fn(async () => ({ fresh: true })))
+    const clientFactory = vi.fn()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+
+    const built = await buildMcpToolProviders(config, { clientFactory })
+    first.lifecycle.onClose?.()
+    expect(built.diagnostics[0]).toMatchObject({
+      status: 'error',
+      available: false,
+      lastError: 'MCP transport closed'
+    })
+
+    const tool = built.providers[0]!.tools[0]!
+    const result = await tool.execute({}, context)
+
+    expect(result).toMatchObject({ output: { result: { fresh: true } } })
+    expect(clientFactory).toHaveBeenCalledTimes(2)
+    expect(built.diagnostics[0]).toMatchObject({
+      status: 'connected',
+      available: true,
+      reconnectAttempts: 1
+    })
+  })
+
+  it('does not mark deterministic tool errors as offline', async () => {
+    const client = new MockMcpClient([descriptor], vi.fn(async () => {
+      throw new Error('Invalid arguments: query is required')
+    }))
+    const built = await buildMcpToolProviders(config, {
+      clientFactory: vi.fn(async () => client)
+    })
+    const tool = built.providers[0]!.tools[0]!
+
+    await expect(tool.execute({}, context)).rejects.toThrow('Invalid arguments')
+
+    expect(built.diagnostics[0]).toMatchObject({
+      status: 'connected',
+      available: true,
+      lastError: 'Invalid arguments: query is required'
+    })
+  })
+})

--- a/kun/src/adapters/tool/mcp-tool-provider.ts
+++ b/kun/src/adapters/tool/mcp-tool-provider.ts
@@ -50,6 +50,12 @@ export type McpClientLike = {
     options?: { signal?: AbortSignal; timeout?: number }
   ): Promise<unknown>
   close(): Promise<void>
+  setLifecycleHandlers?(handlers: McpClientLifecycleHandlers): void
+}
+
+export type McpClientLifecycleHandlers = {
+  onError?: (error: Error) => void
+  onClose?: () => void
 }
 
 export type McpServerDiagnostic = {
@@ -58,11 +64,15 @@ export type McpServerDiagnostic = {
   transport: McpServerConfig['transport']
   trustScope: McpServerConfig['trustScope']
   available: boolean
-  status: 'disabled' | 'connected' | 'error'
+  status: 'disabled' | 'connected' | 'reconnecting' | 'error'
   toolCount: number
   catalogFingerprint?: string
   catalogDrift?: boolean
   lastConnectedAt?: string
+  lastDisconnectedAt?: string
+  lastReconnectAt?: string
+  nextReconnectAt?: string
+  reconnectAttempts?: number
   lastError?: string
 }
 
@@ -131,7 +141,16 @@ type McpConnectionState = {
   catalogFingerprint?: string
   catalogDrift?: boolean
   lastConnectedAt?: string
+  lastDisconnectedAt?: string
+  lastReconnectAt?: string
+  nextReconnectAt?: string
+  reconnectAttempts: number
+  reconnectBackoffMs: number
+  reconnectPromise?: Promise<McpClientLike>
   lastError?: string
+  status: 'connected' | 'reconnecting' | 'error'
+  diagnostic?: McpServerDiagnostic
+  intentionallyClosing?: boolean
 }
 
 export async function buildMcpToolProviders(
@@ -199,8 +218,12 @@ export async function buildMcpToolProviders(
           client,
           clientFactory,
           nowIso,
+          reconnectAttempts: 0,
+          reconnectBackoffMs: DEFAULT_MCP_RECONNECT_BASE_DELAY_MS,
+          status: 'connected',
           lastConnectedAt: nowIso()
         }
+        attachMcpClientLifecycle(state)
         const listed = await refreshMcpConnectionCatalog(state)
         return { state, listed }
       })()
@@ -240,7 +263,7 @@ export async function buildMcpToolProviders(
       available: true,
       tools
     })
-    diagnostics.push(serverDiagnostic(state, 'connected', tools.length))
+    diagnostics.push(syncMcpDiagnostic(state, 'connected', tools.length))
   }
 
   const connectedServers = diagnostics.filter((diagnostic) => diagnostic.status === 'connected').length
@@ -317,7 +340,7 @@ export async function buildMcpToolProviders(
     },
     close: async () => {
       reconnectAborted = true
-      await Promise.all(connected.map((state) => state.client.close().catch(() => undefined)))
+      await Promise.all(connected.map((state) => closeMcpClient(state)))
     }
   }
 }
@@ -366,6 +389,7 @@ async function reconnectFailedMcpServer(
 ): Promise<void> {
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     if (params.isAborted()) return
+    updateFailedServerDiagnostic(params.diagnostics, failed, 'reconnecting', attempt)
     await params.delay(Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1)))
     if (params.isAborted()) return
     try {
@@ -376,17 +400,27 @@ async function reconnectFailedMcpServer(
         client,
         clientFactory: params.clientFactory,
         nowIso: params.nowIso,
+        reconnectAttempts: 0,
+        reconnectBackoffMs: DEFAULT_MCP_RECONNECT_BASE_DELAY_MS,
+        status: 'connected',
         lastConnectedAt: params.nowIso()
       }
+      attachMcpClientLifecycle(state)
       const listed = await refreshMcpConnectionCatalog(state)
       if (params.isAborted()) {
-        await client.close().catch(() => undefined)
+        await closeMcpClient(state)
         return
       }
       registerLateMcpConnection(params, state, listed)
       return
-    } catch {
-      // Leave the diagnostic as "error" and try again until attempts run out.
+    } catch (error) {
+      updateFailedServerDiagnostic(
+        params.diagnostics,
+        failed,
+        'error',
+        attempt,
+        formatMcpConnectionError(error, failed.server)
+      )
     }
   }
 }
@@ -416,10 +450,31 @@ function registerLateMcpConnection(
       // flips to connected below so the UI stops showing the server as failed.
     }
   }
-  const diagnostic = serverDiagnostic(state, 'connected', tools.length)
+  const diagnostic = syncMcpDiagnostic(state, 'connected', tools.length)
   const index = params.diagnostics.findIndex((entry) => entry.id === state.serverId)
   if (index >= 0) params.diagnostics[index] = diagnostic
   else params.diagnostics.push(diagnostic)
+}
+
+function updateFailedServerDiagnostic(
+  diagnostics: McpServerDiagnostic[],
+  failed: FailedMcpServer,
+  status: Extract<McpServerDiagnostic['status'], 'reconnecting' | 'error'>,
+  attempt: number,
+  lastError?: string
+): void {
+  const index = diagnostics.findIndex((entry) => entry.id === failed.serverId)
+  const previous = index >= 0 ? diagnostics[index] : undefined
+  const next: McpServerDiagnostic = {
+    ...(previous ?? serverDiagnostic({ serverId: failed.serverId, server: failed.server }, 'error', 0)),
+    status,
+    available: false,
+    reconnectAttempts: attempt,
+    lastReconnectAt: new Date().toISOString(),
+    ...(lastError ? { lastError: redactSecretText(lastError) } : {})
+  }
+  if (index >= 0) diagnostics[index] = next
+  else diagnostics.push(next)
 }
 
 function defaultMcpReconnectDelay(ms: number): Promise<void> {
@@ -470,7 +525,11 @@ async function createSdkMcpClient(serverId: string, server: McpServerConfig): Pr
       })
     },
     callTool: (input, options) => client.callTool(input, undefined, options),
-    close: () => client.close()
+    close: () => client.close(),
+    setLifecycleHandlers: (handlers) => {
+      client.onerror = handlers.onError
+      client.onclose = handlers.onClose
+    }
   }
 }
 
@@ -539,6 +598,17 @@ function createMcpLocalTool(
           isError: true
         }
       }
+      if (state.status === 'error' && !canAttemptMcpReconnect(state)) {
+        return {
+          output: {
+            error: mcpReconnectCooldownMessage(state),
+            serverId: state.serverId,
+            status: state.status,
+            nextReconnectAt: state.nextReconnectAt
+          },
+          isError: true
+        }
+      }
       const result = await callMcpToolWithReconnect(
         state,
         { name: descriptor.name, arguments: args },
@@ -591,6 +661,7 @@ async function refreshMcpConnectionCatalog(state: McpConnectionState): Promise<M
   state.catalogDrift = Boolean(state.catalogFingerprint && state.catalogFingerprint !== nextFingerprint)
   state.catalogFingerprint = nextFingerprint
   state.lastError = undefined
+  syncMcpDiagnostic(state, state.status, listed.length)
   return listed
 }
 
@@ -601,16 +672,21 @@ async function callMcpToolWithReconnect(
   timeout = state.server.timeoutMs
 ): Promise<unknown> {
   try {
+    await ensureMcpConnectionForCall(state, signal)
     return await state.client.callTool(input, { signal, timeout })
   } catch (error) {
-    state.lastError = redactSecretText(errorMessage(error))
     if (signal?.aborted) throw error
     // Deterministic server-side failures (validation errors, bad
     // arguments) come back identically on a fresh connection; tearing
     // down a healthy session for them just loses server state. Only
     // transport-looking failures earn a reconnect + retry.
-    if (!looksLikeMcpTransportError(error)) throw error
-    const client = await reconnectMcpConnection(state)
+    if (!looksLikeMcpTransportError(error)) {
+      state.lastError = redactSecretText(errorMessage(error))
+      syncMcpDiagnostic(state)
+      throw error
+    }
+    markMcpConnectionError(state, error)
+    const client = await reconnectMcpConnection(state, signal)
     return client.callTool(input, { signal, timeout })
   }
 }
@@ -657,13 +733,110 @@ async function raceStartupTimeout<T extends { state: McpConnectionState }>(
   }
 }
 
-async function reconnectMcpConnection(state: McpConnectionState): Promise<McpClientLike> {
-  await state.client.close().catch(() => undefined)
+async function ensureMcpConnectionForCall(
+  state: McpConnectionState,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  if (state.status === 'connected') return
+  await reconnectMcpConnection(state, signal)
+}
+
+async function reconnectMcpConnection(
+  state: McpConnectionState,
+  signal?: AbortSignal
+): Promise<McpClientLike> {
+  if (state.reconnectPromise) return state.reconnectPromise
+  if (!canAttemptMcpReconnect(state)) {
+    throw new Error(mcpReconnectCooldownMessage(state))
+  }
+  state.status = 'reconnecting'
+  state.reconnectAttempts += 1
+  state.lastReconnectAt = state.nowIso()
+  syncMcpDiagnostic(state, 'reconnecting')
+  state.reconnectPromise = reconnectMcpConnectionOnce(state, signal)
+    .catch((error) => {
+      markMcpReconnectFailed(state, error)
+      throw error
+    })
+    .finally(() => {
+      state.reconnectPromise = undefined
+    })
+  return state.reconnectPromise
+}
+
+async function reconnectMcpConnectionOnce(
+  state: McpConnectionState,
+  signal?: AbortSignal
+): Promise<McpClientLike> {
+  if (signal?.aborted) throw new Error('MCP reconnect aborted')
+  await closeMcpClient(state)
+  if (signal?.aborted) throw new Error('MCP reconnect aborted')
   const client = await state.clientFactory(state.serverId, state.server)
   state.client = client
+  state.status = 'connected'
   state.lastConnectedAt = state.nowIso()
   state.lastError = undefined
+  state.nextReconnectAt = undefined
+  state.reconnectBackoffMs = DEFAULT_MCP_RECONNECT_BASE_DELAY_MS
+  attachMcpClientLifecycle(state)
+  await refreshMcpConnectionCatalog(state)
+  syncMcpDiagnostic(state, 'connected')
   return client
+}
+
+async function closeMcpClient(state: McpConnectionState): Promise<void> {
+  state.intentionallyClosing = true
+  try {
+    await state.client.close().catch(() => undefined)
+  } finally {
+    state.intentionallyClosing = false
+  }
+}
+
+function attachMcpClientLifecycle(state: McpConnectionState): void {
+  state.client.setLifecycleHandlers?.({
+    onError: (error) => {
+      if (looksLikeMcpTransportError(error)) {
+        markMcpConnectionError(state, error)
+      } else {
+        state.lastError = redactSecretText(errorMessage(error))
+        syncMcpDiagnostic(state)
+      }
+    },
+    onClose: () => {
+      if (state.intentionallyClosing) return
+      markMcpConnectionError(state, new Error('MCP transport closed'))
+    }
+  })
+}
+
+function markMcpConnectionError(state: McpConnectionState, error: unknown): void {
+  if (state.intentionallyClosing) return
+  state.status = 'error'
+  state.lastError = redactSecretText(errorMessage(error))
+  state.lastDisconnectedAt = state.nowIso()
+  syncMcpDiagnostic(state, 'error')
+}
+
+function markMcpReconnectFailed(state: McpConnectionState, error: unknown): void {
+  state.status = 'error'
+  state.lastError = redactSecretText(errorMessage(error))
+  state.lastDisconnectedAt = state.nowIso()
+  const nextDelay = state.reconnectBackoffMs
+  state.reconnectBackoffMs = Math.min(DEFAULT_MCP_RECONNECT_MAX_DELAY_MS, nextDelay * 2)
+  state.nextReconnectAt = new Date(Date.now() + nextDelay).toISOString()
+  syncMcpDiagnostic(state, 'error')
+}
+
+function canAttemptMcpReconnect(state: McpConnectionState): boolean {
+  if (!state.nextReconnectAt) return true
+  return Date.now() >= Date.parse(state.nextReconnectAt)
+}
+
+function mcpReconnectCooldownMessage(state: McpConnectionState): string {
+  return state.nextReconnectAt
+    ? `MCP server ${state.serverId} is offline; reconnect is cooling down until ${state.nextReconnectAt}. Last error: ${state.lastError ?? 'unknown error'}`
+    : `MCP server ${state.serverId} is offline. Last error: ${state.lastError ?? 'unknown error'}`
 }
 
 function shouldUseMcpSearch(config: NonNullable<McpCapabilityConfig['search']>, toolCount: number): boolean {
@@ -699,6 +872,39 @@ function serverDiagnostic(
     ...(state.lastConnectedAt ? { lastConnectedAt: state.lastConnectedAt } : {}),
     ...(lastError ? { lastError: redactSecretText(lastError) } : {})
   }
+}
+
+function syncMcpDiagnostic(
+  state: McpConnectionState,
+  status: McpServerDiagnostic['status'] = state.status,
+  toolCount = state.diagnostic?.toolCount ?? 0
+): McpServerDiagnostic {
+  const diagnostic: McpServerDiagnostic = {
+    id: state.serverId,
+    enabled: state.server.enabled,
+    transport: state.server.transport,
+    trustScope: state.server.trustScope,
+    available: status === 'connected',
+    status,
+    toolCount,
+    ...(state.catalogFingerprint ? { catalogFingerprint: state.catalogFingerprint } : {}),
+    ...(state.catalogDrift !== undefined ? { catalogDrift: state.catalogDrift } : {}),
+    ...(state.lastConnectedAt ? { lastConnectedAt: state.lastConnectedAt } : {}),
+    ...(state.lastDisconnectedAt ? { lastDisconnectedAt: state.lastDisconnectedAt } : {}),
+    ...(state.lastReconnectAt ? { lastReconnectAt: state.lastReconnectAt } : {}),
+    ...(state.nextReconnectAt ? { nextReconnectAt: state.nextReconnectAt } : {}),
+    ...(state.reconnectAttempts > 0 ? { reconnectAttempts: state.reconnectAttempts } : {}),
+    ...(state.lastError ? { lastError: redactSecretText(state.lastError) } : {})
+  }
+  if (!state.diagnostic) {
+    state.diagnostic = diagnostic
+    return diagnostic
+  }
+  for (const key of Object.keys(state.diagnostic) as Array<keyof McpServerDiagnostic>) {
+    delete (state.diagnostic as Record<string, unknown>)[key]
+  }
+  Object.assign(state.diagnostic, diagnostic)
+  return state.diagnostic
 }
 
 function catalogFingerprint(values: readonly string[]): string {


### PR DESCRIPTION
﻿## Summary
- Harden MCP client lifecycle handling so transport `onerror` / `onclose` updates live diagnostics instead of staying invisible until the next tool failure.
- Add per-server reconnect single-flight so concurrent tool calls share one reconnect instead of spawning duplicate MCP clients after a disconnect.
- Preserve deterministic tool errors as connected server errors, while transport-like failures move the server through `error` / `reconnecting` / `connected` with backoff metadata.

## Why
MCP disconnects should be a local tool-server health problem, not a reason for the Kun runtime or GUI to flap. This complements the existing startup background reconnect and avoids retry storms when multiple tool calls hit the same disconnected streamable-http/SSE server.

## Changes
- Adds optional MCP client lifecycle hooks wired to the SDK Client `onerror` / `onclose` callbacks.
- Tracks `lastDisconnectedAt`, `lastReconnectAt`, `nextReconnectAt`, and `reconnectAttempts` in MCP diagnostics.
- Reconnects with single-flight and cooldown/backoff, then refreshes the server catalog after reconnect.
- Adds focused tests for concurrent reconnect, lifecycle close recovery, and non-transport tool errors.

## Tests
- `npm.cmd --prefix kun test -- src/adapters/tool/mcp-tool-provider.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `npx.cmd eslint kun/src/adapters/tool/mcp-tool-provider.ts kun/src/adapters/tool/mcp-tool-provider.test.ts`
- `git diff --check`
