### PR TITLE
feat(delegation): enforce child execution contracts

### DIFF
--- a/kun/src/adapters/tool/delegation-tool-provider.ts
+++ b/kun/src/adapters/tool/delegation-tool-provider.ts
@@ -30,6 +30,21 @@ export function buildDelegationToolProviders(runtime: DelegationRuntime | undefi
             detach: {
               type: 'boolean',
               description: 'Fire-and-forget. The call returns immediately with a queued/running record; the child keeps executing in the background and can be checked via diagnostics or aborted from the GUI.'
+            },
+            tokenBudget: {
+              type: 'integer',
+              minimum: 1,
+              description: 'Optional hard cap for total child tokens.'
+            },
+            timeBudgetMs: {
+              type: 'integer',
+              minimum: 1,
+              description: 'Optional wall-clock timeout in milliseconds.'
+            },
+            returnFormat: {
+              type: 'string',
+              enum: ['summary', 'evidence'],
+              description: 'Require either a normal summary or explicit evidence items.'
             }
           },
           required: ['prompt'],
@@ -39,6 +54,12 @@ export function buildDelegationToolProviders(runtime: DelegationRuntime | undefi
         execute: async (args, context, onUpdate) => {
           const prompt = typeof args.prompt === 'string' ? args.prompt.trim() : ''
           if (!prompt) return { output: { error: 'prompt is required' }, isError: true }
+          if (args.tokenBudget !== undefined && !isPositiveInteger(args.tokenBudget)) {
+            return { output: { error: 'tokenBudget must be a positive integer' }, isError: true }
+          }
+          if (args.timeBudgetMs !== undefined && !isPositiveInteger(args.timeBudgetMs)) {
+            return { output: { error: 'timeBudgetMs must be a positive integer' }, isError: true }
+          }
           const record = await runtime.runChild({
             parentThreadId: context.threadId,
             parentTurnId: context.turnId,
@@ -48,6 +69,9 @@ export function buildDelegationToolProviders(runtime: DelegationRuntime | undefi
             ...(typeof args.model === 'string' ? { model: args.model } : {}),
             ...(typeof args.profile === 'string' ? { profile: args.profile } : {}),
             ...(args.detach === true ? { detach: true } : {}),
+            ...(isPositiveInteger(args.tokenBudget) ? { tokenBudget: args.tokenBudget } : {}),
+            ...(isPositiveInteger(args.timeBudgetMs) ? { timeBudgetMs: args.timeBudgetMs } : {}),
+            ...(args.returnFormat === 'evidence' ? { returnFormat: 'evidence' as const } : {}),
             // Emit a partial result the moment the child id exists, so the GUI
             // can offer "open session" (and stream the child live) while the
             // child is still running — not only after it completes.
@@ -65,7 +89,12 @@ export function buildDelegationToolProviders(runtime: DelegationRuntime | undefi
               status: record.status,
               summary: record.summary,
               error: record.error,
+              evidence: record.evidence,
               usage: record.usage,
+              returnFormat: record.returnFormat,
+              ...(record.tokenBudget ? { tokenBudget: record.tokenBudget } : {}),
+              ...(record.timeBudgetMs ? { timeBudgetMs: record.timeBudgetMs } : {}),
+              ...(record.budgetExceeded ? { budgetExceeded: record.budgetExceeded } : {}),
               ...(record.profile ? { profile: record.profile } : {}),
               ...(record.toolPolicy ? { toolPolicy: record.toolPolicy } : {}),
               ...(record.toolInvocations !== undefined ? { toolInvocations: record.toolInvocations } : {}),
@@ -78,6 +107,10 @@ export function buildDelegationToolProviders(runtime: DelegationRuntime | undefi
       })
     ]
   }]
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
 }
 
 function buildDelegateTaskDescription(

--- a/kun/src/delegation/child-agent-executor.ts
+++ b/kun/src/delegation/child-agent-executor.ts
@@ -189,9 +189,12 @@ export function createChildAgentExecutor(options: ChildAgentExecutorOptions): Ch
     })
     // A profile preamble rides in the prompt body (not the system prompt) so
     // the cached stable prefix stays byte-identical to the main agent's.
-    const prompt = input.promptPreamble?.trim()
+    const promptBase = input.promptPreamble?.trim()
       ? `${input.promptPreamble.trim()}\n\n${input.prompt}`
       : input.prompt
