### PR TITLE
feat(checkpoint): add restore manifests

### DIFF
--- a/src/main/ipc/app-ipc-schemas.ts
+++ b/src/main/ipc/app-ipc-schemas.ts
@@ -1443,14 +1443,29 @@ export const gitBranchPayloadSchema = z
 export const gitCheckpointCreatePayloadSchema = z
   .object({
     workspaceRoot: workspaceRootSchema,
-    threadId: trimmedString(MAX_ID_LENGTH)
+    threadId: trimmedString(MAX_ID_LENGTH),
+    turnId: trimmedString(MAX_ID_LENGTH).optional(),
+    userMessageItemId: trimmedString(MAX_ID_LENGTH).optional()
   })
   .strict()
 
 export const gitCheckpointRestorePayloadSchema = z
   .object({
     checkpointId: trimmedString(MAX_ID_LENGTH * 4),
-    allowPartialRestore: z.boolean().optional()
+    allowPartialRestore: z.boolean().optional(),
+    expectedThreadId: trimmedString(MAX_ID_LENGTH).optional(),
+    expectedWorkspaceRoot: workspaceRootSchema.optional(),
+    expectedTurnId: trimmedString(MAX_ID_LENGTH).optional(),
+    expectedUserMessageItemId: trimmedString(MAX_ID_LENGTH).optional()
+  })
+  .strict()
+
+export const gitCheckpointManifestUpdatePayloadSchema = z
+  .object({
+    checkpointId: trimmedString(MAX_ID_LENGTH * 4),
+    threadId: trimmedString(MAX_ID_LENGTH),
+    turnId: trimmedString(MAX_ID_LENGTH),
+    userMessageItemId: trimmedString(MAX_ID_LENGTH)
   })
   .strict()
 

--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -44,6 +44,7 @@ import {
   defaultPathSchema,
   gitBranchPayloadSchema,
   gitCheckpointCreatePayloadSchema,
+  gitCheckpointManifestUpdatePayloadSchema,
   gitCheckpointRestorePayloadSchema,
   gitWorktreeRemoveSchema,
   guiUpdateChannelSchema,
@@ -127,7 +128,7 @@ import {
   removeGitBranchWorktree,
   switchGitBranch
 } from '../services/git-service'
-import { createGitCheckpoint, restoreGitCheckpoint, type GitCheckpointStorageOptions } from '../services/git-checkpoint-service'
+import { createGitCheckpoint, restoreGitCheckpoint, updateGitCheckpointManifest, type GitCheckpointStorageOptions } from '../services/git-checkpoint-service'
 import {
   abortMerge,
   abortRebase,
@@ -1086,6 +1087,24 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
       dataDir: await resolveKunThreadsDataDir(),
       workspaceRoot: request.workspaceRoot,
       threadId: request.threadId,
+      ...(request.turnId ? { turnId: request.turnId } : {}),
+      ...(request.userMessageItemId ? { userMessageItemId: request.userMessageItemId } : {}),
+      storage: resolveCheckpointStorageOptions(settings.checkpointCleanup)
+    })
+  })
+  ipcMain.handle('git:checkpoint:update-manifest', async (_, payload: unknown) => {
+    const request = parseIpcPayload(
+      'git:checkpoint:update-manifest',
+      gitCheckpointManifestUpdatePayloadSchema,
+      payload
+    )
+    const settings = await store.load()
+    return updateGitCheckpointManifest({
+      dataDir: await resolveKunThreadsDataDir(),
+      checkpointId: request.checkpointId,
+      threadId: request.threadId,
+      turnId: request.turnId,
+      userMessageItemId: request.userMessageItemId,
       storage: resolveCheckpointStorageOptions(settings.checkpointCleanup)
     })
   })
@@ -1096,6 +1115,10 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
       dataDir: await resolveKunThreadsDataDir(),
       checkpointId: request.checkpointId,
       ...(request.allowPartialRestore ? { allowPartialRestore: true } : {}),
