### PR TITLE
fix(memory): confirm and restore records

### DIFF
--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -55,6 +55,7 @@ import {
 } from './settings-utils'
 import { loadKunDiagnostics } from '../lib/load-kun-diagnostics'
 import { SETTINGS_CHANGED_EVENT, emitRendererSettingsChanged } from '../lib/keyboard-shortcut-settings'
+import { confirmDialog } from '../lib/confirm-dialog'
 import { GeneralSettingsSection } from './settings-section-general'
 
 const ProvidersSettingsSection = lazy(() =>
@@ -647,11 +648,11 @@ export function SettingsView(): ReactElement {
     }
   }
 
-  const disableMemoryRecord = async (memoryId: string): Promise<void> => {
+  const setMemoryRecordDisabled = async (memoryId: string, disabled: boolean): Promise<void> => {
     const provider = getProvider()
     if (typeof provider.updateMemory !== 'function') return
     try {
-      const memory = await provider.updateMemory(memoryId, { disabled: true }, {
+      const memory = await provider.updateMemory(memoryId, { disabled }, {
         workspace: memoryMutationWorkspace(memoryId)
       })
       setMemoryRecords((records) => records.map((record) => record.id === memoryId ? memory : record))
@@ -663,7 +664,25 @@ export function SettingsView(): ReactElement {
     }
   }
 
+  const disableMemoryRecord = async (memoryId: string): Promise<void> => {
+    const confirmed = await confirmDialog(
+      t('memoryDisableConfirm'),
+      t('memoryDisableConfirmDetail')
+    )
+    if (!confirmed) return
+    await setMemoryRecordDisabled(memoryId, true)
+  }
+
+  const restoreMemoryRecord = async (memoryId: string): Promise<void> => {
+    await setMemoryRecordDisabled(memoryId, false)
+  }
+
   const deleteMemoryRecord = async (memoryId: string): Promise<void> => {
+    const confirmed = await confirmDialog(
+      t('memoryDeleteConfirm'),
+      t('memoryDeleteConfirmDetail')
+    )
+    if (!confirmed) return
     const provider = getProvider()
     if (typeof provider.deleteMemory !== 'function') return
     try {
@@ -1087,6 +1106,7 @@ export function SettingsView(): ReactElement {
     createMemoryRecord,
     updateMemoryRecord,
     disableMemoryRecord,
+    restoreMemoryRecord,
     deleteMemoryRecord,
     pickClawWorkspace,
     resetClawWorkspaceToDefault,

--- a/src/renderer/src/components/settings-section-agents.tsx
+++ b/src/renderer/src/components/settings-section-agents.tsx
@@ -35,6 +35,7 @@ import {
   Loader2,
   LockKeyholeOpen,
   RefreshCw,
+  RotateCcw,
   Settings,
   ShieldQuestion,
   Trash2
@@ -348,6 +349,7 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
     runtimeDiagnosticsNotice,
     refreshKunDiagnostics,
     disableMemoryRecord,
+    restoreMemoryRecord,
     deleteMemoryRecord,
     pickClawWorkspace,
     resetClawWorkspaceToDefault,
@@ -1711,16 +1713,27 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                                   </div>
                                 </div>
                                 <div className="flex shrink-0 items-center gap-1">
-                                  <button
-                                    type="button"
-                                    disabled={Boolean(memory.disabledAt)}
-                                    onClick={() => void disableMemoryRecord(memory.id)}
-                                    className="rounded-lg p-1.5 text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink disabled:cursor-not-allowed disabled:opacity-45"
-                                    aria-label={t('kunMemoryDisable')}
-                                    title={t('kunMemoryDisable')}
-                                  >
-                                    <Ban className="h-3.5 w-3.5" strokeWidth={1.8} />
-                                  </button>
+                                  {memory.disabledAt ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => void restoreMemoryRecord(memory.id)}
+                                      className="rounded-lg p-1.5 text-ds-muted transition hover:bg-emerald-500/10 hover:text-emerald-600"
+                                      aria-label={t('memoryRestore')}
+                                      title={t('memoryRestore')}
+                                    >
+                                      <RotateCcw className="h-3.5 w-3.5" strokeWidth={1.8} />
+                                    </button>
+                                  ) : (
+                                    <button
+                                      type="button"
+                                      onClick={() => void disableMemoryRecord(memory.id)}
+                                      className="rounded-lg p-1.5 text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
+                                      aria-label={t('kunMemoryDisable')}
+                                      title={t('kunMemoryDisable')}
+                                    >
+                                      <Ban className="h-3.5 w-3.5" strokeWidth={1.8} />
+                                    </button>
+                                  )}
                                   <button
                                     type="button"
                                     onClick={() => void deleteMemoryRecord(memory.id)}

--- a/src/renderer/src/components/settings-section-memory.test.ts
+++ b/src/renderer/src/components/settings-section-memory.test.ts
@@ -42,6 +42,7 @@ const labels: Record<string, string> = {
   memoryDetails: 'Details',
   memoryClose: 'Close',
   memoryDisable: 'Disable',
+  memoryRestore: 'Restore',
   memoryDelete: 'Delete',
   memoryDisabled: 'Disabled',
   memoryProject: 'Project',
@@ -50,7 +51,11 @@ const labels: Record<string, string> = {
   memoryDiscardConfirm: 'Discard unsaved changes?',
   memoryDiscardConfirmDetail: 'Your edits will be lost.',
   memoryDiscardConfirmAction: 'Discard',
-  memoryDiscardCancel: 'Keep editing'
+  memoryDiscardCancel: 'Keep editing',
+  memoryDisableConfirm: 'Disable this memory?',
+  memoryDisableConfirmDetail: 'The assistant will stop using this memory.',
+  memoryDeleteConfirm: 'Delete this memory?',
+  memoryDeleteConfirmDetail: 'Deleted memories cannot be restored here.'
 }
 
 function baseCtx(overrides: Record<string, any> = {}): Record<string, any> {
@@ -68,6 +73,7 @@ function baseCtx(overrides: Record<string, any> = {}): Record<string, any> {
     createMemoryRecord: async () => true,
     updateMemoryRecord: async () => true,
     disableMemoryRecord: async () => undefined,
+    restoreMemoryRecord: async () => undefined,
     deleteMemoryRecord: async () => undefined,
     ...overrides
   }
@@ -164,6 +170,18 @@ describe('MemorySettingsSection', () => {
     // to screen readers / hover tooltips.
     const titleAttrPattern = /title="[^"]*this tail should only appear inside the details dialog[^"]*"/
     expect(html).toMatch(titleAttrPattern)
+  })
+
+  it('offers restore instead of disable for a disabled memory', () => {
+    const html = renderToStaticMarkup(createElement(MemorySettingsSection, {
+      ctx: baseCtx({
+        memoryRecords: [sampleRecord({ disabledAt: '2026-07-02T00:00:00.000Z' })]
+      })
+    }))
+
+    expect(html).toContain('aria-label="Restore"')
+    expect(html).not.toContain('aria-label="Disable"')
+    expect(html).toContain('Disabled')
   })
 })
 

--- a/src/renderer/src/components/settings-section-memory.tsx
+++ b/src/renderer/src/components/settings-section-memory.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import type { ReactElement } from 'react'
-import { Ban, BrainCircuit, Eye, Pencil, Plus, Trash2, X } from 'lucide-react'
+import { Ban, BrainCircuit, Eye, Pencil, Plus, RotateCcw, Trash2, X } from 'lucide-react'
 import type { CoreMemoryRecordJson } from '../agent/kun-contract'
 import { confirmDialog } from '../lib/confirm-dialog'
 import { SettingsCard, SettingRow, Toggle } from './settings-controls'
@@ -116,6 +116,7 @@ export function MemorySettingsSection({ ctx }: { ctx: Record<string, any> }): Re
     createMemoryRecord,
     updateMemoryRecord,
     disableMemoryRecord,
+    restoreMemoryRecord,
     deleteMemoryRecord
   } = ctx
 
@@ -323,16 +324,27 @@ export function MemorySettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                         >
                           <Eye className="h-3.5 w-3.5" strokeWidth={1.8} />
                         </button>
-                        <button
-                          type="button"
-                          disabled={Boolean(memory.disabledAt)}
-                          onClick={() => void disableMemoryRecord(memory.id)}
-                          className="rounded-lg p-1.5 text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink disabled:cursor-not-allowed disabled:opacity-45"
-                          aria-label={t('memoryDisable')}
-                          title={t('memoryDisable')}
-                        >
-                          <Ban className="h-3.5 w-3.5" strokeWidth={1.8} />
-                        </button>
+                        {memory.disabledAt ? (
+                          <button
+                            type="button"
+                            onClick={() => void restoreMemoryRecord(memory.id)}
+                            className="rounded-lg p-1.5 text-ds-muted transition hover:bg-emerald-500/10 hover:text-emerald-600"
+                            aria-label={t('memoryRestore')}
+                            title={t('memoryRestore')}
+                          >
+                            <RotateCcw className="h-3.5 w-3.5" strokeWidth={1.8} />
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => void disableMemoryRecord(memory.id)}
+                            className="rounded-lg p-1.5 text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
+                            aria-label={t('memoryDisable')}
+                            title={t('memoryDisable')}
+                          >
+                            <Ban className="h-3.5 w-3.5" strokeWidth={1.8} />
+                          </button>
+                        )}
                         <button
                           type="button"
                           onClick={() => void deleteMemoryRecord(memory.id)}

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -1238,6 +1238,7 @@
   "memoryDetails": "Details",
   "memoryClose": "Close",
   "memoryDisable": "Disable",
+  "memoryRestore": "Restore",
   "memoryDelete": "Delete",
   "memoryDisabled": "disabled",
   "memorySave": "Save",
@@ -1260,5 +1261,9 @@
   "memoryDiscardConfirm": "Discard unsaved changes?",
   "memoryDiscardConfirmDetail": "Your edits will be lost.",
   "memoryDiscardConfirmAction": "Discard",
-  "memoryDiscardCancel": "Keep editing"
+  "memoryDiscardCancel": "Keep editing",
+  "memoryDisableConfirm": "Disable this memory?",
+  "memoryDisableConfirmDetail": "The assistant will stop using this memory. You can restore it later.",
+  "memoryDeleteConfirm": "Delete this memory?",
+  "memoryDeleteConfirmDetail": "Deleted memories are removed from this list and cannot be restored here."
 }

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -1238,6 +1238,7 @@
   "memoryDetails": "详情",
   "memoryClose": "关闭",
   "memoryDisable": "禁用",
+  "memoryRestore": "恢复",
   "memoryDelete": "删除",
   "memoryDisabled": "已禁用",
   "memorySave": "保存",
@@ -1260,5 +1261,9 @@
   "memoryDiscardConfirm": "放弃未保存的更改？",
   "memoryDiscardConfirmDetail": "您的修改将会丢失。",
   "memoryDiscardConfirmAction": "放弃",
-  "memoryDiscardCancel": "继续编辑"
+  "memoryDiscardCancel": "继续编辑",
+  "memoryDisableConfirm": "禁用这条记忆？",
+  "memoryDisableConfirmDetail": "助手将停止使用这条记忆，之后仍可在此恢复。",
+  "memoryDeleteConfirm": "删除这条记忆？",
+  "memoryDeleteConfirmDetail": "删除后将从当前列表移除，且无法在此恢复。"
 }


### PR DESCRIPTION
## Summary

Make memory record actions recoverable and explicit in both memory-management surfaces.

## Changes

- ask for confirmation before disabling a memory record
- ask for confirmation before deleting a memory record and explain that the settings UI cannot restore deleted tombstones
- show a Restore action for disabled records and reuse the existing `PATCH { disabled: false }` runtime API
- keep the dedicated Memory page and the Agents advanced diagnostics list consistent
- add English and Chinese labels plus focused rendering coverage

## Tests

- `npm.cmd test -- settings-section-memory.test.ts settings-section-agents.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `npx.cmd eslint src/renderer/src/components/SettingsView.tsx src/renderer/src/components/settings-section-agents.tsx src/renderer/src/components/settings-section-memory.tsx src/renderer/src/components/settings-section-memory.test.ts` (passes with one pre-existing `writeTypography` hook dependency warning)
- `git diff --check`

Fixes #694