### PR TITLE
feat(memory): govern provenance and expiry

### DIFF
--- a/kun/src/adapters/tool/memory-tool-provider.ts
+++ b/kun/src/adapters/tool/memory-tool-provider.ts
@@ -18,7 +18,9 @@ export function buildMemoryToolProviders(store: MemoryStore | undefined): Capabi
           properties: {
             content: { type: 'string' },
             scope: { type: 'string', enum: ['user', 'workspace', 'project'] },
-            tags: { type: 'array', items: { type: 'string' } }
+            tags: { type: 'array', items: { type: 'string' } },
+            ttlDays: { type: 'number', minimum: 1, description: 'Optional lifetime in days.' },
+            supersedes: { type: 'string', description: 'Optional memory id replaced by this memory.' }
           },
           required: ['content'],
           additionalProperties: false
@@ -36,6 +38,13 @@ export function buildMemoryToolProviders(store: MemoryStore | undefined): Capabi
                 ...(args.scope === 'project' ? { project: context.workspace } : {}),
                 sourceThreadId: context.threadId,
                 sourceTurnId: context.turnId,
+                provenance: { kind: 'user', turnId: context.turnId, origin: 'memory_create' },
+                ...(typeof args.ttlDays === 'number' && Number.isFinite(args.ttlDays) && args.ttlDays > 0
+                  ? { ttlMs: Math.round(args.ttlDays * 24 * 60 * 60 * 1_000) }
+                  : {}),
+                ...(typeof args.supersedes === 'string' && args.supersedes.trim()
+                  ? { supersedes: args.supersedes.trim() }
+                  : {}),
                 tags: Array.isArray(args.tags) ? args.tags.filter((tag): tag is string => typeof tag === 'string') : []
               })
             }

--- a/kun/src/contracts/memory.ts
+++ b/kun/src/contracts/memory.ts
@@ -3,6 +3,17 @@ import { z } from 'zod'
 export const MemoryScope = z.enum(['user', 'workspace', 'project'])
 export type MemoryScope = z.infer<typeof MemoryScope>
 
