### PR TITLE
feat(perf): add HTTP/SSE agent replay benchmarks

### DIFF
--- a/kun/README.md
+++ b/kun/README.md
@@ -51,6 +51,27 @@ Run from the `kun/` directory.
 - `npm run serve` – start the runtime after a build.
 - `npm run dev` – rebuild in watch mode.
 
+- `npm run benchmark:replay -- --suite <file>` - run a read-only HTTP/SSE agent replay suite.
+
+### Agent replay benchmark
+
+Start a Kun runtime, set `KUN_RUNTIME_URL` and `KUN_RUNTIME_TOKEN`, then run the five-task smoke set:
+
+```bash
+npm run benchmark:replay -- --suite benchmarks/agent-core.json --tag smoke --output replay-smoke.json
+```
+
+Run all 20 tasks twice and compare with an earlier report:
+
+```bash
+npm run benchmark:replay -- --suite benchmarks/agent-core.json --repeat 2 \
+  --baseline replay-baseline.json --output replay-current.json --fail-on-regression
+```
+
+Replay threads always use the `read-only` sandbox and disable interactive input. Reports include success rate,
+TTFT, full latency, tool time, SSE delivery delay, token/cache/cost counters, and Kun process peak RSS. The runtime
+token is accepted only through `KUN_RUNTIME_TOKEN`, so it does not leak through process arguments.
+
 ## CLI
 
 `kun serve` accepts the following flags:

--- a/kun/benchmarks/agent-core.json
+++ b/kun/benchmarks/agent-core.json
@@ -1,0 +1,110 @@
+{
+  "version": 1,
+  "name": "kun-agent-core",
+  "defaults": {
+    "reasoningEffort": "off",
+    "timeoutMs": 300000
+  },
+  "tasks": [
+    {
+      "id": "architecture-summary",
+      "tags": ["smoke", "architecture"],
+      "prompt": "Read the repository and explain the active Renderer -> preload -> main -> Kun runtime data path. Cite the most relevant file paths. Do not modify files."
+    },
+    {
+      "id": "runtime-entrypoint",
+      "tags": ["smoke", "runtime"],
+      "prompt": "Find the Kun serve-mode composition root and summarize how stores, model clients, tools, and the agent loop are assembled. Cite exact file paths. Do not modify files."
+    },
+    {
+      "id": "renderer-send-flow",
+      "tags": ["smoke", "frontend"],
+      "prompt": "Trace a chat message from the renderer composer through the preload/main bridge to the Kun turn endpoint. Return a concise ordered call path with files. Do not modify files."
+    },
+    {
+      "id": "sse-replay",
+      "tags": ["smoke", "runtime"],
+      "prompt": "Explain how Kun SSE event replay avoids duplicates and cursor rewind after reconnect or restart. Cite the implementation and tests. Do not modify files."
+    },
+    {
+      "id": "mcp-lifecycle",
+      "tags": ["smoke", "mcp"],
+      "prompt": "Inspect MCP startup, tool discovery, execution, and reconnect behavior. Identify the main reliability boundaries and cite the implementation files. Do not modify files."
+    },
+    {
+      "id": "cache-prefix",
+      "tags": ["cache"],
+      "prompt": "Explain what makes Kun's immutable prompt prefix stable and list dynamic data that must remain outside it. Cite code and documentation. Do not modify files."
+    },
+    {
+      "id": "provider-url-contract",
+      "tags": ["provider"],
+      "prompt": "Trace how baseUrl and endpointFormat affect provider URL construction and request bodies across chat and auxiliary model calls. Cite all important consumers. Do not modify files."
+    },
+    {
+      "id": "attachment-flow",
+      "tags": ["attachments"],
+      "prompt": "Trace an image or local file attachment from renderer selection to model input or fallback. Identify the cross-layer contract fields and failure points. Do not modify files."
+    },
+    {
+      "id": "approval-flow",
+      "tags": ["runtime", "security"],
+      "prompt": "Trace a tool approval request from agent loop creation through SSE/UI resolution back to tool execution. Cite routes, gates, and renderer handlers. Do not modify files."
+    },
+    {
+      "id": "goal-resume",
+      "tags": ["runtime", "goal"],
+      "prompt": "Explain how active goals survive runtime restart, how orphaned turns are reconciled, and where auto-resume is triggered. Cite tests if present. Do not modify files."
+    },
+    {
+      "id": "subagent-permissions",
+      "tags": ["subagent", "security"],
+      "prompt": "Explain how subagent tool policies inherit or restrict built-in tools, MCP servers, and skills without escalating the parent permissions. Cite enforcement points. Do not modify files."
+    },
+    {
+      "id": "settings-persistence",
+      "tags": ["settings"],
+      "prompt": "Trace a Kun settings change from renderer state through validation/persistence to managed runtime restart. Highlight rollback behavior. Do not modify files."
+    },
+    {
+      "id": "test-selection",
+      "tags": ["quality"],
+      "prompt": "Identify how the verify_changes tool selects and runs validation after edits. Explain its safety limits and output contract. Do not modify files."
+    },
+    {
+      "id": "build-pipeline",
+      "tags": ["build"],
+      "prompt": "Summarize the development, typecheck, test, build, and packaging pipeline for Kun. Cite package scripts and packaging configuration. Do not modify files."
+    },
+    {
+      "id": "security-boundaries",
+      "tags": ["security"],
+      "prompt": "Map the main trust boundaries for renderer IPC, filesystem tools, command execution, MCP, and secrets. Cite concrete enforcement files. Do not modify files."
+    },
+    {
+      "id": "runtime-hotspots",
+      "tags": ["performance"],
+      "prompt": "Inspect runtime event persistence, SSE replay, tool execution, and context assembly. Identify three evidence-based performance or memory hotspots with file references. Do not modify files."
+    },
+    {
+      "id": "thread-persistence",
+      "tags": ["storage"],
+      "prompt": "Explain how thread/session data is persisted and indexed across file and hybrid SQLite stores, including usage carryover. Cite implementation files. Do not modify files."
+    },
+    {
+      "id": "model-capabilities",
+      "tags": ["provider"],
+      "prompt": "Explain how model capabilities control image input, tool calling, reasoning effort, endpoint format, and context limits. Cite schemas and request construction. Do not modify files."
+    },
+    {
+      "id": "frontend-chunking",
+      "tags": ["frontend", "performance"],
+      "prompt": "Inspect renderer lazy loading and identify which Workbench surfaces are split into separate chunks and which heavy chat dependencies still load eagerly. Do not modify files."
+    },
+    {
+      "id": "failure-recovery",
+      "tags": ["runtime", "reliability"],
+      "prompt": "Map how the desktop app detects an unhealthy Kun child, budgets restarts, distinguishes settings restarts from crashes, and reports status to the renderer. Do not modify files."
+    }
+  ]
+}

