### PR TITLE
feat(git): add configurable branch prefix

### DIFF
--- a/src/main/ipc/app-ipc-schemas.ts
+++ b/src/main/ipc/app-ipc-schemas.ts
@@ -1364,6 +1364,7 @@ const settingsPatchObjectSchema = z.object({
   conversationWorkspaceRoot: defaultPathSchema,
   log: logPatchSchema.optional(),
   checkpointCleanup: checkpointCleanupPatchSchema.optional(),
+  gitBranchPrefix: trimmedString(128).or(z.literal('')).optional(),
   notifications: notificationsPatchSchema.optional(),
   appBehavior: appBehaviorPatchSchema.optional(),
   keyboardShortcuts: keyboardShortcutsPatchSchema.optional(),

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CHECKPOINT_CLEANUP_ENABLED,
   DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS,
   DEFAULT_CURSOR_SPOTLIGHT_COLOR,
+  DEFAULT_GIT_BRANCH_PREFIX,
   DEFAULT_LOG_RETENTION_DAYS,
   DEFAULT_WRITE_WORKSPACE_ROOT,
   defaultClawSettings,
@@ -31,6 +32,7 @@ import {
   DEFAULT_UI_FONT_SCALE,
   normalizeAppBehaviorSettings,
   normalizeCheckpointCleanupSettings,
+  normalizeGitBranchPrefix,
   normalizeKeyboardShortcuts,
   migrateLegacyAppSettings,
   normalizeAppSettings,
@@ -241,6 +243,7 @@ const defaultSettings = (): AppSettingsV1 => ({
     enabled: DEFAULT_CHECKPOINT_CLEANUP_ENABLED,
     intervalDays: DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS
   },
+  gitBranchPrefix: DEFAULT_GIT_BRANCH_PREFIX,
   notifications: {
     turnComplete: true
   },
@@ -273,6 +276,7 @@ function buildMergedSettings(parsed: Partial<AppSettingsV1>): AppSettingsV1 {
       ...defaults.checkpointCleanup,
       ...migrated.checkpointCleanup
     }),
+    gitBranchPrefix: normalizeGitBranchPrefix(migrated.gitBranchPrefix),
     notifications: { ...defaults.notifications, ...migrated.notifications },
     appBehavior: mergeAppBehaviorSettings(defaults.appBehavior, migrated.appBehavior),
     keyboardShortcuts: normalizeKeyboardShortcuts(migrated.keyboardShortcuts),

--- a/src/renderer/src/components/chat/GitBranchPicker.tsx
+++ b/src/renderer/src/components/chat/GitBranchPicker.tsx
@@ -2,8 +2,16 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 import { createPortal } from 'react-dom'
 import { AlertCircle, Check, ChevronDown, GitBranch, GitFork, Loader2, Plus, Search } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import {
+  applyGitBranchPrefix,
+  DEFAULT_GIT_BRANCH_PREFIX,
+  normalizeGitBranchPrefix,
+  type AppSettingsV1
+} from '@shared/app-settings'
 import type { GitBranchesResult, GitBranchRow } from '@shared/git-branches'
 import { getProvider } from '../../agent/registry'
+import { rendererRuntimeClient } from '../../agent/runtime-client'
+import { SETTINGS_CHANGED_EVENT } from '../../lib/keyboard-shortcut-settings'
 import { middleEllipsize } from '../../lib/middle-ellipsize'
 import {
   forgetThreadWorktree,
@@ -46,6 +54,7 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
   const [actingKind, setActingKind] = useState<'switch' | 'worktree' | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [tooltip, setTooltip] = useState<BranchTooltip | null>(null)
+  const [branchPrefix, setBranchPrefix] = useState(DEFAULT_GIT_BRANCH_PREFIX)
   const wrapRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
 
@@ -78,6 +87,22 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
   }, [load])
 
   useEffect(() => {
+    let cancelled = false
+    const apply = (settings: Pick<AppSettingsV1, 'gitBranchPrefix'>): void => {
+      if (!cancelled) setBranchPrefix(normalizeGitBranchPrefix(settings.gitBranchPrefix))
+    }
+    void rendererRuntimeClient.getSettings().then(apply).catch(() => undefined)
+    const onSettingsChanged = (event: Event): void => {
+      apply((event as CustomEvent<AppSettingsV1>).detail)
+    }
+    window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
+    return () => {
+      cancelled = true
+      window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
+    }
+  }, [])
+
+  useEffect(() => {
     if (!open) return
     void load()
     window.setTimeout(() => inputRef.current?.focus(), 0)
@@ -106,18 +131,19 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
   }, [branches, query])
 
   const trimmedQuery = query.trim()
-  const exactBranchExists = branches.some((branch) => branch.name === trimmedQuery)
-  const switchTargetRow = exactBranchExists
-    ? branches.find((branch) => branch.name === trimmedQuery) ?? null
-    : null
-  const canCreate = trimmedQuery.length > 0 && !exactBranchExists
+  const createBranchName = applyGitBranchPrefix(trimmedQuery, branchPrefix)
+  const switchTargetRow = branches.find((branch) => branch.name === trimmedQuery)
+    ?? branches.find((branch) => branch.name === createBranchName)
+    ?? null
+  const canCreate = createBranchName.length > 0 && !switchTargetRow
   const canCreateWorktree = trimmedQuery.length > 0 && (canCreate || Boolean(switchTargetRow))
   const currentBranch = result?.ok ? result.currentBranch : null
   const label = currentBranch || (result?.ok ? t('gitDetached') : t('gitBranchUnavailable'))
-  const footerBranchLabel = middleEllipsize(trimmedQuery, BRANCH_FOOTER_LABEL_MAX_LENGTH)
+  const footerBranchLabel = middleEllipsize(createBranchName, BRANCH_FOOTER_LABEL_MAX_LENGTH)
   const footerCreateLabel = t('gitCreateNamedBranch', { branch: footerBranchLabel })
-  const footerCreateTitle = t('gitCreateNamedBranch', { branch: trimmedQuery })
-  const footerWorktreeTitle = t('gitNewBranchWorktree', { branch: trimmedQuery })
+  const footerCreateTitle = t('gitCreateNamedBranch', { branch: createBranchName })
+  const footerWorktreeBranch = canCreate ? createBranchName : switchTargetRow?.name ?? trimmedQuery
+  const footerWorktreeTitle = t('gitNewBranchWorktree', { branch: footerWorktreeBranch })
   const showTooltip = useCallback((text: string, clientX: number, clientY: number): void => {
     if (!text.trim()) return
     setTooltip({ text, ...branchTooltipPosition(clientX, clientY) })
@@ -230,7 +256,7 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
   }
 
   const createAndSwitchBranch = async (): Promise<void> => {
-    const branch = query.trim()
+    const branch = createBranchName
     if (!root || !branch) return
     setActingBranch(branch)
     setActingKind('switch')
@@ -280,7 +306,7 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
   }
 
   const createBranchWorktree = async (): Promise<void> => {
-    const branch = query.trim()
+    const branch = createBranchName
     if (!root || !branch) return
     setActingBranch(branch)
     setActingKind('worktree')
@@ -469,7 +495,7 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
                     void createAndSwitchBranch()
                   }}
                 >
-                  {actingBranch === trimmedQuery && actingKind === 'switch' ? (
+                  {actingBranch === createBranchName && actingKind === 'switch' ? (
                     <Loader2 className="h-4 w-4 shrink-0 animate-spin text-ds-muted" strokeWidth={2} />
                   ) : (
                     <Plus className="h-4 w-4 shrink-0 text-ds-muted" strokeWidth={1.9} />
@@ -495,11 +521,11 @@ export function GitBranchPicker({ workspaceRoot }: Props): ReactElement | null {
                   if (canCreate) {
                     void createBranchWorktree()
                   } else {
-                    void checkoutBranchWorktree(trimmedQuery)
+                    void checkoutBranchWorktree(footerWorktreeBranch)
                   }
                 }}
               >
-                {actingBranch === trimmedQuery && actingKind === 'worktree' ? (
+                {actingBranch === footerWorktreeBranch && actingKind === 'worktree' ? (
                   <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2} />
                 ) : (
                   <GitFork className="h-4 w-4" strokeWidth={1.8} />

--- a/src/renderer/src/components/settings-section-worktree.tsx
+++ b/src/renderer/src/components/settings-section-worktree.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { GitBranch, Loader2, RefreshCw, Trash2 } from 'lucide-react'
 import type { NormalizedThread } from '../agent/types'
 import type { GitBranchWorktreeRow, GitBranchWorktreesResult } from '@shared/git-branches'
+import { DEFAULT_GIT_BRANCH_PREFIX } from '@shared/app-settings'
 import { readThreadWorktreeRegistry } from '../lib/thread-worktree-registry'
 import { SettingsCard, SettingRow } from './settings-controls'
 
@@ -99,6 +100,19 @@ export function WorktreeSettingsSection({ ctx }: { ctx: Record<string, any> }): 
 
   return (
     <SettingsCard title={t('sectionWorktree')}>
+      <SettingRow
+        title={t('gitBranchPrefix')}
+        description={t('gitBranchPrefixDesc')}
+        control={
+          <input
+            className="w-full rounded-xl border border-ds-border bg-ds-card px-3 py-2 font-mono text-[13px] text-ds-ink shadow-sm focus:border-accent/40 focus:outline-none focus:ring-1 focus:ring-accent/30"
+            value={String(ctx.form?.gitBranchPrefix ?? DEFAULT_GIT_BRANCH_PREFIX)}
+            placeholder={DEFAULT_GIT_BRANCH_PREFIX}
+            spellCheck={false}
+            onChange={(event) => ctx.update({ gitBranchPrefix: event.target.value })}
+          />
+        }
+      />
       <SettingRow
         title={t('worktreeOverview')}
         description={t('worktreeOverviewDesc')}

--- a/src/renderer/src/components/settings-utils.ts
+++ b/src/renderer/src/components/settings-utils.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS,
   DEFAULT_LOG_RETENTION_DAYS,
   DEFAULT_GUI_UPDATE_CHANNEL,
+  DEFAULT_GIT_BRANCH_PREFIX,
   MIN_KUN_LOCAL_PORT,
   defaultKunRuntimeSettings,
   applyKunRuntimePatch,
@@ -20,6 +21,7 @@ import {
   normalizeCheckpointCleanupSettings,
   normalizeCursorSpotlightColor,
   normalizeGuiUpdateChannel,
+  normalizeGitBranchPrefix,
   normalizeKeyboardShortcuts,
   normalizeModelProviderSettings,
   normalizeScheduleSettings,
@@ -122,6 +124,7 @@ export function coerceRendererSettings(settings: AppSettingsV1): AppSettingsV1 {
     checkpointCleanup: normalizeCheckpointCleanupSettings(
       raw.checkpointCleanup ?? { intervalDays: DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS }
     ),
+    gitBranchPrefix: normalizeGitBranchPrefix(raw.gitBranchPrefix ?? DEFAULT_GIT_BRANCH_PREFIX),
     notifications: {
       turnComplete: raw.notifications?.turnComplete !== false
     },

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -1189,6 +1189,8 @@
   "uiPluginDocsHint": "Developer guide: docs/UI_PLUGINS.md",
   "worktree": "Worktrees",
   "sectionWorktree": "Git worktrees",
+  "gitBranchPrefix": "New branch prefix",
+  "gitBranchPrefixDesc": "Prefix branch names created from the branch picker. Leave blank to create names exactly as entered.",
   "worktreeOverview": "Worktrees",
   "worktreeOverviewDesc": "View Git worktrees checked out from conversations and clean up worktree directories you no longer need.",
   "worktreeMainBranch": "Main branch",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -1189,6 +1189,8 @@
   "uiPluginDocsHint": "开发指南:docs/UI_PLUGINS.md",
   "worktree": "工作树",
   "sectionWorktree": "Git 工作树",
+  "gitBranchPrefix": "新分支前缀",
+  "gitBranchPrefixDesc": "为分支选择器中新建的分支名添加前缀。留空则完全按输入的名称创建。",
   "worktreeOverview": "工作树",
   "worktreeOverviewDesc": "查看从对话中 checkout 出来的 Git 工作树，并清理不再需要的工作树目录。",
   "worktreeMainBranch": "主分支",

--- a/src/shared/app-settings-normalize.ts
+++ b/src/shared/app-settings-normalize.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CHECKPOINT_CLEANUP_ENABLED,
   DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS,
   DEFAULT_CURSOR_SPOTLIGHT_COLOR,
+  DEFAULT_GIT_BRANCH_PREFIX,
   DEFAULT_LOG_RETENTION_DAYS,
   normalizeGuiUpdateChannel,
   normalizeChatContentMaxWidth,
@@ -100,6 +101,7 @@ export function normalizeAppSettings(settings: AppSettingsV1): AppSettingsV1 {
         : DEFAULT_LOG_RETENTION_DAYS
     },
     checkpointCleanup: normalizeCheckpointCleanupSettings(maybeSettings.checkpointCleanup),
+    gitBranchPrefix: normalizeGitBranchPrefix(maybeSettings.gitBranchPrefix),
     notifications: {
       turnComplete: maybeSettings.notifications?.turnComplete !== false
     },
@@ -118,6 +120,23 @@ export function normalizeAppSettings(settings: AppSettingsV1): AppSettingsV1 {
     codePromptPrefix: typeof maybeSettings.codePromptPrefix === 'string' ? maybeSettings.codePromptPrefix : '',
     disabledSkillIds: normalizeDisabledSkillIds(maybeSettings.disabledSkillIds)
   }
+}
+
+export function normalizeGitBranchPrefix(value: unknown): string {
+  const normalized = typeof value === 'string'
+    ? value.trim().replace(/\\/g, '/').replace(/^\/+/, '')
+    : DEFAULT_GIT_BRANCH_PREFIX
+  if (!normalized) return ''
+  return normalized.endsWith('/') ? normalized : `${normalized}/`
+}
+
+export function applyGitBranchPrefix(branch: string, prefix: unknown): string {
+  const normalizedBranch = branch.trim().replace(/^\/+/, '')
+  const normalizedPrefix = normalizeGitBranchPrefix(prefix)
+  if (!normalizedBranch || !normalizedPrefix || normalizedBranch.startsWith(normalizedPrefix)) {
+    return normalizedBranch
+  }
+  return `${normalizedPrefix}${normalizedBranch}`
 }
 
 export function normalizeCheckpointCleanupIntervalDays(value: unknown): CheckpointCleanupIntervalDays {

--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -122,6 +122,7 @@ export const DEFAULT_CHECKPOINT_CLEANUP_INTERVAL_DAYS: CheckpointCleanupInterval
 // Checkpoint cleanup is enabled by default so stale Git checkpoint directories
 // do not accumulate. Users who want to keep every checkpoint can opt out in settings.
 export const DEFAULT_CHECKPOINT_CLEANUP_ENABLED = true
+export const DEFAULT_GIT_BRANCH_PREFIX = 'codex/'
 export const DEFAULT_CURSOR_SPOTLIGHT_COLOR = '#85c1f1'
 export const DEFAULT_WEIXIN_BRIDGE_RPC_URL = 'http://127.0.0.1:18790/api/v1/admin/rpc'
 export const DEFAULT_MODEL_PROVIDER_ID = 'deepseek'
@@ -1771,6 +1772,8 @@ export type AppSettingsV1 = {
   conversationWorkspaceRoot: string
   log: LogConfigV1
   checkpointCleanup: CheckpointCleanupConfigV1
+  /** Prefix applied when the branch picker creates a branch or worktree branch. */
+  gitBranchPrefix?: string
   notifications: NotificationConfigV1
   appBehavior: AppBehaviorConfigV1
   keyboardShortcuts: KeyboardShortcutsConfigV1

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_KUN_MODEL,
   DEFAULT_LOG_RETENTION_DAYS,
   DEFAULT_CURSOR_SPOTLIGHT_COLOR,
+  DEFAULT_GIT_BRANCH_PREFIX,
   DEFAULT_APPROVAL_POLICY,
   DEFAULT_SANDBOX_MODE,
   DEFAULT_WEIXIN_BRIDGE_RPC_URL,
@@ -33,6 +34,8 @@ import {
   migrateLegacyAppSettings,
   normalizeAppSettings,
   normalizeChatContentMaxWidth,
+  normalizeGitBranchPrefix,
+  applyGitBranchPrefix,
   parseClawUserPromptForDisplay,
   inferModelEndpointFormatFromUrl,
   kunToolPermissionModeFromSettings,
@@ -87,6 +90,21 @@ describe('chat content max width', () => {
     expect(normalizeChatContentMaxWidth(896)).toBe(896)
     expect(normalizeChatContentMaxWidth(1300)).toBe(1200)
     expect(normalizeChatContentMaxWidth(905)).toBe(904)
+  })
+})
+
+describe('git branch prefix', () => {
+  it('normalizes separators and applies the default prefix once', () => {
+    expect(normalizeGitBranchPrefix(' feature ')).toBe('feature/')
+    expect(normalizeGitBranchPrefix('team\\')).toBe('team/')
+    expect(normalizeGitBranchPrefix(undefined)).toBe(DEFAULT_GIT_BRANCH_PREFIX)
+    expect(applyGitBranchPrefix('fix/workspace', 'codex/')).toBe('codex/fix/workspace')
+    expect(applyGitBranchPrefix('codex/fix/workspace', 'codex/')).toBe('codex/fix/workspace')
+  })
+
+  it('allows branch prefixes to be disabled', () => {
+    expect(normalizeGitBranchPrefix('')).toBe('')
+    expect(applyGitBranchPrefix('fix/workspace', '')).toBe('fix/workspace')
   })
 })
 


### PR DESCRIPTION
## Summary

- Add a persisted branch prefix setting to the existing Git worktree settings page.
- Apply the prefix when the branch picker creates either a regular branch or a worktree branch.

## Changes

- Normalize branch prefixes to forward-slash form and avoid applying the same prefix twice.
- Default to `codex/`; users can leave the setting blank to preserve names exactly as entered.
- Prefer an already-existing exact or prefixed branch instead of offering a duplicate create action.
- Keep the open branch picker synchronized through the existing renderer settings event.

## Scope

This intentionally does not include the unused merge-method, force-push, PR-status, auto-cleanup, or PR-template fields from the old local `feat/git-settings` branch. Those fields had no execution-path consumers.

## Tests

- `npm.cmd test -- src/shared/app-settings.test.ts src/main/settings-store.test.ts src/main/ipc/app-ipc-schemas.test.ts` (138 tests)
- `npm.cmd run typecheck`
- focused ESLint on changed TypeScript/TSX files
- `npm.cmd run build`
- `git diff --check`