### PR TITLE
fix(attachments): enforce upload safety boundaries

### DIFF
--- a/kun/src/attachments/attachment-store.ts
+++ b/kun/src/attachments/attachment-store.ts
@@ -5,6 +5,8 @@ import type { AttachmentsCapabilityConfig } from '../contracts/capabilities.js'
 import type { AttachmentDiagnostics, AttachmentMetadata, AttachmentTextFallback } from '../contracts/attachments.js'
 import { AttachmentMetadata as AttachmentMetadataSchema } from '../contracts/attachments.js'
 
+const ATTACHMENT_ID_PATTERN = /^att_[0-9a-f]{24}$/
+
 export type AttachmentContent = AttachmentMetadata & {
   data: Buffer
 }
@@ -95,6 +97,7 @@ export class FileAttachmentStore implements AttachmentStore {
   }
 
   async get(id: string): Promise<AttachmentMetadata | null> {
+    if (!ATTACHMENT_ID_PATTERN.test(id)) return null
     try {
       return AttachmentMetadataSchema.parse(JSON.parse(await readFile(this.metadataPath(id), 'utf8')))
     } catch {
@@ -103,6 +106,7 @@ export class FileAttachmentStore implements AttachmentStore {
   }
 
   async resolveContent(id: string, scope: { threadId?: string; workspace?: string }): Promise<AttachmentContent> {
+    if (!ATTACHMENT_ID_PATTERN.test(id)) throw new Error(`invalid attachment id: ${id}`)
     const metadata = await this.get(id)
     if (!metadata) throw new Error(`attachment not found: ${id}`)
     if (!isAuthorized(metadata, scope)) throw new Error(`attachment is not authorized for this turn: ${id}`)

--- a/kun/src/server/read-json-body.ts
+++ b/kun/src/server/read-json-body.ts
@@ -5,9 +5,27 @@ export type ReadJsonBodyResult =
   | { ok: true; value: unknown }
   | { ok: false; response: JsonResponse }
 
-export async function readJsonBody(request: Request): Promise<ReadJsonBodyResult> {
+const DEFAULT_MAX_JSON_BODY_BYTES = 32 * 1024 * 1024
+
+export async function readJsonBody(request: Request, maxBytes = DEFAULT_MAX_JSON_BODY_BYTES): Promise<ReadJsonBodyResult> {
   if (request.body === null) return { ok: true, value: {} }
-  const text = await request.text()
+  const declaredLength = Number(request.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) return bodyTooLarge(maxBytes)
+
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    totalBytes += value.byteLength
+    if (totalBytes > maxBytes) {
+      await reader.cancel().catch(() => undefined)
+      return bodyTooLarge(maxBytes)
+    }
+    chunks.push(value)
+  }
+  const text = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString('utf8')
   if (!text) return { ok: true, value: {} }
   try {
     return { ok: true, value: JSON.parse(text) }
@@ -18,5 +36,12 @@ export async function readJsonBody(request: Request): Promise<ReadJsonBodyResult
       details: error instanceof Error ? error.message : String(error)
     }
     return { ok: false, response: jsonResponse(body, 400) }
+  }
+}
+
+function bodyTooLarge(maxBytes: number): ReadJsonBodyResult {
+  return {
+    ok: false,
+    response: jsonResponse({ code: 'validation_error', message: `JSON body exceeds ${maxBytes} byte limit` }, 413)
   }
 }

--- a/kun/src/server/routes/attachments.ts
+++ b/kun/src/server/routes/attachments.ts
@@ -14,10 +14,11 @@ export async function uploadAttachment(
   const parsed = AttachmentUploadRequest.safeParse(body.value)
   if (!parsed.success) return ERRORS.attachmentValidation('invalid attachment upload body', parsed.error.issues)
   try {
+    const data = decodeBase64(parsed.data.dataBase64)
     const attachment = await store.create({
       name: parsed.data.name,
       mimeType: parsed.data.mimeType,
-      data: Buffer.from(parsed.data.dataBase64, 'base64'),
+      data,
       localFilePath: parsed.data.localFilePath,
       textFallback: parsed.data.textFallback,
       threadId: parsed.data.threadId,
@@ -27,6 +28,16 @@ export async function uploadAttachment(
   } catch (error) {
     return ERRORS.attachmentValidation(errorMessage(error))
   }
+}
+
+function decodeBase64(value: string): Buffer {
+  const normalized = value.replace(/\s/g, '')
+  if (normalized.length === 0 || normalized.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)) {
+    throw new Error('attachment data is not valid base64')
+  }
+  const data = Buffer.from(normalized, 'base64')
+  if (data.toString('base64') !== normalized) throw new Error('attachment data is not valid base64')
+  return data
 }
 
 export async function getAttachmentMetadata(

--- a/kun/tests/attachment-store.test.ts
+++ b/kun/tests/attachment-store.test.ts
@@ -79,6 +79,12 @@ describe('Attachment store and multimodal input', () => {
     })
   })
 
+  it('rejects attachment ids that could escape the store directory', async () => {
+    const store = createStore()
+    await expect(store.get('../outside')).resolves.toBeNull()
+    await expect(store.resolveContent('..\\outside', {})).rejects.toThrow(/invalid attachment id/)
+  })
+
   it('rejects unsupported MIME, size, and dimensions', async () => {
     await expect(createStore().create({
       name: 'bad.txt',
@@ -170,6 +176,21 @@ describe('Attachment store and multimodal input', () => {
       })
     )
     expect(await readJson(diagnostics)).toMatchObject({ enabled: true, count: 1 })
+  })
+
+  it('rejects malformed base64 attachment uploads', async () => {
+    const h = buildHarness()
+    h.runtime.attachmentStore = createStore()
+    const response = await dispatchRequest(
+      h.router,
+      new Request('http://localhost/v1/attachments', {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok-1', 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'shot.png', dataBase64: 'not-base64!' })
+      })
+    )
+    expect(response.status).toBe(400)
+    expect(await readJson(response)).toMatchObject({ message: 'attachment data is not valid base64' })
   })
 
   it('resolves image attachments for vision models and text fallbacks for text-only models', async () => {

--- a/kun/tests/read-json-body.test.ts
+++ b/kun/tests/read-json-body.test.ts
@@ -35,4 +35,25 @@ describe('readJsonBody', () => {
       message: 'invalid JSON body'
     })
   })
+
+  it('rejects a declared body that exceeds the configured byte limit', async () => {
+    const result = await readJsonBody(new Request('http://localhost/v1/demo', {
+      method: 'POST',
+      headers: { 'content-length': '128' },
+      body: '{}'
+    }), 32)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.response.status).toBe(413)
+  })
+
+  it('rejects a streamed body that exceeds the configured byte limit', async () => {
+    const result = await readJsonBody(new Request('http://localhost/v1/demo', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'x'.repeat(128) })
+    }), 32)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.response.status).toBe(413)
+  })
 })


### PR DESCRIPTION
## Summary
- reject attachment IDs before they can reach filesystem path construction
- cap JSON request bodies by declared and streamed byte size
- reject malformed or non-canonical base64 attachment payloads

## Tests
- `npm.cmd --prefix kun test -- tests/attachment-store.test.ts tests/read-json-body.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `git diff --check`