### PR TITLE
feat(settings): enable unused Git checkpoint cleanup by default

### DIFF
--- a/src/main/settings-store.test.ts
+++ b/src/main/settings-store.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_APPROVAL_POLICY,
+  DEFAULT_CHECKPOINT_CLEANUP_ENABLED,
   DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS,
   defaultKunRuntimeSettings,
   defaultModelProviderSettings
@@ -21,8 +22,8 @@ describe('JsonSettingsStore', () => {
     expect(loaded.guiUpdate.channel).toBe(DEFAULT_GUI_UPDATE_CHANNEL)
     expect(loaded.agents.kun.approvalPolicy).toBe(DEFAULT_APPROVAL_POLICY)
     expect(loaded.checkpointCleanup.intervalDays).toBe(DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS)
-    // Checkpoint cleanup deletes data, so it must be opt-in (disabled by default).
-    expect(loaded.checkpointCleanup.enabled).toBe(false)
+    // Checkpoint cleanup is enabled by default to keep stale checkpoints from accumulating.
+    expect(loaded.checkpointCleanup.enabled).toBe(DEFAULT_CHECKPOINT_CLEANUP_ENABLED)
     expect(loaded.appBehavior).toEqual({
       openAtLogin: false,
       startMinimized: false,

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -1163,7 +1163,7 @@
   "logRetentionSeven": "7 days",
   "gitCheckpointTitle": "Git checkpoint management",
   "checkpointCleanupEnabled": "Automatically clean up unused checkpoints",
-  "checkpointCleanupEnabledDesc": "When enabled, periodically delete Git checkpoint directories no longer referenced by any chat. Off by default.",
+  "checkpointCleanupEnabledDesc": "When enabled, periodically delete Git checkpoint directories no longer referenced by any chat. On by default.",
   "checkpointCleanupInterval": "Unused Git checkpoint cleanup",
   "checkpointCleanupIntervalDesc": "Delete Git checkpoint directories that are no longer referenced by any chat on this schedule.",
   "checkpointCleanupInterval1": "Every 1 day",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -1163,7 +1163,7 @@
   "logRetentionSeven": "7 天",
   "gitCheckpointTitle": "Git checkpoint 管理",
   "checkpointCleanupEnabled": "自动清理未使用的 checkpoint",
-  "checkpointCleanupEnabledDesc": "开启后，定期删除不再被任何会话引用的 Git checkpoint 目录。默认关闭。",
+  "checkpointCleanupEnabledDesc": "开启后，定期删除不再被任何会话引用的 Git checkpoint 目录。默认开启。",
   "checkpointCleanupInterval": "未使用 Git checkpoint 清理",
   "checkpointCleanupIntervalDesc": "按所选周期删除不再被任何会话引用的 Git checkpoint 目录。",
   "checkpointCleanupInterval1": "每 1 天",

--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -119,9 +119,9 @@ export const DEFAULT_LOG_RETENTION_DAYS = 3
 export const CHECKPOINT_CLEANUP_INTERVAL_DAYS = [1, 2, 3, 5, 10] as const
 export type CheckpointCleanupIntervalDays = (typeof CHECKPOINT_CLEANUP_INTERVAL_DAYS)[number]
 export const DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS: CheckpointCleanupIntervalDays = 3
-// Checkpoint cleanup deletes data, so it is opt-in: disabled until the user
-// explicitly enables it in settings.
-export const DEFAULT_CHECKPOINT_CLEANUP_ENABLED = false
+// Checkpoint cleanup is enabled by default so stale Git checkpoint directories
+// do not accumulate. Users who want to keep every checkpoint can opt out in settings.
+export const DEFAULT_CHECKPOINT_CLEANUP_ENABLED = true
 export const DEFAULT_CURSOR_SPOTLIGHT_COLOR = '#85c1f1'
 export const DEFAULT_WEIXIN_BRIDGE_RPC_URL = 'http://127.0.0.1:18790/api/v1/admin/rpc'
 export const DEFAULT_MODEL_PROVIDER_ID = 'deepseek'


### PR DESCRIPTION
## Summary

自动清理未使用的 Git checkpoint 默认是关闭的（opt-in）。本 PR 将其改为默认开启，避免 stale checkpoint 目录持续堆积。希望保留所有 checkpoint 的用户仍可在设置中手动关闭。

## Changes

- `src/shared/app-settings-types.ts`: `DEFAULT_CHECKPOINT_CLEANUP_ENABLED` 从 `false` 改为 `true`，并更新注释说明默认开启、可在设置中 opt out。
- `src/main/settings-store.test.ts`: 引入 `DEFAULT_CHECKPOINT_CLEANUP_ENABLED` 并将断言改为基于常量断言，更新注释。
- `src/renderer/src/locales/en/settings.json`: 描述由 "Off by default." 改为 "On by default."。
- `src/renderer/src/locales/zh/settings.json`: 描述由 "默认关闭。" 改为 "默认开启。"。

## Tests

- `npm run typecheck` 通过
- `vitest run src/main/settings-store.test.ts`（23 tests）通过
- `vitest run src/shared/app-settings.test.ts src/shared/app-settings-provider.test.ts src/renderer/src/components/settings-section-general.test.ts`（106 tests）通过
