### PR TITLE
feat(artifacts): offload oversized tool output

### DIFF
--- a/kun/src/adapters/tool/artifact-tool.test.ts
+++ b/kun/src/adapters/tool/artifact-tool.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createReadArtifactTool } from './artifact-tool.js'
+import { InMemoryArtifactStore } from '../../artifacts/artifact-store.js'
+import type { ToolHostContext } from '../../ports/tool-host.js'
+
+function context(artifactStore?: ToolHostContext['artifactStore']): ToolHostContext {
+  return {
+    threadId: 't', turnId: 'tn', workspace: '/ws', approvalPolicy: 'auto',
+    abortSignal: new AbortController().signal, awaitApproval: vi.fn(async () => 'allow' as const),
+    ...(artifactStore ? { artifactStore } : {})
+  }
+}
+
+describe('read_artifact tool', () => {
+  it('reads full content + metadata by id', async () => {
+    const store = new InMemoryArtifactStore(() => 't0')
+    const { meta } = await store.put({ content: 'hello world', source: 'mcp', origin: 'docs' })
+    const tool = createReadArtifactTool()
+    const result = await tool.execute({ artifactId: meta.id }, context(store))
+    expect(result.output).toMatchObject({ content: 'hello world', source: 'mcp', origin: 'docs' })
+  })
+
+  it('reads a line range', async () => {
+    const store = new InMemoryArtifactStore()
+    const { meta } = await store.put({ content: 'l1\nl2\nl3\nl4' })
+    const tool = createReadArtifactTool()
+    const result = await tool.execute({ artifactId: meta.id, startLine: 2, endLine: 3 }, context(store))
+    expect(result.output).toMatchObject({ content: 'l2\nl3', range: { startLine: 2, endLine: 3 } })
+  })
+
+  it('bounds a no-range read and returns a cursor for a large artifact', async () => {
+    const { ARTIFACT_MAX_READ_BYTES } = await import('../../artifacts/artifact-store.js')
+    const store = new InMemoryArtifactStore(() => 't0')
+    const { meta } = await store.put({ content: 'y'.repeat(ARTIFACT_MAX_READ_BYTES + 1_000) })
+    const tool = createReadArtifactTool()
+    const result = await tool.execute({ artifactId: meta.id }, context(store))
+    const out = result.output as Record<string, unknown>
+    expect(Buffer.byteLength(String(out.content), 'utf8')).toBe(ARTIFACT_MAX_READ_BYTES)
+    expect(out.truncated).toBe(true)
+    expect(out.nextOffset).toBe(ARTIFACT_MAX_READ_BYTES)
+  })
+
+  it('errors for an unknown artifact', async () => {
+    const tool = createReadArtifactTool()
+    const result = await tool.execute({ artifactId: 'art_missing' }, context(new InMemoryArtifactStore()))
+    expect(result.isError).toBe(true)
+  })
+
+  it('errors when the artifact store is unavailable', async () => {
+    const tool = createReadArtifactTool()
+    const result = await tool.execute({ artifactId: 'art_x' }, context())
+    expect(result.isError).toBe(true)
+  })
+})

--- a/kun/src/adapters/tool/artifact-tool.ts
+++ b/kun/src/adapters/tool/artifact-tool.ts
@@ -1,0 +1,69 @@
+/**
+ * Agent-callable artifact reader (P0 #5).
+ *
+ * Large tool results are offloaded to the content-addressed artifact store and
+ * the model only sees a bounded summary + an artifact id. This tool lets the
+ * model pull the rest on demand — the full content, a byte range, or a line
+ * range — instead of forcing every big payload into context. Read-only.
+ */
+
+import { LocalToolHost, type LocalTool } from './local-tool-host.js'
+import { readArtifactBounded } from '../../artifacts/artifact-store.js'
+
+export function createReadArtifactTool(): LocalTool {
+  return LocalToolHost.defineTool({
+    name: 'read_artifact',
+    description:
+      'Read a stored artifact (large tool output) by id. Optionally fetch only a slice: ' +
+      'startLine/endLine for a 1-indexed inclusive line range, or offset/length for a UTF-8 byte range. ' +
+      'Use the artifact id returned by a previous tool result (e.g. stdoutArtifactId).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        artifactId: { type: 'string' },
+        offset: { type: 'number' },
+        length: { type: 'number' },
+        startLine: { type: 'number' },
+        endLine: { type: 'number' }
+      },
+      required: ['artifactId'],
+      additionalProperties: false
+    },
+    policy: 'auto',
+    execute: async (args, context) => {
+      if (!context.artifactStore) {
+        return { output: { error: 'artifact store is not available in this runtime' }, isError: true }
+      }
+      const artifactId = typeof args.artifactId === 'string' ? args.artifactId.trim() : ''
+      if (!artifactId) return { output: { error: 'artifactId is required' }, isError: true }
+      const meta = await context.artifactStore.stat(artifactId)
+      if (!meta) return { output: { error: `artifact not found: ${artifactId}` }, isError: true }
+      const range = {
+        ...(typeof args.offset === 'number' ? { offset: args.offset } : {}),
+        ...(typeof args.length === 'number' ? { length: args.length } : {}),
+        ...(typeof args.startLine === 'number' ? { startLine: args.startLine } : {}),
+        ...(typeof args.endLine === 'number' ? { endLine: args.endLine } : {})
+      }
+      // Always read through the bounded reader: a request with no range, or a
+      // range larger than the cap, is clamped to <=1 MiB / <=2000 lines and a
+      // cursor is returned so the model pages rather than pulling a huge result
+      // into context.
+      const bounded = await readArtifactBounded(context.artifactStore, artifactId, meta, range)
+      if (bounded === null) return { output: { error: `artifact content not found: ${artifactId}` }, isError: true }
+      return {
+        output: {
+          artifactId,
+          byteSize: meta.byteSize,
+          lineCount: meta.lineCount,
+          ...(meta.source ? { source: meta.source } : {}),
+          ...(meta.origin ? { origin: meta.origin } : {}),
+          range: bounded.range,
+          truncated: bounded.truncated,
+          ...(bounded.nextOffset !== undefined ? { nextOffset: bounded.nextOffset } : {}),
+          ...(bounded.nextStartLine !== undefined ? { nextStartLine: bounded.nextStartLine } : {}),
+          content: bounded.content
+        }
+      }
+    }
+  })
+}

