### PR TITLE
fix(sdd): make requirement workspace explicit

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -60,11 +60,17 @@ import { composeWritePrompt } from '../write/quoted-selection'
 import { resolveWriteAgentPreset } from '../write/agent-presets'
 import { useWriteWorkspaceStore } from '../write/write-workspace-store'
 import { isWriteThreadId } from '../write/write-thread-registry'
-import { buildSddDraftId, createSddDraft, forgetRememberedSddDraft, useSddDraftStore } from '../sdd/sdd-draft-store'
+import {
+  buildSddDraftId,
+  createSddDraft,
+  forgetRememberedSddDraft,
+  resolveSddRequirementWorkspace,
+  useSddDraftStore
+} from '../sdd/sdd-draft-store'
 import type { SddDraft, SddDraftSaveStatus } from '../sdd/sdd-draft-store'
 import { listSddDraftHistory, titleFromSddDraftContent } from '../sdd/sdd-draft-history'
 import { saveActiveSddDraftToDisk } from '../sdd/sdd-draft-actions'
-import { restoreRememberedSddDraft, restoreSddDraft } from '../sdd/sdd-draft-restore'
+import { restoreSddDraft } from '../sdd/sdd-draft-restore'
 import { composeSddAssistantPrompt } from '../sdd/sdd-assistant-prompt'
 import { frameworkById } from '../sdd/pm-skill-frameworks'
 import { collectSddDraftImages, withAttachmentIds, type SddDraftImageReference } from '../sdd/sdd-draft-images'
@@ -90,7 +96,7 @@ import { CODE_PANEL_PREFERRED, useWorkbenchLayout } from './workbench-layout'
 import { useWorkbenchPlanController } from './workbench-plan-controller'
 import { prepareImageAttachmentUpload } from '../lib/image-attachment-upload'
 import { isChatAttachmentUploadEnabled } from '../lib/attachment-upload-availability'
-import { normalizeWorkspaceRoot } from '../lib/workspace-path'
+import { isConversationWorkspacePath, normalizeWorkspaceRoot } from '../lib/workspace-path'
 import { useKeyboardShortcutSettings } from '../lib/keyboard-shortcut-settings'
 import { collectComposerChangeSummary } from '../lib/composer-change-summary'
 import { formatWorkspacePickerError } from '../lib/format-workspace-picker-error'
