### PR TITLE
fix(provider): correct OpenCode Go DeepSeek v4 profiles

### DIFF
--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -1219,4 +1219,34 @@ describe('provider presets', () => {
     expect(resolved.modelProfiles['minimax-m3'].endpointFormat).toBe('messages')
     expect(resolved.modelProfiles['glm-5.1'].endpointFormat).toBeUndefined()
   })
+
+  it('keeps OpenCode Go DeepSeek v4 profiles aligned with DeepSeek defaults (#658)', () => {
+    const preset = getModelProviderPreset('opencode-go')
+    expect(preset).not.toBeNull()
+    const profile = modelProviderPresetProfile(preset!, 'sk-opencode')
+
+    for (const modelId of ['deepseek-v4-pro', 'deepseek-v4-flash']) {
+      expect(profile.modelProfiles[modelId]).toMatchObject({
+        contextWindowTokens: 1_000_000,
+        reasoning: {
+          supportedEfforts: ['off', 'high', 'max'],
+          defaultEffort: 'max',
+          requestProtocol: 'deepseek-chat-completions'
+        }
+      })
+    }
+
+    const resolved = resolveKunRuntimeSettings({
+      ...settings(),
+      provider: {
+        ...defaultModelProviderSettings(),
+        providers: [...defaultModelProviderSettings().providers, profile]
+      },
+      agents: {
+        kun: { ...defaultKunRuntimeSettings(), providerId: profile.id, model: 'deepseek-v4-pro' }
+      }
+    })
+    expect(resolved.modelProfiles['deepseek-v4-pro']).toEqual(profile.modelProfiles['deepseek-v4-pro'])
+    expect(resolved.modelProfiles['deepseek-v4-flash']).toEqual(profile.modelProfiles['deepseek-v4-flash'])
+  })
 })

--- a/src/shared/model-provider-presets.ts
+++ b/src/shared/model-provider-presets.ts
@@ -157,6 +157,12 @@ const GLM_REASONING: ModelProviderReasoningCapabilityV1 = {
   requestProtocol: 'glm-chat-completions'
 }
 
+const DEEPSEEK_REASONING: ModelProviderReasoningCapabilityV1 = {
+  supportedEfforts: ['off', 'high', 'max'],
+  defaultEffort: 'max',
+  requestProtocol: 'deepseek-chat-completions'
+}
+
 // 通义千问 / 混元 / 豆包的「思考」开关各家用私有 body 字段,无法用现有 requestProtocol 精确映射,
 // 这里统一按「内置推理」建模(requestProtocol: 'none'):只展示 effort 开关、不向上游发送特定协议字段,避免请求被拒。
 const QWEN_REASONING: ModelProviderReasoningCapabilityV1 = {
@@ -350,8 +356,8 @@ export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
       'kimi-k2.7': textChatProfile(131_072),
       'kimi-k2.7-code': textChatProfile(131_072),
       'kimi-k2.6': textChatProfile(131_072),
-      'deepseek-v4-pro': textChatProfile(131_072),
-      'deepseek-v4-flash': textChatProfile(131_072),
+      'deepseek-v4-pro': textChatProfile(1_000_000, DEEPSEEK_REASONING),
+      'deepseek-v4-flash': textChatProfile(1_000_000, DEEPSEEK_REASONING),
       'mimo-v2.5': textChatProfile(131_072),
       'mimo-v2.5-pro': textChatProfile(131_072),
       'mimo-v2-pro': textChatProfile(131_072),


### PR DESCRIPTION
## Summary

- set OpenCode Go `deepseek-v4-pro` and `deepseek-v4-flash` to a 1M context window
- expose the DeepSeek reasoning efforts and request protocol for both models
- cover preset creation and the full settings normalization round trip

## Root cause

The built-in OpenCode Go preset defined both DeepSeek v4 models with the generic 131072-token text profile. Known preset metadata is reapplied during settings normalization, so the incorrect built-in value replaced the edited value after reload.

## Tests

- `npm.cmd test -- src/shared/app-settings-provider.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`

Fixes #658