### PR TITLE
feat(tasks): add persistent agent task graph

### DIFF
--- a/kun/src/adapters/tool/task-graph-tool.test.ts
+++ b/kun/src/adapters/tool/task-graph-tool.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createTaskGraphTool } from './task-graph-tool.js'
+import type { ToolHostContext } from '../../ports/tool-host.js'
+
+function ctx(threadId = 't1'): ToolHostContext {
+  return {
+    threadId, turnId: 'tn', workspace: '/ws', approvalPolicy: 'auto',
+    abortSignal: new AbortController().signal, awaitApproval: vi.fn(async () => 'allow' as const)
+  }
+}
+
+describe('task_graph tool', () => {
+  const dirs: string[] = []
+  afterEach(async () => Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))))
+  it('adds tasks with dependencies and reports runnable set', async () => {
+    const tool = createTaskGraphTool()
+    await tool.execute({ action: 'add', id: 'a', title: 'A' }, ctx())
+    const r = await tool.execute({ action: 'add', id: 'b', title: 'B', dependsOn: ['a'] }, ctx())
+    expect(r.output).toMatchObject({ runnable: ['a'] })
+  })
+
+  it('advances the plan through start/complete and unblocks dependents', async () => {
+    const tool = createTaskGraphTool()
+    await tool.execute({ action: 'add', id: 'a', title: 'A' }, ctx())
+    await tool.execute({ action: 'add', id: 'b', title: 'B', dependsOn: ['a'] }, ctx())
+    await tool.execute({ action: 'start', id: 'a' }, ctx())
+    const done = await tool.execute({ action: 'complete', id: 'a' }, ctx())
+    expect(done.output).toMatchObject({ runnable: ['b'] })
+  })
+
+  it('rejects a dependency cycle', async () => {
+    const tool = createTaskGraphTool()
+    await tool.execute({ action: 'add', id: 'a', title: 'A', dependsOn: ['b'] }, ctx())
+    const r = await tool.execute({ action: 'add', id: 'b', title: 'B', dependsOn: ['a'] }, ctx())
+    expect(r.isError).toBe(true)
+    expect(String((r.output as Record<string, unknown>).error)).toContain('cycle')
+  })
+
+  it('keeps per-thread state isolated', async () => {
+    const tool = createTaskGraphTool()
+    await tool.execute({ action: 'add', id: 'a', title: 'A' }, ctx('t1'))
+    const other = await tool.execute({ action: 'list' }, ctx('t2'))
+    expect(other.output).toMatchObject({ tasks: [] })
+  })
+
+  it('reports retry on failure with attempts remaining', async () => {
+    const tool = createTaskGraphTool()
+    await tool.execute({ action: 'add', id: 'a', title: 'A', maxAttempts: 2 }, ctx())
+    await tool.execute({ action: 'start', id: 'a' }, ctx())
+    const failed = await tool.execute({ action: 'fail', id: 'a', error: 'boom' }, ctx())
+    expect(failed.output).toMatchObject({ retried: true })
+  })
+
+  it('restores a thread graph from disk', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'kun-task-graph-'))
+    dirs.push(rootDir)
+    const tool = createTaskGraphTool({ rootDir })
+    await tool.execute({ action: 'add', id: 'a', title: 'A' }, ctx('t1'))
+    const restored = await createTaskGraphTool({ rootDir }).execute({ action: 'list' }, ctx('t1'))
+    expect(restored.output).toMatchObject({ tasks: [{ id: 'a', title: 'A' }] })
+  })
+})

