### PR TITLE
fix(workspace): run git inspection in selected directory

### DIFF
--- a/kun/src/adapters/workspace/local-workspace-inspector.ts
+++ b/kun/src/adapters/workspace/local-workspace-inspector.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { execFile } from 'node:child_process'
+import { execFile, type ExecFileOptions } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { WorkspaceInspector } from '../../ports/workspace-inspector.js'
 import type { WorkspaceStatus } from '../../contracts/workspace.js'
@@ -16,12 +16,17 @@ const execFileAsync = promisify(execFile)
 export class LocalWorkspaceInspector implements WorkspaceInspector {
   private readonly exec: (
     file: string,
-    args: string[]
+    args: string[],
+    options?: ExecFileOptions
   ) => Promise<{ stdout: string; stderr: string }>
 
   constructor(
     options: {
-      exec?: (file: string, args: string[]) => Promise<{ stdout: string; stderr: string }>
+      exec?: (
+        file: string,
+        args: string[],
+        options?: ExecFileOptions
+      ) => Promise<{ stdout: string; stderr: string }>
     } = {}
   ) {
     this.exec = options.exec ?? execFileAsync
@@ -80,7 +85,7 @@ export class LocalWorkspaceInspector implements WorkspaceInspector {
   }
 
   private async runGit(cwd: string, args: string[]): Promise<string> {
-    const { stdout } = await this.exec('git', args)
+    const { stdout } = await this.exec('git', args, { cwd })
     return stdout.trim()
   }
 }

--- a/kun/tests/local-workspace-inspector.test.ts
+++ b/kun/tests/local-workspace-inspector.test.ts
@@ -1,0 +1,48 @@
+import type { ExecFileOptions } from 'node:child_process'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { LocalWorkspaceInspector } from '../src/adapters/workspace/local-workspace-inspector.js'
+
+describe('LocalWorkspaceInspector', () => {
+  it('runs git commands in the selected workspace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-workspace-'))
+    const workspace = join(root, 'packages', 'app')
+    await mkdir(workspace, { recursive: true })
+
+    const calls: Array<{ args: string[]; cwd?: string }> = []
+    const inspector = new LocalWorkspaceInspector({
+      exec: async (_file: string, args: string[], options?: ExecFileOptions) => {
+        calls.push({ args, cwd: typeof options?.cwd === 'string' ? options.cwd : undefined })
+        const command = args.join(' ')
+        if (command === 'rev-parse --is-inside-work-tree') return { stdout: 'true\n', stderr: '' }
+        if (command === 'rev-parse --abbrev-ref HEAD') return { stdout: 'develop\n', stderr: '' }
+        if (command === 'rev-parse HEAD') return { stdout: 'abc123\n', stderr: '' }
+        if (command === 'status --porcelain') return { stdout: ' M src/app.ts\n', stderr: '' }
+        throw new Error(`unexpected git command: ${command}`)
+      }
+    })
+
+    try {
+      const status = await inspector.status(workspace)
+
+      expect(status).toMatchObject({
+        path: workspace,
+        isGitRepository: true,
+        branch: 'develop',
+        headSha: 'abc123',
+        isDirty: true,
+        fileChangeCount: 1
+      })
+      expect(calls).toEqual([
+        { args: ['rev-parse', '--is-inside-work-tree'], cwd: workspace },
+        { args: ['rev-parse', '--abbrev-ref', 'HEAD'], cwd: workspace },
+        { args: ['rev-parse', 'HEAD'], cwd: workspace },
+        { args: ['status', '--porcelain'], cwd: workspace }
+      ])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Run workspace Git inspection commands in the selected workspace directory.
- Add a regression test for a workspace located below the process working directory.

## Root cause

`LocalWorkspaceInspector.runGit` accepted a `cwd` argument but never passed it to `execFile`. Git therefore inspected the Kun process directory instead of the workspace selected by the user.

## Changes

- Pass `{ cwd }` to every Git subprocess used by workspace inspection.
- Verify repository detection, branch, HEAD, and dirty status all use the selected workspace.

## Tests

- `npm.cmd --prefix kun test -- tests/local-workspace-inspector.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `git diff --check`