--- a/kun/package.json
+++ b/kun/package.json
@@ -61,6 +61,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "transcript:diff": "node ./scripts/transcript-diff.mjs",
+    "benchmark:replay": "npm run build && node ./dist/cli/replay-entry.js",
     "serve": "node ./dist/cli/serve-entry.js",
     "dev": "tsc -p tsconfig.build.json --watch"
   },

--- a/kun/src/benchmark/replay-benchmark.test.ts
+++ b/kun/src/benchmark/replay-benchmark.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+import type { RuntimeEvent } from '../contracts/events.js'
+import {
+  compareReplayReports,
+  ReplaySuiteSchema,
+  SseMessageDecoder,
+  summarizeReplayEvents,
+  summarizeReplayRuns,
+  type ObservedReplayEvent,
+  type ReplayReport,
+  type ReplayRunResult
+} from './replay-benchmark.js'
+
+const baseTimestamp = Date.parse('2026-06-29T00:00:00.000Z')
+
+function observed(event: RuntimeEvent, elapsedMs: number, delayMs = 10): ObservedReplayEvent {
+  return {
+    event,
+    elapsedMs,
+    receivedAtMs: Date.parse(event.timestamp) + delayMs
+  }
+}
+
+function itemBase(kind: string) {
+  return {
+    kind,
+    id: `item_${kind}`,
+    turnId: 'turn_1',
+    threadId: 'thread_1',
+    role: kind === 'tool_result' ? 'tool' : 'assistant',
+    status: 'completed',
+    createdAt: '2026-06-29T00:00:00.000Z'
+  }
+}
+
+describe('replay benchmark', () => {
+  it('decodes SSE messages across arbitrary chunks', () => {
+    const decoder = new SseMessageDecoder()
+    const payload = [
+      'id: 4',
+      'event: turn_completed',
+      `data: ${JSON.stringify({
+        kind: 'turn_completed',
+        seq: 4,
+        timestamp: '2026-06-29T00:00:00.000Z',
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        status: 'completed'
+      })}`,
+      '',
+      ''
+    ].join('\n')
+
+    expect(decoder.push(payload.slice(0, 31))).toEqual([])
+    expect(decoder.push(payload.slice(31))).toEqual([
+      expect.objectContaining({ id: '4', event: 'turn_completed' })
+    ])
+  })
+
+  it('computes TTFT, tool, SSE, usage, and memory metrics from runtime events', () => {
+    const timestamp = (offset: number) => new Date(baseTimestamp + offset).toISOString()
+    const events: ObservedReplayEvent[] = [
+      observed({
+        kind: 'assistant_text_delta',
+        seq: 1,
+        timestamp: timestamp(100),
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        item: { ...itemBase('assistant_text'), kind: 'assistant_text', text: 'hello' }
+      } as RuntimeEvent, 120, 20),
+      observed({
+        kind: 'tool_call_started',
+        seq: 2,
+        timestamp: timestamp(180),
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        item: {
+          ...itemBase('tool_call'),
+          kind: 'tool_call',
+          toolName: 'read',
+          callId: 'call_1',
+          toolKind: 'tool_call',
+          arguments: { path: 'README.md' }
+        }
+      } as RuntimeEvent, 200, 20),
+      observed({
+        kind: 'tool_call_finished',
+        seq: 3,
+        timestamp: timestamp(430),
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        item: {
+          ...itemBase('tool_result'),
+          kind: 'tool_result',
+          toolName: 'read',
+          callId: 'call_1',
+          toolKind: 'tool_call',
+          output: { ok: true },
+          isError: false
+        }
+      } as RuntimeEvent, 450, 20),
+      observed({
+        kind: 'usage',
+        seq: 4,
+        timestamp: timestamp(500),
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        usage: {
+          promptTokens: 100,
+          completionTokens: 20,
+          totalTokens: 120,
+          cacheHitTokens: 60,
+          cacheMissTokens: 40,
+          cacheHitRate: 0.6,
+          cacheableTokenHitRate: 0.75,
+          totalInputTokenHitRate: 0.6,
+          turns: 1,
+          costUsd: 0.001
+        }
+      }, 520, 20),
+      observed({
+        kind: 'turn_completed',
+        seq: 5,
+        timestamp: timestamp(580),
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        status: 'completed'
+      }, 600, 20)
+    ]
+
+    expect(summarizeReplayEvents(events, 600, 256 * 1024 * 1024)).toEqual({
+      ttftMs: 120,
+      totalMs: 600,
+      assistantChars: 5,
+      eventCount: 5,
+      errorEvents: 0,
+      toolCalls: 1,
+      toolDurationMs: 250,
+      toolDurationP95Ms: 250,
+      sseDelayP50Ms: 20,
+      sseDelayP95Ms: 20,
+      promptTokens: 100,
+      completionTokens: 20,
+      totalTokens: 120,
+      cacheHitTokens: 60,
+      cacheMissTokens: 40,
+      cacheHitRate: 0.6,
+      cacheableTokenHitRate: 0.75,
+      totalInputTokenHitRate: 0.6,
+      costUsd: 0.001,
+      peakRssBytes: 256 * 1024 * 1024
+    })
+  })
+
+  it('aggregates reports and identifies material regressions', () => {
+    const baselineRun = replayRun('passed', 100, 1_000, 0.8)
+    const currentRun = replayRun('passed', 200, 1_800, 0.6)
+    const baseline = report([baselineRun], '2026-06-28T00:00:00.000Z')
+    const current = report([currentRun], '2026-06-29T00:00:00.000Z')
+    const comparison = compareReplayReports(current, baseline)
+
+    expect(comparison.ttftP95MsDelta).toBe(100)
+    expect(comparison.totalP95MsDelta).toBe(800)
+    expect(comparison.cacheHitRateDelta).toBeCloseTo(-0.2)
+    expect(comparison.regressions).toEqual(expect.arrayContaining([
+      expect.stringContaining('total latency'),
+      expect.stringContaining('cache hit rate')
+    ]))
+  })
+
+  it('rejects duplicate task ids before spending model tokens', () => {
+    expect(() => ReplaySuiteSchema.parse({
+      version: 1,
+      name: 'duplicate-suite',
+      tasks: [
+        { id: 'same', prompt: 'one' },
+        { id: 'same', prompt: 'two' }
+      ]
+    })).toThrow('duplicate replay task id')
+  })
+})
+
+function replayRun(
+  status: ReplayRunResult['status'],
+  ttftMs: number,
+  totalMs: number,
+  cacheHitRate: number
+): ReplayRunResult {
+  return {
+    id: 'task#1',
+    taskId: 'task',
+    iteration: 1,
+    tags: [],
+    status,
+    failureReasons: [],
+    metrics: {
+      ttftMs,
+      totalMs,
+      assistantChars: 10,
+      eventCount: 5,
+      errorEvents: 0,
+      toolCalls: 0,
+      toolDurationMs: 0,
+      toolDurationP95Ms: null,
+      sseDelayP50Ms: 10,
+      sseDelayP95Ms: 20,
+      promptTokens: 100,
+      completionTokens: 20,
+      totalTokens: 120,
+      cacheHitTokens: cacheHitRate * 100,
+      cacheMissTokens: (1 - cacheHitRate) * 100,
+      cacheHitRate,
+      cacheableTokenHitRate: cacheHitRate,
+      totalInputTokenHitRate: cacheHitRate,
+      costUsd: 0.001,
+      peakRssBytes: 100
+    }
+  }
+}
+
+function report(runs: ReplayRunResult[], generatedAt: string): ReplayReport {
+  return {
+    version: 1,
+    generatedAt,
+    suite: { name: 'test', taskCount: runs.length, repeat: 1 },
+    runtime: { baseUrl: 'http://127.0.0.1', startedAt: generatedAt },
+    summary: summarizeReplayRuns(runs),
+    runs
+  }
+}