@@ -406,6 +412,7 @@ export function Workbench(): ReactElement {
     route,
     pluginHostRoute,
     workspaceRoot,
+    conversationWorkspaceRoot,
     runtimeConnection,
     setRoute,
     openCode,
@@ -471,6 +478,7 @@ export function Workbench(): ReactElement {
       route: s.route,
       pluginHostRoute: s.pluginHostRoute,
       workspaceRoot: s.workspaceRoot,
+      conversationWorkspaceRoot: s.conversationWorkspaceRoot,
       runtimeConnection: s.runtimeConnection,
       setRoute: s.setRoute,
       openCode: s.openCode,
@@ -1506,29 +1514,26 @@ export function Workbench(): ReactElement {
   }
 
   const startNewSddRequirement = async (): Promise<void> => {
-    const activeCodeWorkspace = activeThreadId
-      ? normalizeWorkspaceRoot(codeThreads.find((thread) => thread.id === activeThreadId)?.workspace ?? '')
-      : ''
-    let targetWorkspace = activeCodeWorkspace || normalizeWorkspaceRoot(workspaceRoot)
-    if (!targetWorkspace) {
-      const picked = await chooseWorkspace({ selectThreadAfter: false })
-      targetWorkspace = normalizeWorkspaceRoot(picked ?? useChatStore.getState().workspaceRoot)
+    const suggestedWorkspace = resolveSddRequirementWorkspace(codeThreads, activeThreadId, workspaceRoot)
+    let targetWorkspace = ''
+    try {
+      const picked = await window.kunGui.pickWorkspaceDirectory(suggestedWorkspace || undefined)
+      if (picked.canceled || !picked.path) return
+      targetWorkspace = normalizeWorkspaceRoot(picked.path)
+    } catch (error) {
+      setError(formatWorkspacePickerError(error))
+      return
     }
     if (!targetWorkspace) {
       setError(t('workspaceRequiredToCreateThread'))
       return
     }
-    const restored = await restoreRememberedSddDraft({
-      workspaceRoot: targetWorkspace,
-      readWorkspaceFile: window.kunGui.readWorkspaceFile
-    })
-    if (restored.kind === 'restored') {
-      await openSddRequirementDraft(restored.draft, restored.content, {
-        lastSavedContent: restored.lastSavedContent,
-        saveStatus: restored.saveStatus
-      })
+    if (isConversationWorkspacePath(targetWorkspace, conversationWorkspaceRoot)) {
+      setError(t('workspaceInsideConversationDir'))
       return
     }
+
+    if (useSddDraftStore.getState().activeDraft && !await saveActiveSddDraftToDisk()) return
 
     const draftUuid = globalThis.crypto?.randomUUID?.() ?? `draft-${Date.now()}`
     const draft = createSddDraft({ id: draftUuid, workspaceRoot: targetWorkspace })

--- a/src/renderer/src/components/chat/Sidebar.tsx
+++ b/src/renderer/src/components/chat/Sidebar.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react'
 import type { NormalizedThread } from '../../agent/types'
 import { useChatStore, type SettingsRouteSection } from '../../store/chat-store'
-import type { SddDraft } from '../../sdd/sdd-draft-store'
+import { resolveSddRequirementWorkspace, type SddDraft } from '../../sdd/sdd-draft-store'
 import type {
   ClawImChannelV1,
 } from '@shared/app-settings'
@@ -29,6 +29,7 @@ import { ConnectPhoneSidebarPanel } from './ConnectPhoneView'
 import { SidebarProjectsSection } from './SidebarProjectsSection'
 import { SidebarConversationsSection } from './SidebarConversationsSection'
 import { WorkspaceModeTabs } from './WorkspaceModeTabs'
+import { workspaceLabelFromPath } from '../../lib/workspace-label'
 import {
   SidebarCommandRow,
   SidebarFrame,
@@ -128,6 +129,7 @@ export function Sidebar({
   const deleteClawChannel = useChatStore((s) => s.deleteClawChannel)
   const resetClawChannelSession = useChatStore((s) => s.resetClawChannelSession)
   const [imDialogMode, setImDialogMode] = useState<ClawImDialogMode | null>(null)
+  const requirementWorkspace = resolveSddRequirementWorkspace(threads, activeThreadId, workspaceRoot)
 
   const activeClawChannel = useMemo(
     () => clawChannels.find((channel) => channel.id === activeClawChannelId) ?? clawChannels[0] ?? null,
@@ -210,6 +212,14 @@ export function Sidebar({
               disabled={!runtimeReady}
               disabledHint={t('runtimeActionNeedsConnection')}
               variant="accent"
+              trailing={requirementWorkspace ? (
+                <span
+                  className="max-w-[92px] truncate text-[11.5px] text-ds-faint"
+                  title={requirementWorkspace}
+                >
+                  {workspaceLabelFromPath(requirementWorkspace)}
+                </span>
+              ) : null}
             />
           </>
         ) : null}

--- a/src/renderer/src/sdd/sdd-draft-store.test.ts
+++ b/src/renderer/src/sdd/sdd-draft-store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createSddDraft,
   forgetRememberedSddDraft,
+  resolveSddRequirementWorkspace,
   readRememberedSddDraftContent,
   readRememberedSddDraft,
   useSddDraftStore
@@ -29,6 +30,15 @@ function createMemoryStorage(): Storage {
 }
 
 describe('sdd-draft-store', () => {
+  it('prefers the active thread workspace when creating a requirement', () => {
+    expect(resolveSddRequirementWorkspace(
+      [{ id: 'thread-1', workspace: '/projects/active' }],
+      'thread-1',
+      '/projects/default'
+    )).toBe('/projects/active')
+    expect(resolveSddRequirementWorkspace([], null, '/projects/default/')).toBe('/projects/default')
+  })
+
   beforeEach(() => {
     vi.stubGlobal('localStorage', createMemoryStorage())
     vi.stubGlobal('window', {

--- a/src/renderer/src/sdd/sdd-draft-store.ts
+++ b/src/renderer/src/sdd/sdd-draft-store.ts
@@ -211,6 +211,16 @@ export function createSddDraft(options: {
   }
 }
 
+export function resolveSddRequirementWorkspace(
+  threads: readonly { id: string; workspace?: string }[],
+  activeThreadId: string | null,
+  fallbackWorkspace: string
+): string {
+  return normalizeWorkspaceRoot(
+    threads.find((thread) => thread.id === activeThreadId)?.workspace ?? fallbackWorkspace
+  )
+}
+
 export function rememberSddDraft(draft: SddDraft): void {
   const normalized = normalizeDraft(draft)
   if (!normalized) return


### PR DESCRIPTION
## Summary

- show the workspace targeted by **New requirement** directly in the sidebar
- open the workspace picker with the inferred active project before creating the draft
- always create a new requirement instead of silently reopening the remembered draft
- save the current draft before switching, and stop if that save fails
- keep existing requirements available through the current draft history

## Root cause

The action inferred its workspace from the active thread or global workspace without exposing that decision. It also restored the remembered draft for that workspace, so the button labeled **New requirement** could reopen an old requirement instead of creating a new one.

## Tests

- `npm.cmd test -- src/renderer/src/sdd/sdd-draft-store.test.ts src/renderer/src/sdd/sdd-draft-history.test.ts src/renderer/src/sdd/sdd-draft-restore.test.ts`
- `npm.cmd run typecheck`
- `git diff --check`

Fixes #663