--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { LocalToolHost, echoTool } from './local-tool-host.js'
 import type { ToolHostContext } from '../../ports/tool-host.js'
+import { InMemoryArtifactStore } from '../../artifacts/artifact-store.js'
 
 describe('LocalToolHost approval policy', () => {
   it('asks before auto tools when approval policy is always', async () => {
@@ -25,5 +26,35 @@ describe('LocalToolHost approval policy', () => {
 
     expect(awaitApproval).toHaveBeenCalledTimes(1)
     expect(result.approved).toBe(false)
+  })
+
+  it('offloads oversized successful tool output to the artifact store', async () => {
+    const artifactStore = new InMemoryArtifactStore()
+    const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
+      name: 'large_output',
+      description: 'returns a large payload',
+      inputSchema: { type: 'object' },
+      execute: async () => ({ output: 'x'.repeat(140 * 1024) })
+    })] })
+    const result = await host.execute(
+      { callId: 'call_large', toolName: 'large_output', arguments: {} },
+      {
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        workspace: '/tmp/workspace',
+        approvalPolicy: 'auto',
+        sandboxMode: 'danger-full-access',
+        artifactStore,
+        abortSignal: new AbortController().signal,
+        awaitApproval: vi.fn(async () => 'allow' as const)
+      }
+    )
+    expect(result.item).toMatchObject({
+      kind: 'tool_result',
+      output: { artifactId: expect.stringMatching(/^art_/), truncated: true }
+    })
+    if (result.item.kind !== 'tool_result') throw new Error('expected tool result')
+    const artifactId = String((result.item.output as Record<string, unknown>).artifactId)
+    expect(await artifactStore.get(artifactId)).toHaveLength(140 * 1024)
   })
 })

--- a/kun/src/adapters/tool/local-tool-host.ts
+++ b/kun/src/adapters/tool/local-tool-host.ts
@@ -230,7 +230,7 @@ export class LocalToolHost implements ToolHost {
       }
     }
     const rateLimited = normalizeRateLimitedToolOutput(hookedResult.output)
