### PR TITLE
feat(tools): journal operation outcomes

### DIFF
--- a/kun/src/adapters/tool/local-tool-host.operation-journal.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.operation-journal.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FileOperationJournal } from '../../reliability/operation-journal.js'
+import type { ToolHostContext } from '../../ports/tool-host.js'
+import { LocalToolHost } from './local-tool-host.js'
+
+describe('LocalToolHost operation journal', () => {
+  let rootDir = ''
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), 'kun-tool-journal-'))
+  })
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true })
+  })
+
+  it('reuses the completed result for the same call id without repeating side effects', async () => {
+    const journal = new FileOperationJournal(rootDir)
+    let executions = 0
+    const host = new LocalToolHost({
+      operationJournal: journal,
+      tools: [LocalToolHost.defineTool({
+        name: 'deploy',
+        description: 'deploy once',
+        inputSchema: { type: 'object' },
+        policy: 'auto',
+        execute: async () => ({ output: { deployment: ++executions } })
+      })]
+    })
+    const call = { callId: 'call_1', toolName: 'deploy', arguments: { target: 'production' } }
+
+    const first = await host.execute(call, context('auto'))
+    const replay = await host.execute(call, context('auto'))
+
+    expect(executions).toBe(1)
+    expect(first.item).toMatchObject({ kind: 'tool_result', output: { deployment: 1 } })
+    expect(replay.item).toMatchObject({ kind: 'tool_result', output: { deployment: 1 } })
+  })
+
+  it('blocks an uncertain non-idempotent replay until explicit approval', async () => {
+    const journal = new FileOperationJournal(rootDir)
+    const identity = {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      callId: 'call_1',
+      toolName: 'deploy',
+      arguments: { target: 'production' },
+      replaySafe: false
+    }
+    await journal.start(identity)
+    let executions = 0
+    const host = new LocalToolHost({
+      operationJournal: journal,
+      tools: [LocalToolHost.defineTool({
+        name: 'deploy',
+        description: 'deploy once',
+        inputSchema: { type: 'object' },
+        policy: 'auto',
+        execute: async () => ({ output: { deployment: ++executions } })
+      })]
+    })
+    const call = { callId: 'call_1', toolName: 'deploy', arguments: { target: 'production' } }
+
+    const blocked = await host.execute(call, context('auto'))
+    expect(blocked.item).toMatchObject({
+      kind: 'tool_result',
+      isError: true,
+      output: { code: 'operation_outcome_unknown' }
+    })
+    expect(executions).toBe(0)
+
+    const awaitApproval = vi.fn(async () => 'allow' as const)
+    const approved = await host.execute(call, context('on-request', awaitApproval))
+    expect(awaitApproval).toHaveBeenCalledWith(expect.objectContaining({
+      summary: expect.stringContaining('previous execution outcome is unknown')
+    }))
+    expect(approved.item).toMatchObject({ kind: 'tool_result', output: { deployment: 1 } })
+    expect(executions).toBe(1)
+  })
+})
+
+function context(
+  approvalPolicy: ToolHostContext['approvalPolicy'],
+  awaitApproval = vi.fn(async () => 'allow' as const)
+): ToolHostContext {
+  return {
+    threadId: 'thr_1',
+    turnId: 'turn_1',
+    workspace: '/tmp/workspace',
+    approvalPolicy,
+    sandboxMode: 'danger-full-access',
+    abortSignal: new AbortController().signal,
+    awaitApproval
+  }
+}

--- a/kun/src/adapters/tool/local-tool-host.ts
+++ b/kun/src/adapters/tool/local-tool-host.ts
@@ -27,6 +27,11 @@ import {
   type ReadTrackerOptions
 } from './read-tracker.js'
 import { sandboxBlockForTool, type SandboxBlock } from './sandbox-policy.js'