--- a/kun/src/benchmark/replay-benchmark.ts
+++ b/kun/src/benchmark/replay-benchmark.ts
@@ -1,0 +1,734 @@
+import { resolve } from 'node:path'
+import { z } from 'zod'
+import { RuntimeEvent, type RuntimeEvent as RuntimeEventValue } from '../contracts/events.js'
+import { RuntimeInfoResponse, type RuntimeInfoResponse as RuntimeInfoValue } from '../contracts/runtime-info.js'
+import { TurnReasoningEffortSchema } from '../contracts/turns.js'
+import type { UsageSnapshot } from '../contracts/usage.js'
+
+const ReplayExpectationSchema = z.object({
+  minAssistantChars: z.number().int().nonnegative().default(1),
+  requiredTools: z.array(z.string().min(1)).default([]),
+  maxErrorEvents: z.number().int().nonnegative().default(0),
+  maxTotalMs: z.number().int().positive().optional()
+}).strict()
+
+const ReplayTaskSchema = z.object({
+  id: z.string().regex(/^[a-z0-9][a-z0-9_-]*$/),
+  prompt: z.string().min(1),
+  tags: z.array(z.string().min(1)).default([]),
+  workspace: z.string().min(1).optional(),
+  model: z.string().min(1).optional(),
+  providerId: z.string().min(1).optional(),
+  reasoningEffort: TurnReasoningEffortSchema.optional(),
+  timeoutMs: z.number().int().positive().optional(),
+  expect: ReplayExpectationSchema.default(() => ReplayExpectationSchema.parse({}))
+}).strict()
+
+export const ReplaySuiteSchema = z.object({
+  version: z.literal(1),
+  name: z.string().min(1),
+  defaults: z.object({
+    model: z.string().min(1).optional(),
+    providerId: z.string().min(1).optional(),
+    reasoningEffort: TurnReasoningEffortSchema.optional(),
+    timeoutMs: z.number().int().positive().default(300_000)
+  }).strict().default(() => ({ timeoutMs: 300_000 })),
+  tasks: z.array(ReplayTaskSchema).min(1).max(100)
+}).strict().superRefine((suite, context) => {
+  const ids = new Set<string>()
+  suite.tasks.forEach((task, index) => {
+    if (ids.has(task.id)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['tasks', index, 'id'],
+        message: `duplicate replay task id: ${task.id}`
+      })
+    }
+    ids.add(task.id)
+  })
+})
+
+export type ReplaySuite = z.infer<typeof ReplaySuiteSchema>
+export type ReplayTask = z.infer<typeof ReplayTaskSchema>
+
+export type ObservedReplayEvent = {
+  event: RuntimeEventValue
+  receivedAtMs: number
+  elapsedMs: number
+}
+
+export type ReplayRunMetrics = {
+  ttftMs: number | null
+  totalMs: number
+  assistantChars: number
+  eventCount: number
+  errorEvents: number
+  toolCalls: number
+  toolDurationMs: number
+  toolDurationP95Ms: number | null
+  sseDelayP50Ms: number | null
+  sseDelayP95Ms: number | null
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  cacheHitTokens: number | null
+  cacheMissTokens: number | null
+  cacheHitRate: number | null
+  cacheableTokenHitRate: number | null
+  totalInputTokenHitRate: number | null
+  costUsd: number
+  peakRssBytes: number | null
+}
+
+export type ReplayRunResult = {
+  id: string
+  taskId: string
+  iteration: number
+  tags: string[]
+  threadId?: string
+  turnId?: string
+  status: 'passed' | 'failed' | 'timeout' | 'error'
+  failureReasons: string[]
+  metrics: ReplayRunMetrics
+  error?: string
+}
+
+export type ReplayReportSummary = {
+  runCount: number
+  passed: number
+  failed: number
+  timedOut: number
+  errors: number
+  successRate: number
+  ttftP50Ms: number | null
+  ttftP95Ms: number | null
+  totalP50Ms: number | null
+  totalP95Ms: number | null
+  toolDurationP95Ms: number | null
+  sseDelayP95Ms: number | null
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  cacheHitRate: number | null
+  cacheableTokenHitRate: number | null
+  totalInputTokenHitRate: number | null
+  costUsd: number
+  peakRssBytes: number | null
+}
+
+export type ReplayComparison = {
+  baselineGeneratedAt: string
+  successRateDelta: number
+  ttftP95MsDelta: number | null
+  totalP95MsDelta: number | null
+  promptTokensDelta: number
+  cacheHitRateDelta: number | null
+  costUsdDelta: number
+  peakRssBytesDelta: number | null
+  regressions: string[]
+}
+
+export type ReplayReport = {
+  version: 1
+  generatedAt: string
+  suite: { name: string; taskCount: number; repeat: number; tag?: string }
+  runtime: {
+    baseUrl: string
+    model?: string
+    startedAt: string
+    pid?: number
+  }
+  summary: ReplayReportSummary
+  runs: ReplayRunResult[]
+  comparison?: ReplayComparison
+}
+
+export type RunReplaySuiteOptions = {
+  baseUrl: string
+  token?: string
+  workspace: string
+  repeat?: number
+  concurrency?: number
+  tag?: string
+  keepThreads?: boolean
+  fetchImpl?: typeof fetch
+  onProgress?: (completed: number, total: number, run: ReplayRunResult) => void
+}
+
+type ReplayHttpClient = {
+  getRuntimeInfo(): Promise<RuntimeInfoValue>
+  createThread(body: Record<string, unknown>): Promise<{ id: string }>
+  startTurn(threadId: string, body: Record<string, unknown>): Promise<{ turnId: string }>
+  openEvents(threadId: string, signal: AbortSignal): Promise<Response>
+  deleteThread(threadId: string): Promise<void>
+}
+
+export async function runReplaySuite(
+  suiteInput: unknown,
+  options: RunReplaySuiteOptions
+): Promise<ReplayReport> {
+  const suite = ReplaySuiteSchema.parse(suiteInput)
+  const repeat = clampInteger(options.repeat ?? 1, 1, 20)
+  const concurrency = clampInteger(options.concurrency ?? 1, 1, 8)
+  const baseUrl = options.baseUrl.replace(/\/$/, '')
+  const client = createReplayHttpClient(baseUrl, options.token, options.fetchImpl ?? fetch)
+  const runtime = await client.getRuntimeInfo()
+  const selectedTasks = options.tag
+    ? suite.tasks.filter((task) => task.tags.includes(options.tag!))
+    : suite.tasks
+  if (selectedTasks.length === 0) {
+    throw new Error(`replay suite has no tasks tagged "${options.tag}"`)
+  }
+  const jobs = selectedTasks.flatMap((task) =>
+    Array.from({ length: repeat }, (_, index) => ({ task, iteration: index + 1 }))
+  )
+  const runs = new Array<ReplayRunResult>(jobs.length)
+  let cursor = 0
+  let completed = 0
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const jobIndex = cursor
+      cursor += 1
+      const job = jobs[jobIndex]
+      if (!job) return
+      const run = await runReplayTask({
+        suite,
+        task: job.task,
+        iteration: job.iteration,
+        runtime,
+        client,
+        workspace: options.workspace,
+        keepThread: options.keepThreads === true
+      })
+      runs[jobIndex] = run
+      completed += 1
+      options.onProgress?.(completed, jobs.length, run)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, jobs.length) }, () => worker()))
+  const report: ReplayReport = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    suite: {
+      name: suite.name,
+      taskCount: selectedTasks.length,
+      repeat,
+      ...(options.tag ? { tag: options.tag } : {})
+    },
+    runtime: {
+      baseUrl,
+      ...(runtime.model ? { model: runtime.model } : {}),
+      startedAt: runtime.startedAt,
+      ...(runtime.pid ? { pid: runtime.pid } : {})
+    },
+    summary: summarizeReplayRuns(runs),
+    runs
+  }
+  return report
+}
+
+async function runReplayTask(input: {
+  suite: ReplaySuite
+  task: ReplayTask
+  iteration: number
+  runtime: RuntimeInfoValue
+  client: ReplayHttpClient
+  workspace: string
+  keepThread: boolean
+}): Promise<ReplayRunResult> {
+  const { suite, task, iteration, runtime, client } = input
+  const runId = `${task.id}#${iteration}`
+  const model = task.model ?? suite.defaults.model ?? runtime.model
+  if (!model) return errorReplayRun(runId, task, iteration, 'runtime did not report a default model')
+  const workspace = resolve(input.workspace, task.workspace ?? '.')
+  let threadId: string | undefined
+  try {
+    const thread = await client.createThread({
+      title: `[replay] ${runId}`,
+      titleAuto: false,
+      workspace,
+      model,
+      ...(task.providerId ?? suite.defaults.providerId
+        ? { providerId: task.providerId ?? suite.defaults.providerId }
+        : {}),
+      mode: 'agent',
+      approvalPolicy: 'auto',
+      sandboxMode: 'read-only'
+    })
+    threadId = thread.id
+    const startedAt = performance.now()
+    const turn = await client.startTurn(threadId, {
+      prompt: task.prompt,
+      reasoningEffort: task.reasoningEffort ?? suite.defaults.reasoningEffort ?? 'off',
+      approvalPolicy: 'auto',
+      sandboxMode: 'read-only',
+      disableUserInput: true
+    })
+    const timeoutMs = task.timeoutMs ?? suite.defaults.timeoutMs
+    const collected = await collectReplayEvents({
+      client,
+      threadId,
+      turnId: turn.turnId,
+      startedAt,
+      timeoutMs
+    })
+    const after = await client.getRuntimeInfo().catch(() => runtime)
+    const metrics = summarizeReplayEvents(
+      collected.events,
+      collected.elapsedMs,
+      after.memoryUsage?.peakRssBytes
+    )
+    const failureReasons = replayExpectationFailures(task, collected.timedOut, metrics, collected.events)
+    return {
+      id: runId,
+      taskId: task.id,
+      iteration,
+      tags: task.tags,
+      threadId,
+      turnId: turn.turnId,
+      status: collected.timedOut ? 'timeout' : failureReasons.length > 0 ? 'failed' : 'passed',
+      failureReasons,
+      metrics
+    }
+  } catch (error) {
+    return {
+      ...errorReplayRun(runId, task, iteration, errorMessage(error)),
+      ...(threadId ? { threadId } : {})
+    }
+  } finally {
+    if (threadId && !input.keepThread) {
+      await client.deleteThread(threadId).catch(() => undefined)
+    }
+  }
+}
+
+async function collectReplayEvents(input: {
+  client: ReplayHttpClient
+  threadId: string
+  turnId: string
+  startedAt: number
+  timeoutMs: number
+}): Promise<{ events: ObservedReplayEvent[]; elapsedMs: number; timedOut: boolean }> {
+  const controller = new AbortController()
+  let timedOut = false
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, input.timeoutMs)
+  timer.unref?.()
+  const observed: ObservedReplayEvent[] = []
+  try {
+    const response = await input.client.openEvents(input.threadId, controller.signal)
+    if (!response.body) throw new Error('runtime SSE response has no body')
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    const sse = new SseMessageDecoder()
+    while (true) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+      for (const message of sse.push(decoder.decode(chunk.value, { stream: true }))) {
+        const parsed = parseRuntimeSseMessage(message)
+        if (!parsed) continue
+        const receivedAtMs = Date.now()
+        observed.push({
+          event: parsed,
+          receivedAtMs,
+          elapsedMs: Math.max(0, performance.now() - input.startedAt)
+        })
+        if (parsed.turnId === input.turnId && isTerminalTurnEvent(parsed.kind)) {
+          controller.abort()
+          return {
+            events: observed,
+            elapsedMs: Math.max(0, performance.now() - input.startedAt),
+            timedOut: false
+          }
+        }
+      }
+    }
+    return {
+      events: observed,
+      elapsedMs: Math.max(0, performance.now() - input.startedAt),
+      timedOut
+    }
+  } catch (error) {
+    if (!timedOut && !controller.signal.aborted) throw error
+    return {
+      events: observed,
+      elapsedMs: Math.max(0, performance.now() - input.startedAt),
+      timedOut
+    }
+  } finally {
+    clearTimeout(timer)
+    controller.abort()
+  }
+}
+
+export function summarizeReplayEvents(
+  observed: ObservedReplayEvent[],
+  elapsedMs: number,
+  peakRssBytes?: number
+): ReplayRunMetrics {
+  const firstText = observed.find(({ event }) =>
+    event.kind === 'assistant_text_delta' && event.item.kind === 'assistant_text' && event.item.text.length > 0
+  ) ?? observed.find(({ event }) =>
+    (event.kind === 'item_created' || event.kind === 'item_completed') &&
+    event.item.kind === 'assistant_text' &&
+    event.item.text.length > 0
+  )
+  const assistantTextByItem = new Map<string, string>()
+  const toolStarted = new Map<string, number>()
+  const toolDurations: number[] = []
+  const toolCallIds = new Set<string>()
+  const sseDelays: number[] = []
+  let errorEvents = 0
+  let usage: UsageSnapshot | undefined
+  for (const record of observed) {
+    const eventTime = Date.parse(record.event.timestamp)
+    if (Number.isFinite(eventTime)) sseDelays.push(Math.max(0, record.receivedAtMs - eventTime))
+    if (record.event.kind === 'error' || record.event.kind === 'turn_failed') errorEvents += 1
+    if (record.event.kind === 'usage') usage = record.event.usage
+    if ('item' in record.event && record.event.item.kind === 'assistant_text') {
+      const itemId = record.event.item.id
+      if (record.event.kind === 'assistant_text_delta') {
+        assistantTextByItem.set(itemId, `${assistantTextByItem.get(itemId) ?? ''}${record.event.item.text}`)
+      } else {
+        assistantTextByItem.set(itemId, record.event.item.text)
+      }
+    }
+    if (record.event.kind === 'tool_call_started' && 'item' in record.event && 'callId' in record.event.item) {
+      toolStarted.set(record.event.item.callId, record.elapsedMs)
+      toolCallIds.add(record.event.item.callId)
+    }
+    if (record.event.kind === 'tool_call_finished' && 'item' in record.event && 'callId' in record.event.item) {
+      const started = toolStarted.get(record.event.item.callId)
+      if (started !== undefined) toolDurations.push(Math.max(0, record.elapsedMs - started))
+      toolCallIds.add(record.event.item.callId)
+    }
+  }
+  const assistantChars = [...assistantTextByItem.values()].reduce((total, text) => total + text.length, 0)
+  const hit = usage?.cacheHitTokens
+  const miss = usage?.cacheMissTokens
+  const cacheTotal = (hit ?? 0) + (miss ?? 0)
+  return {
+    ttftMs: firstText ? roundMetric(firstText.elapsedMs) : null,
+    totalMs: roundMetric(elapsedMs),
+    assistantChars,
+    eventCount: observed.length,
+    errorEvents,
+    toolCalls: toolCallIds.size,
+    toolDurationMs: roundMetric(toolDurations.reduce((total, value) => total + value, 0)),
+    toolDurationP95Ms: percentile(toolDurations, 0.95),
+    sseDelayP50Ms: percentile(sseDelays, 0.5),
+    sseDelayP95Ms: percentile(sseDelays, 0.95),
+    promptTokens: usage?.promptTokens ?? 0,
+    completionTokens: usage?.completionTokens ?? 0,
+    totalTokens: usage?.totalTokens ?? 0,
+    cacheHitTokens: hit ?? null,
+    cacheMissTokens: miss ?? null,
+    cacheHitRate: usage?.cacheHitRate ?? (cacheTotal > 0 ? (hit ?? 0) / cacheTotal : null),
+    cacheableTokenHitRate: usage?.cacheableTokenHitRate ?? null,
+    totalInputTokenHitRate: usage?.totalInputTokenHitRate ?? null,
+    costUsd: usage?.costUsd ?? 0,
+    peakRssBytes: peakRssBytes ?? null
+  }
+}
+
+export function summarizeReplayRuns(runs: ReplayRunResult[]): ReplayReportSummary {
+  const ttft = compactNumbers(runs.map((run) => run.metrics.ttftMs))
+  const total = runs.map((run) => run.metrics.totalMs)
+  const toolP95 = compactNumbers(runs.map((run) => run.metrics.toolDurationP95Ms))
+  const sseP95 = compactNumbers(runs.map((run) => run.metrics.sseDelayP95Ms))
+  const hitTokens = compactNumbers(runs.map((run) => run.metrics.cacheHitTokens)).reduce(sum, 0)
+  const missTokens = compactNumbers(runs.map((run) => run.metrics.cacheMissTokens)).reduce(sum, 0)
+  const cacheableRates = compactNumbers(runs.map((run) => run.metrics.cacheableTokenHitRate))
+  const totalInputRates = compactNumbers(runs.map((run) => run.metrics.totalInputTokenHitRate))
+  const passed = runs.filter((run) => run.status === 'passed').length
+  return {
+    runCount: runs.length,
+    passed,
+    failed: runs.filter((run) => run.status === 'failed').length,
+    timedOut: runs.filter((run) => run.status === 'timeout').length,
+    errors: runs.filter((run) => run.status === 'error').length,
+    successRate: runs.length > 0 ? passed / runs.length : 0,
+    ttftP50Ms: percentile(ttft, 0.5),
+    ttftP95Ms: percentile(ttft, 0.95),
+    totalP50Ms: percentile(total, 0.5),
+    totalP95Ms: percentile(total, 0.95),
+    toolDurationP95Ms: percentile(toolP95, 0.95),
+    sseDelayP95Ms: percentile(sseP95, 0.95),
+    promptTokens: runs.reduce((totalValue, run) => totalValue + run.metrics.promptTokens, 0),
+    completionTokens: runs.reduce((totalValue, run) => totalValue + run.metrics.completionTokens, 0),
+    totalTokens: runs.reduce((totalValue, run) => totalValue + run.metrics.totalTokens, 0),
+    cacheHitRate: hitTokens + missTokens > 0 ? hitTokens / (hitTokens + missTokens) : null,
+    cacheableTokenHitRate: average(cacheableRates),
+    totalInputTokenHitRate: average(totalInputRates),
+    costUsd: runs.reduce((totalValue, run) => totalValue + run.metrics.costUsd, 0),
+    peakRssBytes: maxNullable(compactNumbers(runs.map((run) => run.metrics.peakRssBytes)))
+  }
+}
+
+export function compareReplayReports(current: ReplayReport, baseline: ReplayReport): ReplayComparison {
+  const successRateDelta = current.summary.successRate - baseline.summary.successRate
+  const ttftP95MsDelta = nullableDelta(current.summary.ttftP95Ms, baseline.summary.ttftP95Ms)
+  const totalP95MsDelta = nullableDelta(current.summary.totalP95Ms, baseline.summary.totalP95Ms)
+  const cacheHitRateDelta = nullableDelta(current.summary.cacheHitRate, baseline.summary.cacheHitRate)
+  const peakRssBytesDelta = nullableDelta(current.summary.peakRssBytes, baseline.summary.peakRssBytes)
+  const regressions: string[] = []
+  if (successRateDelta < 0) regressions.push(`success rate dropped by ${formatPercent(-successRateDelta)}`)
+  if (isRelativeRegression(current.summary.ttftP95Ms, baseline.summary.ttftP95Ms, 0.2, 300)) {
+    regressions.push(`TTFT p95 increased by ${ttftP95MsDelta}ms`)
+  }
+  if (isRelativeRegression(current.summary.totalP95Ms, baseline.summary.totalP95Ms, 0.2, 500)) {
+    regressions.push(`total latency p95 increased by ${totalP95MsDelta}ms`)
+  }
+  if (cacheHitRateDelta !== null && cacheHitRateDelta < -0.05) {
+    regressions.push(`cache hit rate dropped by ${formatPercent(-cacheHitRateDelta)}`)
+  }
+  if (baseline.summary.costUsd > 0 && current.summary.costUsd > baseline.summary.costUsd * 1.1) {
+    regressions.push(`cost increased by $${(current.summary.costUsd - baseline.summary.costUsd).toFixed(6)}`)
+  }
+  return {
+    baselineGeneratedAt: baseline.generatedAt,
+    successRateDelta,
+    ttftP95MsDelta,
+    totalP95MsDelta,
+    promptTokensDelta: current.summary.promptTokens - baseline.summary.promptTokens,
+    cacheHitRateDelta,
+    costUsdDelta: current.summary.costUsd - baseline.summary.costUsd,
+    peakRssBytesDelta,
+    regressions
+  }
+}
+
+export type SseMessage = { event?: string; id?: string; data: string }
+
+export class SseMessageDecoder {
+  private buffer = ''
+
+  push(chunk: string): SseMessage[] {
+    this.buffer += chunk.replace(/\r\n/g, '\n')
+    const messages: SseMessage[] = []
+    let boundary = this.buffer.indexOf('\n\n')
+    while (boundary >= 0) {
+      const block = this.buffer.slice(0, boundary)
+      this.buffer = this.buffer.slice(boundary + 2)
+      const message = parseSseBlock(block)
+      if (message) messages.push(message)
+      boundary = this.buffer.indexOf('\n\n')
+    }
+    return messages
+  }
+}
+
+function createReplayHttpClient(
+  baseUrl: string,
+  token: string | undefined,
+  fetchImpl: typeof fetch
+): ReplayHttpClient {
+  const headers = (): Headers => {
+    const value = new Headers({ accept: 'application/json' })
+    if (token) value.set('authorization', `Bearer ${token}`)
+    return value
+  }
+  const requestJson = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
+    const requestHeaders = headers()
+    if (init.body) requestHeaders.set('content-type', 'application/json')
+    new Headers(init.headers).forEach((value, key) => requestHeaders.set(key, value))
+    const response = await fetchImpl(`${baseUrl}${path}`, {
+      ...init,
+      headers: requestHeaders
+    })
+    if (!response.ok) {
+      const body = (await response.text().catch(() => '')).slice(0, 1_000)
+      throw new Error(`${init.method ?? 'GET'} ${path} failed (${response.status}): ${body}`)
+    }
+    return await response.json() as T
+  }
+  return {
+    async getRuntimeInfo() {
+      return RuntimeInfoResponse.parse(await requestJson('/v1/runtime/info'))
+    },
+    createThread: (body) => requestJson('/v1/threads', { method: 'POST', body: JSON.stringify(body) }),
+    startTurn: (threadId, body) => requestJson(`/v1/threads/${encodeURIComponent(threadId)}/turns`, {
+      method: 'POST',
+      body: JSON.stringify(body)
+    }),
+    async openEvents(threadId, signal) {
+      const requestHeaders = headers()
+      requestHeaders.set('accept', 'text/event-stream')
+      const response = await fetchImpl(`${baseUrl}/v1/threads/${encodeURIComponent(threadId)}/events?since_seq=0`, {
+        headers: requestHeaders,
+        signal
+      })
+      if (!response.ok) {
+        const body = (await response.text().catch(() => '')).slice(0, 1_000)
+        throw new Error(`GET events failed (${response.status}): ${body}`)
+      }
+      return response
+    },
+    async deleteThread(threadId) {
+      await requestJson(`/v1/threads/${encodeURIComponent(threadId)}`, { method: 'DELETE' })
+    }
+  }
+}
+
+function parseSseBlock(block: string): SseMessage | null {
+  if (!block.trim()) return null
+  let event: string | undefined
+  let id: string | undefined
+  const data: string[] = []
+  for (const line of block.split('\n')) {
+    if (!line || line.startsWith(':')) continue
+    const separator = line.indexOf(':')
+    const field = separator >= 0 ? line.slice(0, separator) : line
+    const value = separator >= 0 ? line.slice(separator + 1).replace(/^ /, '') : ''
+    if (field === 'event') event = value
+    else if (field === 'id') id = value
+    else if (field === 'data') data.push(value)
+  }
+  if (data.length === 0) return null
+  return { ...(event ? { event } : {}), ...(id ? { id } : {}), data: data.join('\n') }
+}
+
+function parseRuntimeSseMessage(message: SseMessage): RuntimeEventValue | null {
+  let value: unknown
+  try {
+    value = JSON.parse(message.data)
+  } catch {
+    return null
+  }
+  const parsed = RuntimeEvent.safeParse(value)
+  if (parsed.success) return parsed.data
+  if (message.event === 'error') {
+    const detail = value && typeof value === 'object' && 'message' in value
+      ? String((value as { message?: unknown }).message ?? 'unknown SSE error')
+      : 'unknown SSE error'
+    throw new Error(`runtime SSE error: ${detail}`)
+  }
+  return null
+}
+
+function replayExpectationFailures(
+  task: ReplayTask,
+  timedOut: boolean,
+  metrics: ReplayRunMetrics,
+  events: ObservedReplayEvent[]
+): string[] {
+  const failures: string[] = []
+  if (timedOut) failures.push('turn timed out')
+  const terminal = events.find(({ event }) => event.kind === 'turn_completed' || event.kind === 'turn_failed' || event.kind === 'turn_aborted')
+  if (!terminal) failures.push('no terminal turn event')
+  else if (terminal.event.kind !== 'turn_completed') failures.push(`turn ended with ${terminal.event.kind}`)
+  if (metrics.assistantChars < task.expect.minAssistantChars) {
+    failures.push(`assistant output ${metrics.assistantChars} chars is below ${task.expect.minAssistantChars}`)
+  }
+  if (metrics.errorEvents > task.expect.maxErrorEvents) {
+    failures.push(`error event count ${metrics.errorEvents} exceeds ${task.expect.maxErrorEvents}`)
+  }
+  if (task.expect.maxTotalMs && metrics.totalMs > task.expect.maxTotalMs) {
+    failures.push(`total latency ${metrics.totalMs}ms exceeds ${task.expect.maxTotalMs}ms`)
+  }
+  const usedTools = new Set(events.flatMap(({ event }) => {
+    if (!('item' in event) || !('toolName' in event.item)) return []
+    return [event.item.toolName]
+  }))
+  for (const tool of task.expect.requiredTools) {
+    if (!usedTools.has(tool)) failures.push(`required tool was not used: ${tool}`)
+  }
+  return failures
+}
+
+function errorReplayRun(id: string, task: ReplayTask, iteration: number, error: string): ReplayRunResult {
+  return {
+    id,
+    taskId: task.id,
+    iteration,
+    tags: task.tags,
+    status: 'error',
+    failureReasons: [error],
+    metrics: emptyReplayMetrics(),
+    error
+  }
+}
+
+function emptyReplayMetrics(): ReplayRunMetrics {
+  return {
+    ttftMs: null,
+    totalMs: 0,
+    assistantChars: 0,
+    eventCount: 0,
+    errorEvents: 0,
+    toolCalls: 0,
+    toolDurationMs: 0,
+    toolDurationP95Ms: null,
+    sseDelayP50Ms: null,
+    sseDelayP95Ms: null,
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    cacheHitTokens: null,
+    cacheMissTokens: null,
+    cacheHitRate: null,
+    cacheableTokenHitRate: null,
+    totalInputTokenHitRate: null,
+    costUsd: 0,
+    peakRssBytes: null
+  }
+}
+
+function isTerminalTurnEvent(kind: RuntimeEventValue['kind']): boolean {
+  return kind === 'turn_completed' || kind === 'turn_failed' || kind === 'turn_aborted'
+}
+
+function percentile(values: number[], quantile: number): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((left, right) => left - right)
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(quantile * sorted.length) - 1))
+  return roundMetric(sorted[index] ?? 0)
+}
+
+function average(values: number[]): number | null {
+  return values.length > 0 ? values.reduce(sum, 0) / values.length : null
+}
+
+function maxNullable(values: number[]): number | null {
+  return values.length > 0 ? Math.max(...values) : null
+}
+
+function compactNumbers(values: Array<number | null | undefined>): number[] {
+  return values.filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+}
+
+function nullableDelta(current: number | null, baseline: number | null): number | null {
+  return current === null || baseline === null ? null : current - baseline
+}
+
+function isRelativeRegression(
+  current: number | null,
+  baseline: number | null,
+  ratio: number,
+  minimumDelta: number
+): boolean {
+  if (current === null || baseline === null || baseline <= 0) return false
+  return current - baseline >= minimumDelta && current > baseline * (1 + ratio)
+}
+
+function roundMetric(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+function clampInteger(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Math.floor(value)))
+}
+
+function sum(left: number, right: number): number {
+  return left + right
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(2)}%`
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/kun/src/cli/replay-entry.ts
+++ b/kun/src/cli/replay-entry.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import {
+  compareReplayReports,
+  runReplaySuite,
+  type ReplayReport
+} from '../benchmark/replay-benchmark.js'
+
+type CliOptions = {
+  suitePath?: string
+  baseUrl: string
+  workspace: string
+  outputPath?: string
+  baselinePath?: string
+  repeat: number
+  concurrency: number
+  tag?: string
+  keepThreads: boolean
+  failOnRegression: boolean
+  help: boolean
+}
+
+const options = parseArgs(process.argv.slice(2))
+if (options.help) {
+  printUsage()
+  process.exit(0)
+}
+if (!options.suitePath) {
+  printUsage()
+  process.exit(2)
+}
+
+const suitePath = resolve(options.suitePath)
+const suite = JSON.parse(await readFile(suitePath, 'utf8')) as unknown
+const report = await runReplaySuite(suite, {
+  baseUrl: options.baseUrl,
+  token: process.env.KUN_RUNTIME_TOKEN,
+  workspace: options.workspace,
+  repeat: options.repeat,
+  concurrency: options.concurrency,
+  ...(options.tag ? { tag: options.tag } : {}),
+  keepThreads: options.keepThreads,
+  onProgress: (completed, total, run) => {
+    const ttft = run.metrics.ttftMs === null ? 'n/a' : `${Math.round(run.metrics.ttftMs)}ms`
+    console.error(
+      `[${completed}/${total}] ${run.id} ${run.status} ` +
+      `ttft=${ttft} total=${Math.round(run.metrics.totalMs)}ms tokens=${run.metrics.totalTokens}`
+    )
+  }
+})
+
+if (options.baselinePath) {
+  const baseline = JSON.parse(await readFile(resolve(options.baselinePath), 'utf8')) as ReplayReport
+  report.comparison = compareReplayReports(report, baseline)
+}
+
+printSummary(report)
+if (options.outputPath) {
+  const outputPath = resolve(options.outputPath)
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+  console.error(`Replay report written to ${outputPath}`)
+} else {
+  console.log(JSON.stringify(report, null, 2))
+}
+
+if (options.failOnRegression && report.comparison?.regressions.length) {
+  process.exitCode = 1
+}
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    baseUrl: process.env.KUN_RUNTIME_URL ?? 'http://127.0.0.1:18788',
+    workspace: resolve(process.env.INIT_CWD ?? process.cwd()),
+    repeat: 1,
+    concurrency: 1,
+    keepThreads: false,
+    failOnRegression: false,
+    help: false
+  }
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    switch (arg) {
+      case '--suite':
+        options.suitePath = requiredValue(args, ++index, arg)
+        break
+      case '--base-url':
+        options.baseUrl = requiredValue(args, ++index, arg)
+        break
+      case '--workspace':
+        options.workspace = resolve(requiredValue(args, ++index, arg))
+        break
+      case '--output':
+        options.outputPath = requiredValue(args, ++index, arg)
+        break
+      case '--baseline':
+        options.baselinePath = requiredValue(args, ++index, arg)
+        break
+      case '--tag':
+        options.tag = requiredValue(args, ++index, arg)
+        break
+      case '--repeat':
+        options.repeat = positiveInteger(requiredValue(args, ++index, arg), arg)
+        break
+      case '--concurrency':
+        options.concurrency = positiveInteger(requiredValue(args, ++index, arg), arg)
+        break
+      case '--keep-threads':
+        options.keepThreads = true
+        break
+      case '--fail-on-regression':
+        options.failOnRegression = true
+        break
+      case '--help':
+      case '-h':
+        options.help = true
+        break
+      default:
+        throw new Error(`unknown replay option: ${arg}`)
+    }
+  }
+  return options
+}
+
+function requiredValue(args: string[], index: number, flag: string): string {
+  const value = args[index]
+  if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function positiveInteger(value: string, flag: string): number {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${flag} must be a positive integer`)
+  return parsed
+}
+
+function printUsage(): void {
+  console.log('Usage:')
+  console.log('  npm --prefix kun run benchmark:replay -- --suite <file> [options]')
+  console.log('')
+  console.log('Options:')
+  console.log('  --base-url <url>          Kun runtime URL (or KUN_RUNTIME_URL)')
+  console.log('  --workspace <path>        Workspace for replay tasks')
+  console.log('  --tag <tag>               Run only tasks with this tag')
+  console.log('  --repeat <n>              Repeat each selected task (default 1)')
+  console.log('  --concurrency <n>         Parallel tasks, capped at 8 (default 1)')
+  console.log('  --baseline <report.json>  Compare against an earlier report')
+  console.log('  --output <report.json>    Write the full machine-readable report')
+  console.log('  --keep-threads            Keep generated replay threads')
+  console.log('  --fail-on-regression      Exit 1 when comparison thresholds regress')
+  console.log('')
+  console.log('Authentication: set KUN_RUNTIME_TOKEN; it is intentionally not accepted as a CLI flag.')
+}
+
+function printSummary(report: ReplayReport): void {
+  const summary = report.summary
+  console.error('')
+  console.error(`Replay suite: ${report.suite.name}`)
+  console.error(`Success: ${summary.passed}/${summary.runCount} (${formatRate(summary.successRate)})`)
+  console.error(`TTFT p50/p95: ${formatMs(summary.ttftP50Ms)} / ${formatMs(summary.ttftP95Ms)}`)
+  console.error(`Total p50/p95: ${formatMs(summary.totalP50Ms)} / ${formatMs(summary.totalP95Ms)}`)
+  console.error(`SSE delay p95: ${formatMs(summary.sseDelayP95Ms)}`)
+  console.error(`Tokens: ${summary.promptTokens} input + ${summary.completionTokens} output`)
+  console.error(`Cache hit: ${formatRate(summary.cacheHitRate)}`)
+  console.error(`Cost: $${summary.costUsd.toFixed(6)}`)
+  console.error(`Peak RSS: ${summary.peakRssBytes === null ? 'n/a' : formatBytes(summary.peakRssBytes)}`)
+  if (report.comparison) {
+    console.error(`Regressions: ${report.comparison.regressions.length}`)
+    for (const regression of report.comparison.regressions) console.error(`  - ${regression}`)
+  }
+}
+
+function formatMs(value: number | null): string {
+  return value === null ? 'n/a' : `${Math.round(value)}ms`
+}
+
+function formatRate(value: number | null): string {
+  return value === null ? 'n/a' : `${(value * 100).toFixed(2)}%`
+}
+
+function formatBytes(value: number): string {
+  return `${(value / 1024 / 1024).toFixed(1)} MiB`
+}