-    const output = rateLimited.rateLimited ? rateLimited.output : hookedResult.output
+    let output = rateLimited.rateLimited ? rateLimited.output : hookedResult.output
     const isError = hookedResult.isError || rateLimited.isError
     this.readTracker.observeToolResult({
       context,
@@ -238,6 +238,7 @@ export class LocalToolHost implements ToolHost {
       output,
       isError
     })
+    if (!isError) output = await offloadLargeToolOutput(output, activeCall.toolName, context)
     const item = makeToolResultItem({
       id: `item_${activeCall.callId}`,
       turnId: context.turnId,
@@ -337,6 +338,35 @@ export class LocalToolHost implements ToolHost {
       execute: tool.execute,
       ...(tool.shouldAdvertise ? { shouldAdvertise: tool.shouldAdvertise } : {})
     }
+  }
+}
+
+const ARTIFACT_OUTPUT_THRESHOLD_BYTES = 128 * 1024
+
+async function offloadLargeToolOutput(
+  output: unknown,
+  toolName: string,
+  context: ToolHostContext
+): Promise<unknown> {
+  if (!context.artifactStore) return output
+  let content: string
+  try {
+    content = typeof output === 'string' ? output : JSON.stringify(output)
+  } catch {
+    return output
+  }
+  if (Buffer.byteLength(content, 'utf8') <= ARTIFACT_OUTPUT_THRESHOLD_BYTES) return output
+  try {
+    const stored = await context.artifactStore.put({ content, source: 'tool', origin: toolName })
+    return {
+      artifactId: stored.meta.id,
+      byteSize: stored.meta.byteSize,
+      lineCount: stored.meta.lineCount,
+      truncated: stored.summary.truncated,
+      preview: stored.summary.inline
+    }
+  } catch {
+    return output
   }
 }
 

--- a/kun/src/artifacts/artifact-store.test.ts
+++ b/kun/src/artifacts/artifact-store.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { FileArtifactStore, InMemoryArtifactStore, type ArtifactStore } from './artifact-store.js'
+
+function runStoreContract(name: string, make: () => Promise<{ store: ArtifactStore; cleanup?: () => Promise<void> }>) {
+  describe(name, () => {
+    it('stores content and returns a bounded summary + stable id', async () => {
+      const { store, cleanup } = await make()
+      try {
+        const big = 'x'.repeat(10_000)
+        const result = await store.put({ content: big, maxInlineChars: 200, source: 'mcp', origin: 'docs/lookup' })
+        expect(result.meta.byteSize).toBe(10_000)
+        expect(result.summary.truncated).toBe(true)
+        expect(result.summary.inline.length).toBeLessThan(400)
+        expect(result.meta.id).toBe(result.summary.artifactId)
+        expect(await store.get(result.meta.id)).toBe(big)
+      } finally {
+        await cleanup?.()
+      }
+    })
+
+    it('dedupes identical content by hash', async () => {
+      const { store, cleanup } = await make()
+      try {
+        const a = await store.put({ content: 'same' })
+        const b = await store.put({ content: 'same' })
+        expect(a.meta.id).toBe(b.meta.id)
+        expect(b.deduped).toBe(true)
+      } finally {
+        await cleanup?.()
+      }
+    })
+
+    it('reads a line range on demand', async () => {
+      const { store, cleanup } = await make()
+      try {
+        const content = ['l1', 'l2', 'l3', 'l4', 'l5'].join('\n')
+        const { meta } = await store.put({ content })
+        expect(await store.readRange(meta.id, { startLine: 2, endLine: 4 })).toBe('l2\nl3\nl4')
+      } finally {
+        await cleanup?.()
+      }
+    })
+
+    it('reads a byte range on demand', async () => {
+      const { store, cleanup } = await make()
+      try {
+        const { meta } = await store.put({ content: 'abcdefghij' })
+        expect(await store.readRange(meta.id, { offset: 2, length: 3 })).toBe('cde')
+      } finally {
+        await cleanup?.()
+      }
+    })
+
+    it('returns null for an unknown id', async () => {
+      const { store, cleanup } = await make()
+      try {
+        expect(await store.get('art_missing')).toBeNull()
+        expect(await store.readRange('art_missing', {})).toBeNull()
+        expect(await store.stat('art_missing')).toBeNull()
+      } finally {
+        await cleanup?.()
+      }
+    })
+
+    it('records source metadata', async () => {
+      const { store, cleanup } = await make()
+      try {
+        const { meta } = await store.put({ content: 'hi', source: 'web', origin: 'web_fetch' })
+        const stat = await store.stat(meta.id)
+        expect(stat).toMatchObject({ source: 'web', origin: 'web_fetch' })
+      } finally {
+        await cleanup?.()
+      }
+    })
+  })
+}
+
+runStoreContract('InMemoryArtifactStore', async () => ({
+  store: new InMemoryArtifactStore(() => '2026-06-29T00:00:00.000Z')
+}))
+
+runStoreContract('FileArtifactStore', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'kun-artifacts-'))
+  return {
+    store: new FileArtifactStore(dir, () => '2026-06-29T00:00:00.000Z'),
+    cleanup: () => rm(dir, { recursive: true, force: true })
+  }
+})
+
+describe('FileArtifactStore streaming reads', () => {
+  it('seeks a byte range and a line window from a large artifact without loading it whole', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kun-artifacts-'))
+    try {
+      const store = new FileArtifactStore(dir, () => 't0')
+      const lines = Array.from({ length: 100_000 }, (_, i) => `line ${i + 1}`)
+      const content = lines.join('\n')
+      const { meta } = await store.put({ content })
+      // Line window stops early — only the selected lines come back.
+      expect(await store.readRange(meta.id, { startLine: 5, endLine: 7 })).toBe('line 5\nline 6\nline 7')
+      // Byte range seek.
+      expect(await store.readRange(meta.id, { offset: 0, length: 6 })).toBe('line 1')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns the trailing line when no final newline and the range covers it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kun-artifacts-'))
+    try {
+      const store = new FileArtifactStore(dir, () => 't0')
+      const { meta } = await store.put({ content: 'a\nb\nc' })
+      expect(await store.readRange(meta.id, { startLine: 3, endLine: 3 })).toBe('c')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('stitches a multibyte UTF-8 char split across a 64KiB read boundary (P2-04)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kun-artifacts-'))
+    try {
+      const store = new FileArtifactStore(dir, () => 't0')
+      // Pad so a 3-byte char (世) straddles the 65536-byte chunk boundary, then
+      // read the line that contains it; without incremental decoding the char
+      // would surface as replacement characters.
+      const head = 'a'.repeat(65_535)
+      const content = `${head}世界\nsecond line`
+      const { meta } = await store.put({ content })
+      const firstLine = await store.readRange(meta.id, { startLine: 1, endLine: 1 })
+      expect(firstLine).toBe(`${head}世界`)
+      expect(firstLine).not.toContain('\uFFFD')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('readArtifactBounded', () => {
+  it('pages UTF-8 text without replacement characters or skipped bytes', async () => {
+    const { readArtifactBounded } = await import('./artifact-store.js')
+    const store = new InMemoryArtifactStore(() => 't0')
+    const { meta } = await store.put({ content: '中文测试' })
+    const pages: string[] = []
+    let offset = 0
+    while (offset < meta.byteSize) {
+      const page = await readArtifactBounded(store, meta.id, meta, { offset, length: 2 })
+      expect(page).not.toBeNull()
+      pages.push(page!.content)
+      expect(page!.content).not.toContain('�')
+      if (!page!.nextOffset) break
+      expect(page!.nextOffset).toBeGreaterThan(offset)
+      offset = page!.nextOffset
+    }
+    expect(pages.join('')).toBe('中文测试')
+  })
+
+  it('clamps a no-range read to the byte cap and returns a cursor', async () => {
+    const { readArtifactBounded, ARTIFACT_MAX_READ_BYTES } = await import('./artifact-store.js')
+    const store = new InMemoryArtifactStore(() => 't0')
+    const big = 'x'.repeat(ARTIFACT_MAX_READ_BYTES + 5_000)
+    const { meta } = await store.put({ content: big })
+    const result = await readArtifactBounded(store, meta.id, meta, {})
+    expect(result).not.toBeNull()
+    expect(Buffer.byteLength(result!.content, 'utf8')).toBe(ARTIFACT_MAX_READ_BYTES)
+    expect(result!.truncated).toBe(true)
+    expect(result!.nextOffset).toBe(ARTIFACT_MAX_READ_BYTES)
+  })
+
+  it('clamps an oversized line range to the line cap and returns a line cursor', async () => {
+    const { readArtifactBounded, ARTIFACT_MAX_READ_LINES } = await import('./artifact-store.js')
+    const store = new InMemoryArtifactStore(() => 't0')
+    const content = Array.from({ length: ARTIFACT_MAX_READ_LINES + 500 }, (_, i) => `l${i + 1}`).join('\n')
+    const { meta } = await store.put({ content })
+    const result = await readArtifactBounded(store, meta.id, meta, { startLine: 1, endLine: ARTIFACT_MAX_READ_LINES + 500 })
+    expect(result).not.toBeNull()
+    expect(result!.range.endLine).toBe(ARTIFACT_MAX_READ_LINES)
+    expect(result!.truncated).toBe(true)
+    expect(result!.nextStartLine).toBe(ARTIFACT_MAX_READ_LINES + 1)
+  })
+
+  it('reports not-truncated and no cursor when the whole artifact fits', async () => {
+    const { readArtifactBounded } = await import('./artifact-store.js')
+    const store = new InMemoryArtifactStore(() => 't0')
+    const { meta } = await store.put({ content: 'small content' })
+    const result = await readArtifactBounded(store, meta.id, meta, {})
+    expect(result!.content).toBe('small content')
+    expect(result!.truncated).toBe(false)
+    expect(result!.nextOffset).toBeUndefined()
+  })
+})

--- a/kun/src/artifacts/artifact-store.ts
+++ b/kun/src/artifacts/artifact-store.ts
@@ -1,0 +1,384 @@
+/**
+ * Content-addressed Artifact Store (P0 #5).
+ *
+ * A unified mechanism for large tool results — MCP payloads, browser output,
+ * big JSON, remote logs, attachments — so the model only ever sees a bounded
+ * summary + a stable artifact id, and can fetch specific byte/line ranges on
+ * demand. Content is addressed by hash, so identical results dedupe. Two
+ * implementations: an in-memory store (tests / ephemeral runtime) and a
+ * file-backed store (persistent, survives restart for replay/audit).
+ */
+
+import { mkdir, readFile, readdir, rename, rm, writeFile, stat as fsStat, open as fsOpen } from 'node:fs/promises'
+import { join } from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
+import { artifactId, summarizeForModel, type ArtifactSummary } from './artifact-summary.js'
+
+export type ArtifactSourceKind = 'mcp' | 'web' | 'bash' | 'attachment' | 'remote-log' | 'tool' | 'other'
+
+export type StoredArtifactMeta = {
+  id: string
+  byteSize: number
+  lineCount: number
+  mimeType?: string
+  source?: ArtifactSourceKind
+  /** Tool / origin label, e.g. an MCP tool name or `web_fetch`. */
+  origin?: string
+  createdAt: string
+}
+
+export type PutArtifactInput = {
+  content: string
+  mimeType?: string
+  source?: ArtifactSourceKind
+  origin?: string
+  /** Inline preview budget handed to the model. Default 4000. */
+  maxInlineChars?: number
+}
+
+export type PutArtifactResult = {
+  meta: StoredArtifactMeta
+  summary: ArtifactSummary
+  /** True when this content already existed (deduped by hash). */
+  deduped: boolean
+}
+
+export type ReadRangeOptions = {
+  /** Byte offset (UTF-8) for a raw slice. */
+  offset?: number
+  length?: number
+  /** 1-indexed inclusive line range (takes precedence over byte offset). */
+  startLine?: number
+  endLine?: number
+}
+
+export interface ArtifactStore {
+  put(input: PutArtifactInput): Promise<PutArtifactResult>
+  get(id: string): Promise<string | null>
+  readRange(id: string, options: ReadRangeOptions): Promise<string | null>
+  stat(id: string): Promise<StoredArtifactMeta | null>
+}
+
+const DEFAULT_MAX_INLINE = 4_000
+
+/** Hard cap on any single artifact read: bytes and lines (P0 #5). A read that
+ * would exceed these is clamped and a cursor is returned so the caller pages. */
+export const ARTIFACT_MAX_READ_BYTES = 1_048_576
+export const ARTIFACT_MAX_READ_LINES = 2_000
+
+/** Artifact ids are content hashes; reject anything else so an id can never
+ * escape the store directory (path traversal) when used in a file path. */
+const ARTIFACT_ID_PATTERN = /^art_[0-9a-f]{1,64}$/
+
+export function isValidArtifactId(id: string): boolean {
+  return ARTIFACT_ID_PATTERN.test(id)
+}
+
+export type BoundedArtifactRead = {
+  content: string
+  range: ReadRangeOptions
+  /** True when more content remains beyond what was returned. */
+  truncated: boolean
+  /** Byte cursor for the next page (byte-range reads). */
+  nextOffset?: number
+  /** Line cursor for the next page (line-range reads). */
+  nextStartLine?: number
+}
+
+/**
+ * Read an artifact with a HARD upper bound (P0 #5). Any request — including one
+ * with no range, or a range larger than the cap — is clamped to at most
+ * {@link ARTIFACT_MAX_READ_BYTES} / {@link ARTIFACT_MAX_READ_LINES}, and a
+ * cursor (`nextOffset` / `nextStartLine`) is returned when content remains so a
+ * caller can page instead of pulling a multi-GB artifact into memory/context.
+ * Byte accounting is derived from the requested window + the artifact size (not
+ * the decoded string) so the cursor is exact even when a byte slice lands on a
+ * multibyte UTF-8 boundary.
+ */
+export async function readArtifactBounded(
+  store: ArtifactStore,
+  id: string,
+  meta: StoredArtifactMeta,
+  requested: ReadRangeOptions
+): Promise<BoundedArtifactRead | null> {
+  const lineMode = requested.startLine !== undefined || requested.endLine !== undefined
+  if (lineMode) {
+    const startLine = Math.max(1, requested.startLine ?? 1)
+    const requestedEnd = requested.endLine ?? startLine + ARTIFACT_MAX_READ_LINES - 1
+    const endLine = Math.min(requestedEnd, startLine + ARTIFACT_MAX_READ_LINES - 1)
+    const range: ReadRangeOptions = { startLine, endLine }
+    const content = await store.readRange(id, range)
+    if (content === null) return null
+    const truncated = endLine < meta.lineCount
+    return { content, range, truncated, ...(truncated ? { nextStartLine: endLine + 1 } : {}) }
+  }
+  const offset = Math.max(0, requested.offset ?? 0)
+  const requestedLen = requested.length ?? ARTIFACT_MAX_READ_BYTES
+  const length = Math.min(Math.max(0, requestedLen), ARTIFACT_MAX_READ_BYTES)
+  const content = await store.readRange(id, { offset, length })
+  if (content === null) return null
+  const bytesConsumed = Buffer.byteLength(content, 'utf8')
+  const range: ReadRangeOptions = { offset, length: bytesConsumed }
+  const truncated = offset + bytesConsumed < meta.byteSize
+  return { content, range, truncated, ...(truncated ? { nextOffset: offset + bytesConsumed } : {}) }
+}
+
+function buildMeta(input: PutArtifactInput, id: string, nowIso: () => string): StoredArtifactMeta {
+  const byteSize = Buffer.byteLength(input.content, 'utf8')
+  const lineCount = input.content.length === 0 ? 0 : input.content.split('\n').length
+  return {
+    id,
+    byteSize,
+    lineCount,
+    ...(input.mimeType ? { mimeType: input.mimeType } : {}),
+    ...(input.source ? { source: input.source } : {}),
+    ...(input.origin ? { origin: input.origin } : {}),
+    createdAt: nowIso()
+  }
+}
+
+function sliceContent(content: string, options: ReadRangeOptions): string {
+  if (options.startLine !== undefined || options.endLine !== undefined) {
+    const lines = content.split('\n')
+    const start = Math.max(1, options.startLine ?? 1)
+    const end = Math.min(lines.length, options.endLine ?? lines.length)
+    if (start > end) return ''
+    return lines.slice(start - 1, end).join('\n')
+  }
+  if (options.offset !== undefined || options.length !== undefined) {
+    const buffer = Buffer.from(content, 'utf8')
+    const offset = Math.max(0, options.offset ?? 0)
+    const length = options.length !== undefined ? Math.max(0, options.length) : buffer.length - offset
+    return decodeUtf8Window(buffer.subarray(offset, offset + length + 3), length)
+  }
+  return content
+}
+
+export class InMemoryArtifactStore implements ArtifactStore {
+  private readonly contents = new Map<string, string>()
+  private readonly metas = new Map<string, StoredArtifactMeta>()
+
+  constructor(private readonly nowIso: () => string = () => new Date().toISOString()) {}
+
+  async put(input: PutArtifactInput): Promise<PutArtifactResult> {
+    const id = artifactId(input.content)
+    const summary = summarizeForModel({
+      content: input.content,
+      maxInlineChars: input.maxInlineChars ?? DEFAULT_MAX_INLINE
+    })
+    const deduped = this.contents.has(id)
+    if (!deduped) {
+      this.contents.set(id, input.content)
+      this.metas.set(id, buildMeta(input, id, this.nowIso))
+    }
+    return { meta: this.metas.get(id)!, summary, deduped }
+  }
+
+  async get(id: string): Promise<string | null> {
+    return this.contents.get(id) ?? null
+  }
+
+  async readRange(id: string, options: ReadRangeOptions): Promise<string | null> {
+    const content = this.contents.get(id)
+    if (content === undefined) return null
+    return sliceContent(content, options)
+  }
+
+  async stat(id: string): Promise<StoredArtifactMeta | null> {
+    return this.metas.get(id) ?? null
+  }
+}
+
+export class FileArtifactStore implements ArtifactStore {
+  private ready?: Promise<void>
+
+  constructor(
+    private readonly dir: string,
+    private readonly nowIso: () => string = () => new Date().toISOString(),
+    private readonly limits: { maxTotalBytes?: number; maxArtifacts?: number } = {}
+  ) {}
+
+  private async ensureDir(): Promise<void> {
+    if (!this.ready) this.ready = mkdir(this.dir, { recursive: true }).then(() => undefined)
+    return this.ready
+  }
+
+  private contentPath(id: string): string {
+    return join(this.dir, `${id}.bin`)
+  }
+
+  private metaPath(id: string): string {
+    return join(this.dir, `${id}.json`)
+  }
+
+  async put(input: PutArtifactInput): Promise<PutArtifactResult> {
+    await this.ensureDir()
+    const id = artifactId(input.content)
+    const summary = summarizeForModel({
+      content: input.content,
+      maxInlineChars: input.maxInlineChars ?? DEFAULT_MAX_INLINE
+    })
+    let deduped = true
+    try {
+      await Promise.all([fsStat(this.contentPath(id)), fsStat(this.metaPath(id))])
+    } catch {
+      deduped = false
+    }
+    let meta: StoredArtifactMeta
+    if (!deduped) {
+      meta = buildMeta(input, id, this.nowIso)
+      await this.enforceQuota(meta.byteSize)
+      const suffix = `${process.pid}.${Date.now()}.tmp`
+      const contentTemporaryPath = `${this.contentPath(id)}.${suffix}`
+      const metaTemporaryPath = `${this.metaPath(id)}.${suffix}`
+      try {
+        await writeFile(contentTemporaryPath, input.content, 'utf8')
+        await writeFile(metaTemporaryPath, JSON.stringify(meta), 'utf8')
+        await rename(contentTemporaryPath, this.contentPath(id))
+        await rename(metaTemporaryPath, this.metaPath(id))
+      } finally {
+        await Promise.all([
+          rm(contentTemporaryPath, { force: true }),
+          rm(metaTemporaryPath, { force: true })
+        ]).catch(() => undefined)
+      }
+    } else {
+      meta = (await this.stat(id)) ?? buildMeta(input, id, this.nowIso)
+    }
+    return { meta, summary, deduped }
+  }
+
+  async get(id: string): Promise<string | null> {
+    if (!isValidArtifactId(id)) return null
+    try {
+      return await readFile(this.contentPath(id), 'utf8')
+    } catch {
+      return null
+    }
+  }
+
+  async readRange(id: string, options: ReadRangeOptions): Promise<string | null> {
+    if (!isValidArtifactId(id)) return null
+    if (options.startLine !== undefined || options.endLine !== undefined) {
+      return this.readLineRange(id, options.startLine, options.endLine)
+    }
+    if (options.offset !== undefined || options.length !== undefined) {
+      return this.readByteRange(id, options.offset ?? 0, options.length)
+    }
+    return this.get(id)
+  }
+
+  /** True seek read of a byte window — never loads the whole artifact. */
+  private async readByteRange(id: string, offset: number, length?: number): Promise<string | null> {
+    let handle: import('node:fs/promises').FileHandle | undefined
+    try {
+      handle = await fsOpen(this.contentPath(id), 'r')
+      const { size } = await handle.stat()
+      const start = Math.max(0, Math.min(offset, size))
+      const want = length !== undefined ? Math.max(0, length) : size - start
+      const count = Math.min(want + 3, size - start)
+      if (count <= 0) return ''
+      const buffer = Buffer.alloc(count)
+      await handle.read(buffer, 0, count, start)
+      return decodeUtf8Window(buffer, want)
+    } catch {
+      return null
+    } finally {
+      await handle?.close().catch(() => undefined)
+    }
+  }
+
+  /**
+   * Stream a 1-indexed inclusive line window, stopping once `endLine` is read —
+   * so a small slice of a multi-GB artifact stays cheap. Only the selected
+   * lines are buffered.
+   */
+  private async readLineRange(id: string, startLine?: number, endLine?: number): Promise<string | null> {
+    const start = Math.max(1, startLine ?? 1)
+    const end = endLine ?? Number.MAX_SAFE_INTEGER
+    if (start > end) return ''
+    let handle: import('node:fs/promises').FileHandle | undefined
+    try {
+      handle = await fsOpen(this.contentPath(id), 'r')
+    } catch {
+      return null
+    }
+    try {
+      const collected: string[] = []
+      let lineNo = 1
+      let pending = ''
+      // Decode incrementally so a multibyte UTF-8 sequence split across a 64KiB
+      // read boundary is buffered and stitched, not turned into replacement
+      // characters (P2-04).
+      const decoder = new StringDecoder('utf8')
+      const chunk = Buffer.alloc(64 * 1_024)
+      for (;;) {
+        const { bytesRead } = await handle.read(chunk, 0, chunk.length, null)
+        if (bytesRead === 0) break
+        pending += decoder.write(chunk.subarray(0, bytesRead))
+        let nl = pending.indexOf('\n')
+        while (nl !== -1) {
+          const line = pending.slice(0, nl)
+          if (lineNo >= start && lineNo <= end) collected.push(line)
+          lineNo += 1
+          if (lineNo > end) return collected.join('\n')
+          pending = pending.slice(nl + 1)
+          nl = pending.indexOf('\n')
+        }
+      }
+      // Flush any bytes the decoder was holding for an incomplete sequence.
+      pending += decoder.end()
+      // Trailing line without a final newline.
+      if (lineNo >= start && lineNo <= end && pending.length > 0) collected.push(pending)
+      return collected.join('\n')
+    } catch {
+      return null
+    } finally {
+      await handle.close().catch(() => undefined)
+    }
+  }
+
+  async stat(id: string): Promise<StoredArtifactMeta | null> {
+    if (!isValidArtifactId(id)) return null
+    try {
+      return JSON.parse(await readFile(this.metaPath(id), 'utf8')) as StoredArtifactMeta
+    } catch {
+      return null
+    }
+  }
+
+  private async enforceQuota(incomingBytes: number): Promise<void> {
+    const maxTotalBytes = this.limits.maxTotalBytes ?? 512 * 1024 * 1024
+    const maxArtifacts = this.limits.maxArtifacts ?? 2_000
+    if (incomingBytes > maxTotalBytes) throw new Error(`artifact exceeds ${maxTotalBytes} byte store quota`)
+    const entries = await readdir(this.dir).catch(() => [])
+    const metas = (await Promise.all(entries
+      .filter((entry) => entry.endsWith('.json'))
+      .map(async (entry) => {
+        try {
+          return JSON.parse(await readFile(join(this.dir, entry), 'utf8')) as StoredArtifactMeta
+        } catch {
+          return null
+        }
+      })))
+      .filter((meta): meta is StoredArtifactMeta => Boolean(meta && isValidArtifactId(meta.id)))
+    const totalBytes = metas.reduce((sum, meta) => sum + meta.byteSize, 0)
+    if (totalBytes + incomingBytes > maxTotalBytes || metas.length + 1 > maxArtifacts) {
+      throw new Error('artifact store quota exceeded; remove unneeded artifacts before retrying')
+    }
+  }
+}
+
+function decodeUtf8Window(buffer: Buffer, requestedBytes: number): string {
+  const decode = (bytes: Buffer): string => {
+    const decoder = new StringDecoder('utf8')
+    return decoder.write(bytes)
+  }
+  const bounded = buffer.subarray(0, Math.min(requestedBytes, buffer.length))
+  const text = decode(bounded)
+  if (text || bounded.length === 0 || buffer.length <= bounded.length) return text
+  // Very small ranges can end before the first multibyte code point completes.
+  // Include that one complete character so the cursor advances without losing
+  // bytes or looping forever; the overrun is at most three bytes.
+  return decode(buffer.subarray(0, Math.min(requestedBytes + 3, buffer.length)))
+}

--- a/kun/src/artifacts/artifact-summary.test.ts
+++ b/kun/src/artifacts/artifact-summary.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { artifactId, summarizeForModel } from './artifact-summary.js'
+
+describe('artifactId', () => {
+  it('is content-addressed and stable', () => {
+    expect(artifactId('hello')).toBe(artifactId('hello'))
+    expect(artifactId('hello')).not.toBe(artifactId('world'))
+    expect(artifactId('hello')).toMatch(/^art_[0-9a-f]{24}$/)
+  })
+})
+
+describe('summarizeForModel', () => {
+  it('returns content verbatim when within budget', () => {
+    const result = summarizeForModel({ content: 'short output', maxInlineChars: 100 })
+    expect(result.truncated).toBe(false)
+    expect(result.inline).toBe('short output')
+    expect(result.lineCount).toBe(1)
+  })
+
+  it('truncates with head + tail + reference marker when oversized', () => {
+    const content = `${'H'.repeat(500)}\n${'T'.repeat(500)}`
+    const result = summarizeForModel({ content, maxInlineChars: 200 })
+    expect(result.truncated).toBe(true)
+    expect(result.inline).toContain(`[artifact ${result.artifactId}:`)
+    expect(result.inline).toContain('elided')
+    // Keeps a head and a tail excerpt.
+    expect(result.inline.startsWith('H')).toBe(true)
+    expect(result.inline.trimEnd().endsWith('T')).toBe(true)
+    // The byte size reflects the full content, not the preview.
+    expect(result.byteSize).toBe(Buffer.byteLength(content, 'utf8'))
+  })
+
+  it('keeps the preview within roughly the requested budget', () => {
+    const result = summarizeForModel({ content: 'x'.repeat(10_000), maxInlineChars: 300 })
+    // head + marker + tail; allow the marker line + newlines as overhead.
+    expect(result.inline.length).toBeLessThanOrEqual(400)
+  })
+
+  it('counts lines on the full content', () => {
+    expect(summarizeForModel({ content: 'a\nb\nc', maxInlineChars: 100 }).lineCount).toBe(3)
+  })
+})

--- a/kun/src/artifacts/artifact-summary.ts
+++ b/kun/src/artifacts/artifact-summary.ts
@@ -1,0 +1,77 @@
+/**
+ * Content-addressed artifact summarization (P0 #5).
+ *
+ * Bash output already has truncation, but MCP results, browser output, large
+ * JSON, and attachments do not share a mechanism. Large results should be
+ * stored by content hash and the model should see only a bounded preview plus
+ * a stable reference, fetching specific slices on demand. This module is the
+ * pure core: a content-address id + a head/tail-bounded preview with an
+ * explicit reference marker. The byte store itself is a thin layer on top.
+ */
+
+import { createHash } from 'node:crypto'
+
+export function artifactId(content: string | Buffer): string {
+  const hash = createHash('sha256').update(content).digest('hex')
+  return `art_${hash.slice(0, 24)}`
+}
+
+export type ArtifactSummary = {
+  artifactId: string
+  byteSize: number
+  lineCount: number
+  /** The bounded preview handed to the model. */
+  inline: string
+  /** True when `inline` is a head/tail excerpt rather than the full content. */
+  truncated: boolean
+}
+
+/**
+ * Produce a model-facing summary of a (possibly huge) text result. When the
+ * content fits within `maxInlineChars` it is returned verbatim. Otherwise a
+ * head + tail excerpt is returned with a reference marker telling the model how
+ * many bytes/lines were elided and how to fetch the full artifact by id.
+ */
+export function summarizeForModel(input: {
+  content: string
+  maxInlineChars: number
+  /** Fraction of the budget devoted to the head excerpt (rest is tail). Default 0.7. */
+  headRatio?: number
+}): ArtifactSummary {
+  const content = input.content
+  const byteSize = Buffer.byteLength(content, 'utf8')
+  const lineCount = content.length === 0 ? 0 : content.split('\n').length
+  const id = artifactId(content)
+  const maxInline = Math.max(0, input.maxInlineChars)
+
+  if (content.length <= maxInline) {
+    return { artifactId: id, byteSize, lineCount, inline: content, truncated: false }
+  }
+
+  const headRatio = clampRatio(input.headRatio ?? 0.7)
+  // Reserve room for the marker so the final inline stays within budget.
+  const markerPlaceholder = referenceMarker(id, 0, 0)
+  const budget = Math.max(0, maxInline - markerPlaceholder.length)
+  const headChars = Math.floor(budget * headRatio)
+  const tailChars = Math.max(0, budget - headChars)
+  const head = content.slice(0, headChars)
+  const tail = tailChars > 0 ? content.slice(content.length - tailChars) : ''
+  const omittedChars = content.length - head.length - tail.length
+  const omittedLines = Math.max(0, lineCount - countLines(head) - countLines(tail))
+  const marker = referenceMarker(id, omittedChars, omittedLines)
+  const inline = tail ? `${head}\n${marker}\n${tail}` : `${head}\n${marker}`
+  return { artifactId: id, byteSize, lineCount, inline, truncated: true }
+}
+
+function referenceMarker(id: string, omittedChars: number, omittedLines: number): string {
+  return `[artifact ${id}: ${omittedChars} char(s) / ${omittedLines} line(s) elided — fetch the full artifact or a specific range by id]`
+}
+
+function countLines(text: string): number {
+  return text.length === 0 ? 0 : text.split('\n').length
+}
+
+function clampRatio(value: number): number {
+  if (!Number.isFinite(value)) return 0.7
+  return Math.min(0.95, Math.max(0.05, value))
+}

--- a/kun/src/delegation/child-agent-executor.ts
+++ b/kun/src/delegation/child-agent-executor.ts
@@ -16,6 +16,7 @@ import { InflightTracker } from '../loop/inflight-tracker.js'
 import { SteeringQueue } from '../loop/steering-queue.js'
 import type { TokenEconomyConfig } from '../loop/token-economy.js'
 import type { MemoryStore } from '../memory/memory-store.js'
+import type { ArtifactStore } from '../artifacts/artifact-store.js'
 import type { ModelClient } from '../ports/model-client.js'
 import { RandomIdGenerator } from '../ports/id-generator.js'
 import type { SessionStore } from '../ports/session-store.js'
@@ -43,6 +44,7 @@ export type ChildAgentExecutorOptions = {
   modelCapabilities?: (model: string) => ModelCapabilityMetadata
   skillRuntime?: SkillRuntime
   memoryStore?: MemoryStore
+  artifactStore?: ArtifactStore
   /**
    * Persistence wiring. When the main runtime's stores + event recorder are
    * supplied, the child runs as a persisted `relation: 'side'` thread on the
@@ -159,6 +161,7 @@ export function createChildAgentExecutor(options: ChildAgentExecutorOptions): Ch
       ...(options.modelCapabilities ? { modelCapabilities: options.modelCapabilities } : {}),
       ...(options.skillRuntime ? { skillRuntime: options.skillRuntime } : {}),
       ...(options.memoryStore ? { memoryStore: options.memoryStore } : {}),
+      ...(options.artifactStore ? { artifactStore: options.artifactStore } : {}),
       ...(options.contextCompaction ? { contextCompaction: options.contextCompaction } : {}),
       ...(options.tokenEconomy ? { tokenEconomy: options.tokenEconomy } : {}),
       ...(options.runtime?.toolStorm ? { toolStorm: options.runtime.toolStorm } : {}),

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -63,6 +63,7 @@ import type { SkillRuntime } from '../skills/skill-runtime.js'
 import type { AttachmentContent, AttachmentStore } from '../attachments/attachment-store.js'
 import type { ModelInputAttachment, ModelTextAttachmentFallback } from '../ports/model-client.js'
 import type { MemoryStore } from '../memory/memory-store.js'
+import type { ArtifactStore } from '../artifacts/artifact-store.js'
 import {
   hasHooksForPhase,
   runObserverHooks,
@@ -672,6 +673,7 @@ export type AgentLoopOptions = {
   skillRuntime?: SkillRuntime
   attachmentStore?: AttachmentStore
   memoryStore?: MemoryStore
+  artifactStore?: ArtifactStore
   /** Kun runtime data root for sandbox-safe background shell output reads. */
   runtimeDataDir?: string
   tokenEconomy?: TokenEconomyConfig
@@ -2225,6 +2227,7 @@ export class AgentLoop {
       approvalPolicy: input.approvalPolicy,
       sandboxMode: input.sandboxMode,
       ...(this.opts.runtimeDataDir ? { runtimeDataDir: this.opts.runtimeDataDir } : {}),
+      ...(this.opts.artifactStore ? { artifactStore: this.opts.artifactStore } : {}),
       abortSignal: input.signal,
       awaitApproval: async (approval) => {
         await this.opts.events.record({

--- a/kun/src/ports/tool-host.ts
+++ b/kun/src/ports/tool-host.ts
@@ -2,6 +2,7 @@ import type { ApprovalPolicy, SandboxMode } from '../contracts/policy.js'
 import type { ApprovalRequest } from '../domain/approval.js'
 import type { TurnItem } from '../contracts/items.js'
 import type { ModelCapabilityMetadata } from '../contracts/capabilities.js'
+import type { ArtifactStore } from '../artifacts/artifact-store.js'
 import type {
   UserInputRequest,
   UserInputResolution
@@ -93,6 +94,8 @@ export type ToolHostContext = {
   sandboxMode?: SandboxMode
   /** Kun runtime data root; used to allow sandbox-safe reads of background shell output files. */
   runtimeDataDir?: string
+  /** Store used to offload oversized tool results from model context. */
+  artifactStore?: ArtifactStore
   abortSignal: AbortSignal
   /** Resolves a pending approval with the user's decision. */
   awaitApproval: (approval: ApprovalRequest) => Promise<'allow' | 'deny'>

--- a/kun/src/server/runtime-factory.ts
+++ b/kun/src/server/runtime-factory.ts
@@ -16,6 +16,8 @@ import { createAgentSdkRuntime } from '../runtime/agent-sdk/agent-sdk-runtime-fa
 import { buildGoalLocalTools } from '../adapters/tool/goal-tools.js'
 import { buildTodoLocalTools } from '../adapters/tool/todo-tools.js'
 import { LocalToolHost, buildDefaultLocalTools } from '../adapters/tool/local-tool-host.js'
+import { createReadArtifactTool } from '../adapters/tool/artifact-tool.js'
+import { FileArtifactStore } from '../artifacts/artifact-store.js'
 import { buildMcpToolProviders } from '../adapters/tool/mcp-tool-provider.js'
 import { buildMemoryToolProviders } from '../adapters/tool/memory-tool-provider.js'
 import { buildSkillToolProviders } from '../adapters/tool/skill-tool-provider.js'
@@ -167,6 +169,7 @@ export async function createKunServeRuntime(
     ]
   })
   const threadService = new ThreadService({ threadStore, sessionStore, events, ids, nowIso })
+  const artifactStore = new FileArtifactStore(join(options.dataDir, 'artifacts'), nowIso)
   const modelProfiles = modelContextProfilesFromConfig({
     contextCompaction: options.contextCompaction,
     models: options.models
@@ -309,6 +312,13 @@ export async function createKunServeRuntime(
       available: true,
       tools: withBackgroundShellTools(buildDefaultLocalTools())
     },
+    {
+      id: 'artifacts',
+      kind: 'built-in' as const,
+      enabled: true,
+      available: true,
+      tools: [createReadArtifactTool()]
+    },
     ...mcpProviders.providers,
     ...webProviders.providers,
     ...buildMemoryToolProviders(memoryStore),
@@ -359,6 +369,7 @@ export async function createKunServeRuntime(
           events,
           ...(options.runtime ? { runtime: options.runtime } : {}),
           ...(memoryStore ? { memoryStore } : {}),
+          artifactStore,
           nowIso
         }),
         recordExternalUsage: (threadId, usage) => {
@@ -521,6 +532,7 @@ export async function createKunServeRuntime(
     ...(options.runtime?.toolArgumentRepair ? { toolArgumentRepair: options.runtime.toolArgumentRepair } : {}),
     ...(resolvedHooks.length ? { hooks: resolvedHooks } : {}),
     ...(attachmentStore ? { attachmentStore } : {}),
+    artifactStore,
     ...(memoryStore ? { memoryStore } : {}),
     runtimeDataDir: options.dataDir,
     onPlanWritten: async ({ threadId, planId, relativePath, markdown }) => {


### PR DESCRIPTION
## Summary
- add a content-addressed artifact store with deduplication, quotas, path-safe IDs, and bounded UTF-8 byte/line paging
- automatically offload oversized successful tool output while preserving small and error results
- expose `read_artifact` to parent and child agents and persist artifacts across runtime restarts

## Tests
- `npm.cmd --prefix kun test -- src/artifacts/artifact-store.test.ts src/artifacts/artifact-summary.test.ts src/adapters/tool/artifact-tool.test.ts src/adapters/tool/local-tool-host.test.ts tests/delegation-runtime.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `git diff --check HEAD`