### PR TITLE
fix(usage): align cache hit rate across session views

### DIFF
--- a/src/renderer/src/components/SessionHeader.tsx
+++ b/src/renderer/src/components/SessionHeader.tsx
@@ -10,7 +10,7 @@ import {
   formatCacheMissReason,
   formatCost,
   formatPercent,
-  primaryCacheHitRate,
+  cumulativeCacheHitRate,
   useThreadUsage
 } from '../hooks/use-thread-usage'
 
@@ -214,7 +214,7 @@ export function SessionHeader({ compact = false, className = '' }: Props): React
                       }
                     )}
                   >
-                    {t('sessionUsageCache', { cache: formatPercent(primaryCacheHitRate(threadUsage)) })}
+                    {t('sessionUsageCache', { cache: formatPercent(cumulativeCacheHitRate(threadUsage)) })}
                   </span>
                 </>
               ) : null}

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -82,7 +82,7 @@ import {
   formatCompactNumber,
   formatCost,
   formatPercent,
-  primaryCacheHitRate,
+  cumulativeCacheHitRate,
   useThreadUsageState
 } from '../../hooks/use-thread-usage'
 import { buildContextCapacity, estimateBlockTokens } from '../../lib/context-capacity'
@@ -2485,7 +2485,7 @@ export function FloatingComposer({
                         <span className="ds-composer-usage-cache-separator text-ds-faint">·</span>
                         <span className="ds-composer-usage-cache shrink-0 truncate tabular-nums">
                           {t('sessionUsageCache', {
-                            cache: formatPercent(primaryCacheHitRate(threadUsage))
+                            cache: formatPercent(cumulativeCacheHitRate(threadUsage))
                           })}
                         </span>
                       </>

--- a/src/renderer/src/hooks/use-thread-usage.test.ts
+++ b/src/renderer/src/hooks/use-thread-usage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { formatCost, loadThreadUsage, primaryCacheHitRate } from './use-thread-usage'
+import { cumulativeCacheHitRate, formatCost, loadThreadUsage, primaryCacheHitRate } from './use-thread-usage'
 
 type RuntimeRequest = (path: string, method?: string) => Promise<{ ok: boolean; status: number; body: string }>
 
@@ -38,6 +38,15 @@ describe('thread usage formatting', () => {
     expect(primaryCacheHitRate({ cacheHitRate: 0.4, lastTurnCacheHitRate: 0.95 })).toBe(0.95)
     expect(primaryCacheHitRate({ cacheHitRate: 0.4, lastTurnCacheHitRate: null })).toBe(0.4)
     expect(primaryCacheHitRate({ cacheHitRate: null, lastTurnCacheHitRate: null })).toBeNull()
+  })
+
+  it('derives the cumulative cache rate from tokens to match the overall usage panel (#654)', () => {
+    // Last-turn rate could be 0 while the thread cumulative is non-zero — the
+    // chip must show the token-derived cumulative so it matches the overall panel.
+    expect(cumulativeCacheHitRate({ cachedTokens: 41, cacheMissTokens: 959, cacheHitRate: 0 })).toBeCloseTo(0.041, 3)
+    // Falls back to the provided rate when there is no token telemetry.
+    expect(cumulativeCacheHitRate({ cachedTokens: 0, cacheMissTokens: 0, cacheHitRate: 0.8 })).toBe(0.8)
+    expect(cumulativeCacheHitRate({ cachedTokens: 0, cacheMissTokens: 0, cacheHitRate: null })).toBeNull()
   })
 
   it('keeps cache hit rate unknown for cachedTokens-only thread usage buckets', async () => {

--- a/src/renderer/src/hooks/use-thread-usage.ts
+++ b/src/renderer/src/hooks/use-thread-usage.ts
@@ -88,6 +88,22 @@ export function primaryCacheHitRate(
   return usage.lastTurnCacheHitRate ?? usage.cacheHitRate
 }
 
+/**
+ * Cumulative thread cache hit rate derived from token counts — the SAME formula
+ * the overall usage panel uses (cachedTokens / (cachedTokens + cacheMissTokens)).
+ * This keeps the conversation bottom bar consistent with the overall stats
+ * (issue #654): the last-turn rate could read 0% while the thread cumulative is
+ * non-zero. Falls back to the backend-provided `cacheHitRate` when no token
+ * telemetry is available.
+ */
+export function cumulativeCacheHitRate(
+  usage: Pick<ThreadUsageSummary, 'cachedTokens' | 'cacheMissTokens' | 'cacheHitRate'>
+): number | null {
+  const total = usage.cachedTokens + usage.cacheMissTokens
+  if (total > 0) return usage.cachedTokens / total
+  return usage.cacheHitRate
+}
+
 export function formatCacheMissReason(reason: string): string {
   switch (reason) {
     case 'cold_request':


### PR DESCRIPTION
## Summary

- calculate the bottom usage chip from cumulative cached and uncached input tokens
- keep the recent-turn cache rate in the tooltip for diagnostics
- make the session header and usage panel report the same cache hit percentage

## Tests

- npm.cmd test -- src/renderer/src/hooks/use-thread-usage.test.ts
- npm.cmd run typecheck
- git diff --check kunagent/develop...HEAD

Fixes #654