### PR TITLE
feat(replay): add quality assertions

### DIFF
--- a/kun/src/benchmark/replay-benchmark.test.ts
+++ b/kun/src/benchmark/replay-benchmark.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { RuntimeEvent } from '../contracts/events.js'
 import {
   compareReplayReports,
+  evaluateReplayQuality,
   ReplaySuiteSchema,
   runReplaySuite,
   SseMessageDecoder,
@@ -181,6 +182,91 @@ describe('replay benchmark', () => {
     })).toThrow('duplicate replay task id')
   })
 
+  it('scores required output, changed files, forbidden behavior, and cost', () => {
+    const task = ReplaySuiteSchema.parse({
+      version: 1,
+      name: 'quality-suite',
+      tasks: [{
+        id: 'quality',
+        prompt: 'fix the pool',
+        expect: {
+          requiredOutputs: ['poolSize'],
+          expectedChangedFiles: ['src/db.ts'],
+          forbiddenBehaviors: ['force push'],
+          maxCostUsd: 0.01
+        }
+      }]
+    }).tasks[0]!
+    const events: ObservedReplayEvent[] = [
+      observed({
+        kind: 'item_completed',
+        seq: 1,
+        timestamp: '2026-06-29T00:00:00.000Z',
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        item: {
+          ...itemBase('tool_call'),
+          kind: 'tool_call',
+          toolName: 'edit',
+          callId: 'call_edit',
+          toolKind: 'file_change',
+          arguments: { path: 'src/db.ts' }
+        }
+      } as RuntimeEvent, 10),
+      observed({
+        kind: 'item_completed',
+        seq: 2,
+        timestamp: '2026-06-29T00:00:00.010Z',
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        item: { ...itemBase('assistant_text'), kind: 'assistant_text', text: 'Updated poolSize safely.' }
+      } as RuntimeEvent, 20)
+    ]
+
+    const quality = evaluateReplayQuality(task, { ...replayRun('passed', 10, 20, 0.8).metrics, costUsd: 0.005 }, events)
+
+    expect(quality).toMatchObject({ score: 1, passed: true, violations: [] })
+    expect(quality.breakdown.map((entry) => entry.dimension)).toEqual([
+      'files',
+      'forbidden',
+      'outputs',
+      'cost'
+    ])
+  })
+
+  it('hard-fails replay quality when a forbidden behavior is observed', () => {
+    const task = ReplaySuiteSchema.parse({
+      version: 1,
+      name: 'unsafe-suite',
+      tasks: [{
+        id: 'unsafe',
+        prompt: 'publish changes',
+        expect: { forbiddenBehaviors: ['force push'] }
+      }]
+    }).tasks[0]!
+    const events = [observed({
+      kind: 'item_completed',
+      seq: 1,
+      timestamp: '2026-06-29T00:00:00.000Z',
+      threadId: 'thread_1',
+      turnId: 'turn_1',
+      item: {
+        ...itemBase('tool_call'),
+        kind: 'tool_call',
+        toolName: 'bash',
+        callId: 'call_bash',
+        toolKind: 'command_execution',
+        arguments: { command: 'force push origin main' }
+      }
+    } as RuntimeEvent, 10)]
+
+    const quality = evaluateReplayQuality(task, replayRun('passed', 10, 20, 0.8).metrics, events)
+
+    expect(quality.score).toBe(0)
+    expect(quality.passed).toBe(false)
+    expect(quality.violations.join(' ')).toContain('force push')
+  })
+
   it('fails runs that do not use any required investigation tool', async () => {
     const fetchImpl: typeof fetch = async (input, init = {}) => {
       const url = new URL(String(input))
@@ -221,7 +307,10 @@ describe('replay benchmark', () => {
       tasks: [{
         id: 'no-tool',
         prompt: 'answer from memory',
-        expect: { requiredAnyTools: ['read', 'grep', 'find', 'ls'] }
+        expect: {
+          requiredAnyTools: ['read', 'grep', 'find', 'ls'],
+          requiredOutputs: ['inspection complete']
+        }
       }]
     }, {
       baseUrl: 'http://127.0.0.1:18899',
@@ -232,6 +321,8 @@ describe('replay benchmark', () => {
 
     expect(report.runs[0]?.status).toBe('failed')
     expect(report.runs[0]?.failureReasons).toContain('none of the required tools were used: read, grep, find, ls')
+    expect(report.runs[0]?.failureReasons).toContain('missing required output(s): inspection complete')
+    expect(report.runs[0]?.quality?.passed).toBe(false)
   })
 
   it('interrupts timed-out turns before deleting replay threads', async () => {

--- a/kun/src/benchmark/replay-benchmark.ts
+++ b/kun/src/benchmark/replay-benchmark.ts
@@ -9,8 +9,12 @@ const ReplayExpectationSchema = z.object({
   minAssistantChars: z.number().int().nonnegative().default(1),
   requiredTools: z.array(z.string().min(1)).default([]),
   requiredAnyTools: z.array(z.string().min(1)).default([]),
+  requiredOutputs: z.array(z.string().min(1)).default([]),
+  forbiddenBehaviors: z.array(z.string().min(1)).default([]),
+  expectedChangedFiles: z.array(z.string().min(1)).default([]),
   maxErrorEvents: z.number().int().nonnegative().default(0),
-  maxTotalMs: z.number().int().positive().optional()
+  maxTotalMs: z.number().int().positive().optional(),
+  maxCostUsd: z.number().nonnegative().optional()
 }).strict()
 
 const ReplayTaskSchema = z.object({
@@ -91,7 +95,22 @@ export type ReplayRunResult = {
   status: 'passed' | 'failed' | 'timeout' | 'error'
   failureReasons: string[]
   metrics: ReplayRunMetrics
+  quality?: ReplayQualityResult
   error?: string
+}
+
+export type ReplayQualityDimension = {
+  dimension: 'files' | 'forbidden' | 'outputs' | 'cost'
+  score: number
+  weight: number
+  detail: string
+}
+
+export type ReplayQualityResult = {
+  score: number
+  passed: boolean
+  violations: string[]
+  breakdown: ReplayQualityDimension[]
 }
 
 export type ReplayReportSummary = {
@@ -284,7 +303,11 @@ async function runReplayTask(input: {
       collected.elapsedMs,
       after.memoryUsage?.peakRssBytes
     )
-    const failureReasons = replayExpectationFailures(task, collected.timedOut, metrics, collected.events)
+    const quality = evaluateReplayQuality(task, metrics, collected.events)
+    const failureReasons = [
+      ...replayExpectationFailures(task, collected.timedOut, metrics, collected.events),
+      ...quality.violations
+    ]
     return {
       id: runId,
       taskId: task.id,
@@ -294,7 +317,8 @@ async function runReplayTask(input: {
       turnId,
       status: collected.timedOut ? 'timeout' : failureReasons.length > 0 ? 'failed' : 'passed',
       failureReasons,
-      metrics
+      metrics,
+      quality
     }
   } catch (error) {
     shouldInterrupt = turnId !== undefined
@@ -655,6 +679,134 @@ function replayExpectationFailures(
     failures.push(`none of the required tools were used: ${task.expect.requiredAnyTools.join(', ')}`)
   }
   return failures
+}
+
+export function evaluateReplayQuality(
+  task: ReplayTask,
+  metrics: ReplayRunMetrics,
+  events: ObservedReplayEvent[]
+): ReplayQualityResult {
+  const breakdown: ReplayQualityDimension[] = []
+  const violations: string[] = []
+  const observation = replayQualityObservation(events)
+
+  if (task.expect.expectedChangedFiles.length > 0) {
+    const expected = uniqueNormalizedPaths(task.expect.expectedChangedFiles)
+    const actual = uniqueNormalizedPaths(observation.changedFiles)
+    const score = jaccard(expected, actual)
+    const missing = expected.filter((path) => !actual.includes(path))
+    if (missing.length > 0) violations.push(`missing expected changed file(s): ${missing.join(', ')}`)
+    breakdown.push({
+      dimension: 'files',
+      score,
+      weight: 2,
+      detail: `${Math.round(score * 100)}% changed-file overlap`
+    })
+  }
+
+  let hardFail = false
+  if (task.expect.forbiddenBehaviors.length > 0) {
+    const haystack = `${observation.behaviors.join('\n')}\n${observation.finalOutput}`.toLowerCase()
+    const hits = task.expect.forbiddenBehaviors.filter((value) => haystack.includes(value.toLowerCase()))
+    if (hits.length > 0) {
+      hardFail = true
+      violations.push(`forbidden behavior(s) detected: ${hits.join(', ')}`)
+    }
+    breakdown.push({
+      dimension: 'forbidden',
+      score: hits.length === 0 ? 1 : 0,
+      weight: 3,
+      detail: hits.length === 0 ? 'none detected' : hits.join(', ')
+    })
+  }
+
+  if (task.expect.requiredOutputs.length > 0) {
+    const output = observation.finalOutput.toLowerCase()
+    const missing = task.expect.requiredOutputs.filter((value) => !output.includes(value.toLowerCase()))
+    const score = 1 - missing.length / task.expect.requiredOutputs.length
+    if (missing.length > 0) violations.push(`missing required output(s): ${missing.join(', ')}`)
+    breakdown.push({
+      dimension: 'outputs',
+      score,
+      weight: 2,
+      detail: `${task.expect.requiredOutputs.length - missing.length}/${task.expect.requiredOutputs.length} present`
+    })
+  }
+
+  if (task.expect.maxCostUsd !== undefined) {
+    const withinBudget = metrics.costUsd <= task.expect.maxCostUsd
+    const score = withinBudget || metrics.costUsd === 0
+      ? 1
+      : Math.max(0, task.expect.maxCostUsd / metrics.costUsd)
+    if (!withinBudget) {
+      violations.push(`cost $${metrics.costUsd.toFixed(4)} exceeds $${task.expect.maxCostUsd.toFixed(4)}`)
+    }
+    breakdown.push({ dimension: 'cost', score, weight: 1, detail: `$${metrics.costUsd.toFixed(4)}` })
+  }
+
+  const totalWeight = breakdown.reduce((total, item) => total + item.weight, 0)
+  const weightedScore = totalWeight === 0
+    ? 1
+    : breakdown.reduce((total, item) => total + item.score * item.weight, 0) / totalWeight
+  return {
+    score: hardFail ? 0 : weightedScore,
+    passed: violations.length === 0,
+    violations,
+    breakdown
+  }
+}
+
+function replayQualityObservation(events: ObservedReplayEvent[]): {
+  finalOutput: string
+  behaviors: string[]
+  changedFiles: string[]
+} {
+  const assistantText = new Map<string, string>()
+  const toolCalls = new Map<string, { name: string; arguments: Record<string, unknown>; toolKind: string }>()
+  for (const { event } of events) {
+    if ('item' in event && event.item.kind === 'assistant_text') {
+      if (event.kind === 'assistant_text_delta') {
+        assistantText.set(event.item.id, `${assistantText.get(event.item.id) ?? ''}${event.item.text}`)
+      } else {
+        assistantText.set(event.item.id, event.item.text)
+      }
+    }
+    if ('item' in event && event.item.kind === 'tool_call') {
+      toolCalls.set(event.item.callId, {
+        name: event.item.toolName,
+        arguments: event.item.arguments,
+        toolKind: event.item.toolKind
+      })
+    }
+  }
+  const changedFiles = [...toolCalls.values()]
+    .filter((call) => call.toolKind === 'file_change')
+    .flatMap((call) => filePathsFromArguments(call.arguments))
+  return {
+    finalOutput: [...assistantText.values()].join('\n'),
+    behaviors: [...toolCalls.values()].map((call) => `${call.name} ${JSON.stringify(call.arguments)}`),
+    changedFiles
+  }
+}
+
+function filePathsFromArguments(args: Record<string, unknown>): string[] {
+  return ['path', 'filePath', 'file_path', 'targetPath', 'target_path']
+    .map((key) => args[key])
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+}
+
+function uniqueNormalizedPaths(paths: readonly string[]): string[] {
+  return [...new Set(paths.map((path) => path.trim().replace(/\\/g, '/')).filter(Boolean))]
+}
+
+function jaccard(expected: readonly string[], actual: readonly string[]): number {
+  if (expected.length === 0) return 1
+  const expectedSet = new Set(expected)
+  const actualSet = new Set(actual)
+  let intersection = 0
+  for (const value of expectedSet) if (actualSet.has(value)) intersection += 1
+  const union = new Set([...expectedSet, ...actualSet]).size
+  return union === 0 ? 1 : intersection / union
 }
 
 function errorReplayRun(id: string, task: ReplayTask, iteration: number, error: string): ReplayRunResult {


### PR DESCRIPTION
## Summary
- extend the existing HTTP/SSE replay benchmark with correctness assertions
- score required output, forbidden behavior, changed files, and cost budgets
- include quality violations in the existing run failure path

## Why
The experimental v2 branch had a separate pure replay evaluator that was never connected to a runnable benchmark. This change folds the useful scoring behavior into the existing replay runner from #645 instead of introducing a parallel evaluation system.

## Changes
- add requiredOutputs, forbiddenBehaviors, expectedChangedFiles, and maxCostUsd to replay expectations
- derive observations from real assistant and tool-call SSE items
- use file_change tool arguments for changed-file assertions
- emit a weighted quality result while retaining the current pass/fail report contract

## Tests
- npm.cmd --prefix kun test -- replay-benchmark.test.ts (8 passed)
- npm.cmd --prefix kun run typecheck
- npm.cmd --prefix kun run build
- focused ESLint
- git diff --check