+      ...(request.expectedThreadId ? { expectedThreadId: request.expectedThreadId } : {}),
+      ...(request.expectedWorkspaceRoot ? { expectedWorkspaceRoot: request.expectedWorkspaceRoot } : {}),
+      ...(request.expectedTurnId ? { expectedTurnId: request.expectedTurnId } : {}),
+      ...(request.expectedUserMessageItemId ? { expectedUserMessageItemId: request.expectedUserMessageItemId } : {}),
       storage: resolveCheckpointStorageOptions(settings.checkpointCleanup),
       // Bridge the main-process runtimeRequest into the shape restoreGitCheckpoint
       // expects ((path, {method, body}) => {ok,status,body}). On a transport-level

--- a/src/main/services/git-checkpoint-service.test.ts
+++ b/src/main/services/git-checkpoint-service.test.ts
@@ -8,6 +8,7 @@ import {
   cleanupUnusedGitCheckpointsIfDue,
   createGitCheckpoint,
   restoreGitCheckpoint,
+  updateGitCheckpointManifest,
   testResolvePathWithinRepository
 } from './git-checkpoint-service'
 
@@ -48,9 +49,21 @@ describe('git checkpoint service', () => {
 
     const checkpointDir = join(dataDir, 'git-checkpoints', checkpoint.checkpointId)
     const metadata = JSON.parse(await readFile(join(checkpointDir, 'metadata.json'), 'utf-8')) as {
+      version?: number
+      threadId?: string
+      workspaceRoot?: string
       checkpointRef?: string
     }
+    expect(metadata.version).toBe(1)
+    expect(metadata.threadId).toBe('thr_1')
+    expect(normalize(metadata.workspaceRoot ?? '')).toBe(normalize(repoRoot))
     expect(metadata.checkpointRef).toBeUndefined()
+    expect(checkpoint.manifest.version).toBe(1)
+    expect(checkpoint.manifest.checkpointId).toBe(checkpoint.checkpointId)
+    expect(checkpoint.manifest.threadId).toBe('thr_1')
+    expect(normalize(checkpoint.manifest.workspaceRoot)).toBe(normalize(repoRoot))
+    expect(normalize(checkpoint.manifest.repositoryRoot)).toBe(normalize(repoRoot))
+    expect(checkpoint.manifest.completeness).toBe('complete')
     await expect(stat(join(checkpointDir, 'head.bundle'))).resolves.toBeTruthy()
 
     const refs = execFileSync('git', ['-C', repoRoot, 'show-ref'], { encoding: 'utf-8' })
@@ -91,6 +104,86 @@ describe('git checkpoint service', () => {
       .split('\n')
       .filter(Boolean)
       .sort()).toEqual([' M tracked.txt', 'M  staged.txt', '?? untracked.txt'].sort())
+  })
+
+  it('refuses coordinated restore when the active thread or workspace does not match the manifest', async () => {
+    const checkpoint = await createGitCheckpoint({
+      dataDir,
+      workspaceRoot: repoRoot,
+      threadId: 'thr_1'
+    })
+    expect(checkpoint.ok).toBe(true)
+    if (!checkpoint.ok) throw new Error(checkpoint.message)
+
+    await writeFile(join(repoRoot, 'tracked.txt'), 'agent changed\n')
+    const wrongThread = await restoreGitCheckpoint({
+      dataDir,
+      checkpointId: checkpoint.checkpointId,
+      expectedThreadId: 'thr_other'
+    })
+    expect(wrongThread.ok).toBe(false)
+    if (wrongThread.ok) throw new Error('expected restore to be refused')
+    expect(wrongThread.reason).toBe('mismatch')
+    expect(await readFile(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('agent changed\n')
+
+    const otherRepo = join(sandbox, 'other-repo')
+    execFileSync('git', ['init', '-b', 'main', otherRepo], { stdio: 'pipe' })
+    const wrongWorkspace = await restoreGitCheckpoint({
+      dataDir,
+      checkpointId: checkpoint.checkpointId,
+      expectedThreadId: 'thr_1',
+      expectedWorkspaceRoot: otherRepo
+    })
+    expect(wrongWorkspace.ok).toBe(false)
+    if (wrongWorkspace.ok) throw new Error('expected restore to be refused')
+    expect(wrongWorkspace.reason).toBe('mismatch')
+    expect(await readFile(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('agent changed\n')
+  })
+
+  it('updates the manifest with turn ids and refuses restore for the wrong turn', async () => {
+    const checkpoint = await createGitCheckpoint({
+      dataDir,
+      workspaceRoot: repoRoot,
+      threadId: 'thr_1'
+    })
+    expect(checkpoint.ok).toBe(true)
+    if (!checkpoint.ok) throw new Error(checkpoint.message)
+
+    const wrongThread = await updateGitCheckpointManifest({
+      dataDir,
+      checkpointId: checkpoint.checkpointId,
+      threadId: 'thr_other',
+      turnId: 'turn_1',
+      userMessageItemId: 'item_turn_1_user'
+    })
+    expect(wrongThread.ok).toBe(false)
+    if (wrongThread.ok) throw new Error('expected manifest update to be refused')
+    expect(wrongThread.reason).toBe('mismatch')
+
+    const updated = await updateGitCheckpointManifest({
+      dataDir,
+      checkpointId: checkpoint.checkpointId,
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      userMessageItemId: 'item_turn_1_user'
+    })
+    expect(updated.ok).toBe(true)
+    if (!updated.ok) throw new Error(updated.message)
+    expect(updated.manifest.turnId).toBe('turn_1')
+    expect(updated.manifest.userMessageItemId).toBe('item_turn_1_user')
+
+    await writeFile(join(repoRoot, 'tracked.txt'), 'agent changed\n')
+    const wrongTurn = await restoreGitCheckpoint({
+      dataDir,
+      checkpointId: checkpoint.checkpointId,
+      expectedThreadId: 'thr_1',
+      expectedTurnId: 'turn_2',
+      expectedUserMessageItemId: 'item_turn_1_user',
+    })
+    expect(wrongTurn.ok).toBe(false)
+    if (wrongTurn.ok) throw new Error('expected restore to be refused')
+    expect(wrongTurn.reason).toBe('mismatch')
+    expect(await readFile(join(repoRoot, 'tracked.txt'), 'utf-8')).toBe('agent changed\n')
   })
 
   it('rolls back commits created after the checkpoint', async () => {

--- a/src/main/services/git-checkpoint-service.ts
+++ b/src/main/services/git-checkpoint-service.ts
@@ -5,12 +5,16 @@ import { randomUUID } from 'node:crypto'
 import { runGit, resolveGitCwd } from './git-service'
 import type {
   GitCheckpointCreateResult,
+  GitCheckpointManifest,
+  GitCheckpointManifestUpdateResult,
   GitCheckpointRestoreResult
 } from '../../shared/git-checkpoint'
 
 type GitCheckpointMetadata = {
+  version?: 1
   checkpointId: string
   threadId: string
+  workspaceRoot?: string
   repositoryRoot: string
   head: string
   checkpointRef?: string | null
@@ -26,6 +30,8 @@ type GitCheckpointMetadata = {
    * partial checkpoint unless the caller explicitly opts in.
    */
   completeness?: 'complete' | 'partial'
+  turnId?: string
+  userMessageItemId?: string
 }
 
 /**
@@ -150,6 +156,36 @@ async function readMetadata(root: string, checkpointId: string): Promise<GitChec
   }
 }
 
+function checkpointManifest(metadata: GitCheckpointMetadata): GitCheckpointManifest {
+  const skippedUntracked = metadata.skippedUntracked?.filter(Boolean) ?? []
+  return {
+    version: 1,
+    checkpointId: metadata.checkpointId,
+    threadId: metadata.threadId,
+    workspaceRoot: metadata.workspaceRoot ?? metadata.repositoryRoot,
+    repositoryRoot: metadata.repositoryRoot,
+    head: metadata.head,
+    currentBranch: metadata.currentBranch,
+    createdAt: metadata.createdAt,
+    completeness: metadata.completeness ?? (skippedUntracked.length ? 'partial' : 'complete'),
+    untrackedFiles: metadata.untrackedFiles ?? [],
+    ...(skippedUntracked.length ? { skippedUntracked } : {}),
+    ...(metadata.turnId ? { turnId: metadata.turnId } : {}),
+    ...(metadata.userMessageItemId ? { userMessageItemId: metadata.userMessageItemId } : {})
+  }
+}
+
+async function pathKey(path: string): Promise<string> {
+  let canonical = path
+  try {
+    canonical = await realpath(path)
+  } catch {
+    canonical = resolve(path)
+  }
+  const normalized = normalize(resolve(canonical))
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
 async function writePatch(repositoryRoot: string, args: string[], path: string): Promise<void> {
   const { stdout } = await runGit(repositoryRoot, args, 30_000)
   await writeFile(path, stdout, 'utf-8')
@@ -200,6 +236,74 @@ async function resolveRepositoryRoot(workspaceRoot: string): Promise<string | nu
   if (!cwd) return null
   const { stdout } = await runGit(cwd, ['rev-parse', '--show-toplevel'])
   return stdout.trim()
+}
+
+async function validateRestoreExpectation(
+  metadata: GitCheckpointMetadata,
+  expected: {
+    threadId?: string
+    workspaceRoot?: string
+    turnId?: string
+    userMessageItemId?: string
+  }
+): Promise<Extract<GitCheckpointRestoreResult, { ok: false }> | null> {
+  const expectedThreadId = expected.threadId?.trim()
+  if (expectedThreadId && metadata.threadId !== expectedThreadId) {
+    return {
+      ok: false,
+      reason: 'mismatch',
+      message: 'Checkpoint belongs to thread ' + metadata.threadId + ', not the active thread ' + expectedThreadId + '.'
+    }
+  }
+
+  const expectedTurnId = expected.turnId?.trim()
+  if (expectedTurnId && metadata.turnId && metadata.turnId !== expectedTurnId) {
+    return {
+      ok: false,
+      reason: 'mismatch',
+      message: 'Checkpoint belongs to turn ' + metadata.turnId + ', not turn ' + expectedTurnId + '.'
+    }
+  }
+
+  const expectedUserMessageItemId = expected.userMessageItemId?.trim()
+  if (
+    expectedUserMessageItemId &&
+    metadata.userMessageItemId &&
+    metadata.userMessageItemId !== expectedUserMessageItemId
+  ) {
+    return {
+      ok: false,
+      reason: 'mismatch',
+      message:
+        'Checkpoint belongs to message ' +
+        metadata.userMessageItemId +
+        ', not message ' +
+        expectedUserMessageItemId +
+        '.'
+    }
+  }
+
+  const expectedWorkspaceRoot = expected.workspaceRoot?.trim()
+  if (expectedWorkspaceRoot) {
+    const expectedRepositoryRoot = await resolveRepositoryRoot(expectedWorkspaceRoot)
+    if (!expectedRepositoryRoot) {
+      return { ok: false, reason: 'no_workspace', message: 'No working directory selected.' }
+    }
+    if ((await pathKey(expectedRepositoryRoot)) !== (await pathKey(metadata.repositoryRoot))) {
+      return {
+        ok: false,
+        reason: 'mismatch',
+        message:
+          'Checkpoint belongs to ' +
+          metadata.repositoryRoot +
+          ', not the active workspace ' +
+          expectedRepositoryRoot +
+          '.'
+      }
+    }
+  }
+
+  return null
 }
 
 /**
@@ -493,6 +597,8 @@ export async function createGitCheckpoint(params: {
   dataDir: string
   workspaceRoot: string
   threadId: string
+  turnId?: string
+  userMessageItemId?: string
   checkpointId?: string
   storage?: GitCheckpointStorageOptions
 }): Promise<GitCheckpointCreateResult> {
@@ -556,26 +662,71 @@ export async function createGitCheckpoint(params: {
     }
 
     const metadata: GitCheckpointMetadata = {
+      version: 1,
       checkpointId,
       threadId: params.threadId,
+      workspaceRoot: resolve(workspaceRoot),
       repositoryRoot,
       head,
       currentBranch,
       createdAt: new Date().toISOString(),
       untrackedFiles,
       ...(skippedUntracked.length ? { skippedUntracked } : {}),
-      completeness: skippedUntracked.length ? 'partial' : 'complete'
+      completeness: skippedUntracked.length ? 'partial' : 'complete',
+      ...(params.turnId?.trim() ? { turnId: params.turnId.trim() } : {}),
+      ...(params.userMessageItemId?.trim() ? { userMessageItemId: params.userMessageItemId.trim() } : {})
     }
     await writeFile(join(dir, 'metadata.json'), JSON.stringify(metadata, null, 2), 'utf-8')
     // Bound per-thread retention so an active thread cannot grow unboundedly.
     await pruneThreadCheckpoints(root, params.threadId, maxPerThread, checkpointId).catch(() => undefined)
-    return { ok: true, checkpointId, repositoryRoot, head, currentBranch }
+    return { ok: true, checkpointId, repositoryRoot, head, currentBranch, manifest: checkpointManifest(metadata) }
   } catch (error) {
     const failure = checkpointFailure(error)
     if (/merge conflicts/i.test(failure.message)) {
       return { ...failure, reason: 'conflict' }
     }
     return failure
+  }
+}
+
+export async function updateGitCheckpointManifest(params: {
+  dataDir: string
+  checkpointId: string
+  threadId: string
+  turnId: string
+  userMessageItemId: string
+  storage?: GitCheckpointStorageOptions
+}): Promise<GitCheckpointManifestUpdateResult> {
+  const checkpointId = params.checkpointId.trim()
+  const root = resolveCheckpointsRoot(params.dataDir, params.storage?.checkpointsRoot)
+  const metadata = await readMetadata(root, checkpointId)
+  if (!metadata) {
+    return { ok: false, reason: 'not_found', message: `Git checkpoint not found: ${checkpointId}` }
+  }
+  const threadId = params.threadId.trim()
+  if (metadata.threadId !== threadId) {
+    return {
+      ok: false,
+      reason: 'mismatch',
+      message: 'Checkpoint belongs to thread ' + metadata.threadId + ', not thread ' + threadId + '.'
+    }
+  }
+  const turnId = params.turnId.trim()
+  const userMessageItemId = params.userMessageItemId.trim()
+  if (!turnId || !userMessageItemId) {
+    return { ok: false, reason: 'error', message: 'Checkpoint manifest update requires turn and user message ids.' }
+  }
+  const next: GitCheckpointMetadata = {
+    ...metadata,
+    version: 1,
+    turnId,
+    userMessageItemId
+  }
+  try {
+    await writeFile(metadataPath(root, checkpointId), JSON.stringify(next, null, 2), 'utf-8')
+    return { ok: true, checkpointId, manifest: checkpointManifest(next) }
+  } catch (error) {
+    return { ok: false, reason: 'error', message: error instanceof Error ? error.message : String(error) }
   }
 }
 
@@ -632,6 +783,10 @@ export async function restoreGitCheckpoint(params: {
   dataDir: string
   checkpointId: string
   storage?: GitCheckpointStorageOptions
+  expectedThreadId?: string
+  expectedWorkspaceRoot?: string
+  expectedTurnId?: string
+  expectedUserMessageItemId?: string
   /**
    * Opt-in to restoring a PARTIAL checkpoint (one whose snapshot skipped some
    * untracked files because they were over the size budget). A partial restore
@@ -656,6 +811,18 @@ export async function restoreGitCheckpoint(params: {
   const metadata = await readMetadata(root, checkpointId)
   if (!metadata) {
     return { ok: false, reason: 'not_found', message: `Git checkpoint not found: ${checkpointId}` }
+  }
+
+  try {
+    const expectationFailure = await validateRestoreExpectation(metadata, {
+      threadId: params.expectedThreadId,
+      workspaceRoot: params.expectedWorkspaceRoot,
+      turnId: params.expectedTurnId,
+      userMessageItemId: params.expectedUserMessageItemId
+    })
+    if (expectationFailure) return expectationFailure
+  } catch (error) {
+    return restoreFailure(error)
   }
 
   // Partial-checkpoint data-loss guard (P0-01). If the snapshot skipped any
@@ -798,7 +965,8 @@ export async function restoreGitCheckpoint(params: {
       repositoryRoot,
       head: metadata.head,
       currentBranch: metadata.currentBranch,
-      rescueCheckpointId
+      rescueCheckpointId,
+      manifest: checkpointManifest(metadata)
     }
   } catch (error) {
     const failure = restoreFailure(error)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -102,6 +102,8 @@ const api = {
     ipcRenderer.invoke('git:create-and-switch-branch', { workspaceRoot, branch }),
   createGitCheckpoint: (payload) =>
     ipcRenderer.invoke('git:checkpoint:create', payload),
+  updateGitCheckpointManifest: (payload) =>
+    ipcRenderer.invoke('git:checkpoint:update-manifest', payload),
   restoreGitCheckpoint: (payload) =>
     ipcRenderer.invoke('git:checkpoint:restore', payload),
   checkoutGitBranchWorktree: (workspaceRoot, branch) =>

--- a/src/renderer/src/store/chat-store-maintenance-actions.test.ts
+++ b/src/renderer/src/store/chat-store-maintenance-actions.test.ts
@@ -201,7 +201,13 @@ describe('chat-store-maintenance-actions workspace rollback', () => {
 
       await actions.rollbackWorkspaceToCheckpoint(' gcp_1 ')
 
-      expect(restoreGitCheckpoint).toHaveBeenCalledWith({ checkpointId: 'gcp_1' })
+      expect(restoreGitCheckpoint).toHaveBeenCalledWith({
+        checkpointId: 'gcp_1',
+        expectedThreadId: 'thr_existing',
+        expectedWorkspaceRoot: '/workspace/deepseek-gui',
+        expectedTurnId: 'turn_1',
+        expectedUserMessageItemId: 'user_1'
+      })
       expect(provider.rewindThread).not.toHaveBeenCalled()
       expect(sendMessage).not.toHaveBeenCalled()
       expect(state.blocks).toHaveLength(2)
@@ -309,7 +315,13 @@ describe('chat-store-maintenance-actions workspace rollback', () => {
 
       await actions.rollbackWorkspaceToCheckpoint('gcp_1')
 
-      expect(restoreGitCheckpoint).toHaveBeenCalledWith({ checkpointId: 'gcp_1' })
+      expect(restoreGitCheckpoint).toHaveBeenCalledWith({
+        checkpointId: 'gcp_1',
+        expectedThreadId: 'thr_existing',
+        expectedWorkspaceRoot: '/workspace/deepseek-gui',
+        expectedTurnId: 'turn_1',
+        expectedUserMessageItemId: 'user_1'
+      })
       expect(consoleInfo).toHaveBeenCalledTimes(1)
       const logArgs = consoleInfo.mock.calls[0]
       expect(logArgs[0]).toBe('[rollback] rescue checkpoint:')

--- a/src/renderer/src/store/chat-store-maintenance-actions.ts
+++ b/src/renderer/src/store/chat-store-maintenance-actions.ts
@@ -126,6 +126,45 @@ type StoreActionContext = {
   sseAbortRef: SseAbortRef
 }
 
+function buildCheckpointRestorePayload(
+  state: ChatState,
+  checkpointId: string,
+  options: { allowPartialRestore?: boolean; turnId?: string; userMessageItemId?: string } = {}
+): {
+  checkpointId: string
+  allowPartialRestore?: boolean
+  expectedThreadId?: string
+  expectedWorkspaceRoot?: string
+  expectedTurnId?: string
+  expectedUserMessageItemId?: string
+} {
+  const activeThreadId = state.activeThreadId?.trim()
+  const activeThread = activeThreadId
+    ? state.threads.find((thread) => thread.id === activeThreadId)
+    : null
+  const expectedWorkspaceRoot =
+    normalizeWorkspaceRoot(activeThread?.workspace) || normalizeWorkspaceRoot(state.workspaceRoot)
+  const checkpointBlock = state.blocks.find(
+    (block) => block.kind === 'user' && block.meta?.workspaceCheckpointId?.trim() === checkpointId
+  )
+  return {
+    checkpointId,
+    ...(options.allowPartialRestore ? { allowPartialRestore: true } : {}),
+    ...(activeThreadId ? { expectedThreadId: activeThreadId } : {}),
+    ...(expectedWorkspaceRoot ? { expectedWorkspaceRoot } : {}),
+    ...(options.turnId?.trim()
+      ? { expectedTurnId: options.turnId.trim() }
+      : checkpointBlock?.kind === 'user' && (checkpointBlock.meta?.turnId || checkpointBlock.turnId)
+        ? { expectedTurnId: checkpointBlock.meta?.turnId || checkpointBlock.turnId }
+        : {}),
+    ...(options.userMessageItemId?.trim()
+      ? { expectedUserMessageItemId: options.userMessageItemId.trim() }
+      : checkpointBlock?.kind === 'user'
+        ? { expectedUserMessageItemId: checkpointBlock.id }
+        : {})
+  }
+}
+
 function applyGoalSnapshot(
   set: ChatStoreSet,
   threadId: string,
@@ -721,11 +760,18 @@ export function createMaintenanceActions(
     }
     const checkpointId = targetBlock.meta?.workspaceCheckpointId
     if (checkpointId) {
-      const restored = await window.kunGui.restoreGitCheckpoint({ checkpointId }).catch((error) => ({
-        ok: false as const,
-        reason: 'error' as const,
-        message: error instanceof Error ? error.message : String(error)
-      }))
+      const restored = await window.kunGui
+        .restoreGitCheckpoint(
+          buildCheckpointRestorePayload(state, checkpointId, {
+            turnId,
+            userMessageItemId: targetBlock.id
+          })
+        )
+        .catch((error) => ({
+          ok: false as const,
+          reason: 'error' as const,
+          message: error instanceof Error ? error.message : String(error)
+        }))
       if (!restored.ok) {
         set({ error: restored.message })
         return
@@ -796,8 +842,10 @@ export function createMaintenanceActions(
       set({ error: i18n.t('common:rollbackWorkspaceBusyError') })
       return
     }
-    const { activeThreadId, workspaceRoot } = get()
-    let restored = await window.kunGui.restoreGitCheckpoint({ checkpointId: targetCheckpointId }).catch((error) => ({
+    const state = get()
+    const { activeThreadId, workspaceRoot } = state
+    const restorePayload = buildCheckpointRestorePayload(state, targetCheckpointId)
+    let restored = await window.kunGui.restoreGitCheckpoint(restorePayload).catch((error) => ({
       ok: false as const,
       reason: 'error' as const,
       message: error instanceof Error ? error.message : String(error)
@@ -824,7 +872,7 @@ export function createMaintenanceActions(
         return
       }
       restored = await window.kunGui
-        .restoreGitCheckpoint({ checkpointId: targetCheckpointId, allowPartialRestore: true })
+        .restoreGitCheckpoint({ ...restorePayload, allowPartialRestore: true })
         .catch((error) => ({
           ok: false as const,
           reason: 'error' as const,

--- a/src/renderer/src/store/chat-store-thread-actions.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.ts
@@ -905,6 +905,36 @@ export function createThreadActions(
         ...(workspaceCheckpointId ? { workspaceCheckpointId } : {}),
         ...(fileReferences.length ? { fileReferences } : {})
       })
+      if (workspaceCheckpointId && userMessageItemId && typeof window.kunGui.updateGitCheckpointManifest === 'function') {
+        void window.kunGui
+          .updateGitCheckpointManifest({
+            checkpointId: workspaceCheckpointId,
+            threadId: activeThreadId,
+            turnId,
+            userMessageItemId
+          })
+          .then((updated) => {
+            if (!updated.ok) {
+              void window.kunGui.logError('git-checkpoint', 'Failed to update Git checkpoint manifest', {
+                message: updated.message,
+                reason: updated.reason,
+                checkpointId: workspaceCheckpointId,
+                threadId: activeThreadId,
+                turnId,
+                userMessageItemId
+              }).catch(() => undefined)
+            }
+          })
+          .catch((error) => {
+            void window.kunGui.logError('git-checkpoint', 'Failed to update Git checkpoint manifest', {
+              message: error instanceof Error ? error.message : String(error),
+              checkpointId: workspaceCheckpointId,
+              threadId: activeThreadId,
+              turnId,
+              userMessageItemId
+            }).catch(() => undefined)
+          })
+      }
       // Mirror the composer model selection against the runtime's stable
       // user_message item id so the badge survives page refresh / thread
       // re-selection. The runtime itself doesn't persist per-turn metadata.

--- a/src/shared/git-checkpoint.ts
+++ b/src/shared/git-checkpoint.ts
@@ -1,3 +1,19 @@
+export type GitCheckpointManifest = {
+  version: 1
+  checkpointId: string
+  threadId: string
+  workspaceRoot: string
+  repositoryRoot: string
+  head: string
+  currentBranch: string | null
+  createdAt: string
+  completeness: 'complete' | 'partial'
+  untrackedFiles: string[]
+  skippedUntracked?: string[]
+  turnId?: string
+  userMessageItemId?: string
+}
+
 export type GitCheckpointCreateResult =
   | {
       ok: true
@@ -5,10 +21,23 @@ export type GitCheckpointCreateResult =
       repositoryRoot: string
       head: string
       currentBranch: string | null
+      manifest: GitCheckpointManifest
     }
   | {
       ok: false
       reason: 'no_workspace' | 'not_git_repo' | 'git_unavailable' | 'conflict' | 'error'
+      message: string
+    }
+
+export type GitCheckpointManifestUpdateResult =
+  | {
+      ok: true
+      checkpointId: string
+      manifest: GitCheckpointManifest
+    }
+  | {
+      ok: false
+      reason: 'not_found' | 'mismatch' | 'error'
       message: string
     }
 
@@ -20,6 +49,7 @@ export type GitCheckpointRestoreResult =
       head: string
       currentBranch: string | null
       rescueCheckpointId: string | null
+      manifest: GitCheckpointManifest
     }
   | {
       ok: false
@@ -30,6 +60,7 @@ export type GitCheckpointRestoreResult =
         | 'not_found'
         | 'conflict'
         | 'partial'
+        | 'mismatch'
         | 'error'
       message: string
       /**

--- a/src/shared/kun-gui-api.ts
+++ b/src/shared/kun-gui-api.ts
@@ -18,7 +18,7 @@ import type {
 } from './app-settings'
 import type { EditorListResult, EditorOpenResult, OpenEditorPathOptions } from './editor'
 import type { GitBranchesResult, GitBranchWorktreesResult, GitWorktreeCheckoutResult } from './git-branches'
-import type { GitCheckpointCreateResult, GitCheckpointRestoreResult } from './git-checkpoint'
+import type { GitCheckpointCreateResult, GitCheckpointManifestUpdateResult, GitCheckpointRestoreResult } from './git-checkpoint'
 import type {
   MergeResult,
   SyncResult,
@@ -385,10 +385,22 @@ export type KunGuiApi = {
   createGitCheckpoint: (params: {
     workspaceRoot: string
     threadId: string
+    turnId?: string
+    userMessageItemId?: string
   }) => Promise<GitCheckpointCreateResult>
+  updateGitCheckpointManifest: (params: {
+    checkpointId: string
+    threadId: string
+    turnId: string
+    userMessageItemId: string
+  }) => Promise<GitCheckpointManifestUpdateResult>
   restoreGitCheckpoint: (params: {
     checkpointId: string
     allowPartialRestore?: boolean
+    expectedThreadId?: string
+    expectedWorkspaceRoot?: string
+    expectedTurnId?: string
+    expectedUserMessageItemId?: string
   }) => Promise<GitCheckpointRestoreResult>
   checkoutGitBranchWorktree: (workspaceRoot: string, branch: string) => Promise<GitWorktreeCheckoutResult>
   createGitBranchWorktree: (workspaceRoot: string, branch: string) => Promise<GitWorktreeCheckoutResult>


### PR DESCRIPTION
﻿## Summary

Adds explicit Git checkpoint restore manifests and coordinated restore guards so rollback requests can verify they are being applied to the intended thread and workspace.

## Changes

- Persist a versioned checkpoint manifest alongside the existing Git checkpoint metadata.
- Return manifests from create and restore, and add an IPC bridge to update a checkpoint with the runtime turn and user message ids once the turn is accepted.
- Pass expected thread, workspace, turn, and message context from renderer rollback and rewind paths into restore.
- Refuse restore with mismatch before any destructive git command if the active context does not match the manifest.
- Keep old checkpoint compatibility by synthesizing a manifest from legacy metadata.

## Tests

- npm.cmd run typecheck
- npm.cmd test -- src/renderer/src/store/chat-store-maintenance-actions.test.ts
- npm.cmd test -- src/main/services/git-checkpoint-service.test.ts -t "stores checkpoint heads|refuses coordinated|updates the manifest" --testTimeout 20000
- npm.cmd test -- src/main/ipc/app-ipc-schemas.test.ts
- npm.cmd run build
- git diff --check

Note: the full src/main/services/git-checkpoint-service.test.ts file still hits existing Windows-environment issues outside this change: symlink creation requires elevated privileges and a couple of git bundle/retention tests exceed Vitest's default 5s timeout in this worktree.
