### PR TITLE
fix(settings): add visible background to log file path display

### DIFF
--- a/src/renderer/src/components/settings-section-general.tsx
+++ b/src/renderer/src/components/settings-section-general.tsx
@@ -550,7 +550,7 @@ export function GeneralSettingsSection({ ctx }: { ctx: Record<string, any> }): R
                   control={
                     <div className="flex w-full min-w-0 flex-col items-start gap-2">
                       {logPath ? (
-                        <code className="block w-full max-w-full break-all rounded-xl bg-ds-main/70 px-3 py-2 font-mono text-[12px] text-ds-muted shadow-sm">
+                        <code className="block w-full max-w-full break-all rounded-xl border border-ds-border-muted bg-ds-main/60 px-3 py-2 font-mono text-[12px] text-ds-ink">
                           {compactHomePath(logPath)}
                         </code>
                       ) : (


### PR DESCRIPTION
## Summary

通用设置里「日志文件路径」的文字显示不好看：底色 `bg-ds-main/70` 实际等于应用背景色 `var(--bg-app)`，70% 透明度后几乎与卡片背景融为一体，底色看不出来；文字又是偏淡的 `text-ds-muted`，整体缺乏层次。

## Changes

- `src/renderer/src/components/settings-section-general.tsx`：调整日志路径 `<code>` 的 className，参考设置页其他路径/代码块显示（worktree pool dir、write inline completion debug log）：
  - 加边框 `border border-ds-border-muted`，让底色区域有清晰边界
  - 文字颜色 `text-ds-muted` → `text-ds-ink`，更深更清晰
  - 去掉 `shadow-sm`，统一用边框界定区域
  - 底色透明度 `/70` → `/60`，与 worktree 风格协调

## Tests

- 仅 className 字符串调整，无逻辑/类型变化
- 本地 `vitest` 因依赖未安装无法运行（环境基线问题，与本次改动无关）
- 视觉验证：日志路径现在带明显边框 + 底色区域，与设置页其他路径显示风格一致
