### PR TITLE
fix(skills): preserve project and global root scopes

### DIFF
--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -841,7 +841,9 @@ describe('syncGuiManagedKunConfig', () => {
     expect(parsed.capabilities.skills.enabled).toBe(true)
     expect(parsed.capabilities.skills.legacySkillMd).toBe(true)
     expect(parsed.capabilities.skills.roots).toEqual(expect.arrayContaining([
-      join(workspaceRoot, '.codex', 'skills'),
+      join(workspaceRoot, '.codex', 'skills')
+    ]))
+    expect(parsed.capabilities.skills.globalRoots).toEqual(expect.arrayContaining([
       extraRoot
     ]))
   })

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -643,9 +643,20 @@ async function skillCapabilityConfigForRuntime(
       path.length > 0 &&
       !managed.has(comparableSkillRootPath(path)) &&
       !isCodexPluginCacheRoot(path))
+  const manualGlobalExisting = stringArrayValue(existing.globalRoots)
+    .map(normalizeSkillRootPath)
+    .filter((path) =>
+      path.length > 0 &&
+      !managed.has(comparableSkillRootPath(path)) &&
+      !isCodexPluginCacheRoot(path))
+  const guiRoots = await guiSkillRootsForRuntime(settings)
   const roots = uniqueStrings([
     ...manualExisting,
-    ...(await guiSkillRootsForRuntime(settings)).map((root) => root.path)
+    ...guiRoots.filter((root) => root.scope === 'project').map((root) => root.path)
+  ])
+  const globalRoots = uniqueStrings([
+    ...manualGlobalExisting,
+    ...guiRoots.filter((root) => root.scope === 'global').map((root) => root.path)
   ])
   return {
     ...existing,
@@ -653,11 +664,11 @@ async function skillCapabilityConfigForRuntime(
     // enable toggle, so a persisted `enabled: false` is only ever the schema
     // default leaking onto disk — it must not permanently suppress discovered
     // skills. An explicit `true` still forces on even with no roots.
-    enabled: roots.length > 0 || existing.enabled === true,
+    enabled: roots.length > 0 || globalRoots.length > 0 || existing.enabled === true,
     roots,
     workspaceRoots: guiSkillWorkspaceRootsForRuntime(settings),
     // #149: Pass global skill roots from settings (e.g. ~/.kun/skills)
-    globalRoots: existing.globalRoots ?? [],
+    globalRoots,
     // Skills the user disabled in the GUI. Forwarded so the runtime drops them
     // from discovery — without this they stay loadable via load_skill and keep
     // appearing in the catalog despite the GUI toggle (#392).


### PR DESCRIPTION
## Summary

- Preserve the project/global scope assigned by the GUI skill root discovery service.
- Keep manually configured project and global roots in their matching Kun capability fields.

## Root cause

`guiSkillRootsForRuntime` already labels each root as `project` or `global`, but `syncGuiManagedKunConfig` discarded that label and appended every GUI root to `capabilities.skills.roots`. The runtime consequently diagnosed and prioritized global skills as project skills.

## Changes

- Split GUI-managed roots into `roots` and `globalRoots` by their existing scope.
- Filter stale GUI-managed entries from both persisted root lists before rebuilding them.
- Enable the capability when either scoped root list is populated.
- Extend the existing config sync test to assert both fields.

## Tests

- `npm.cmd test -- src/main/kun-process.test.ts` (38 tests)
- `npm.cmd run typecheck`
- `git diff --check`