### PR TITLE
feat(write): expose runtime skills in assistant

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -2404,6 +2404,8 @@ export function Workbench(): ReactElement {
                 composerProviderId={resolvedWriteAssistantProviderId}
                 composerPickList={writeAssistantPickList}
                 composerModelGroups={composerModelGroups}
+                skillCommands={runtimeSkills}
+                disabledSkillIds={disabledSkillIds}
                 composerReasoningEffort={composerReasoningEffort}
                 setComposerModel={setWriteAssistantModel}
                 setComposerReasoningEffort={setComposerReasoningEffort}

--- a/src/renderer/src/components/write/WriteAssistantPanel.test.ts
+++ b/src/renderer/src/components/write/WriteAssistantPanel.test.ts
@@ -1,0 +1,78 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import '../../i18n'
+import { useChatStore } from '../../store/chat-store'
+import { useWriteWorkspaceStore } from '../../write/write-workspace-store'
+import { WriteAssistantPanel } from './WriteAssistantPanel'
+
+describe('WriteAssistantPanel', () => {
+  it('forwards enabled runtime Skills to the compact composer', () => {
+    useChatStore.setState({
+      activeThreadId: 'thr_write',
+      activeThreadGoal: null,
+      route: 'write',
+      workspaceRoot: '/workspace',
+      threads: []
+    })
+    useWriteWorkspaceStore.setState({
+      workspaceRoot: '/workspace',
+      activeFilePath: '/workspace/draft.md'
+    })
+
+    const html = renderToStaticMarkup(createElement(WriteAssistantPanel, {
+      input: '/style',
+      setInput: () => undefined,
+      mode: 'agent',
+      setMode: () => undefined,
+      busy: false,
+      runtimeConnection: 'ready',
+      activeThreadId: 'thr_write',
+      blocks: [],
+      liveReasoning: '',
+      liveAssistant: '',
+      composerModel: '',
+      composerPickList: [],
+      composerReasoningEffort: 'max',
+      setComposerModel: () => undefined,
+      setComposerReasoningEffort: () => undefined,
+      queuedMessages: [],
+      removeQueuedMessage: () => undefined,
+      skillCommands: [
+        {
+          id: 'style-guide',
+          name: 'Style Guide',
+          description: 'Apply the project writing style',
+          root: '/workspace/.codex/skills/style-guide',
+          scope: 'project',
+          legacy: true,
+          version: '1',
+          triggers: { commands: [], fileTypes: [], promptPatterns: [] },
+          allowedTools: []
+        },
+        {
+          id: 'disabled-skill',
+          name: 'Disabled Skill',
+          root: '/workspace/.codex/skills/disabled-skill',
+          scope: 'project',
+          legacy: true,
+          version: '1',
+          triggers: { commands: [], fileTypes: [], promptPatterns: [] },
+          allowedTools: []
+        }
+      ],
+      disabledSkillIds: ['disabled-skill'],
+      onSend: () => undefined,
+      onInterrupt: () => undefined,
+      onRetryConnection: () => undefined,
+      onOpenSettings: () => undefined,
+      onNewConversation: () => undefined,
+      onPickWorkspace: () => undefined,
+      onCollapse: () => undefined
+    }))
+
+    expect(html).toContain('Style Guide')
+    expect(html).toContain('/skill:style-guide')
+    expect(html).not.toContain('Disabled Skill')
+  })
+})

--- a/src/renderer/src/components/write/WriteAssistantPanel.tsx
+++ b/src/renderer/src/components/write/WriteAssistantPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { AttachmentReference, RuntimeConnectionStatus, ChatBlock } from '../../agent/types'
+import type { CoreRuntimeSkillJson } from '../../agent/kun-contract'
 import type { QueuedUserMessage } from '../../store/chat-store-types'
 import type { ModelProviderModelGroup } from '@shared/kun-gui-api'
 import {
@@ -37,6 +38,8 @@ type Props = {
   composerProviderId?: string
   composerPickList: string[]
   composerModelGroups?: ModelProviderModelGroup[]
+  skillCommands?: CoreRuntimeSkillJson[]
+  disabledSkillIds?: string[]
   composerReasoningEffort: ComposerReasoningEffort
   setComposerModel: (modelId: string, providerId?: string) => void
   setComposerReasoningEffort: (effort: ComposerReasoningEffort) => void
@@ -60,6 +63,8 @@ type Props = {
   className?: string
 }
 
+const EMPTY_SKILL_COMMANDS: CoreRuntimeSkillJson[] = []
+
 export function WriteAssistantPanel({
   input,
   setInput,
@@ -75,6 +80,8 @@ export function WriteAssistantPanel({
   composerProviderId,
   composerPickList,
   composerModelGroups = [],
+  skillCommands = EMPTY_SKILL_COMMANDS,
+  disabledSkillIds,
   composerReasoningEffort,
   setComposerModel,
   setComposerReasoningEffort,
@@ -309,6 +316,8 @@ export function WriteAssistantPanel({
           composerProviderId={composerProviderId}
           composerPickList={composerPickList}
           composerModelGroups={composerModelGroups}
+          skillCommands={skillCommands}
+          disabledSkillIds={disabledSkillIds}
           composerReasoningEffort={composerReasoningEffort}
           onComposerModelChange={setComposerModel}
           onComposerReasoningEffortChange={setComposerReasoningEffort}


### PR DESCRIPTION
## Summary

- Show discovered runtime Skills in the Write assistant slash-command menu.
- Honor the same disabled Skill list used by the main chat composer.

## Root cause

The Write assistant already reused `FloatingComposer`, and the Kun runtime already recognizes `/skill:<id>`. Workbench loaded the active workspace Skill catalog but only passed it to the main chat composer, so the compact Write composer always received an empty list.

## Changes

- Forward `runtimeSkills` and `disabledSkillIds` from Workbench to `WriteAssistantPanel`.
- Pass both values into the existing compact `FloatingComposer`.
- Add a panel-level regression test covering an enabled and disabled Skill.

Fixes #674

## Tests

- `npm.cmd test -- src/renderer/src/components/write/WriteAssistantPanel.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts` (63 tests)
- `npm.cmd run typecheck`
- focused ESLint on the changed TSX/test files
- `git diff --check`