+    const prompt = input.returnFormat === 'evidence'
+      ? `${promptBase}\n\nReturn a concise evidence-based conclusion. Inspect the task with tools so the parent can verify the result.`
+      : promptBase
     const started = await turns.startTurn({
       threadId: thread.id,
       request: {
@@ -227,11 +230,15 @@ export function createChildAgentExecutor(options: ChildAgentExecutorOptions): Ch
     const toolInvocations = items.filter(
       (item) => item.turnId === started.turnId && item.kind === 'tool_call'
     ).length
+    const evidence = input.returnFormat === 'evidence'
+      ? childToolEvidence(items, started.turnId)
+      : undefined
     if (status !== 'completed') {
       throw new Error(summary || `child agent ${status}`)
     }
     return {
       summary,
+      ...(evidence ? { evidence } : {}),
       usage: usage.forThread(thread.id),
       toolInvocations,
       // The child loop was constructed with the main agent's immutable
@@ -240,6 +247,30 @@ export function createChildAgentExecutor(options: ChildAgentExecutorOptions): Ch
       inheritedHistoryItems: 0
     }
   }
+}
+
+function childToolEvidence(items: readonly TurnItem[], turnId: string): string[] {
+  const results = new Map(items
+    .filter((item): item is Extract<TurnItem, { kind: 'tool_result' }> =>
+      item.turnId === turnId && item.kind === 'tool_result')
+    .map((item) => [item.callId, item]))
+  return items
+    .filter((item): item is Extract<TurnItem, { kind: 'tool_call' }> =>
+      item.turnId === turnId && item.kind === 'tool_call')
+    .slice(0, 32)
+    .map((item) => {
+      const result = results.get(item.callId)
+      const target = toolEvidenceTarget(item.arguments)
+      return `${item.toolName}${target ? ` ${target}` : ''}: ${result?.isError ? 'failed' : 'completed'}`
+    })
+}
+
+function toolEvidenceTarget(args: Record<string, unknown>): string {
+  for (const key of ['path', 'filePath', 'file_path', 'query', 'command']) {
+    const value = args[key]
+    if (typeof value === 'string' && value.trim()) return value.trim().slice(0, 300)
+  }
+  return ''
 }
 
 function childThreadTitle(childId: string, label?: string, profile?: string): string {

--- a/kun/src/delegation/delegation-runtime.ts
+++ b/kun/src/delegation/delegation-runtime.ts
@@ -24,6 +24,9 @@ const ChildRunUsage = z.object({
   tokenEconomySavingsCny: z.number().nonnegative().optional()
 })
 
+const ChildReturnFormat = z.enum(['summary', 'evidence'])
+export type ChildReturnFormat = z.infer<typeof ChildReturnFormat>
+
 export const ChildRunRecord = z.object({
   id: z.string().min(1),
   parentThreadId: z.string().min(1),
@@ -40,6 +43,11 @@ export const ChildRunRecord = z.object({
   toolPolicy: SubagentToolPolicy.optional(),
   status: z.enum(['queued', 'running', 'completed', 'failed', 'aborted']),
   summary: z.string().optional(),
+  evidence: z.array(z.string().min(1).max(2_000)).max(32).optional(),
+  tokenBudget: z.number().int().positive().optional(),
+  timeBudgetMs: z.number().int().positive().optional(),
+  returnFormat: ChildReturnFormat.default('summary'),
+  budgetExceeded: z.enum(['token', 'time']).optional(),
   error: z.string().optional(),
   usage: ChildRunUsage.default({ promptTokens: 0, completionTokens: 0, totalTokens: 0 }),
   /** True when the child reused the main agent's cached stable prefix. */
@@ -82,6 +90,9 @@ export type ChildRunExecutor = (input: {
   promptPreamble?: string
   /** Reasoning depth for this profile's child model requests (default 'off'). */
   reasoningEffort?: string
+  tokenBudget?: number
+  timeBudgetMs?: number
+  returnFormat?: ChildReturnFormat
   signal: AbortSignal
 }) => Promise<{
   summary: string
@@ -89,6 +100,7 @@ export type ChildRunExecutor = (input: {
   toolInvocations?: number
   prefixReused?: boolean
   inheritedHistoryItems?: number
+  evidence?: string[]
 }>
 
 export type ChildRunAggregate = {
@@ -174,6 +186,9 @@ export class DelegationRuntime {
     model?: string
     providerId?: string
     profile?: string
+    tokenBudget?: number
+    timeBudgetMs?: number
+    returnFormat?: ChildReturnFormat
     /**
      * When true, runChild returns the queued ChildRunRecord immediately and
      * continues execution in the background. The detached run gets its own
@@ -219,6 +234,9 @@ export class DelegationRuntime {
     const resolvedBlockedSkills = profile?.blockedSkills
     const promptPreamble = profile?.promptPreamble
     const resolvedReasoningEffort = profile?.reasoningEffort
+    const tokenBudget = positiveInteger(input.tokenBudget)
+    const timeBudgetMs = positiveInteger(input.timeBudgetMs)
+    const returnFormat = input.returnFormat ?? 'summary'
 
     // Reserve against the per-thread budget before persisting anything.
     await this.ensureSeeded(input.parentThreadId)
@@ -239,6 +257,9 @@ export class DelegationRuntime {
       providerId: resolvedProviderId,
       profile: profileName,
       toolPolicy,
+      tokenBudget,
+      timeBudgetMs,
+      returnFormat,
       status: 'queued',
       createdAt: queuedAt,
       updatedAt: queuedAt
@@ -271,6 +292,9 @@ export class DelegationRuntime {
         resolvedBlockedSkills,
         promptPreamble,
         resolvedReasoningEffort,
+        tokenBudget,
+        timeBudgetMs,
+        returnFormat,
         workspace: input.workspace,
         label: input.label,
         parentThreadId: input.parentThreadId,
@@ -303,7 +327,7 @@ export class DelegationRuntime {
     await this.recordChildEvent(record)
     try {
       const executor: ChildRunExecutor = this.options.executor ?? defaultExecutor
-      const result = await executor({
+      const result = await executeWithinTimeBudget(input.signal, timeBudgetMs, (signal) => executor({
         childId: id,
         parentThreadId: input.parentThreadId,
         parentTurnId: input.parentTurnId,
@@ -321,17 +345,31 @@ export class DelegationRuntime {
         toolPolicy,
         ...(promptPreamble ? { promptPreamble } : {}),
         ...(resolvedReasoningEffort ? { reasoningEffort: resolvedReasoningEffort } : {}),
-        signal: input.signal
-      })
+        ...(tokenBudget ? { tokenBudget } : {}),
+        ...(timeBudgetMs ? { timeBudgetMs } : {}),
+        returnFormat,
+        signal
+      }))
       const finishedAt = this.now()
+      const usage = result.usage ?? record.usage
+      const contractError = childContractError({ tokenBudget, returnFormat }, result.evidence, usage)
       record = ChildRunRecord.parse({
         ...record,
-        status: 'completed',
+        status: contractError ? 'failed' : 'completed',
         summary: result.summary,
-        usage: result.usage ?? record.usage,
+        evidence: result.evidence,
+        usage,
         toolInvocations: result.toolInvocations,
         prefixReused: result.prefixReused,
         inheritedHistoryItems: result.inheritedHistoryItems,
+        ...(contractError
+          ? {
+              error: contractError,
+              ...(usage.totalTokens > (tokenBudget ?? Number.POSITIVE_INFINITY)
+                ? { budgetExceeded: 'token' as const }
+                : {})
+            }
+          : {}),
         durationMs: elapsedMs(startedAt, finishedAt),
         updatedAt: finishedAt
       })
@@ -345,6 +383,7 @@ export class DelegationRuntime {
         ...record,
         status: input.signal.aborted ? 'aborted' : 'failed',
         error: errorMessage(error),
+        ...(error instanceof ChildTimeBudgetExceededError ? { budgetExceeded: 'time' } : {}),
         durationMs: elapsedMs(startedAt, finishedAt),
         updatedAt: finishedAt
       })
@@ -377,6 +416,9 @@ export class DelegationRuntime {
     resolvedBlockedSkills: string[] | undefined
     promptPreamble: string | undefined
     resolvedReasoningEffort: string | undefined
+    tokenBudget: number | undefined
+    timeBudgetMs: number | undefined
+    returnFormat: ChildReturnFormat
     workspace: string | undefined
     label: string | undefined
     parentThreadId: string
@@ -406,7 +448,7 @@ export class DelegationRuntime {
     await this.recordChildEvent(record)
     try {
       const executor: ChildRunExecutor = this.options.executor ?? defaultExecutor
-      const result = await executor({
+      const result = await executeWithinTimeBudget(args.signal, args.timeBudgetMs, (signal) => executor({
         childId: record.id,
         parentThreadId: args.parentThreadId,
         parentTurnId: args.parentTurnId,
@@ -424,17 +466,35 @@ export class DelegationRuntime {
         toolPolicy: args.toolPolicy,
         ...(args.promptPreamble ? { promptPreamble: args.promptPreamble } : {}),
         ...(args.resolvedReasoningEffort ? { reasoningEffort: args.resolvedReasoningEffort } : {}),
-        signal: args.signal
-      })
+        ...(args.tokenBudget ? { tokenBudget: args.tokenBudget } : {}),
+        ...(args.timeBudgetMs ? { timeBudgetMs: args.timeBudgetMs } : {}),
+        returnFormat: args.returnFormat,
+        signal
+      }))
       const finishedAt = this.now()
+      const usage = result.usage ?? record.usage
+      const contractError = childContractError(
+        { tokenBudget: args.tokenBudget, returnFormat: args.returnFormat },
+        result.evidence,
+        usage
+      )
       record = ChildRunRecord.parse({
         ...record,
-        status: 'completed',
+        status: contractError ? 'failed' : 'completed',
         summary: result.summary,
-        usage: result.usage ?? record.usage,
+        evidence: result.evidence,
+        usage,
         toolInvocations: result.toolInvocations,
         prefixReused: result.prefixReused,
         inheritedHistoryItems: result.inheritedHistoryItems,
+        ...(contractError
+          ? {
+              error: contractError,
+              ...(usage.totalTokens > (args.tokenBudget ?? Number.POSITIVE_INFINITY)
+                ? { budgetExceeded: 'token' as const }
+                : {})
+            }
+          : {}),
         durationMs: elapsedMs(startedAt, finishedAt),
         updatedAt: finishedAt
       })
@@ -448,6 +508,7 @@ export class DelegationRuntime {
         ...record,
         status: args.signal.aborted ? 'aborted' : 'failed',
         error: errorMessage(error),
+        ...(error instanceof ChildTimeBudgetExceededError ? { budgetExceeded: 'time' } : {}),
         durationMs: elapsedMs(startedAt, finishedAt),
         updatedAt: finishedAt
       })
@@ -635,7 +696,6 @@ export class DelegationRuntime {
   }
 
   private recordExternalUsage(record: ChildRunRecord): void {
-    if (record.status !== 'completed') return
     const usage = toUsageSnapshot(record.usage)
     if (usage.totalTokens <= 0 && usage.costUsd === undefined && usage.costCny === undefined) return
     this.options.recordExternalUsage?.(record.parentThreadId, usage)
@@ -704,6 +764,67 @@ export function aggregateChildRuns(records: readonly ChildRunRecord[]): ChildRun
     b.totalTokens - a.totalTokens ||
     a.key.localeCompare(b.key)
   )
+}
+
+class ChildTimeBudgetExceededError extends Error {
+  constructor(readonly timeBudgetMs: number) {
+    super(`child time budget exhausted after ${timeBudgetMs}ms`)
+    this.name = 'ChildTimeBudgetExceededError'
+  }
+}
+
+async function executeWithinTimeBudget<T>(
+  parentSignal: AbortSignal,
+  timeBudgetMs: number | undefined,
+  execute: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  if (parentSignal.aborted) throw new Error('child run aborted')
+  if (!timeBudgetMs) return execute(parentSignal)
+
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let rejectCancellation: ((error: Error) => void) | undefined
+  const cancellation = new Promise<never>((_resolve, reject) => {
+    rejectCancellation = reject
+  })
+  const onParentAbort = (): void => {
+    controller.abort(parentSignal.reason)
+    rejectCancellation?.(new Error('child run aborted'))
+  }
+  parentSignal.addEventListener('abort', onParentAbort, { once: true })
+  timer = setTimeout(() => {
+    const error = new ChildTimeBudgetExceededError(timeBudgetMs)
+    controller.abort(error)
+    rejectCancellation?.(error)
+  }, timeBudgetMs)
+  timer.unref?.()
+
+  try {
+    return await Promise.race([execute(controller.signal), cancellation])
+  } finally {
+    if (timer) clearTimeout(timer)
+    parentSignal.removeEventListener('abort', onParentAbort)
+  }
+}
+
+function childContractError(
+  contract: { tokenBudget: number | undefined; returnFormat: ChildReturnFormat },
+  evidence: string[] | undefined,
+  usage: ChildRunRecord['usage']
+): string | undefined {
+  if (contract.tokenBudget !== undefined && usage.totalTokens > contract.tokenBudget) {
+    return `child token budget exhausted (${usage.totalTokens} > ${contract.tokenBudget})`
+  }
+  if (contract.returnFormat === 'evidence' && !evidence?.some((item) => item.trim().length > 0)) {
+    return 'child contract requires evidence but none was returned'
+  }
+  return undefined
+}
+
+function positiveInteger(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined
+  if (!Number.isInteger(value) || value <= 0) throw new Error('child budgets must be positive integers')
+  return value
 }
 
 const defaultExecutor: ChildRunExecutor = async (input) => {

--- a/kun/tests/child-agent-executor.test.ts
+++ b/kun/tests/child-agent-executor.test.ts
@@ -87,6 +87,56 @@ describe('child agent executor', () => {
     expect(seen[0]?.tools).toEqual([])
   })
 
+  it('returns bounded tool evidence when the contract requests it', async () => {
+    let step = 0
+    const evidenceModel: ModelClient = {
+      provider: 'evidence-test',
+      model: 'evidence-test',
+      async *stream(): AsyncIterable<ModelStreamChunk> {
+        step += 1
+        if (step === 1) {
+          yield {
+            kind: 'tool_call_complete',
+            callId: 'call_inspect',
+            toolName: 'inspect',
+            arguments: { path: 'src/index.ts' }
+          }
+          yield { kind: 'completed', stopReason: 'tool_calls' }
+          return
+        }
+        yield { kind: 'assistant_text_delta', text: 'Inspection complete.' }
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    }
+    const inspect = LocalToolHost.defineTool({
+      name: 'inspect',
+      description: 'Inspect a source file.',
+      inputSchema: { type: 'object' },
+      policy: 'auto',
+      execute: async () => ({ output: { ok: true } })
+    })
+    const executor = createChildAgentExecutor({
+      model: evidenceModel,
+      toolHost: new LocalToolHost({ tools: [inspect] }),
+      prefix: createImmutablePrefix({ systemPrompt: 'child system' }),
+      defaultModel: 'evidence-test',
+      nowIso: () => '2026-06-03T00:00:00.000Z'
+    })
+
+    const result = await executor({
+      childId: 'child_evidence',
+      parentThreadId: 'thr_parent',
+      parentTurnId: 'turn_parent',
+      prompt: 'Inspect the entry point',
+      toolPolicy: 'inherit',
+      returnFormat: 'evidence',
+      signal: new AbortController().signal
+    })
+
+    expect(result.summary).toBe('Inspection complete.')
+    expect(result.evidence).toEqual(['inspect src/index.ts: completed'])
+  })
+
   it('fails the child run when the child loop cannot produce a completed turn', async () => {
     const executor = createChildAgentExecutor({
       model: model([{ kind: 'error', message: 'model failed', code: 'bad_model' }]),

--- a/kun/tests/delegation-runtime.test.ts
+++ b/kun/tests/delegation-runtime.test.ts
@@ -81,6 +81,80 @@ describe('DelegationRuntime', () => {
     })).rejects.toThrow(/budget/)
   })
 
+  it('enforces per-child token and time budgets', async () => {
+    const externalUsage: unknown[] = []
+    const tokenRuntime = createRuntime({
+      recordExternalUsage: (_threadId, usage) => externalUsage.push(usage),
+      executor: async () => ({
+        summary: 'used too many tokens',
+        usage: { promptTokens: 8, completionTokens: 4, totalTokens: 12 }
+      })
+    })
+    const tokenLimited = await tokenRuntime.runChild({
+      parentThreadId: 'thr_tokens',
+      parentTurnId: 'turn_tokens',
+      prompt: 'bounded task',
+      tokenBudget: 10,
+      signal: new AbortController().signal
+    })
+    expect(tokenLimited).toMatchObject({
+      status: 'failed',
+      tokenBudget: 10,
+      budgetExceeded: 'token',
+      usage: { totalTokens: 12 }
+    })
+    expect(tokenLimited.error).toContain('12 > 10')
+    expect(externalUsage).toHaveLength(1)
+
+    const timeRuntime = createRuntime({
+      executor: async ({ signal }) => new Promise<never>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    const timeLimited = await timeRuntime.runChild({
+      parentThreadId: 'thr_time',
+      parentTurnId: 'turn_time',
+      prompt: 'slow task',
+      timeBudgetMs: 10,
+      signal: new AbortController().signal
+    })
+    expect(timeLimited).toMatchObject({
+      status: 'failed',
+      timeBudgetMs: 10,
+      budgetExceeded: 'time'
+    })
+    expect(timeLimited.error).toContain('10ms')
+  })
+
+  it('validates evidence-return contracts', async () => {
+    const withEvidence = createRuntime({
+      executor: async () => ({ summary: 'done', evidence: ['read src/index.ts', 'ran unit tests'] })
+    })
+    await expect(withEvidence.runChild({
+      parentThreadId: 'thr_evidence',
+      parentTurnId: 'turn_evidence',
+      prompt: 'investigate',
+      returnFormat: 'evidence',
+      signal: new AbortController().signal
+    })).resolves.toMatchObject({
+      status: 'completed',
+      returnFormat: 'evidence',
+      evidence: ['read src/index.ts', 'ran unit tests']
+    })
+
+    const withoutEvidence = createRuntime({ executor: async () => ({ summary: 'done' }) })
+    await expect(withoutEvidence.runChild({
+      parentThreadId: 'thr_missing_evidence',
+      parentTurnId: 'turn_missing_evidence',
+      prompt: 'investigate',
+      returnFormat: 'evidence',
+      signal: new AbortController().signal
+    })).resolves.toMatchObject({
+      status: 'failed',
+      error: 'child contract requires evidence but none was returned'
+    })
+  })
+
   it('executes delegate_task through the normal tool host', async () => {
     const runtime = createRuntime()
     const host = new LocalToolHost({
@@ -107,6 +181,28 @@ describe('DelegationRuntime', () => {
         usage: { totalTokens: 3 }
       })
     }
+  })
+
+  it('rejects invalid delegate_task budgets before starting a child', async () => {
+    const runtime = createRuntime()
+    const host = new LocalToolHost({
+      registry: new CapabilityRegistry(buildDelegationToolProviders(runtime))
+    })
+    const result = await host.execute({
+      callId: 'call_invalid_budget',
+      toolName: 'delegate_task',
+      arguments: { prompt: 'Investigate', tokenBudget: 0 }
+    }, {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      workspace: '/tmp/ws',
+      approvalPolicy: 'auto',
+      abortSignal: new AbortController().signal,
+      awaitApproval: async () => 'allow'
+    })
+
+    expect(result.item).toMatchObject({ kind: 'tool_result', isError: true })
+    expect((await runtime.diagnostics('thr_1')).childRuns).toEqual([])
   })
 
   it('caps concurrency at maxParallel and queues the overflow instead of erroring', async () => {


### PR DESCRIPTION
## Summary
- add per-child token and wall-clock budgets to delegate_task
- support evidence-return contracts backed by actual child tool calls
- persist contract outcomes and count usage even when a child exceeds budget

## Why
The v2 branch had a standalone SubagentContract module that was referenced only by its unit test. Kun already has a production DelegationRuntime, profiles, tool policies, queues, persisted child records, and GUI events. This change integrates the useful contract behavior into that path instead of creating a parallel protocol.

## Changes
- expose tokenBudget, timeBudgetMs, and returnFormat on delegate_task
- abort the child signal when its wall-clock budget expires
- fail completed children whose reported token usage exceeds their budget
- derive bounded evidence entries from persisted child tool calls/results
- require non-empty evidence only when returnFormat=evidence
- include budget/evidence fields in persisted records and tool output
- keep failed-child usage in runtime accounting

## Compatibility
Writable-worktree merge-conflict detection from the experimental module is intentionally excluded: current children share the parent workspace, so claiming isolated patch merge semantics would be incorrect. A merge-tree check confirms this branch auto-merges cleanly with open artifact PR #669 despite both touching child-agent-executor.ts.

## Tests
- npm.cmd --prefix kun test -- delegation-runtime.test.ts child-agent-executor.test.ts (34 passed)
- npm.cmd --prefix kun run typecheck
- npm.cmd --prefix kun run build
- focused ESLint
- git diff --check
- git merge-tree with #669