--- a/kun/src/adapters/tool/task-graph-tool.ts
+++ b/kun/src/adapters/tool/task-graph-tool.ts
@@ -1,0 +1,135 @@
+/**
+ * Agent-callable task graph (P1 #2).
+ *
+ * Lets the model plan and drive a dependency-aware task DAG instead of a flat
+ * todo list: add tasks with dependencies/priority/retries, ask which are
+ * runnable now (respecting deps + concurrency), and record start/success/
+ * failure. State is kept per thread in-memory so a multi-step plan persists
+ * across turns within the conversation. This is an agent tool, not a core-loop
+ * scheduler — the model decides when to advance the plan.
+ */
+
+import { LocalToolHost, type LocalTool } from './local-tool-host.js'
+import { TaskGraph } from '../../tasks/task-graph.js'
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export function createTaskGraphTool(options: { rootDir?: string } = {}): LocalTool {
+  const graphs = new Map<string, TaskGraph>()
+  const graphFor = async (threadId: string): Promise<TaskGraph> => {
+    let graph = graphs.get(threadId)
+    if (graph) return graph
+    graph = options.rootDir ? await loadGraph(options.rootDir, threadId) : new TaskGraph({ concurrency: 1 })
+    graphs.set(threadId, graph)
+    return graph
+  }
+  const save = async (threadId: string, graph: TaskGraph): Promise<void> => {
+    if (options.rootDir) await saveGraph(options.rootDir, threadId, graph)
+  }
+  const snapshot = (graph: TaskGraph) => ({
+    tasks: graph.list().map((t) => ({
+      id: t.id, title: t.title, state: t.state, dependsOn: t.dependsOn,
+      priority: t.priority, attempts: t.attempts, maxAttempts: t.maxAttempts,
+      ...(t.lastError ? { lastError: t.lastError } : {})
+    })),
+    runnable: graph.nextRunnable().map((t) => t.id),
+    complete: graph.isComplete()
+  })
+
+  return LocalToolHost.defineTool({
+    name: 'task_graph',
+    description:
+      'Plan and drive a dependency-aware task graph for this thread. actions: ' +
+      '"add" (id,title,dependsOn?,priority?,maxAttempts?), "list", "next" (runnable now), ' +
+      '"start" (id), "complete" (id), "fail" (id,error), "pause"/"resume"/"cancel" (id), ' +
+      '"set_concurrency" (concurrency). Tasks become runnable only when their dependencies succeed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['add', 'list', 'next', 'start', 'complete', 'fail', 'pause', 'resume', 'cancel', 'set_concurrency'] },
+        id: { type: 'string' },
+        title: { type: 'string' },
+        dependsOn: { type: 'array', items: { type: 'string' } },
+        priority: { type: 'number' },
+        maxAttempts: { type: 'number' },
+        error: { type: 'string' },
+        concurrency: { type: 'number' }
+      },
+      required: ['action'],
+      additionalProperties: false
+    },
+    policy: 'auto',
+    execute: async (args, context) => {
+      const graph = await graphFor(context.threadId)
+      const action = typeof args.action === 'string' ? args.action : ''
+      const id = typeof args.id === 'string' ? args.id.trim() : ''
+      try {
+        switch (action) {
+          case 'add': {
+            if (!id || typeof args.title !== 'string' || !args.title.trim()) {
+              return { output: { error: 'id and title are required for add' }, isError: true }
+            }
+            graph.add({
+              id,
+              title: args.title.trim(),
+              ...(Array.isArray(args.dependsOn) ? { dependsOn: args.dependsOn.filter((d): d is string => typeof d === 'string') } : {}),
+              ...(typeof args.priority === 'number' ? { priority: args.priority } : {}),
+              ...(typeof args.maxAttempts === 'number' ? { maxAttempts: args.maxAttempts } : {})
+            })
+            await save(context.threadId, graph)
+            return { output: { action, added: id, ...snapshot(graph) } }
+          }
+          case 'list':
+          case 'next':
+            return { output: { action, ...snapshot(graph) } }
+          case 'start':
+            graph.markRunning(id)
+            await save(context.threadId, graph)
+            return { output: { action, id, ...snapshot(graph) } }
+          case 'complete':
+            graph.markSucceeded(id)
+            await save(context.threadId, graph)
+            return { output: { action, id, ...snapshot(graph) } }
+          case 'fail': {
+            const outcome = graph.markFailed(id, typeof args.error === 'string' ? args.error : 'unspecified failure')
+            await save(context.threadId, graph)
+            return { output: { action, id, retried: outcome.retried, ...snapshot(graph) } }
+          }
+          case 'pause': graph.pause(id); await save(context.threadId, graph); return { output: { action, id, ...snapshot(graph) } }
+          case 'resume': graph.resume(id); await save(context.threadId, graph); return { output: { action, id, ...snapshot(graph) } }
+          case 'cancel': graph.cancel(id); await save(context.threadId, graph); return { output: { action, id, ...snapshot(graph) } }
+          case 'set_concurrency':
+            graph.setConcurrency(typeof args.concurrency === 'number' ? args.concurrency : 1)
+            await save(context.threadId, graph)
+            return { output: { action, ...snapshot(graph) } }
+          default:
+            return { output: { error: `unknown action: ${action}` }, isError: true }
+        }
+      } catch (error) {
+        return { output: { action, error: error instanceof Error ? error.message : String(error) }, isError: true }
+      }
+    }
+  })
+}
+
+async function loadGraph(rootDir: string, threadId: string): Promise<TaskGraph> {
+  try {
+    return TaskGraph.fromJSON(JSON.parse(await readFile(graphPath(rootDir, threadId), 'utf8')))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return new TaskGraph({ concurrency: 1 })
+    throw error
+  }
+}
+
+async function saveGraph(rootDir: string, threadId: string, graph: TaskGraph): Promise<void> {
+  await mkdir(rootDir, { recursive: true })
+  const target = graphPath(rootDir, threadId)
+  const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`
+  await writeFile(temporary, JSON.stringify(graph.toJSON(), null, 2), 'utf8')
+  await rename(temporary, target)
+}
+
+function graphPath(rootDir: string, threadId: string): string {
+  return join(rootDir, `${createHash('sha256').update(threadId).digest('hex')}.json`)
+}

--- a/kun/src/server/runtime-factory.ts
+++ b/kun/src/server/runtime-factory.ts
@@ -18,6 +18,7 @@ import { buildTodoLocalTools } from '../adapters/tool/todo-tools.js'
 import { LocalToolHost, buildDefaultLocalTools } from '../adapters/tool/local-tool-host.js'
 import { createReadArtifactTool } from '../adapters/tool/artifact-tool.js'
 import { FileArtifactStore } from '../artifacts/artifact-store.js'
+import { createTaskGraphTool } from '../adapters/tool/task-graph-tool.js'
 import { buildMcpToolProviders } from '../adapters/tool/mcp-tool-provider.js'
 import { buildMemoryToolProviders } from '../adapters/tool/memory-tool-provider.js'
 import { buildSkillToolProviders } from '../adapters/tool/skill-tool-provider.js'
@@ -304,6 +305,7 @@ export async function createKunServeRuntime(
   const musicGenProviders = buildMusicGenToolProviders(options.capabilities?.musicGen, { nowIso })
   const videoGenProviders = buildVideoGenToolProviders(options.capabilities?.videoGen, { nowIso })
   const computerUseProviders = await buildComputerUseToolProviders(options.capabilities?.computerUse)
+  const taskGraphTool = createTaskGraphTool({ rootDir: join(options.dataDir, 'task-graphs') })
   const baseToolProviders = [
     {
       id: 'builtin',
@@ -450,6 +452,13 @@ export async function createKunServeRuntime(
       enabled: true,
       available: true,
       tools: buildTodoLocalTools(threadService)
+    },
+    {
+      id: 'planning',
+      kind: 'built-in' as const,
+      enabled: true,
+      available: true,
+      tools: [taskGraphTool]
     },
     ...buildDelegationToolProviders(delegationRuntime)
   ])

--- a/kun/src/tasks/task-graph.test.ts
+++ b/kun/src/tasks/task-graph.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { TaskGraph } from './task-graph.js'
+
+describe('TaskGraph', () => {
+  it('marks tasks ready only when dependencies have succeeded', () => {
+    const g = new TaskGraph({ concurrency: 2 })
+    g.add({ id: 'a', title: 'A' })
+    g.add({ id: 'b', title: 'B', dependsOn: ['a'] })
+    g.reconcile()
+    expect(g.get('a')?.state).toBe('ready')
+    expect(g.get('b')?.state).toBe('pending')
+    g.markRunning('a'); g.markSucceeded('a')
+    expect(g.get('b')?.state).toBe('ready')
+  })
+
+  it('respects priority and concurrency in nextRunnable', () => {
+    const g = new TaskGraph({ concurrency: 2 })
+    g.add({ id: 'low', title: 'low', priority: 1 })
+    g.add({ id: 'high', title: 'high', priority: 10 })
+    g.add({ id: 'mid', title: 'mid', priority: 5 })
+    const batch = g.nextRunnable()
+    expect(batch.map((t) => t.id)).toEqual(['high', 'mid'])
+  })
+
+  it('does not exceed the concurrency limit', () => {
+    const g = new TaskGraph({ concurrency: 1 })
+    g.add({ id: 'a', title: 'A' })
+    g.add({ id: 'b', title: 'B' })
+    const first = g.nextRunnable()
+    expect(first).toHaveLength(1)
+    g.markRunning(first[0].id)
+    expect(g.nextRunnable()).toHaveLength(0)
+  })
+
+  it('retries a failed task until attempts are exhausted', () => {
+    const g = new TaskGraph()
+    g.add({ id: 'a', title: 'A', maxAttempts: 2 })
+    g.reconcile()
+    g.markRunning('a')
+    expect(g.markFailed('a', 'boom').retried).toBe(true)
+    expect(g.get('a')?.state).toBe('ready')
+    g.markRunning('a')
+    expect(g.markFailed('a', 'boom again').retried).toBe(false)
+    expect(g.get('a')?.state).toBe('failed')
+  })
+
+  it('blocks dependents when a dependency fails terminally', () => {
+    const g = new TaskGraph()
+    g.add({ id: 'a', title: 'A', maxAttempts: 1 })
+    g.add({ id: 'b', title: 'B', dependsOn: ['a'] })
+    g.reconcile()
+    g.markRunning('a')
+    g.markFailed('a', 'x')
+    expect(g.get('b')?.state).toBe('blocked')
+  })
+
+  it('detects dependency cycles', () => {
+    const g = new TaskGraph()
+    g.add({ id: 'a', title: 'A', dependsOn: ['c'] })
+    g.add({ id: 'b', title: 'B', dependsOn: ['a'] })
+    expect(() => g.add({ id: 'c', title: 'C', dependsOn: ['b'] })).toThrow(/dependency cycle/)
+    expect(g.get('c')).toBeUndefined()
+    expect(g.detectCycle()).toBeNull()
+  })
+
+  it('pause/resume removes and restores a task from scheduling', () => {
+    const g = new TaskGraph()
+    g.add({ id: 'a', title: 'A' })
+    g.pause('a')
+    expect(g.nextRunnable()).toHaveLength(0)
+    g.resume('a')
+    expect(g.nextRunnable().map((t) => t.id)).toEqual(['a'])
+  })
+
+  it('round-trips through JSON', () => {
+    const g = new TaskGraph({ concurrency: 3 })
+    g.add({ id: 'a', title: 'A', tokenBudget: 1000, worktree: '/wt/a' })
+    const restored = TaskGraph.fromJSON(g.toJSON())
+    expect(restored.get('a')).toMatchObject({ tokenBudget: 1000, worktree: '/wt/a' })
+    expect(restored.toJSON().concurrency).toBe(3)
+  })
+
+  it('reports completion when all tasks are terminal', () => {
+    const g = new TaskGraph()
+    g.add({ id: 'a', title: 'A' })
+    g.reconcile(); g.markRunning('a'); g.markSucceeded('a')
+    expect(g.isComplete()).toBe(true)
+  })
+
+  it('does not rewrite a completed task when cancellation is replayed', () => {
+    const g = new TaskGraph()
+    g.add({ id: 'a', title: 'A' })
+    g.reconcile(); g.markRunning('a'); g.markSucceeded('a')
+    g.cancel('a')
+    expect(g.get('a')?.state).toBe('succeeded')
+  })
+
+  it('blocks a task with a missing dependency and treats blocked as terminal', () => {
+    const g = new TaskGraph()
+    g.add({ id: 'b', title: 'B', dependsOn: ['does-not-exist'] })
+    g.reconcile()
+    expect(g.get('b')?.state).toBe('blocked')
+    expect(g.isComplete()).toBe(true)
+  })
+
+  it('applies exponential backoff between retries via the injected clock', () => {
+    let now = 1000
+    const g = new TaskGraph({ now: () => now, retryBaseDelayMs: 100, retryMaxDelayMs: 10_000 })
+    g.add({ id: 'a', title: 'A', maxAttempts: 3 })
+    g.reconcile(); g.markRunning('a'); g.markFailed('a', 'boom')
+    // Immediately after failure the task is ready but gated by backoff.
+    expect(g.get('a')?.state).toBe('ready')
+    expect(g.nextRunnable()).toHaveLength(0)
+    now += 100
+    expect(g.nextRunnable().map((t) => t.id)).toEqual(['a'])
+  })
+})

--- a/kun/src/tasks/task-graph.ts
+++ b/kun/src/tasks/task-graph.ts
@@ -1,0 +1,269 @@
+/**
+ * Persistent task graph (P1 #2).
+ *
+ * More than a flat todo list or a single useWorktree flag: tasks form a DAG with
+ * dependencies, priority, a concurrency limit, pause/resume, failure retry, a
+ * per-task resource budget, and an optional per-task worktree. This is the pure
+ * scheduling core — it computes the ready set (respecting deps + concurrency),
+ * applies state transitions, handles retry with backoff bookkeeping, and detects
+ * cycles. Persistence and actual execution live in a thin layer on top.
+ */
+
+export type TaskState = 'pending' | 'ready' | 'running' | 'blocked' | 'paused' | 'succeeded' | 'failed' | 'cancelled'
+
+export type TaskNode = {
+  id: string
+  title: string
+  /** Ids this task depends on; it cannot start until all have succeeded. */
+  dependsOn: string[]
+  /** Higher runs first among ready tasks. Default 0. */
+  priority: number
+  state: TaskState
+  attempts: number
+  maxAttempts: number
+  /** Optional per-task worktree path. */
+  worktree?: string
+  /** Optional resource budget (tokens) for the task. */
+  tokenBudget?: number
+  lastError?: string
+  /** Earliest time (ms epoch) the task may be retried after a failure. */
+  nextAttemptAt?: number
+}
+
+export type TaskGraphData = {
+  tasks: Record<string, TaskNode>
+  /** Max tasks allowed in `running` at once. */
+  concurrency: number
+}
+
+export type AddTaskInput = {
+  id: string
+  title: string
+  dependsOn?: string[]
+  priority?: number
+  maxAttempts?: number
+  worktree?: string
+  tokenBudget?: number
+}
+
+export type TaskGraphOptions = {
+  concurrency?: number
+  now?: () => number
+  /** First retry backoff; doubles per attempt up to retryMaxDelayMs. Default 1000. */
+  retryBaseDelayMs?: number
+  retryMaxDelayMs?: number
+}
+
+export class TaskGraph {
+  private readonly tasks = new Map<string, TaskNode>()
+  private concurrency: number
+  private readonly now: () => number
+  private readonly retryBaseDelayMs: number
+  private readonly retryMaxDelayMs: number
+
+  constructor(input: TaskGraphOptions = {}) {
+    this.concurrency = Math.max(1, input.concurrency ?? 1)
+    this.now = input.now ?? (() => Date.now())
+    this.retryBaseDelayMs = input.retryBaseDelayMs ?? 1_000
+    this.retryMaxDelayMs = input.retryMaxDelayMs ?? 30_000
+  }
+
+  add(input: AddTaskInput): TaskNode {
+    if (this.tasks.has(input.id)) throw new Error(`duplicate task id: ${input.id}`)
+    const node: TaskNode = {
+      id: input.id,
+      title: input.title,
+      dependsOn: [...(input.dependsOn ?? [])],
+      priority: input.priority ?? 0,
+      state: 'pending',
+      attempts: 0,
+      maxAttempts: Math.max(1, input.maxAttempts ?? 1),
+      ...(input.worktree ? { worktree: input.worktree } : {}),
+      ...(input.tokenBudget ? { tokenBudget: input.tokenBudget } : {})
+    }
+    this.tasks.set(input.id, node)
+    const cycle = this.detectCycle()
+    if (cycle) {
+      this.tasks.delete(input.id)
+      throw new Error(`dependency cycle: ${cycle.join(' -> ')}`)
+    }
+    return node
+  }
+
+  setConcurrency(limit: number): void {
+    this.concurrency = Math.max(1, limit)
+  }
+
+  get(id: string): TaskNode | undefined {
+    return this.tasks.get(id)
+  }
+
+  list(): TaskNode[] {
+    return [...this.tasks.values()]
+  }
+
+  /** Detect a dependency cycle; returns the cycle path or null when acyclic. */
+  detectCycle(): string[] | null {
+    const visited = new Set<string>()
+    const stack = new Set<string>()
+    const path: string[] = []
+    const visit = (id: string): string[] | null => {
+      if (stack.has(id)) return [...path.slice(path.indexOf(id)), id]
+      if (visited.has(id)) return null
+      visited.add(id)
+      stack.add(id)
+      path.push(id)
+      for (const dep of this.tasks.get(id)?.dependsOn ?? []) {
+        if (!this.tasks.has(dep)) continue
+        const cycle = visit(dep)
+        if (cycle) return cycle
+      }
+      stack.delete(id)
+      path.pop()
+      return null
+    }
+    for (const id of this.tasks.keys()) {
+      const cycle = visit(id)
+      if (cycle) return cycle
+    }
+    return null
+  }
+
+  private depsSucceeded(node: TaskNode): boolean {
+    return node.dependsOn.every((dep) => this.tasks.get(dep)?.state === 'succeeded')
+  }
+
+  private depsUnsatisfiable(node: TaskNode): boolean {
+    return node.dependsOn.some((dep) => {
+      const depNode = this.tasks.get(dep)
+      // A missing dependency can never be satisfied → the task is blocked, not
+      // left pending forever.
+      if (!depNode) return true
+      return depNode.state === 'failed' || depNode.state === 'cancelled' || depNode.state === 'blocked'
+    })
+  }
+
+  /**
+   * Recompute derived states: a pending task whose deps all succeeded becomes
+   * `ready`; one with a failed/cancelled/blocked/missing dep becomes `blocked`.
+   * Running/paused/terminal states are left untouched.
+   */
+  reconcile(): void {
+    for (const node of this.tasks.values()) {
+      if (node.state !== 'pending' && node.state !== 'ready' && node.state !== 'blocked') continue
+      if (this.depsUnsatisfiable(node)) {
+        node.state = 'blocked'
+      } else if (this.depsSucceeded(node)) {
+        node.state = 'ready'
+      } else {
+        node.state = 'pending'
+      }
+    }
+  }
+
+  /** Number of tasks currently running. */
+  runningCount(): number {
+    return this.list().filter((node) => node.state === 'running').length
+  }
+
+  /**
+   * The next batch of tasks to start: ready tasks (deps satisfied, not paused),
+   * highest priority first, bounded by remaining concurrency.
+   */
+  nextRunnable(): TaskNode[] {
+    this.reconcile()
+    const slots = this.concurrency - this.runningCount()
+    if (slots <= 0) return []
+    return this.list()
+      .filter((node) => node.state === 'ready')
+      .filter((node) => node.nextAttemptAt === undefined || node.nextAttemptAt <= this.now())
+      .sort((a, b) => (b.priority - a.priority) || a.id.localeCompare(b.id))
+      .slice(0, slots)
+  }
+
+  markRunning(id: string): void {
+    const node = this.require(id)
+    if (node.state !== 'ready') throw new Error(`task ${id} is not ready (state: ${node.state})`)
+    node.state = 'running'
+    node.attempts += 1
+    node.nextAttemptAt = undefined
+  }
+
+  markSucceeded(id: string): void {
+    const node = this.require(id)
+    if (node.state !== 'running') throw new Error(`task ${id} is not running (state: ${node.state})`)
+    node.state = 'succeeded'
+    node.lastError = undefined
+    this.reconcile()
+  }
+
+  /**
+   * Fail a running task. Retries (back to `ready`) while attempts remain;
+   * otherwise terminal `failed`, which cascades dependents to `blocked` on the
+   * next reconcile.
+   */
+  markFailed(id: string, error: string): { retried: boolean } {
+    const node = this.require(id)
+    if (node.state !== 'running') throw new Error(`task ${id} is not running (state: ${node.state})`)
+    node.lastError = error
+    if (node.attempts < node.maxAttempts) {
+      node.state = 'ready'
+      // Exponential backoff so a flapping task does not hot-loop; nextRunnable
+      // skips it until nextAttemptAt.
+      const delay = Math.min(this.retryMaxDelayMs, this.retryBaseDelayMs * 2 ** (node.attempts - 1))
+      node.nextAttemptAt = this.now() + delay
+      return { retried: true }
+    }
+    node.state = 'failed'
+    this.reconcile()
+    return { retried: false }
+  }
+
+  pause(id: string): void {
+    const node = this.require(id)
+    if (node.state === 'succeeded' || node.state === 'failed' || node.state === 'cancelled') return
+    node.state = 'paused'
+  }
+
+  resume(id: string): void {
+    const node = this.require(id)
+    if (node.state !== 'paused') return
+    node.state = 'pending'
+    this.reconcile()
+  }
+
+  cancel(id: string): void {
+    const node = this.require(id)
+    if (node.state === 'succeeded' || node.state === 'failed' || node.state === 'cancelled') return
+    node.state = 'cancelled'
+    this.reconcile()
+  }
+
+  /** True when every task reached a terminal state (blocked is terminal: its deps can never satisfy). */
+  isComplete(): boolean {
+    this.reconcile()
+    return this.list().every((node) => ['succeeded', 'failed', 'cancelled', 'blocked'].includes(node.state))
+  }
+
+  toJSON(): TaskGraphData {
+    const tasks: Record<string, TaskNode> = {}
+    for (const [id, node] of this.tasks) tasks[id] = { ...node, dependsOn: [...node.dependsOn] }
+    return { tasks, concurrency: this.concurrency }
+  }
+
+  static fromJSON(data: TaskGraphData): TaskGraph {
+    const graph = new TaskGraph({ concurrency: data.concurrency })
+    for (const node of Object.values(data.tasks)) {
+      graph.tasks.set(node.id, { ...node, dependsOn: [...node.dependsOn] })
+    }
+    const cycle = graph.detectCycle()
+    if (cycle) throw new Error(`dependency cycle: ${cycle.join(' -> ')}`)
+    return graph
+  }
+
+  private require(id: string): TaskNode {
+    const node = this.tasks.get(id)
+    if (!node) throw new Error(`unknown task: ${id}`)
+    return node
+  }
+}


### PR DESCRIPTION
## Summary
- add a dependency-aware per-thread task graph with priority, concurrency, retries, pause/resume, and terminal-state handling
- expose it as the `task_graph` agent tool without overlapping the desktop Worktree execution queue
- persist graph state atomically under the Kun data directory so plans survive runtime restarts

## Tests
- `npm.cmd --prefix kun test -- src/tasks/task-graph.test.ts src/adapters/tool/task-graph-tool.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `git diff --check HEAD`