--- a/kun/src/contracts/runtime-info.ts
+++ b/kun/src/contracts/runtime-info.ts
@@ -17,6 +17,13 @@ export const RuntimeInfoResponse = z
     insecure: z.boolean().optional(),
     startedAt: z.string(),
     pid: z.number().int().positive().optional(),
+    memoryUsage: z.object({
+      rssBytes: z.number().int().nonnegative(),
+      peakRssBytes: z.number().int().nonnegative(),
+      heapUsedBytes: z.number().int().nonnegative(),
+      heapTotalBytes: z.number().int().nonnegative(),
+      externalBytes: z.number().int().nonnegative()
+    }).strict().optional(),
     capabilities: RuntimeCapabilityManifest
   })
   .strict()

--- a/kun/src/server/runtime-factory.ts
+++ b/kun/src/server/runtime-factory.ts
@@ -570,21 +570,32 @@ export async function createKunServeRuntime(
     insecure: options.insecure,
     allocateSeq,
     nowIso,
-    info: () => ({
-      host: options.host,
-      port: options.port,
-      configPath: options.configPath,
-      dataDir: options.dataDir,
-      model: options.model,
-      endpointFormat: options.endpointFormat ?? DEFAULT_MODEL_ENDPOINT_FORMAT,
-      approvalPolicy: options.approvalPolicy,
-      sandboxMode: options.sandboxMode,
-      tokenEconomyMode: options.tokenEconomyMode,
-      insecure: options.insecure,
-      startedAt,
-      pid: process.pid,
-      capabilities
-    }),
+    info: () => {
+      const memory = process.memoryUsage()
+      const peakRssBytes = Math.max(memory.rss, process.resourceUsage().maxRSS * 1024)
+      return {
+        host: options.host,
+        port: options.port,
+        configPath: options.configPath,
+        dataDir: options.dataDir,
+        model: options.model,
+        endpointFormat: options.endpointFormat ?? DEFAULT_MODEL_ENDPOINT_FORMAT,
+        approvalPolicy: options.approvalPolicy,
+        sandboxMode: options.sandboxMode,
+        tokenEconomyMode: options.tokenEconomyMode,
+        insecure: options.insecure,
+        startedAt,
+        pid: process.pid,
+        memoryUsage: {
+          rssBytes: memory.rss,
+          peakRssBytes,
+          heapUsedBytes: memory.heapUsed,
+          heapTotalBytes: memory.heapTotal,
+          externalBytes: memory.external
+        },
+        capabilities
+      }
+    },
     toolDiagnostics: async () => ({
       providers: registry.diagnostics(),
       mcpServers: mcpProviders.diagnostics,

--- a/src/renderer/src/agent/kun-contract.ts
+++ b/src/renderer/src/agent/kun-contract.ts
@@ -261,6 +261,13 @@ export type CoreRuntimeInfoJson = {
   insecure?: boolean
   startedAt: string
   pid?: number
+  memoryUsage?: {
+    rssBytes: number
+    peakRssBytes: number
+    heapUsedBytes: number
+    heapTotalBytes: number
+    externalBytes: number
+  }
   capabilities: CoreRuntimeCapabilityManifestJson
 }
 


### PR DESCRIPTION
## Summary

Adds a repeatable HTTP/SSE replay benchmark for Kun agent changes so latency, token usage, cache behavior, cost, tool time, SSE delivery, and runtime memory can be compared before merging.

## Changes

- adds a 20-task read-only agent suite with a five-task smoke subset
- runs real thread turns over the existing HTTP/SSE runtime contract with bounded concurrency and cleanup
- records TTFT, total latency, tool duration, SSE delivery p50/p95, token/cache/cost counters, success rate, and peak RSS
- compares reports against a baseline and can fail CI on material regressions
- exposes process memory counters through `/v1/runtime/info`
- keeps runtime credentials in `KUN_RUNTIME_TOKEN` instead of process arguments

## Tests

- `npm.cmd --prefix kun test -- src/benchmark/replay-benchmark.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd --prefix kun run build`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- focused ESLint and `git diff --check`
- CLI help and 20-task suite parse smoke checks

A live model replay was intentionally not run during development because it would consume the maintainer's provider credentials and tokens. The included smoke suite is ready to run against any configured Kun runtime.