### PR TITLE
fix(release): restore develop validation checks

### DIFF
--- a/kun/tests/builtin-tools.test.ts
+++ b/kun/tests/builtin-tools.test.ts
@@ -341,7 +341,7 @@ describe('Kun built-in tools', () => {
 
   it('exposes pi-style coding and read-only tool groups', () => {
     expect(buildCodingBuiltinLocalTools().map((tool) => tool.name)).toEqual(['read', 'bash', 'edit', 'write'])
-    expect(buildReadOnlyBuiltinLocalTools().map((tool) => tool.name)).toEqual(['read', 'grep', 'find', 'ls'])
+    expect(buildReadOnlyBuiltinLocalTools().map((tool) => tool.name)).toEqual(['read', 'grep', 'find', 'ls', 'repo_map'])
   })
 
   it('supports pi-style configurable built-in tool factory APIs', async () => {
@@ -352,7 +352,18 @@ describe('Kun built-in tools', () => {
       ls: { defaultLimit: 1 },
       bash: { defaultTimeoutSeconds: 5 }
     })
-    expect(Object.keys(toolRecord).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'lsp', 'read', 'write'])
+    expect(Object.keys(toolRecord).sort()).toEqual([
+      'bash',
+      'edit',
+      'find',
+      'grep',
+      'ls',
+      'lsp',
+      'read',
+      'repo_map',
+      'verify_changes',
+      'write'
+    ])
 
     await writeFile(join(workspace, 'limited.txt'), 'one\ntwo\nthree\n', 'utf8')
     const customHost = new LocalToolHost({ tools: [toolRecord.read, toolRecord.ls] })
@@ -369,13 +380,35 @@ describe('Kun built-in tools', () => {
     expect(defaultGrepLocalToolOperations).toEqual({})
     expect(defaultLsLocalToolOperations.readdir).toBeTypeOf('function')
     expect(createCodingTools().map((tool) => tool.name)).toEqual(['read', 'bash', 'edit', 'write'])
-    expect(createReadOnlyTools().map((tool) => tool.name)).toEqual(['read', 'grep', 'find', 'ls'])
+    expect(createReadOnlyTools().map((tool) => tool.name)).toEqual(['read', 'grep', 'find', 'ls', 'repo_map'])
     expect(createCodingToolDefinitions().map((tool) => tool.name)).toEqual(['read', 'bash', 'edit', 'write'])
-    expect(createReadOnlyToolDefinitions().map((tool) => tool.name)).toEqual(['read', 'grep', 'find', 'ls'])
+    expect(createReadOnlyToolDefinitions().map((tool) => tool.name)).toEqual(['read', 'grep', 'find', 'ls', 'repo_map'])
     const allTools = createAllTools()
     const allDefinitions = createAllToolDefinitions()
-    expect(Object.keys(allTools).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'lsp', 'read', 'write'])
-    expect(Object.keys(allDefinitions).sort()).toEqual(['bash', 'edit', 'find', 'grep', 'ls', 'lsp', 'read', 'write'])
+    expect(Object.keys(allTools).sort()).toEqual([
+      'bash',
+      'edit',
+      'find',
+      'grep',
+      'ls',
+      'lsp',
+      'read',
+      'repo_map',
+      'verify_changes',
+      'write'
+    ])
+    expect(Object.keys(allDefinitions).sort()).toEqual([
+      'bash',
+      'edit',
+      'find',
+      'grep',
+      'ls',
+      'lsp',
+      'read',
+      'repo_map',
+      'verify_changes',
+      'write'
+    ])
     expect(createReadTool).toBe(createReadLocalTool)
     expect(createReadToolDefinition).toBe(createReadLocalTool)
     expect(createWriteTool).toBeTypeOf('function')

--- a/kun/tests/child-agent-executor.test.ts
+++ b/kun/tests/child-agent-executor.test.ts
@@ -187,7 +187,7 @@ describe('child agent executor', () => {
     })
 
     const toolNames = (seen[0]?.tools ?? []).map((tool) => tool.name).sort()
-    expect(toolNames).toEqual(['find', 'grep', 'ls', 'read'])
+    expect(toolNames).toEqual(['find', 'grep', 'ls', 'read', 'repo_map'])
     expect(seen[0]?.history?.[0]).toMatchObject({
       kind: 'user_message',
       text: 'Read-only review.\n\nInvestigate the bug'

--- a/kun/tests/create-plan-tool.test.ts
+++ b/kun/tests/create-plan-tool.test.ts
@@ -92,6 +92,7 @@ describe('create_plan tool: advertisement', () => {
       'grep',
       'find',
       'ls',
+      'repo_map',
       'user_input',
       'request_user_input',
       CREATE_PLAN_TOOL_NAME
@@ -104,7 +105,7 @@ describe('create_plan tool: advertisement', () => {
     const tools = await host.listTools(buildContext({ threadMode: 'plan' }))
     const names = tools.map((tool) => tool.name)
 
-    expect(names).toEqual(['read', 'grep', 'find', 'ls', CREATE_PLAN_TOOL_NAME])
+    expect(names).toEqual(['read', 'grep', 'find', 'ls', 'repo_map', CREATE_PLAN_TOOL_NAME])
   })
 
   it('keeps the normal agent-mode default tool advertisement unchanged', async () => {

--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -27,6 +27,7 @@ vi.mock('electron', () => ({
 }))
 
 let tempRoot: string | null = null
+let testKunPort = 18899
 
 function createSettings(binaryPath: string): AppSettingsV1 {
   return {
@@ -38,7 +39,7 @@ function createSettings(binaryPath: string): AppSettingsV1 {
     provider: defaultModelProviderSettings(),
     agents: {
       kun: {
-        ...defaultKunRuntimeSettings(18899),
+        ...defaultKunRuntimeSettings(testKunPort),
         binaryPath,
         autoStart: true
       }
@@ -96,8 +97,24 @@ function canBindTestPort(port: number): Promise<boolean> {
   })
 }
 
-beforeEach(() => {
+function allocateTestPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.unref()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      server.close(() => {
+        if (address && typeof address === 'object') resolve(address.port)
+        else reject(new Error('failed to allocate a test port'))
+      })
+    })
+  })
+}
+
+beforeEach(async () => {
   tempRoot = mkdtempSync(join(tmpdir(), 'kun-process-'))
+  testKunPort = await allocateTestPort()
   configureLogger({ dir: tempRoot, enabled: true, retentionDays: 7 })
 })
 
@@ -117,7 +134,7 @@ describe('startKunChild', () => {
       'ready-child.js',
       [
         "const http = require('node:http')",
-        "const port = 18899",
+        `const port = ${testKunPort}`,
         "const server = http.createServer((req, res) => {",
         "  res.setHeader('content-type', 'application/json')",
         "  res.end(JSON.stringify({ service: 'kun', mode: 'serve', status: 'ok' }))",
@@ -136,7 +153,7 @@ describe('startKunChild', () => {
     await module.stopKunChildAndWait()
     const logText = await readKunLog()
     expect(logText).toContain('KUN_READY')
-    expect(logText).toContain('ready marker received on port 18899')
+    expect(logText).toContain(`ready marker received on port ${testKunPort}`)
   })
 
   it('does not settle on the ready marker until the /health endpoint responds', async () => {
@@ -148,7 +165,7 @@ describe('startKunChild', () => {
         "const http = require('node:http')",
         "const { existsSync } = require('node:fs')",
         `const healthSignalPath = ${JSON.stringify(healthSignalPath)}`,
-        "const port = 18899",
+        `const port = ${testKunPort}`,
         // Emit the ready marker right away but serve no /health yet: the
         // marker alone must NOT be enough to settle the launch.
         "process.stdout.write('KUN_READY ' + JSON.stringify({ service: 'kun', mode: 'serve', port }) + '\\n')",
@@ -195,7 +212,7 @@ describe('startKunChild', () => {
         "const http = require('node:http')",
         "const { existsSync } = require('node:fs')",
         `const readySignalPath = ${JSON.stringify(readySignalPath)}`,
-        "const port = 18899",
+        `const port = ${testKunPort}`,
         'let sentReady = false',
         // Only stand up the /health server once the signal exists so the
         // parallel health probe cannot settle the launch before then.
@@ -306,7 +323,7 @@ describe('waitForKunStartupSettled', () => {
         "const http = require('node:http')",
         "const { existsSync } = require('node:fs')",
         `const readySignalPath = ${JSON.stringify(readySignalPath)}`,
-        "const port = 18899",
+        `const port = ${testKunPort}`,
         'let sentReady = false',
         // Only stand up the /health server once the signal exists so the
         // parallel health probe cannot settle the launch before then.

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -542,11 +542,10 @@ function MessageTurn({
   )
   const onlyCompactionProcess = processBlocks.length > 0 && workProcessBlocks.length === 0
   const hasProcessError = workProcessBlocks.some(processBlockHasError)
-  // Only force the work process open (and lock it open) while the turn is still
-  // running. Once the turn completes — even if a tool call failed mid-turn — the
-  // panel should auto-collapse like a normal completed turn and stay user-toggleable.
+  // Error details should stay visible after completion so provider/runtime
+  // failures do not disappear into a collapsed work summary.
   const forceExpandForError = isProcessing && hasProcessError
-  const workExpanded = forceExpandForError || (workExpandedOverride ?? isProcessing)
+  const workExpanded = forceExpandForError || (workExpandedOverride ?? (isProcessing || hasProcessError))
   const reviewBlocks = useMemo(
     () => turn.blocks.filter((block) => block.kind === 'review'),
     [turn.blocks]

--- a/src/renderer/src/components/chat/message-timeline-process.tsx
+++ b/src/renderer/src/components/chat/message-timeline-process.tsx
@@ -215,10 +215,6 @@ export function ProcessSectionRow({
   const { t } = useTranslation('common')
   const [userExpanded, setUserExpanded] = useState<boolean | null>(null)
 
-  if (section.kind === 'subagent') {
-    return <SubagentGroup blocks={section.blocks} />
-  }
-
   const assistantBlocks =
     section.kind === 'output'
       ? section.blocks.filter(
@@ -245,11 +241,16 @@ export function ProcessSectionRow({
   const reasoningText = section.kind === 'reasoning' ? getReasoningSectionText(section) : ''
   const canToggleSection = hasDetails && !forceExpanded
   const showActiveError = active && hasError
+  const shouldDeferDetails = section.kind !== 'subagent'
   const { ref: deferredDetailRef, shouldRender: shouldRenderDetail } = useDeferredRender<HTMLDivElement>({
-    enabled: expanded,
-    immediate: active || section.kind === 'execution',
+    enabled: shouldDeferDetails && expanded,
+    immediate: shouldDeferDetails && (active || section.kind === 'execution'),
     root: viewportRef
   })
+
+  if (section.kind === 'subagent') {
+    return <SubagentGroup blocks={section.blocks} />
+  }
 
   if (section.kind === 'execution' && section.blocks.length === 1) {
     const [block] = section.blocks
@@ -384,8 +385,8 @@ function ProcessStackRows({
         const autoOpenPending = processBlockIsAutoOpenPending(block, processing) || isPendingApproval(block)
         const errorTone = processBlockErrorTone(block)
         const isError = errorTone !== null
-        // Tool-call errors stay collapsed (red header only); other error blocks still auto-open.
-        const defaultOpen = isError && block.kind !== 'tool'
+        // Error details are visible by default but remain collapsible.
+        const defaultOpen = isError
         const forceOpen = autoOpenPending || autoOpenRequestInput
         const userClosed = closedBlockIds.has(block.id)
         const userOpened = openBlockId === block.id
@@ -500,8 +501,8 @@ function ProcessEntryRow({
   const errorTone = processBlockErrorTone(block)
   const isError = errorTone !== null
   const forceOpen = isAutoOpenPending || isAssistantProcessText || isStreamingAssistant
-  // Tool-call errors stay collapsed (red header only); other error blocks still auto-open.
-  const defaultOpen = isError && block.kind !== 'tool'
+  // Error details are visible by default but remain collapsible.
+  const defaultOpen = isError
   const open =
     canExpand &&
     (forceOpen || (userOpen ?? defaultOpen))


### PR DESCRIPTION
Summary
- Update Kun tool expectation tests for repo_map and verify_changes after recent tool surface changes.
- Make Kun process startup tests allocate an ephemeral port instead of assuming 18899 is free.
- Keep failed tool/runtime details visible by default and fix the hook ordering lint issue in process sections.

Tests
- npm run typecheck
- npm --prefix kun run typecheck
- npm run lint
- npm test
- npm --prefix kun test
- npm run build
- git diff --check