+export const MemorySourceKind = z.enum(['user', 'tool', 'inference', 'file', 'web'])
+export type MemorySourceKind = z.infer<typeof MemorySourceKind>
+
+export const MemoryProvenance = z.object({
+  kind: MemorySourceKind,
+  turnId: z.string().optional(),
+  file: z.string().optional(),
+  origin: z.string().optional()
+}).strict()
+export type MemoryProvenance = z.infer<typeof MemoryProvenance>
+
 export const MemoryRecord = z.object({
   id: z.string().min(1),
   content: z.string().min(1),
@@ -11,10 +22,15 @@ export const MemoryRecord = z.object({
   project: z.string().optional(),
   sourceThreadId: z.string().optional(),
   sourceTurnId: z.string().optional(),
+  provenance: MemoryProvenance.optional(),
   tags: z.array(z.string()).default([]),
   confidence: z.number().min(0).max(1).default(1),
   createdAt: z.string(),
   updatedAt: z.string(),
+  expiresAt: z.string().datetime().optional(),
+  supersedes: z.string().optional(),
+  supersededAt: z.string().optional(),
+  correctedFrom: z.string().optional(),
   disabledAt: z.string().optional(),
   deletedAt: z.string().optional()
 }).strict()
@@ -27,8 +43,11 @@ export const MemoryCreateRequest = z.object({
   project: z.string().optional(),
   sourceThreadId: z.string().optional(),
   sourceTurnId: z.string().optional(),
+  provenance: MemoryProvenance.optional(),
+  ttlMs: z.number().int().positive().optional(),
+  supersedes: z.string().min(1).optional(),
   tags: z.array(z.string()).default([]),
-  confidence: z.number().min(0).max(1).default(1)
+  confidence: z.number().min(0).max(1).optional()
 }).strict()
 export type MemoryCreateRequest = z.input<typeof MemoryCreateRequest>
 
@@ -36,6 +55,7 @@ export const MemoryUpdateRequest = z.object({
   content: z.string().min(1).optional(),
   tags: z.array(z.string()).optional(),
   confidence: z.number().min(0).max(1).optional(),
+  expiresAt: z.string().datetime().nullable().optional(),
   disabled: z.boolean().optional()
 }).strict()
 export type MemoryUpdateRequest = z.input<typeof MemoryUpdateRequest>

--- a/kun/src/memory/memory-store.ts
+++ b/kun/src/memory/memory-store.ts
@@ -5,9 +5,12 @@ import { atomicWriteFile } from '../adapters/file/atomic-write.js'
 import {
   MemoryDiagnostics,
   MemoryRecord,
+  type MemoryProvenance,
   type MemoryCreateRequest,
   type MemoryUpdateRequest
 } from '../contracts/memory.js'
+
+const DEFAULT_MEMORY_CONFIDENCE_HALF_LIFE_MS = 180 * 24 * 60 * 60 * 1_000
 
 export interface MemoryStore {
   create(input: MemoryCreateRequest): Promise<MemoryRecord>
@@ -30,6 +33,8 @@ export class FileMemoryStore implements MemoryStore {
       config: MemoryCapabilityConfig
       nowIso?: () => string
       idGenerator?: () => string
+      confidenceHalfLifeMs?: number
+      minConfidence?: number
     }
   ) {}
 
@@ -39,6 +44,7 @@ export class FileMemoryStore implements MemoryStore {
     const scope = input.scope ?? 'workspace'
     const workspace = normalizeScopePath(input.workspace)
     const project = normalizeScopePath(input.project ?? (scope === 'project' ? input.workspace : undefined))
+    const provenance = input.provenance ?? defaultProvenance(input)
     const parsed = MemoryRecord.parse({
       id: this.options.idGenerator?.() ?? `mem_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
       content: input.content,
@@ -47,11 +53,21 @@ export class FileMemoryStore implements MemoryStore {
       ...(scope === 'project' && project ? { project } : {}),
       sourceThreadId: input.sourceThreadId,
       sourceTurnId: input.sourceTurnId,
+      provenance,
       tags: input.tags ?? [],
-      confidence: input.confidence ?? 1,
+      confidence: input.confidence ?? defaultConfidence(provenance.kind),
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      ...(input.ttlMs ? { expiresAt: new Date(Date.parse(now) + input.ttlMs).toISOString() } : {}),
+      ...(input.supersedes ? { supersedes: input.supersedes } : {})
     })
+    if (input.supersedes) {
+      const older = await this.mustGet(input.supersedes, { workspace })
+      if (older.scope !== parsed.scope) {
+        throw new Error('a memory can only supersede another memory in the same scope')
+      }
+      await this.write(MemoryRecord.parse({ ...older, supersededAt: now, updatedAt: now }))
+    }
     await this.write(parsed)
     return parsed
   }
@@ -59,11 +75,23 @@ export class FileMemoryStore implements MemoryStore {
   async update(id: string, patch: MemoryUpdateRequest, access?: MemoryAccess): Promise<MemoryRecord> {
     const current = await this.mustGet(id, access)
     const now = this.now()
+    const corrected = patch.content !== undefined && patch.content !== current.content
     const next = MemoryRecord.parse({
       ...current,
       ...(patch.content !== undefined ? { content: patch.content } : {}),
       ...(patch.tags !== undefined ? { tags: patch.tags } : {}),
-      ...(patch.confidence !== undefined ? { confidence: patch.confidence } : {}),
+      ...(patch.confidence !== undefined
+        ? { confidence: patch.confidence }
+        : corrected
+          ? { confidence: 1 }
+          : {}),
+      ...(corrected
+        ? {
+            correctedFrom: current.correctedFrom ?? current.content,
+            provenance: { ...(current.provenance ?? defaultLegacyProvenance(current)), kind: 'user' }
+          }
+        : {}),
+      ...(patch.expiresAt !== undefined ? { expiresAt: patch.expiresAt ?? undefined } : {}),
       ...(patch.disabled === true ? { disabledAt: current.disabledAt ?? now } : {}),
       ...(patch.disabled === false ? { disabledAt: undefined } : {}),
       updatedAt: now
@@ -94,8 +122,14 @@ export class FileMemoryStore implements MemoryStore {
 
   async retrieve(input: { query: string; workspace?: string; limit: number }): Promise<MemoryRecord[]> {
     if (!this.options.config.enabled) return []
+    const nowMs = Date.parse(this.now())
     const active = (await this.list({ workspace: input.workspace }))
-      .filter((record) => !record.disabledAt)
+      .filter((record) => isMemoryActive(
+        record,
+        nowMs,
+        this.options.minConfidence ?? 0,
+        this.options.confidenceHalfLifeMs ?? DEFAULT_MEMORY_CONFIDENCE_HALF_LIFE_MS
+      ))
     // User-scope memories are persistent identity facts (name, preferences,
     // account) — small in number, high in value, and frequently queried by
     // semantic prompts ("who am I?", "what do you know about me") that share
@@ -105,7 +139,12 @@ export class FileMemoryStore implements MemoryStore {
     const userMemories = active.filter((record) => record.scope === 'user')
     const scored = active
       .filter((record) => record.scope !== 'user')
-      .map((record) => ({ record, score: scoreMemory(record, input.query) }))
+      .map((record) => ({ record, score: scoreMemory(
+        record,
+        input.query,
+        nowMs,
+        this.options.confidenceHalfLifeMs ?? DEFAULT_MEMORY_CONFIDENCE_HALF_LIFE_MS
+      ) }))
       .filter((entry) => entry.score > 0)
       .sort((a, b) => b.score - a.score || b.record.updatedAt.localeCompare(a.record.updatedAt))
       .map((entry) => entry.record)
@@ -114,10 +153,16 @@ export class FileMemoryStore implements MemoryStore {
 
   async diagnostics(): Promise<MemoryDiagnostics> {
     const records = await this.readAll()
+    const nowMs = Date.parse(this.now())
     return {
       enabled: this.options.config.enabled,
       rootDir: this.options.rootDir,
-      activeCount: records.filter((record) => !record.deletedAt && !record.disabledAt).length,
+      activeCount: records.filter((record) => isMemoryActive(
+        record,
+        nowMs,
+        this.options.minConfidence ?? 0,
+        this.options.confidenceHalfLifeMs ?? DEFAULT_MEMORY_CONFIDENCE_HALF_LIFE_MS
+      )).length,
       tombstoneCount: records.filter((record) => Boolean(record.deletedAt)).length,
       lastInjectedIds: [...this.lastInjectedIds]
     }
@@ -176,7 +221,12 @@ function normalizeScopePath(value: string | undefined): string | undefined {
   return process.platform === 'win32' ? normalized.toLowerCase() : normalized
 }
 
-function scoreMemory(record: MemoryRecord, query: string): number {
+function scoreMemory(
+  record: MemoryRecord,
+  query: string,
+  nowMs: number,
+  confidenceHalfLifeMs: number
+): number {
   // Build n-gram fingerprints so matching works for both Latin words and CJK
   // text. The previous implementation split on `[^a-z0-9_]+`, which treated
   // every Chinese/Japanese/Korean character as a separator and produced an
@@ -190,7 +240,61 @@ function scoreMemory(record: MemoryRecord, query: string): number {
   }
   // Normalize by query coverage so long queries do not drown out short ones.
   const coverage = overlap / queryGrams.size
-  return (overlap + coverage) * record.confidence
+  return (overlap + coverage) * effectiveMemoryConfidence(record, nowMs, confidenceHalfLifeMs)
+}
+
+export function isMemoryActive(
+  record: MemoryRecord,
+  nowMs: number,
+  minConfidence = 0,
+  halfLifeMs = DEFAULT_MEMORY_CONFIDENCE_HALF_LIFE_MS
+): boolean {
+  if (record.deletedAt || record.disabledAt || record.supersededAt) return false
+  if (record.expiresAt && Date.parse(record.expiresAt) <= nowMs) return false
+  return effectiveMemoryConfidence(
+    record,
+    nowMs,
+    halfLifeMs
+  ) >= minConfidence
+}
+
+export function effectiveMemoryConfidence(
+  record: MemoryRecord,
+  nowMs: number,
+  halfLifeMs = DEFAULT_MEMORY_CONFIDENCE_HALF_LIFE_MS
+): number {
+  const provenance = record.provenance ?? defaultLegacyProvenance(record)
+  if (provenance.kind === 'user' || halfLifeMs <= 0) return record.confidence
+  const createdAtMs = Date.parse(record.createdAt)
+  if (!Number.isFinite(createdAtMs)) return record.confidence
+  const ageMs = Math.max(0, nowMs - createdAtMs)
+  return record.confidence * Math.pow(0.5, ageMs / halfLifeMs)
+}
+
+function defaultProvenance(input: MemoryCreateRequest): MemoryProvenance {
+  return {
+    kind: 'user',
+    ...(input.sourceTurnId ? { turnId: input.sourceTurnId } : {}),
+    origin: 'memory'
+  }
+}
+
+function defaultLegacyProvenance(record: Pick<MemoryRecord, 'sourceTurnId'>): MemoryProvenance {
+  return {
+    kind: 'user',
+    ...(record.sourceTurnId ? { turnId: record.sourceTurnId } : {}),
+    origin: 'legacy'
+  }
+}
+
+function defaultConfidence(kind: MemoryProvenance['kind']): number {
+  switch (kind) {
+    case 'user': return 1
+    case 'file': return 0.8
+    case 'tool': return 0.7
+    case 'web': return 0.5
+    case 'inference': return 0.4
+  }
 }
 
 /**

--- a/kun/tests/memory-store.test.ts
+++ b/kun/tests/memory-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -6,7 +6,7 @@ import { CapabilityRegistry } from '../src/adapters/tool/capability-registry.js'
 import { LocalToolHost } from '../src/adapters/tool/local-tool-host.js'
 import { buildMemoryToolProviders } from '../src/adapters/tool/memory-tool-provider.js'
 import { KunCapabilitiesConfig, type MemoryCapabilityConfig } from '../src/contracts/capabilities.js'
-import { FileMemoryStore } from '../src/memory/memory-store.js'
+import { effectiveMemoryConfidence, FileMemoryStore } from '../src/memory/memory-store.js'
 import type { ModelClient, ModelRequest } from '../src/ports/model-client.js'
 import { dispatchRequest } from '../src/server/http-server.js'
 import { bootstrapThread, makeHarness } from './loop-test-harness.js'
@@ -50,6 +50,77 @@ describe('Memory store and recall', () => {
     await store.delete(memory.id)
     expect(await store.retrieve({ query: 'pnpm', workspace: '/tmp/ws', limit: 3 })).toEqual([])
     expect((await store.list({ workspace: '/tmp/ws', includeDeleted: true })).find((item) => item.id === memory.id)?.deletedAt).toBeTruthy()
+  })
+
+  it('tracks provenance, expiry, confidence decay, and legacy records', async () => {
+    let now = '2026-06-03T00:00:00.000Z'
+    const store = new FileMemoryStore({
+      rootDir: join(dir, 'memory'),
+      config: memoryConfig(),
+      nowIso: () => now,
+      idGenerator: () => `mem_${nextId++}`,
+      confidenceHalfLifeMs: 1_000
+    })
+    const memory = await store.create({
+      content: 'Observed build uses a generated manifest',
+      scope: 'workspace',
+      workspace: '/tmp/ws',
+      provenance: { kind: 'inference', turnId: 'turn_1', origin: 'analysis' },
+      ttlMs: 2_000
+    })
+    expect(memory).toMatchObject({
+      confidence: 0.4,
+      provenance: { kind: 'inference', turnId: 'turn_1', origin: 'analysis' },
+      expiresAt: '2026-06-03T00:00:02.000Z'
+    })
+    expect(effectiveMemoryConfidence(memory, Date.parse(now) + 1_000, 1_000)).toBeCloseTo(0.2)
+    expect(await store.retrieve({ query: 'generated manifest', workspace: '/tmp/ws', limit: 3 })).toHaveLength(1)
+
+    now = '2026-06-03T00:00:03.000Z'
+    expect(await store.retrieve({ query: 'generated manifest', workspace: '/tmp/ws', limit: 3 })).toEqual([])
+    expect((await store.diagnostics()).activeCount).toBe(0)
+
+    await mkdir(join(dir, 'memory'), { recursive: true })
+    await writeFile(join(dir, 'memory', 'legacy.json'), JSON.stringify({
+      id: 'legacy',
+      content: 'Legacy user preference',
+      scope: 'user',
+      tags: [],
+      confidence: 1,
+      createdAt: now,
+      updatedAt: now
+    }))
+    expect((await store.list({ all: true })).find((item) => item.id === 'legacy')).toBeTruthy()
+  })
+
+  it('supersedes older memories and preserves user corrections', async () => {
+    const store = createStore()
+    const older = await store.create({
+      content: 'Use npm for frontend installs',
+      scope: 'workspace',
+      workspace: '/tmp/ws'
+    })
+    const newer = await store.create({
+      content: 'Use pnpm for frontend installs',
+      scope: 'workspace',
+      workspace: '/tmp/ws',
+      provenance: { kind: 'tool', origin: 'package-manager-check' },
+      supersedes: older.id
+    })
+
+    const records = await store.list({ workspace: '/tmp/ws' })
+    expect(records.find((item) => item.id === older.id)?.supersededAt).toBeTruthy()
+    expect((await store.retrieve({ query: 'frontend installs', workspace: '/tmp/ws', limit: 3 })).map((item) => item.id)).toEqual([newer.id])
+
+    const corrected = await store.update(newer.id, { content: 'Use Bun for frontend installs' }, {
+      workspace: '/tmp/ws'
+    })
+    expect(corrected).toMatchObject({
+      content: 'Use Bun for frontend installs',
+      correctedFrom: 'Use pnpm for frontend installs',
+      confidence: 1,
+      provenance: { kind: 'user' }
+    })
   })
 
   it('exposes memory API routes with diagnostics', async () => {
@@ -153,7 +224,7 @@ describe('Memory store and recall', () => {
 
     await h.loop.runTurn(h.threadId, h.turnId)
 
-    expect(seenRequests.at(-1)?.contextInstructions?.[0]).toContain(memory.id)
+    expect(seenRequests.at(-1)?.contextInstructions?.join('\n')).toContain(memory.id)
     expect((await h.turns.getTurn(h.threadId, h.turnId))?.injectedMemoryIds).toEqual([memory.id])
     expect((await store.diagnostics()).lastInjectedIds).toEqual([memory.id])
 


### PR DESCRIPTION
## Summary
- add provenance, expiry, supersession, and correction metadata to existing memories
- keep old memory JSON records readable
- prevent expired and superseded records from entering model context

## Why
The v2 branch contained an isolated GovernedMemory type that duplicated the production MemoryRecord and was never used by MemoryStore. This change folds the governance rules into the existing contract and persistence path.

## Changes
- persist source kind/origin/turn provenance on new records
- support optional TTL and supersedes through memory_create
- decay confidence for non-user sources while keeping explicit user memories stable
- preserve the prior content when a user corrects a memory
- exclude deleted, disabled, expired, superseded, and below-threshold records from recall
- treat legacy records without provenance as user-authored for compatibility

## Tests
- npm.cmd --prefix kun test -- memory-store.test.ts contracts.test.ts (47 passed)
- npm.cmd --prefix kun run typecheck
- npm.cmd --prefix kun run build
- focused ESLint
- git diff --check