+import type {
+  OperationIdentity,
+  OperationInspection,
+  OperationJournal
+} from '../../reliability/operation-journal.js'
 
 /**
  * A single registered tool. Tools are pure functions that observe the
@@ -43,6 +48,8 @@ export type LocalTool = {
    * prompts unless the call is in an allow-list.
    */
   policy: 'auto' | 'on-request' | 'suggest' | 'never' | 'untrusted'
+  /** True only when repeating the same interrupted call cannot duplicate side effects. */
+  replaySafe?: boolean
   /**
    * Optional gating predicate. When present, the tool is only listed
    * and only executed when `shouldAdvertise` returns true for the
@@ -66,6 +73,8 @@ export type LocalToolHostOptions = {
   hooks?: readonly ResolvedHook[]
   /** Runtime read-before-edit guard. Disabled by default for direct unit use. */
   readTracker?: boolean | ReadTrackerOptions
+  /** Durable tool-call journal used for crash recovery and duplicate-call reuse. */
+  operationJournal?: OperationJournal
 }
 
 /**
@@ -88,12 +97,14 @@ export class LocalToolHost implements ToolHost {
   private readonly allowList: Set<string>
   private readonly hooks: readonly ResolvedHook[]
   private readonly readTracker: ReadTracker
+  private readonly operationJournal?: OperationJournal
 
   constructor(options: LocalToolHostOptions) {
     this.registry = options.registry ?? CapabilityRegistry.fromLocalTools(options.tools ?? [])
     this.allowList = new Set(options.allowList ?? [])
     this.hooks = options.hooks ?? []
     this.readTracker = new ReadTracker(normalizeReadTrackerOptions(options.readTracker))
+    this.operationJournal = options.operationJournal
   }
 
   listTools(context?: ToolHostContext) {
@@ -162,7 +173,73 @@ export class LocalToolHost implements ToolHost {
         approved: false
       }
     }
-    const needsApproval = !preHooks.autoApproved && this.requiresApproval(tool, activeCall, context)
+    const operation: OperationIdentity = {
+      threadId: context.threadId,
+      turnId: context.turnId,
+      callId: activeCall.callId,
+      toolName: activeCall.toolName,
+      arguments: activeCall.arguments,
+      replaySafe: tool.replaySafe === true
+    }
+    let operationInspection: OperationInspection | undefined
+    if (this.operationJournal) {
+      try {
+        operationInspection = await this.operationJournal.inspect(operation)
+      } catch (error) {
+        return {
+          item: this.errorToolResult(
+            context,
+            activeCall,
+            tool,
+            `operation journal is unavailable: ${hookErrorMessage(error)}`,
+            'operation_journal_failed'
+          ),
+          approved: false
+        }
+      }
+      if (operationInspection.kind === 'collision') {
+        return {
+          item: this.errorToolResult(
+            context,
+            activeCall,
+            tool,
+            'tool call id was already journaled with different arguments; refusing ambiguous replay',
+            'operation_identity_collision'
+          ),
+          approved: false
+        }
+      }
+      if (operationInspection.kind === 'reuse') {
+        return {
+          item: makeToolResultItem({
+            id: `item_${activeCall.callId}`,
+            turnId: context.turnId,
+            threadId: context.threadId,
+            callId: activeCall.callId,
+            toolName: activeCall.toolName,
+            toolKind: activeCall.toolKind ?? tool.toolKind,
+            output: operationInspection.result.output,
+            isError: operationInspection.result.isError
+          }),
+          approved: true
+        }
+      }
+    }
+    const uncertainReplay = operationInspection?.kind === 'uncertain'
+    if (uncertainReplay && (context.approvalPolicy === 'auto' || context.approvalPolicy === 'never')) {
+      return {
+        item: this.errorToolResult(
+          context,
+          activeCall,
+          tool,
+          'the previous non-idempotent execution has an unknown outcome; explicit user approval is required before retrying',
+          'operation_outcome_unknown'
+        ),
+        approved: false
+      }
+    }
+    const needsApproval = uncertainReplay ||
+      (!preHooks.autoApproved && this.requiresApproval(tool, activeCall, context))
     if (needsApproval) {
       const approvalId = `appr_${activeCall.callId}`
       const approval: ApprovalRequest = createApprovalRequest({
@@ -170,7 +247,9 @@ export class LocalToolHost implements ToolHost {
         threadId: context.threadId,
         turnId: context.turnId,
         toolName: activeCall.toolName,
-        summary: this.buildApprovalSummary(activeCall)
+        summary: uncertainReplay
+          ? `Retry ${activeCall.toolName}: the previous execution outcome is unknown and may already have applied side effects.`
+          : this.buildApprovalSummary(activeCall)
       })
       const decision = await context.awaitApproval(approval)
       if (decision !== 'allow') {
@@ -187,6 +266,23 @@ export class LocalToolHost implements ToolHost {
     }
     if (context.abortSignal.aborted) {
       throw new Error('tool call aborted while waiting for approval')
+    }
+    let operationId: string | undefined
+    if (this.operationJournal) {
+      try {
+        operationId = (await this.operationJournal.start(operation)).operationId
+      } catch (error) {
+        return {
+          item: this.errorToolResult(
+            context,
+            activeCall,
+            tool,
+            `failed to persist operation start: ${hookErrorMessage(error)}`,
+            'operation_journal_failed'
+          ),
+          approved: needsApproval
+        }
+      }
     }
     let result: Awaited<ReturnType<LocalTool['execute']>>
     try {
@@ -211,6 +307,9 @@ export class LocalToolHost implements ToolHost {
       // whole turn. Only abort keeps propagating.
       if (context.abortSignal.aborted) throw error
       const message = error instanceof Error ? error.message : String(error)
+      if (operationId && this.operationJournal) {
+        await this.operationJournal.fail(operationId, message).catch(() => undefined)
+      }
       return {
         item: this.errorToolResult(context, activeCall, tool, message, 'tool_execution_failed'),
         approved: true
@@ -224,6 +323,9 @@ export class LocalToolHost implements ToolHost {
         result
       })
     } catch (error) {
+      if (operationId && this.operationJournal) {
+        await this.operationJournal.fail(operationId, hookErrorMessage(error)).catch(() => undefined)
+      }
       return {
         item: this.errorToolResult(context, activeCall, tool, hookErrorMessage(error), 'hook_failed'),
         approved: true
@@ -239,6 +341,22 @@ export class LocalToolHost implements ToolHost {
       isError
     })
     if (!isError) output = await offloadLargeToolOutput(output, activeCall.toolName, context)
+    if (operationId && this.operationJournal) {
+      try {
+        await this.operationJournal.complete(operationId, { output, isError })
+      } catch (error) {
+        return {
+          item: this.errorToolResult(
+            context,
+            activeCall,
+            tool,
+            `tool finished, but its outcome could not be journaled; do not retry automatically: ${hookErrorMessage(error)}`,
+            'operation_journal_failed'
+          ),
+          approved: needsApproval
+        }
+      }
+    }
     const item = makeToolResultItem({
       id: `item_${activeCall.callId}`,
       turnId: context.turnId,
@@ -336,6 +454,7 @@ export class LocalToolHost implements ToolHost {
       inputSchema: tool.inputSchema,
       toolKind: tool.toolKind ?? 'tool_call',
       execute: tool.execute,
+      ...(tool.replaySafe !== undefined ? { replaySafe: tool.replaySafe } : {}),
       ...(tool.shouldAdvertise ? { shouldAdvertise: tool.shouldAdvertise } : {})
     }
   }

--- a/kun/src/reliability/operation-journal.test.ts
+++ b/kun/src/reliability/operation-journal.test.ts
@@ -1,0 +1,82 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  FileOperationJournal,
+  hashOperationInput,
+  operationIdFor,
+  type OperationIdentity
+} from './operation-journal.js'
+
+describe('FileOperationJournal', () => {
+  let rootDir = ''
+  let now = '2026-07-01T00:00:00.000Z'
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), 'kun-operation-journal-'))
+    now = '2026-07-01T00:00:00.000Z'
+  })
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true })
+  })
+
+  it('reuses only a completed result from the same call identity', async () => {
+    const journal = new FileOperationJournal(rootDir, () => now)
+    const input = operation()
+    expect(await journal.inspect(input)).toEqual({
+      kind: 'new',
+      operationId: operationIdFor(input.threadId, input.callId)
+    })
+    const started = await journal.start(input)
+    now = '2026-07-01T00:00:01.000Z'
+    await journal.complete(started.operationId, { output: { deployed: true } })
+
+    expect(await journal.inspect(input)).toMatchObject({
+      kind: 'reuse',
+      result: { output: { deployed: true } }
+    })
+    expect(await journal.inspect({ ...input, arguments: { target: 'other' } })).toMatchObject({
+      kind: 'collision'
+    })
+  })
+
+  it('requires confirmation for uncertain mutating calls but permits declared safe replay', async () => {
+    const journal = new FileOperationJournal(rootDir, () => now)
+    const input = operation()
+    await journal.start(input)
+
+    expect(await journal.inspect(input)).toMatchObject({ kind: 'uncertain' })
+    expect(await journal.inspect({ ...input, replaySafe: true })).toMatchObject({ kind: 'replay-safe' })
+  })
+
+  it('does not persist oversized results for implicit replay', async () => {
+    const journal = new FileOperationJournal(rootDir, () => now)
+    const input = operation()
+    const started = await journal.start(input)
+    await journal.complete(started.operationId, { output: 'x'.repeat(70 * 1024) })
+
+    expect(await journal.inspect(input)).toMatchObject({
+      kind: 'uncertain',
+      record: { status: 'completed', resultStored: false }
+    })
+  })
+
+  it('hashes equivalent argument objects canonically', () => {
+    expect(hashOperationInput('deploy', { b: 2, a: { y: 2, x: 1 } })).toBe(
+      hashOperationInput('deploy', { a: { x: 1, y: 2 }, b: 2 })
+    )
+  })
+})
+
+function operation(): OperationIdentity {
+  return {
+    threadId: 'thr_1',
+    turnId: 'turn_1',
+    callId: 'call_1',
+    toolName: 'deploy',
+    arguments: { target: 'production' },
+    replaySafe: false
+  }
+}

--- a/kun/src/reliability/operation-journal.ts
+++ b/kun/src/reliability/operation-journal.ts
@@ -1,0 +1,182 @@
+import { createHash } from 'node:crypto'
+import { mkdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { z } from 'zod'
+import { atomicWriteFile } from '../adapters/file/atomic-write.js'
+
+const MAX_STORED_RESULT_BYTES = 64 * 1024
+
+const OperationResult = z.object({
+  output: z.unknown(),
+  isError: z.boolean().optional()
+}).strict()
+
+export const OperationRecord = z.object({
+  operationId: z.string().min(1),
+  threadId: z.string().min(1),
+  turnId: z.string().min(1),
+  callId: z.string().min(1),
+  toolName: z.string().min(1),
+  inputHash: z.string().min(1),
+  replaySafe: z.boolean(),
+  status: z.enum(['started', 'completed', 'failed']),
+  attempt: z.number().int().positive(),
+  startedAt: z.string(),
+  finishedAt: z.string().optional(),
+  resultStored: z.boolean().default(false),
+  result: OperationResult.optional(),
+  error: z.string().optional()
+}).strict()
+export type OperationRecord = z.infer<typeof OperationRecord>
+
+export type OperationIdentity = {
+  threadId: string
+  turnId: string
+  callId: string
+  toolName: string
+  arguments: Record<string, unknown>
+  replaySafe: boolean
+}
+
+export type OperationInspection =
+  | { kind: 'new'; operationId: string }
+  | { kind: 'reuse'; record: OperationRecord; result: z.infer<typeof OperationResult> }
+  | { kind: 'replay-safe'; record: OperationRecord }
+  | { kind: 'uncertain'; record: OperationRecord }
+  | { kind: 'collision'; record: OperationRecord }
+
+export interface OperationJournal {
+  inspect(input: OperationIdentity): Promise<OperationInspection>
+  start(input: OperationIdentity): Promise<OperationRecord>
+  complete(operationId: string, result: { output: unknown; isError?: boolean }): Promise<OperationRecord>
+  fail(operationId: string, error: string): Promise<OperationRecord>
+}
+
+export class FileOperationJournal implements OperationJournal {
+  constructor(
+    private readonly rootDir: string,
+    private readonly nowIso: () => string = () => new Date().toISOString()
+  ) {}
+
+  async inspect(input: OperationIdentity): Promise<OperationInspection> {
+    const operationId = operationIdFor(input.threadId, input.callId)
+    const record = await this.read(operationId)
+    if (!record) return { kind: 'new', operationId }
+    if (record.toolName !== input.toolName || record.inputHash !== hashOperationInput(input.toolName, input.arguments)) {
+      return { kind: 'collision', record }
+    }
+    if (record.status === 'completed' && record.resultStored && record.result) {
+      return { kind: 'reuse', record, result: record.result }
+    }
+    if (input.replaySafe) return { kind: 'replay-safe', record }
+    return { kind: 'uncertain', record }
+  }
+
+  async start(input: OperationIdentity): Promise<OperationRecord> {
+    const operationId = operationIdFor(input.threadId, input.callId)
+    const existing = await this.read(operationId)
+    const record = OperationRecord.parse({
+      operationId,
+      threadId: input.threadId,
+      turnId: input.turnId,
+      callId: input.callId,
+      toolName: input.toolName,
+      inputHash: hashOperationInput(input.toolName, input.arguments),
+      replaySafe: input.replaySafe,
+      status: 'started',
+      attempt: (existing?.attempt ?? 0) + 1,
+      startedAt: this.nowIso(),
+      resultStored: false
+    })
+    await this.write(record)
+    return record
+  }
+
+  async complete(
+    operationId: string,
+    result: { output: unknown; isError?: boolean }
+  ): Promise<OperationRecord> {
+    const current = await this.mustRead(operationId)
+    const stored = storableResult(result)
+    const record = OperationRecord.parse({
+      ...current,
+      status: 'completed',
+      finishedAt: this.nowIso(),
+      resultStored: stored !== undefined,
+      result: stored,
+      error: undefined
+    })
+    await this.write(record)
+    return record
+  }
+
+  async fail(operationId: string, error: string): Promise<OperationRecord> {
+    const current = await this.mustRead(operationId)
+    const record = OperationRecord.parse({
+      ...current,
+      status: 'failed',
+      finishedAt: this.nowIso(),
+      resultStored: false,
+      result: undefined,
+      error
+    })
+    await this.write(record)
+    return record
+  }
+
+  private async read(operationId: string): Promise<OperationRecord | null> {
+    try {
+      return OperationRecord.parse(JSON.parse(await readFile(this.path(operationId), 'utf8')))
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+      throw error
+    }
+  }
+
+  private async mustRead(operationId: string): Promise<OperationRecord> {
+    const record = await this.read(operationId)
+    if (!record) throw new Error(`operation journal record not found: ${operationId}`)
+    return record
+  }
+
+  private async write(record: OperationRecord): Promise<void> {
+    await mkdir(this.rootDir, { recursive: true })
+    await atomicWriteFile(this.path(record.operationId), JSON.stringify(record, null, 2))
+  }
+
+  private path(operationId: string): string {
+    const key = createHash('sha256').update(operationId).digest('hex')
+    return join(this.rootDir, `${key}.json`)
+  }
+}
+
+export function operationIdFor(threadId: string, callId: string): string {
+  return `op_${createHash('sha256').update(`${threadId}\n${callId}`).digest('hex').slice(0, 32)}`
+}
+
+export function hashOperationInput(toolName: string, input: unknown): string {
+  return createHash('sha256')
+    .update(`${toolName}\n${JSON.stringify(sortKeys(input))}`)
+    .digest('hex')
+    .slice(0, 32)
+}
+
+function storableResult(result: { output: unknown; isError?: boolean }): z.infer<typeof OperationResult> | undefined {
+  try {
+    const json = JSON.stringify(result)
+    if (Buffer.byteLength(json, 'utf8') > MAX_STORED_RESULT_BYTES) return undefined
+    return OperationResult.parse(JSON.parse(json))
+  } catch {
+    return undefined
+  }
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => [key, sortKeys((value as Record<string, unknown>)[key])]))
+  }
+  return value
+}

--- a/kun/src/server/runtime-factory.ts
+++ b/kun/src/server/runtime-factory.ts
@@ -86,6 +86,7 @@ import { stopBashSessionById, createBashLocalTool } from '../adapters/tool/built
 import { createBackgroundShellTool } from '../adapters/tool/background-shell-tool.js'
 import { createSecretEncryptor, defaultSecretCommandRunner } from '../security/secret-store.js'
 import type { LocalTool } from '../adapters/tool/local-tool-host.js'
+import { FileOperationJournal } from '../reliability/operation-journal.js'
 
 export type KunServeRuntimeOptions = {
   host: string
@@ -310,6 +311,7 @@ export async function createKunServeRuntime(
         nowIso
       })
     : undefined
+  const operationJournal = new FileOperationJournal(join(options.dataDir, 'operation-journal'), nowIso)
   const imageGenProviders = buildImageGenToolProviders(options.capabilities?.imageGen, {
     attachmentStore,
     nowIso
@@ -357,6 +359,7 @@ export async function createKunServeRuntime(
   const childToolHost = new LocalToolHost({
     registry: childRegistry,
     readTracker: true,
+    operationJournal,
     ...(resolvedHooks.length ? { hooks: resolvedHooks } : {})
   })
   const delegationRuntime = options.capabilities?.subagents.enabled
@@ -478,6 +481,7 @@ export async function createKunServeRuntime(
   const toolHost = new LocalToolHost({
     registry,
     readTracker: true,
+    operationJournal,
     ...(resolvedHooks.length ? { hooks: resolvedHooks } : {})
   })
   // Keep retrying MCP servers that lost the fast startup connect race so a slow


### PR DESCRIPTION
﻿## Summary
- Add a durable operation journal for local tool calls so crash/retry handling has an explicit outcome record.
- Reuse completed same-call results only for the same thread/call identity when the stored result is small enough.
- Require explicit approval before retrying unknown non-idempotent outcomes; replay-safe tools can proceed.

## Changes
- Adds FileOperationJournal with stable identity based on threadId + callId and canonical input hashing.
- Wires the journal into LocalToolHost before execution and records completed/failed outcomes after post-hooks and large-output offload.
- Blocks ambiguous same-call collisions and unsafe automatic retries after interrupted/unknown non-idempotent executions.
- Adds focused unit coverage for journal inspection/reuse/collisions and LocalToolHost retry behavior.

## Notes
This is the rewritten version of the isolated v2 operation-journal module. It deliberately avoids deduping by tool name + arguments, because repeating the same side-effecting command may be intentional. Only the same call identity can reuse a stored result.

## Tests
- `npm.cmd --prefix kun test -- operation-journal.test.ts local-tool-host.operation-journal.test.ts local-tool-host.test.ts runtime-factory.test.ts`
- `npm.cmd --prefix kun run typecheck`
- focused `eslint`
- `npm.cmd --prefix kun run build`
- `git diff --check`

