### PR TITLE
fix(renderer): preserve Vietnamese output while streaming

### DIFF
--- a/src/renderer/src/components/chat/StreamdownAssistant.test.ts
+++ b/src/renderer/src/components/chat/StreamdownAssistant.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { nextVisibleLength } from './StreamdownAssistant'
+import { nextVisibleLength, visibleTextForTypewriter } from './StreamdownAssistant'
 
 describe('nextVisibleLength', () => {
   it('stays put when caught up', () => {
@@ -29,5 +29,21 @@ describe('nextVisibleLength', () => {
       expect(current).toBeLessThanOrEqual(target)
     }
     expect(current).toBe(target)
+  })
+})
+
+describe('visibleTextForTypewriter', () => {
+  it('does not split decomposed Vietnamese accents mid-stream', () => {
+    const text = `Pha\u0302n ti\u0301ch`
+
+    expect(visibleTextForTypewriter(text, 3)).toBe(`Pha\u0302`)
+    expect(visibleTextForTypewriter(text, 8)).toBe(`Pha\u0302n ti\u0301`)
+  })
+
+  it('keeps joined emoji intact', () => {
+    const text = '👩‍💻 demo'
+
+    expect(visibleTextForTypewriter(text, 1)).toBe('👩‍💻')
+    expect(visibleTextForTypewriter(text, 2)).toBe('👩‍💻')
   })
 })

--- a/src/renderer/src/components/chat/StreamdownAssistant.tsx
+++ b/src/renderer/src/components/chat/StreamdownAssistant.tsx
@@ -17,6 +17,12 @@ const CATCHUP_DIVISOR = 8
  * thread, burst from a fast model) drains as fast typing instead of a
  * near-instant wall of text. */
 const MAX_STEP_PER_FRAME = 32
+const COMBINING_MARK_REGEX = /\p{Mark}/u
+const VARIATION_SELECTOR_REGEX = /\p{Variation_Selector}/u
+const graphemeSegmenter =
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null
 
 export function nextVisibleLength(current: number, target: number): number {
   if (current === target) return current
@@ -24,6 +30,52 @@ export function nextVisibleLength(current: number, target: number): number {
   if (current > target) return target
   const backlog = target - current
   return current + Math.min(MAX_STEP_PER_FRAME, Math.max(1, Math.ceil(backlog / CATCHUP_DIVISOR)))
+}
+
+function fallbackBoundary(text: string, length: number): number {
+  let boundary = length
+  const previousCode = text.charCodeAt(boundary - 1)
+  if (previousCode >= 0xd800 && previousCode <= 0xdbff && boundary < text.length) {
+    boundary += 1
+  }
+
+  while (boundary < text.length) {
+    const codePoint = text.codePointAt(boundary)
+    if (codePoint == null) break
+    const char = String.fromCodePoint(codePoint)
+    if (COMBINING_MARK_REGEX.test(char) || VARIATION_SELECTOR_REGEX.test(char)) {
+      boundary += char.length
+      continue
+    }
+    if (codePoint === 0x200d) {
+      boundary += 1
+      const joinedCodePoint = text.codePointAt(boundary)
+      if (joinedCodePoint == null) break
+      boundary += String.fromCodePoint(joinedCodePoint).length
+      continue
+    }
+    break
+  }
+
+  return boundary
+}
+
+function nextTextBoundary(text: string, visibleLength: number): number {
+  const length = Math.max(0, Math.min(visibleLength, text.length))
+  if (length === 0 || length === text.length) return length
+
+  if (graphemeSegmenter) {
+    for (const segment of graphemeSegmenter.segment(text)) {
+      const boundary = segment.index + segment.segment.length
+      if (boundary >= length) return boundary
+    }
+  }
+
+  return fallbackBoundary(text, length)
+}
+
+export function visibleTextForTypewriter(text: string, visibleLength: number): string {
+  return text.slice(0, nextTextBoundary(text, visibleLength))
 }
 
 /**
@@ -51,11 +103,7 @@ function useTypewriterText(text: string, streaming: boolean): string {
   }, [streaming])
 
   if (!streaming) return text
-  let length = Math.min(visibleLength, text.length)
-  // Don't cut a surrogate pair in half mid-reveal.
-  const code = text.charCodeAt(length - 1)
-  if (code >= 0xd800 && code <= 0xdbff) length += 1
-  return text.slice(0, length)
+  return visibleTextForTypewriter(text, visibleLength)
 }
 
 const rehypePlugins = [

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -855,7 +855,8 @@ body {
   position: relative;
   isolation: isolate;
   font-family:
-    'SF Pro Text', 'PingFang SC', 'Noto Sans SC', 'Helvetica Neue', Arial, sans-serif;
+    -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', 'Helvetica Neue', Arial, 'Noto Sans',
+    'PingFang SC', 'Hiragino Sans GB', 'Noto Sans SC', 'Microsoft YaHei', sans-serif;
   background-color: var(--ds-bg-main);
   color: var(--ds-text);
   user-select: none;

--- a/src/renderer/src/styles/markdown-code.css
+++ b/src/renderer/src/styles/markdown-code.css
@@ -29,7 +29,7 @@
 .ds-markdown h2,
 .ds-markdown h3 {
   margin: 0 0 0.42rem;
-  font-family: 'SF Pro Display', 'PingFang SC', 'Noto Sans SC', sans-serif;
+  font-family: 'SF Pro Display', 'Segoe UI', 'Noto Sans', 'PingFang SC', 'Noto Sans SC', sans-serif;
   font-weight: 600;
   letter-spacing: 0;
   line-height: 1.2;


### PR DESCRIPTION
## Summary
- fix streamed assistant markdown so it does not split Vietnamese grapheme clusters mid-render
- improve default UI font fallbacks used by assistant output

## Changes
- add grapheme-aware slicing in `StreamdownAssistant` using `Intl.Segmenter` with a safe fallback for combining marks, variation selectors, and ZWJ sequences
- add regression coverage for decomposed Vietnamese accents and joined emoji sequences
- expand the default sans-serif fallback stack for chat markdown and inherited UI text

## Tests
- `npm run typecheck`
- `npx vitest run src/renderer/src/components/chat/StreamdownAssistant.test.ts`
