### PR TITLE
feat(cache): detect hit-rate regressions

### DIFF
--- a/kun/src/cache/cache-regression.test.ts
+++ b/kun/src/cache/cache-regression.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { analyzeCacheRegression, explainCacheRegression } from './cache-regression.js'
+
+describe('analyzeCacheRegression', () => {
+  it('reports no regression when the hit rate holds steady', () => {
+    const report = analyzeCacheRegression({
+      current: 0.9,
+      baseline: [0.92, 0.91, 0.93],
+      reasons: []
+    })
+    expect(report.severity).toBe('none')
+    expect(report.explanation).toBeNull()
+  })
+
+  it('classifies a catastrophic drop as a cliff and attributes the prefix change', () => {
+    const report = analyzeCacheRegression({
+      current: 0.05,
+      baseline: [0.95, 0.93, 0.94],
+      reasons: ['stable_prefix_changed', 'provider_cache_miss']
+    })
+    expect(report.severity).toBe('cliff')
+    expect(report.primaryReason).toBe('stable_prefix_changed')
+    expect(report.dropPercentagePoints).toBeGreaterThan(80)
+    expect(report.explanation).toContain('Cache hit rate dropped')
+    expect(report.explanation).toContain('stable system prefix changed')
+  })
+
+  it('classifies a mid-size drop as major and a small one as minor', () => {
+    expect(analyzeCacheRegression({ current: 0.6, baseline: [0.9, 0.9], reasons: [] }).severity).toBe('major')
+    expect(analyzeCacheRegression({ current: 0.81, baseline: [0.9, 0.92], reasons: [] }).severity).toBe('minor')
+  })
+
+  it('prefers the most decisive reason when several are present', () => {
+    const report = analyzeCacheRegression({
+      current: 0.1,
+      baseline: [0.9, 0.9],
+      reasons: ['provider_cache_miss', 'tool_catalog_changed', 'cache_ttl_unknown']
+    })
+    expect(report.primaryReason).toBe('tool_catalog_changed')
+  })
+
+  it('stays silent until enough baseline samples exist', () => {
+    const report = analyzeCacheRegression({
+      current: 0.0,
+      baseline: [0.95],
+      reasons: ['stable_prefix_changed'],
+      minBaselineSamples: 2
+    })
+    expect(report.severity).toBe('none')
+    expect(report.explanation).toBeNull()
+  })
+
+  it('ignores non-rate samples and null current values', () => {
+    expect(analyzeCacheRegression({ current: null, baseline: [0.9, 0.9], reasons: [] }).severity).toBe('none')
+    const report = analyzeCacheRegression({
+      current: 0.1,
+      baseline: [null, 0.9, Number.NaN as unknown as number, 0.9],
+      reasons: ['stable_prefix_changed']
+    })
+    expect(report.severity).toBe('cliff')
+    expect(report.baselineHitRate).toBeCloseTo(0.9, 5)
+  })
+
+  it('uses a median baseline so a single cold-start outlier does not fake a regression', () => {
+    // [0.9, 0.0(cold start), 0.9] → median 0.9; current 0.85 is a 5pp dip, not a drop.
+    const report = analyzeCacheRegression({ current: 0.85, baseline: [0.9, 0.0, 0.9], reasons: [] })
+    expect(report.baselineHitRate).toBeCloseTo(0.9, 5)
+    expect(report.severity).toBe('none')
+  })
+})
+describe('explainCacheRegression', () => {
+  it('formats a percentage-point drop with the attributed cause', () => {
+    const text = explainCacheRegression({ baseline: 0.92, current: 0.08, primaryReason: 'tool_catalog_changed' })
+    expect(text).toBe('Cache hit rate dropped from 92% to 8% (-84pp). Likely cause: the tool catalog changed (MCP/Skill tools), which invalidated the cached prefix.')
+  })
+
+  it('omits the cause clause when no reason is known', () => {
+    const text = explainCacheRegression({ baseline: 0.8, current: 0.5, primaryReason: null })
+    expect(text).toBe('Cache hit rate dropped from 80% to 50% (-30pp).')
+  })
+})

