### PR TITLE
fix(runtime): recover missing replies after SSE disconnect

### DIFF
--- a/src/main/runtime-sse-ipc.test.ts
+++ b/src/main/runtime-sse-ipc.test.ts
@@ -64,6 +64,9 @@ describe('runtime-sse-ipc', () => {
             if (chunk === '__ERROR__') {
               throw new Error('Network Disruption')
             }
+            if (chunk === '__TERMINATED__') {
+              throw new Error('terminated')
+            }
             return { done: false, value: enc.encode(chunk) }
           }
         }
@@ -166,5 +169,64 @@ describe('runtime-sse-ipc', () => {
     expect(allEvents[1].text).toBe('world')
     expect(allEvents[2].seq).toBe(3)
     expect(allEvents[2].text).toBe('bye')
+  })
+
+  it('treats terminated stream reads as reconnectable SSE disconnects', async () => {
+    registerRuntimeSseIpc({
+      ipcMain: mockIpcMain,
+      store: mockStore,
+      ensureRuntime: mockEnsureRuntime,
+      logError: mockLogError
+    })
+
+    const startHandler = handlers.get('runtime:sse:start')
+    expect(startHandler).toBeDefined()
+
+    const stream1 = mockReadableStream([
+      'id: 7\ndata: {"text": "partial"}\n\n',
+      '__TERMINATED__'
+    ])
+    const stream2 = mockReadableStream([
+      'id: 8\ndata: {"text": "final"}\n\n'
+    ])
+
+    mockFetch.mockImplementation(async () => {
+      const callCount = mockFetch.mock.calls.length
+      if (callCount === 1) {
+        return { ok: true, status: 200, body: stream1 }
+      }
+      if (callCount === 2) {
+        return { ok: true, status: 200, body: stream2 }
+      }
+      return { ok: false, status: 400 }
+    })
+
+    const startRes = await startHandler!(mockEvent, {
+      threadId: 'thread-terminated',
+      sinceSeq: 0
+    })
+
+    await vi.advanceTimersByTimeAsync(750)
+
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(mockFetch.mock.calls[1][0].toString()).toContain('since_seq=7')
+    expect(mockEvent.sender.send).not.toHaveBeenCalledWith(
+      'runtime:sse-error',
+      expect.objectContaining({ streamId: startRes.streamId, message: 'terminated' })
+    )
+    expect(mockLogError).not.toHaveBeenCalledWith(
+      'sse',
+      expect.stringContaining('SSE stream error'),
+      expect.objectContaining({ message: 'terminated' })
+    )
+
+    const stopHandler = handlers.get('runtime:sse:stop')
+    expect(stopHandler).toBeDefined()
+    await stopHandler!(mockEvent, startRes.streamId)
+
+    const allEvents = mockEvent.sender.send.mock.calls
+      .filter((call: any) => call[0] === 'runtime:sse-event')
+      .flatMap((call: any) => call[1].events)
+    expect(allEvents.map((event: any) => event.seq)).toEqual([7, 8])
   })
 })

--- a/src/main/runtime-sse-ipc.ts
+++ b/src/main/runtime-sse-ipc.ts
@@ -111,6 +111,10 @@ function isFatalSseStatus(status: number | undefined): boolean {
   return typeof status === 'number' && status >= 400 && status < 500 && status !== 408 && status !== 429
 }
 
