### PR TITLE
feat(tools): prefer specialized MCP inspection

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -91,6 +91,7 @@ import { GET_GOAL_TOOL_NAME, UPDATE_GOAL_TOOL_NAME } from '../adapters/tool/goal
 import { TODO_LIST_TOOL_NAME, TODO_WRITE_TOOL_NAME } from '../adapters/tool/todo-tools.js'
 import { shellRuntimeInstruction } from '../adapters/tool/builtin-tool-utils.js'
 import { VERIFY_CHANGES_TOOL_NAME } from '../adapters/tool/builtin-verify-tool.js'
+import { buildToolPreferenceInstruction } from '../prompt/kun-system-prompt.js'
 import {
   GoalResumeCoordinator,
   DEFAULT_MAX_GOAL_RESUME_NO_PROGRESS_ATTEMPTS,
@@ -1534,6 +1535,7 @@ export class AgentLoop {
           nowIso: this.opts.nowIso()
         })
       : null
+    const toolPreferenceInstruction = buildToolPreferenceInstruction(tools)
     const contextInstructions = [
       ...(runtimeContextInstruction ? [runtimeContextInstruction] : []),
       ...(activeGoalInstruction ? [activeGoalInstruction] : []),
@@ -1554,6 +1556,7 @@ export class AgentLoop {
       ...(skillResolution.catalogInstruction ? [skillResolution.catalogInstruction] : []),
       ...skillResolution.instructions,
       ...(userInputDisabled ? [userInputUnavailableInstruction()] : []),
+      ...(toolPreferenceInstruction ? [toolPreferenceInstruction] : []),
       ...(effectiveToolSpecs.some((tool) => tool.name === 'bash') ? [shellRuntimeInstruction()] : []),
       ...(suggestVerification ? [verificationSuggestionInstruction()] : []),
       ...(toolCatalogDriftMessage ? [toolCatalogDriftMessage] : [])

--- a/kun/src/prompt/kun-system-prompt.ts
+++ b/kun/src/prompt/kun-system-prompt.ts
@@ -27,7 +27,7 @@ export const KUN_SYSTEM_PROMPT = [
   'Tool behavior:',
   '- Use tools when they are available and relevant. Do not claim a file, command, route, or UI state was checked unless it was actually checked.',
   '- The default built-in coding tool family is `read`, `bash`, `edit`, `write`, `grep`, `find`, and `ls`. Prefer these over ad hoc prose about what you would inspect or change.',
-  '- Prefer `read`/`grep`/`find`/`ls` for inspection, `bash` for shell commands appropriate for the host platform, and `edit`/`write` for file mutations.',
+  '- Prefer the most specific advertised tool for the task. Use `read`/`grep`/`find`/`ls` as general inspection fallbacks, `bash` for shell commands appropriate for the host platform, and `edit`/`write` for file mutations.',
   '- Approval and request_user_input are explicit GUI gates. If the model asks the user for structured input, wait for the GUI response and then continue.',
   '- Tool results are part of conversation history. Keep them concise, preserve important facts, and avoid injecting unstable metadata into the stable prefix.',
   '- If a tool is not advertised in the current turn, do not call it.',
@@ -57,3 +57,47 @@ export const KUN_SYSTEM_PROMPT = [
   '- If a requirement says a capability must not be missing, audit the old surface and prove parity with code paths and tests.',
   '- A task is complete only when the current code, tests, build, and relevant runtime behavior prove it.'
 ].join('\n')
+
+type ToolPreferenceSpec = {
+  name: string
+  description: string
+  providerKind?: string
+}
+
+const SOURCE_EXPLORATION_PATTERN =
+  /\b(?:code(?:base|graph)?|source|repository|repo|symbol|definition|reference|implementation|dependency|call[ -]?graph|ast)\b/i
+
+/**
+ * Keep availability-dependent guidance after the immutable system prefix.
+ * Tool schemas remain canonically sorted for prompt-cache stability; this
+ * instruction carries the semantic preference instead of reordering them.
+ */
+export function buildToolPreferenceInstruction(
+  tools: readonly ToolPreferenceSpec[]
+): string | null {
+  const mcpTools = tools.filter((tool) => tool.providerKind === 'mcp')
+  if (mcpTools.length === 0) return null
+
+  const sourceTools = mcpTools.filter((tool) =>
+    SOURCE_EXPLORATION_PATTERN.test(`${tool.name.replace(/[_-]+/g, ' ')} ${tool.description}`)
+  )
+  if (sourceTools.length > 0) {
+    return [
+      `Specialized source-code MCP tools are available for this turn: ${formatToolNames(sourceTools)}.`,
+      'For source navigation and structural inspection, prefer a listed MCP tool whose description matches the task before broad `read`/`grep`/`find`/`ls` scans.',
+      'Use the built-in inspection tools for unsupported files, narrow fallback checks, and verification.'
+    ].join(' ')
+  }
+
+  if (mcpTools.some((tool) => tool.name === 'mcp_search')) {
+    return 'MCP tool discovery is available through `mcp_search`. When a task may benefit from a specialized external tool, search the MCP catalog before using a general built-in fallback.'
+  }
+
+  return `Specialized MCP tools are available for this turn: ${formatToolNames(mcpTools)}. Prefer one when its advertised description directly matches the task; otherwise use the built-in tools.`
+}
+
+function formatToolNames(tools: readonly ToolPreferenceSpec[]): string {
+  const names = tools.slice(0, 8).map((tool) => `\`${tool.name}\``).join(', ')
+  const remaining = tools.length - 8
+  return remaining > 0 ? `${names}, and ${remaining} more` : names
+}

--- a/kun/tests/loop.test.ts
+++ b/kun/tests/loop.test.ts
@@ -67,6 +67,52 @@ describe('AgentLoop', () => {
     expect(request.tools.map((tool) => tool.name)).toContain('bash')
     expect(request.contextInstructions?.join('\n')).toContain('<shell_environment>')
     expect(request.contextInstructions?.join('\n')).toContain('<syntax>')
+    expect(request.contextInstructions?.join('\n')).not.toContain('Specialized MCP tools are available')
+  })
+
+  it('prefers specialized MCP tools only when they are advertised', async () => {
+    let observedRequest: ModelRequest | null = null
+    const sourceExplorer = LocalToolHost.defineTool({
+      name: 'mcp_semantic_find_symbol',
+      description: 'Find source-code symbols and their references.',
+      inputSchema: { type: 'object' },
+      policy: 'auto',
+      execute: async () => ({ output: {} })
+    })
+    const registry = new CapabilityRegistry([
+      {
+        id: 'builtin',
+        kind: 'built-in',
+        enabled: true,
+        available: true,
+        tools: buildDefaultLocalTools()
+      },
+      {
+        id: 'mcp:semantic',
+        kind: 'mcp',
+        enabled: true,
+        available: true,
+        tools: [sourceExplorer]
+      }
+    ])
+    const h = makeHarness({
+      provider: 'tool-preference',
+      model: 'tool-preference',
+      async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+        observedRequest = request
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    }, { toolHost: new LocalToolHost({ registry }) })
+    await bootstrapThread(h)
+
+    await h.loop.runTurn(h.threadId, h.turnId)
+
+    const request = observedRequest as ModelRequest | null
+    if (!request) throw new Error('expected model request')
+    const instructions = request.contextInstructions?.join('\n') ?? ''
+    expect(instructions).toContain('Specialized source-code MCP tools are available')
+    expect(instructions).toContain('`mcp_semantic_find_symbol`')
+    expect(instructions).toContain('before broad `read`/`grep`/`find`/`ls` scans')
   })
 
   it('records elapsed seconds for active goals after a turn finishes', async () => {


### PR DESCRIPTION
## Summary
- prefer specialized MCP inspection tools when they are actually advertised
- keep built-in read/grep/find/ls tools as fallbacks
- preserve canonical tool ordering and the immutable prompt-cache prefix

## Changes
- replace the conflicting built-in-only preference in the stable system contract with a generic most-specific-tool rule
- derive a per-turn MCP preference instruction from the active tool registry
- recognize source exploration semantically from tool names and descriptions instead of hardcoding an MCP server
- route MCP catalog mode through mcp_search when direct tools are not advertised

## Design note
The alphabetical normalization in compat-model-client is intentional cache canonicalization, so this change does not reorder tool schemas. Availability-dependent guidance is appended through contextInstructions after stable history.

## Tests
- npm.cmd --prefix kun test -- loop.test.ts (99 passed)
- npm.cmd --prefix kun run typecheck
- npm.cmd --prefix kun run build
- focused ESLint
- git diff --check

Fixes #643