--- a/kun/src/cache/cache-regression.ts
+++ b/kun/src/cache/cache-regression.ts
@@ -1,0 +1,154 @@
+import type { CacheMissReason } from './cache-diagnostics.js'
+
+/**
+ * Trend-based cache-hit-rate regression analysis.
+ *
+ * {@link diagnoseCacheUsage} explains the per-turn miss reasons, but it does
+ * not know whether the *rate itself dropped* relative to how the thread had
+ * been performing. This module compares the current cacheable hit rate against
+ * a rolling baseline of recent turns, classifies the severity of any drop, and
+ * attributes it to the most likely cause so the GUI can say, for example:
+ * "Cache hit rate dropped from 92% to 8% (-84pp). Likely cause: the stable
+ * system prefix changed."
+ */
+
+export type CacheRegressionSeverity = 'none' | 'minor' | 'major' | 'cliff'
+
+export type CacheRegressionReport = {
+  severity: CacheRegressionSeverity
+  baselineHitRate: number | null
+  currentHitRate: number | null
+  /** Drop in percentage points (baseline - current) * 100, rounded to 1dp. */
+  dropPercentagePoints: number | null
+  /** The miss reason most likely responsible for the drop, when known. */
+  primaryReason: CacheMissReason | null
+  /** Human-readable explanation, only set when severity is not 'none'. */
+  explanation: string | null
+}
+
+// Absolute drop thresholds in hit-rate fraction (0..1).
+const MINOR_DROP = 0.08
+const MAJOR_DROP = 0.2
+const CLIFF_DROP = 0.4
+
+/**
+ * Reasons ordered by how decisively they explain a cache regression. The first
+ * present reason wins, so a prefix change (which invalidates the whole cached
+ * prefix) is reported ahead of a generic provider miss.
+ */
+const REASON_PRIORITY: readonly CacheMissReason[] = [
+  'stable_prefix_changed',
+  'tool_catalog_changed',
+  'skills_changed',
+  'model_changed',
+  'provider_changed',
+  'endpoint_changed',
+  'provider_cache_miss',
+  'cache_ttl_unknown',
+  'cold_request',
+  'provider_metrics_unavailable'
+]
+
+const REASON_TEXT: Record<CacheMissReason, string> = {
+  cold_request: 'this was the first request in the thread, so there was no warm cache yet',
+  model_changed: 'the model changed, which starts a new provider cache',
+  provider_changed: 'the provider changed, which starts a new provider cache',
+  endpoint_changed: 'the endpoint format changed, which starts a new provider cache',
+  stable_prefix_changed: 'the stable system prefix changed and invalidated the cached prefix',
+  tool_catalog_changed: 'the tool catalog changed (MCP/Skill tools), which invalidated the cached prefix',
+  skills_changed: 'the active Skill set changed, which invalidated the cached prefix',
+  cache_ttl_unknown: 'the provider cache TTL likely expired before this turn',
+  provider_cache_miss: 'the provider reported a full cache miss for this turn',
+  provider_metrics_unavailable: 'the provider did not report cache metrics, so the cause cannot be confirmed'
+}
+
+export function analyzeCacheRegression(input: {
+  current: number | null
+  baseline: readonly (number | null)[]
+  reasons?: readonly CacheMissReason[]
+  /** Minimum number of usable baseline samples before reporting a drop. */
+  minBaselineSamples?: number
+}): CacheRegressionReport {
+  const minSamples = Math.max(1, input.minBaselineSamples ?? 1)
+  const samples = input.baseline.filter((value): value is number => isRate(value))
+  const current = isRate(input.current) ? input.current : null
+  // Median is robust to a single cold-start zero or one anomalous spike, so a
+  // lone outlier in the window cannot drag the baseline and fake a regression.
+  const baseline = samples.length > 0 ? median(samples) : null
+  const primaryReason = pickPrimaryReason(input.reasons ?? [])
+
+  if (current === null || baseline === null || samples.length < minSamples) {
+    return {
+      severity: 'none',
+      baselineHitRate: baseline,
+      currentHitRate: current,
+      dropPercentagePoints: null,
+      primaryReason,
+      explanation: null
+    }
+  }
+
+  const drop = baseline - current
+  const severity = classifyDrop(drop)
+  const dropPercentagePoints = round1(drop * 100)
+  if (severity === 'none') {
+    return { severity, baselineHitRate: baseline, currentHitRate: current, dropPercentagePoints, primaryReason, explanation: null }
+  }
+  return {
+    severity,
+    baselineHitRate: baseline,
+    currentHitRate: current,
+    dropPercentagePoints,
+    primaryReason,
+    explanation: explainCacheRegression({ baseline, current, primaryReason })
+  }
+}
+
+export function explainCacheRegression(input: {
+  baseline: number
+  current: number
+  primaryReason: CacheMissReason | null
+}): string {
+  const drop = round1((input.baseline - input.current) * 100)
+  const head = `Cache hit rate dropped from ${pct(input.baseline)} to ${pct(input.current)} (-${drop}pp).`
+  const cause = input.primaryReason ? ` Likely cause: ${REASON_TEXT[input.primaryReason]}.` : ''
+  return `${head}${cause}`
+}
+
+function classifyDrop(drop: number): CacheRegressionSeverity {
+  if (drop >= CLIFF_DROP) return 'cliff'
+  if (drop >= MAJOR_DROP) return 'major'
+  if (drop >= MINOR_DROP) return 'minor'
+  return 'none'
+}
+
+function pickPrimaryReason(reasons: readonly CacheMissReason[]): CacheMissReason | null {
+  for (const reason of REASON_PRIORITY) {
+    if (reasons.includes(reason)) return reason
+  }
+  return null
+}
+
+function isRate(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+/** Ordinal severity for cooldown comparisons; higher means a worse drop. */
+export function cacheRegressionSeverityRank(severity: CacheRegressionSeverity): number {
+  return { none: 0, minor: 1, major: 2, cliff: 3 }[severity]
+}
+
+/** Median of the sample window — robust to a single cold-start or outlier. */
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+function round1(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+function pct(rate: number): string {
+  return `${Math.round(rate * 100)}%`
+}

--- a/kun/src/services/usage-service.test.ts
+++ b/kun/src/services/usage-service.test.ts
@@ -30,6 +30,72 @@ describe('usage cache diagnostics', () => {
     expect(current.cacheMissReasons).toContain('cold_request')
   })
 
+  it('explains a hit-rate regression once a thread has a warm baseline', () => {
+    const usage = new UsageService()
+    const warm = (hit: number, miss: number) => ({
+      promptTokens: hit + miss,
+      completionTokens: 10,
+      totalTokens: hit + miss + 10,
+      cacheHitTokens: hit,
+      cacheMissTokens: miss,
+      cacheHitRate: hit / (hit + miss),
+      turns: 1
+    })
+
+    // Two warm turns at ~90% establish the baseline (no regression yet).
+    usage.record('thread-r', warm(900, 100), signature)
+    usage.record('thread-r', warm(900, 100), signature)
+    // A prefix change collapses the hit rate — should be explained.
+    const dropped = usage.record('thread-r', warm(50, 950), {
+      ...signature,
+      prefixFingerprint: 'prefix-b'
+    })
+
+    expect(dropped.cacheMissReasons).toContain('stable_prefix_changed')
+    expect(dropped.cacheSuggestions?.some((s) => /Cache hit rate dropped/.test(s))).toBe(true)
+    expect(dropped.cacheSuggestions?.some((s) => /stable system prefix changed/.test(s))).toBe(true)
+  })
+
+  it('does not re-announce the same regression every turn (cooldown)', () => {
+    const usage = new UsageService()
+    const warm = (hit: number, miss: number) => ({
+      promptTokens: hit + miss,
+      completionTokens: 10,
+      totalTokens: hit + miss + 10,
+      cacheHitTokens: hit,
+      cacheMissTokens: miss,
+      cacheHitRate: hit / (hit + miss),
+      turns: 1
+    })
+    usage.record('thread-c', warm(900, 100), signature)
+    usage.record('thread-c', warm(900, 100), signature)
+    const first = usage.record('thread-c', warm(50, 950), { ...signature, prefixFingerprint: 'prefix-b' })
+    const second = usage.record('thread-c', warm(50, 950), { ...signature, prefixFingerprint: 'prefix-b' })
+
+    expect(first.cacheSuggestions?.some((s) => /Cache hit rate dropped/.test(s))).toBe(true)
+    // The very next turn at the same low rate must NOT repeat the announcement.
+    expect(second.cacheSuggestions?.some((s) => /Cache hit rate dropped/.test(s))).toBe(false)
+  })
+
+  it('starts a fresh baseline when the model changes (no cross-model false regression)', () => {
+    const usage = new UsageService()
+    const warm = (hit: number, miss: number) => ({
+      promptTokens: hit + miss,
+      completionTokens: 10,
+      totalTokens: hit + miss + 10,
+      cacheHitTokens: hit,
+      cacheMissTokens: miss,
+      cacheHitRate: hit / (hit + miss),
+      turns: 1
+    })
+    usage.record('thread-m', warm(900, 100), signature)
+    usage.record('thread-m', warm(900, 100), signature)
+    // Switch model: the first turn on model-b is cold and has a low hit rate,
+    // but must not be reported as a regression against model-a's baseline.
+    const switched = usage.record('thread-m', warm(50, 950), { ...signature, model: 'model-b' })
+    expect(switched.cacheSuggestions?.some((s) => /Cache hit rate dropped/.test(s))).toBe(false)
+  })
+
   it('surfaces the latest-turn cache diagnostic fields in thread usage', () => {
     const records: ThreadUsageRecord[] = [
       {

--- a/kun/src/services/usage-service.ts
+++ b/kun/src/services/usage-service.ts
@@ -4,6 +4,7 @@ import {
   diagnoseCacheUsage,
   type CacheRequestSignature
 } from '../cache/cache-diagnostics.js'
+import { analyzeCacheRegression, cacheRegressionSeverityRank } from '../cache/cache-regression.js'
 import type {
   DailyUsageBucket,
   DailyUsageCounters,
@@ -24,6 +25,18 @@ export class UsageService {
   private readonly counter = new UsageCounter()
   private readonly cache = new CacheTelemetry()
   private readonly cacheSignatures = new Map<string, CacheRequestSignature>()
+  /**
+   * Rolling cacheable-hit-rate history keyed by thread + provider/model/endpoint
+   * so a model or provider switch starts a FRESH baseline instead of polluting
+   * the previous one. Cold-start and outliers are absorbed by the analyzer's
+   * median baseline.
+   */
+  private readonly cacheHitHistory = new Map<string, number[]>()
+  /**
+   * Cooldown state per history key so one regression isn't re-announced every
+   * turn: we only re-emit when the cooldown window elapses or severity worsens.
+   */
+  private readonly cacheRegressionCooldown = new Map<string, { severityRank: number; turnsSinceEmit: number }>()
 
   record(
     threadId: string,
@@ -50,6 +63,7 @@ export class UsageService {
     this.cache.reset(threadId)
     this.cache.ingest(threadId, seeded)
     this.cacheSignatures.delete(threadId)
+    this.clearCacheHistory(threadId)
     return seeded
   }
 
@@ -70,6 +84,23 @@ export class UsageService {
     this.cache.reset(threadId)
     if (threadId === undefined) this.cacheSignatures.clear()
     else this.cacheSignatures.delete(threadId)
+    if (threadId === undefined) {
+      this.cacheHitHistory.clear()
+      this.cacheRegressionCooldown.clear()
+    } else {
+      this.clearCacheHistory(threadId)
+    }
+  }
+
+  /** Drop all signature-keyed cache history + cooldown rows for one thread. */
+  private clearCacheHistory(threadId: string): void {
+    const prefix = `${threadId}::`
+    for (const key of this.cacheHitHistory.keys()) {
+      if (key === threadId || key.startsWith(prefix)) this.cacheHitHistory.delete(key)
+    }
+    for (const key of this.cacheRegressionCooldown.keys()) {
+      if (key === threadId || key.startsWith(prefix)) this.cacheRegressionCooldown.delete(key)
+    }
   }
 
   private withCacheDiagnostics(
@@ -86,17 +117,65 @@ export class UsageService {
       ...signature,
       activeSkillIds: [...signature.activeSkillIds]
     })
+    // Trend-based regression: compare this turn's cacheable hit rate against
+    // the thread's recent baseline FOR THE SAME provider/model/endpoint so we
+    // can explain a *drop* (not just the per-turn miss reasons). A cooldown
+    // stops the same regression from being re-announced every turn.
+    const historyKey = cacheHistoryKey(threadId, signature)
+    const history = this.cacheHitHistory.get(historyKey) ?? []
+    const regression = analyzeCacheRegression({
+      current: diagnostic.cacheableTokenHitRate,
+      baseline: history,
+      reasons: diagnostic.reasons,
+      minBaselineSamples: 2
+    })
+    const cooldown = this.cacheRegressionCooldown.get(historyKey) ?? { severityRank: 0, turnsSinceEmit: CACHE_REGRESSION_COOLDOWN_TURNS }
+    cooldown.turnsSinceEmit += 1
+    const severityRank = cacheRegressionSeverityRank(regression.severity)
+    const shouldAnnounce = Boolean(regression.explanation) && (
+      cooldown.turnsSinceEmit >= CACHE_REGRESSION_COOLDOWN_TURNS || severityRank > cooldown.severityRank
+    )
+    const suggestions = shouldAnnounce && regression.explanation
+      ? [regression.explanation, ...diagnostic.suggestions]
+      : diagnostic.suggestions
+    if (shouldAnnounce) {
+      this.cacheRegressionCooldown.set(historyKey, { severityRank, turnsSinceEmit: 0 })
+    } else if (regression.severity === 'none') {
+      // Recovered — clear cooldown so the next genuine drop is announced promptly.
+      this.cacheRegressionCooldown.set(historyKey, { severityRank: 0, turnsSinceEmit: cooldown.turnsSinceEmit })
+    } else {
+      this.cacheRegressionCooldown.set(historyKey, cooldown)
+    }
+    if (typeof diagnostic.cacheableTokenHitRate === 'number') {
+      this.cacheHitHistory.set(historyKey, [...history, diagnostic.cacheableTokenHitRate].slice(-CACHE_HIT_HISTORY_LIMIT))
+    }
     return {
       ...usage,
       cacheableTokenHitRate: diagnostic.cacheableTokenHitRate,
       totalInputTokenHitRate: diagnostic.totalInputTokenHitRate,
       cacheMissReasons: diagnostic.reasons,
-      cacheSuggestions: diagnostic.suggestions
+      cacheSuggestions: [...new Set(suggestions)]
     }
   }
 }
 
 export const MAX_DAILY_USAGE_DAYS = 370
+
+/** Rolling window of recent cacheable-hit-rate samples kept per thread. */
+const CACHE_HIT_HISTORY_LIMIT = 20
+
+/** Turns to wait before re-announcing the same cache regression severity. */
+const CACHE_REGRESSION_COOLDOWN_TURNS = 5
+
+/**
+ * History/cooldown key: per thread AND per provider/model/endpoint so a model
+ * or provider switch starts a fresh baseline instead of polluting the prior
+ * one. The prefix fingerprint is intentionally excluded — a prefix change is a
+ * regression *cause* we want to detect, not a reason to reset the baseline.
+ */
+function cacheHistoryKey(threadId: string, signature: CacheRequestSignature): string {
+  return `${threadId}::${signature.providerId}::${signature.model}::${signature.endpointFormat}`
+}
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 


### PR DESCRIPTION
## Summary

- Detect cache hit-rate regressions against a rolling per-thread baseline.
- Add the attributed regression explanation to the existing cache suggestions surface.

## Changes

- Compare the current cacheable hit rate with the median of recent usable samples.
- Classify drops as minor, major, or cliff and prefer concrete causes such as stable-prefix, tool-catalog, skill, model, provider, or endpoint changes.
- Keep baselines isolated by thread, provider, model, and endpoint format.
- Require two baseline samples and use a cooldown so one sustained drop is not announced every turn.
- Clear trend state when usage is seeded or reset.

## Scope

This is the cache-regression slice extracted from the local `codex/mcp-oauth-runtime-v2` branch. It reuses the existing `cacheSuggestions` contract and does not overlap #662, which only aligns renderer hit-rate display.

## Tests

- `npm.cmd --prefix kun test -- src/cache/cache-regression.test.ts src/services/usage-service.test.ts` (14 tests)
- `npm.cmd --prefix kun run typecheck`
- focused ESLint on the four changed files
- `git diff --check`