+function isTransientSseErrorMessage(message: string): boolean {
+  return /sse start timeout|fetch failed|network|terminated|aborted|socket|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR/i.test(message)
+}
+
 async function fetchSseWithStartTimeout(
   url: URL,
   headers: Record<string, string>,
@@ -285,7 +289,7 @@ export function registerRuntimeSseIpc(options: {
           } catch (e) {
             if (state.stoppedByClient || ac.signal.aborted) return
             const msg = e instanceof Error ? e.message : String(e)
-            if (/sse start timeout/i.test(msg) || /fetch failed/i.test(msg) || /network/i.test(msg)) {
+            if (isTransientSseErrorMessage(msg)) {
               await sleepWithAbort(reconnectDelayMs, ac.signal)
               reconnectDelayMs = Math.min(reconnectDelayMs * 2, SSE_RECONNECT_MAX_MS)
               continue

--- a/src/renderer/src/store/chat-store-runtime.test.ts
+++ b/src/renderer/src/store/chat-store-runtime.test.ts
@@ -39,7 +39,9 @@ function makeSinkHarness(overrides: Partial<ChatState> = {}): {
     watchTurnCompletion: {},
     unreadThreadIds: {},
     queuedMessages: [],
-    threads: []
+    threads: [],
+    refreshThreads: vi.fn(async () => undefined),
+    drainQueuedMessages: vi.fn(async () => undefined)
   } as unknown as ChatState
   state = { ...state, ...overrides }
   const get = (): ChatState => state
@@ -138,6 +140,44 @@ describe('thread event sink binding', () => {
     sink.onSeq(3)
 
     expect(getState().lastSeq).toBe(500)
+  })
+
+  it('reconciles a completed turn from persisted detail when live assistant text was missed', async () => {
+    const getThreadDetail = vi.fn(async () => ({
+      blocks: [
+        { kind: 'user' as const, id: 'user-current', turnId: 'turn-current', text: 'check the workspace' },
+        { kind: 'assistant' as const, id: 'assistant-current', turnId: 'turn-current', text: 'Workspace is /tmp/project.' }
+      ],
+      latestSeq: 42,
+      threadStatus: 'completed'
+    }))
+    const { getState, set, get } = makeSinkHarness({
+      activeThreadId: 'thread-current',
+      blocks: [{ kind: 'user', id: 'user-current', turnId: 'turn-current', text: 'check the workspace' }],
+      liveAssistant: '',
+      lastSeq: 10,
+      busy: true,
+      currentTurnId: 'turn-current',
+      currentTurnUserId: 'user-current'
+    })
+    const sink = buildThreadEventSink(set, get, {
+      threadId: 'thread-current',
+      getThreadDetail
+    })
+
+    sink.onTurnComplete()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(getThreadDetail).toHaveBeenCalledWith('thread-current')
+    expect(getState().busy).toBe(false)
+    expect(getState().lastSeq).toBe(42)
+    expect(getState().blocks).toContainEqual({
+      kind: 'assistant',
+      id: 'assistant-current',
+      turnId: 'turn-current',
+      text: 'Workspace is /tmp/project.'
+    })
   })
 })
 

--- a/src/renderer/src/store/chat-store-runtime.ts
+++ b/src/renderer/src/store/chat-store-runtime.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentProvider,
   ChatBlock,
   CompactionBlock,
   NormalizedThread,
@@ -18,7 +19,7 @@ import { isClawWorkspacePath, isInternalTemporaryWorkspace, normalizeWorkspaceRo
 import type { ClawImChannelV1 } from '@shared/app-settings'
 import { isBackgroundShellNoticeUserMessage } from '@shared/background-shell-notice'
 import type { ChatState } from './chat-store-types'
-import { isClawThread } from './chat-store-helpers'
+import { hydrateBlockModelLabels, isClawThread } from './chat-store-helpers'
 import {
   collectAssistantTextForTurn,
   isOptimisticUserBlockId,
@@ -258,7 +259,13 @@ export function clearWatchedCompletionNotification(threadId: string): void {
 }
 
 function notifyTurnComplete(threadId: string | null, state: ChatState, dedupeKey: string): void {
-  if (!threadId || typeof window.kunGui?.showTurnCompleteNotification !== 'function') return
+  if (
+    !threadId ||
+    typeof window === 'undefined' ||
+    typeof window.kunGui?.showTurnCompleteNotification !== 'function'
+  ) {
+    return
+  }
   if (!rememberCompletionNotificationKey(dedupeKey)) return
 
   const threadTitle =
@@ -594,6 +601,85 @@ export type ThreadEventSinkBinding = {
    * live bubble.
    */
   sinceSeq?: number
+  getThreadDetail?: AgentProvider['getThreadDetail']
+}
+
+function assistantTextAfterUser(blocks: ChatBlock[], userBlockId: string): string {
+  const userIndex = blocks.findIndex((block) => block.kind === 'user' && block.id === userBlockId)
+  if (userIndex < 0) return ''
+  const parts: string[] = []
+  for (let index = userIndex + 1; index < blocks.length; index += 1) {
+    const block = blocks[index]
+    if (block.kind === 'user') break
+    if (block.kind === 'assistant' && block.text.trim()) parts.push(block.text.trim())
+  }
+  return parts.join('\n\n').trim()
+}
+
+function hasAssistantTextForCompletedTurn(
+  state: Pick<ChatState, 'blocks' | 'liveAssistant'>,
+  turnId: string | null | undefined,
+  userBlockId: string | null | undefined
+): boolean {
+  if (state.liveAssistant.trim()) return true
+  const normalizedTurnId = turnId?.trim()
+  if (normalizedTurnId) {
+    return state.blocks.some(
+      (block) => block.kind === 'assistant' && block.turnId === normalizedTurnId && block.text.trim()
+    )
+  }
+  const normalizedUserBlockId = userBlockId?.trim()
+  return normalizedUserBlockId ? !!assistantTextAfterUser(state.blocks, normalizedUserBlockId) : false
+}
+
+async function reconcileCompletedTurnFromThreadDetail(input: {
+  threadId: string | null | undefined
+  turnId: string | null | undefined
+  userBlockId: string | null | undefined
+  loadThreadDetail: AgentProvider['getThreadDetail']
+  set: (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) => void
+  get: () => ChatState
+}): Promise<void> {
+  const threadId = input.threadId?.trim()
+  if (!threadId) return
+  if (hasAssistantTextForCompletedTurn(input.get(), input.turnId, input.userBlockId)) return
+
+  try {
+    const detail = await input.loadThreadDetail(threadId)
+    const loaded = hydrateBlockModelLabels(threadId, detail.blocks)
+    const hasPersistedCompletion =
+      hasAssistantTextForCompletedTurn(
+        { blocks: loaded, liveAssistant: '' } as Pick<ChatState, 'blocks' | 'liveAssistant'>,
+        input.turnId,
+        input.userBlockId
+      ) || detail.latestSeq > input.get().lastSeq
+    if (!hasPersistedCompletion) return
+
+    input.set((state) => {
+      if (state.activeThreadId !== threadId) return {}
+      if (state.busy) return {}
+      if (state.currentTurnId && state.currentTurnId !== input.turnId) return {}
+      if (hasAssistantTextForCompletedTurn(state, input.turnId, input.userBlockId)) return {}
+
+      const busy = threadSnapshotLooksRunning(loaded, detail.threadStatus)
+      const blocks = busy ? loaded : settlePendingRuntimeWorkAfterInterrupt(loaded)
+      return {
+        blocks,
+        lastSeq: Math.max(state.lastSeq, detail.latestSeq),
+        liveReasoning: '',
+        liveAssistant: '',
+        activeThreadGoal: detail.goal ?? state.activeThreadGoal,
+        activeThreadTodos: detail.todos ?? state.activeThreadTodos,
+        error: clearRuntimeStreamRecoveringError(state.error)
+      }
+    })
+  } catch (error) {
+    if (typeof window === 'undefined') return
+    void window.kunGui?.logError?.('turn-completion-reconcile', 'Failed to reconcile completed turn', {
+      message: error instanceof Error ? error.message : String(error),
+      threadId
+    }).catch(() => undefined)
+  }
 }
 
 export function buildThreadEventSink(
@@ -603,6 +689,7 @@ export function buildThreadEventSink(
 ): ThreadEventSink {
   const boundThreadId = binding.threadId?.trim() ?? ''
   let appliedDeltaSeqFloor = binding.sinceSeq ?? 0
+  const loadThreadDetail = binding.getThreadDetail ?? ((threadId: string) => getProvider().getThreadDetail(threadId))
   const isCurrentStream = (): boolean => {
     if (binding.signal?.aborted) return false
     return !boundThreadId || get().activeThreadId === boundThreadId
@@ -1139,6 +1226,12 @@ export function buildThreadEventSink(
       const completedState = get()
       const completedThreadId = completedState.activeThreadId
       const completedTurnId = completedState.currentTurnId
+      const completedUserBlockId = completedState.currentTurnUserId
+      const shouldReconcileCompletion = !hasAssistantTextForCompletedTurn(
+        completedState,
+        completedTurnId,
+        completedUserBlockId
+      )
       const completedKey = completedState.currentTurnId
         ? `turn:${completedState.currentTurnId}`
         : `active:${completedThreadId ?? 'unknown'}:${completedState.lastSeq}`
@@ -1181,6 +1274,16 @@ export function buildThreadEventSink(
       notifyWriteWorkspaceFileRefresh(get)
       notifySddChatTranscriptMirror(get)
       syncTurnCompletionPoll(set, get)
+      if (shouldReconcileCompletion) {
+        void reconcileCompletedTurnFromThreadDetail({
+          threadId: completedThreadId,
+          turnId: completedTurnId,
+          userBlockId: completedUserBlockId,
+          loadThreadDetail,
+          set,
+          get
+        })
+      }
       void get().refreshThreads()
       // Release worktree when the turn finishes and there are no queued
       // follow-ups that would start a new turn in the same thread.


### PR DESCRIPTION
Summary
- Treat local SSE `terminated` stream reads as transient disconnects so the main process reconnects from the last delivered sequence instead of ending the stream.
- Reconcile completed turns from persisted Kun thread detail when the renderer receives completion without any visible assistant text.
- Add regression coverage for `terminated` SSE reconnects and completion-time assistant reply recovery.

Changes
- Broadened runtime SSE transient error classification to cover abrupt local stream termination/socket errors.
- Added a guarded completion reconciliation path in the chat event sink that only fetches thread detail when the completed turn has no local assistant text, and skips state replacement if the user switched threads or started another turn.
- Hardened turn completion notification against non-browser test environments.

Tests
- `npm test -- src/main/runtime-sse-ipc.test.ts src/renderer/src/store/chat-store-runtime.test.ts`
- `npm run typecheck`
- `npm run build`
- `npx eslint src/main/runtime-sse-ipc.ts src/main/runtime-sse-ipc.test.ts src/renderer/src/store/chat-store-runtime.ts src/renderer/src/store/chat-store-runtime.test.ts`
- `npm run lint` currently fails on existing baseline `react-hooks/rules-of-hooks` in `src/renderer/src/components/chat/message-timeline-process.tsx:248` plus existing hook dependency warnings.

Fixes #653
