### PR TITLE
feat(tools): freeze virtual catalog per turn

### DIFF
--- a/kun/src/adapters/tool/index.ts
+++ b/kun/src/adapters/tool/index.ts
@@ -18,6 +18,7 @@ export * from './memory-tool-provider.js'
 export * from './output-accumulator.js'
 export * from './read.js'
 export * from './truncate.js'
+export * from './virtual-tool-catalog.js'
 export * from './web-tool-provider.js'
 export * from './write.js'
 export {

--- a/kun/src/adapters/tool/mcp-tool-search.ts
+++ b/kun/src/adapters/tool/mcp-tool-search.ts
@@ -5,11 +5,17 @@ import type {
 import type { ToolHostContext } from '../../ports/tool-host.js'
 import type { CapabilityToolProvider } from './capability-registry.js'
 import { LocalToolHost, type LocalTool } from './local-tool-host.js'
+import {
+  VirtualToolCatalog,
+  type FrozenToolCatalogView,
+  type VirtualToolEntry
+} from './virtual-tool-catalog.js'
 
 const MCP_SEARCH_TOOL_NAME = 'mcp_search'
 const MCP_DESCRIBE_TOOL_NAME = 'mcp_describe'
 const MCP_CALL_TOOL_NAME = 'mcp_call'
 const MCP_REFRESH_CATALOG_TOOL_NAME = 'mcp_refresh_catalog'
+const MAX_FROZEN_MCP_CATALOGS = 256
 
 const STOP_WORDS = new Set([
   'the',
@@ -121,6 +127,11 @@ export type McpSearchProviderOptions = {
   isServerAvailable: (server: McpServerConfig, workspace: string) => boolean
 }
 
+type McpVirtualCatalogRuntime = {
+  live: VirtualToolCatalog<McpSearchCatalogRecord>
+  frozenByTurn: Map<string, FrozenToolCatalogView<McpSearchCatalogRecord>>
+}
+
 type IndexedTool = {
   record: McpSearchCatalogRecord
   tokens: string[]
@@ -151,12 +162,16 @@ type SearchResult = {
 export function createMcpSearchProvider(
   options: McpSearchProviderOptions
 ): CapabilityToolProvider {
+  const catalog: McpVirtualCatalogRuntime = {
+    live: new VirtualToolCatalog(toVirtualCatalogEntries(options.state.records)),
+    frozenByTurn: new Map()
+  }
   return {
     id: 'mcp:search',
     kind: 'mcp',
     enabled: true,
     available: true,
-    tools: createMcpSearchTools(options)
+    tools: createMcpSearchTools(options, catalog)
   }
 }
 
@@ -212,7 +227,10 @@ export function tokenizeMcpSearchText(text = ''): string[] {
   return tokens
 }
 
-function createMcpSearchTools(options: McpSearchProviderOptions): LocalTool[] {
+function createMcpSearchTools(
+  options: McpSearchProviderOptions,
+  catalog: McpVirtualCatalogRuntime
+): LocalTool[] {
   return [
     LocalToolHost.defineTool({
       name: MCP_SEARCH_TOOL_NAME,
@@ -232,14 +250,17 @@ function createMcpSearchTools(options: McpSearchProviderOptions): LocalTool[] {
         if (!query) return { output: { error: 'query is required' }, isError: true }
         const serverId = stringArg(args.serverId)
         const topK = clampPositiveInt(numberArg(args.topK), options.config.topKDefault, options.config.topKMax)
-        const records = availableRecords(options, context)
+        const view = frozenMcpCatalogView(options, catalog, context)
+        const records = availableRecords(options, view, context)
           .filter((record) => !serverId || record.serverId === serverId)
         const results = searchRecords(records, query, topK, options.config)
         return {
           output: {
             query,
-            totalIndexed: options.state.records.length,
+            totalIndexed: view.size(),
             searchedTools: records.length,
+            catalogVersion: view.frozenVersion,
+            catalogUpdatePending: view.pendingUpdate(),
             results: results.map(formatSearchResult)
           }
         }
@@ -258,7 +279,7 @@ function createMcpSearchTools(options: McpSearchProviderOptions): LocalTool[] {
       policy: 'auto',
       execute: async (args, context) => {
         const toolId = stringArg(args.toolId)
-        const record = resolveAvailableRecord(options, context, toolId)
+        const record = resolveAvailableRecord(options, catalog, context, toolId)
         if (!record) return { output: { error: `unknown MCP tool: ${toolId}` }, isError: true }
         return { output: describeRecord(record) }
       }
@@ -277,7 +298,7 @@ function createMcpSearchTools(options: McpSearchProviderOptions): LocalTool[] {
       policy: 'on-request',
       execute: async (args, context) => {
         const toolId = stringArg(args.toolId)
-        const record = resolveAvailableRecord(options, context, toolId)
+        const record = resolveAvailableRecord(options, catalog, context, toolId)
         if (!record) return { output: { error: `unknown MCP tool: ${toolId}` }, isError: true }
         const callArgs = objectArg(args.arguments)
         const result = await record.client.callTool(
@@ -303,14 +324,20 @@ function createMcpSearchTools(options: McpSearchProviderOptions): LocalTool[] {
         properties: {}
       },
       policy: 'auto',
-      execute: async () => {
+      execute: async (_args, context) => {
+        const visible = frozenMcpCatalogView(options, catalog, context)
         const records = await options.refreshCatalog()
+        options.state.records = records
+        catalog.live.replaceAll(toVirtualCatalogEntries(records))
         return {
           output: {
             refreshedAt: options.state.lastRefreshedAt,
             totalIndexed: records.length,
             catalogFingerprint: options.state.catalogFingerprint,
-            catalogDrift: options.state.catalogDrift === true
+            catalogDrift: options.state.catalogDrift === true,
+            visibleCatalogVersion: visible.frozenVersion,
+            catalogVersion: catalog.live.currentVersion(),
+            catalogUpdatePending: visible.pendingUpdate()
           }
         }
       }
@@ -318,9 +345,13 @@ function createMcpSearchTools(options: McpSearchProviderOptions): LocalTool[] {
   ]
 }
 
-function availableRecords(options: McpSearchProviderOptions, context: ToolHostContext): McpSearchCatalogRecord[] {
+function availableRecords(
+  options: McpSearchProviderOptions,
+  view: FrozenToolCatalogView<McpSearchCatalogRecord>,
+  context: ToolHostContext
+): McpSearchCatalogRecord[] {
   const blocked = context.blockedProviderIds
-  return options.state.records.filter((record) =>
+  return view.list().flatMap((entry) => entry.value ? [entry.value] : []).filter((record) =>
     options.isServerAvailable(record.server, context.workspace)
     // Honor the per-turn provider deny-list (e.g. a subagent's blockedMcpServers).
     // In search mode the per-server `mcp:<id>` provider is never registered, so
@@ -333,11 +364,53 @@ function availableRecords(options: McpSearchProviderOptions, context: ToolHostCo
 
 function resolveAvailableRecord(
   options: McpSearchProviderOptions,
+  catalog: McpVirtualCatalogRuntime,
   context: ToolHostContext,
   toolId: string
 ): McpSearchCatalogRecord | undefined {
   if (!toolId) return undefined
-  return availableRecords(options, context).find((record) => record.toolId === toolId)
+  const view = frozenMcpCatalogView(options, catalog, context)
+  return availableRecords(options, view, context).find((record) => record.toolId === toolId)
+}
+
+function frozenMcpCatalogView(
+  options: McpSearchProviderOptions,
+  catalog: McpVirtualCatalogRuntime,
+  context: ToolHostContext
+): FrozenToolCatalogView<McpSearchCatalogRecord> {
+  catalog.live.replaceAll(toVirtualCatalogEntries(options.state.records))
+  const key = JSON.stringify([context.threadId, context.turnId])
+  const existing = catalog.frozenByTurn.get(key)
+  if (existing) return existing
+  const frozen = catalog.live.freeze()
+  catalog.frozenByTurn.set(key, frozen)
+  if (catalog.frozenByTurn.size > MAX_FROZEN_MCP_CATALOGS) {
+    const oldest = catalog.frozenByTurn.keys().next().value
+    if (oldest !== undefined) catalog.frozenByTurn.delete(oldest)
+  }
+  return frozen
+}
+
+function toVirtualCatalogEntries(
+  records: McpSearchCatalogRecord[]
+): VirtualToolEntry<McpSearchCatalogRecord>[] {
+  return records.map((record) => ({
+    id: record.toolId,
+    name: record.descriptor.name,
+    kind: 'mcp',
+    description: record.descriptor.description ?? '',
+    inputSchema: record.descriptor.inputSchema ?? { type: 'object' },
+    keywords: [record.serverId, record.normalizedName],
+    metadata: {
+      outputSchema: record.descriptor.outputSchema,
+      annotations: record.descriptor.annotations,
+      execution: record.descriptor.execution,
+      icons: record.descriptor.icons,
+      meta: record.descriptor._meta,
+      policy: record.policy
+    },
+    value: record
+  }))
 }
 
 function searchRecords(

--- a/kun/src/adapters/tool/virtual-tool-catalog.ts
+++ b/kun/src/adapters/tool/virtual-tool-catalog.ts
@@ -1,0 +1,186 @@
+import { createHash } from 'node:crypto'
+
+export type VirtualToolKind = 'builtin' | 'mcp' | 'skill' | 'connector'
+
+export type VirtualToolEntry<T = unknown> = {
+  id: string
+  name: string
+  kind: VirtualToolKind
+  description: string
+  inputSchema?: Record<string, unknown>
+  keywords?: string[]
+  alwaysOn?: boolean
+  metadata?: unknown
+  value?: T
+}
+
+export type VirtualToolSearchResult<T = unknown> = {
+  entry: VirtualToolEntry<T>
+  score: number
+}
+
+export class VirtualToolCatalog<T = unknown> {
+  private entries = new Map<string, VirtualToolEntry<T>>()
+  private version = catalogVersion<T>([])
+
+  constructor(entries: VirtualToolEntry<T>[] = []) {
+    this.replaceAll(entries)
+  }
+
+  currentVersion(): string {
+    return this.version
+  }
+
+  size(): number {
+    return this.entries.size
+  }
+
+  replaceAll(entries: VirtualToolEntry<T>[]): string {
+    this.entries = new Map(entries.map((entry) => [entry.id, entry]))
+    this.version = catalogVersion([...this.entries.values()])
+    return this.version
+  }
+
+  list(): VirtualToolEntry<T>[] {
+    return [...this.entries.values()]
+  }
+
+  load(id: string): VirtualToolEntry<T> | undefined {
+    return this.entries.get(id)
+  }
+
+  alwaysOn(): VirtualToolEntry<T>[] {
+    return this.list().filter((entry) => entry.alwaysOn)
+  }
+
+  search(
+    query: string,
+    options: { topK?: number; kinds?: VirtualToolKind[] } = {}
+  ): VirtualToolSearchResult<T>[] {
+    const queryTokens = new Set(tokenize(query))
+    if (queryTokens.size === 0) return []
+    const kinds = options.kinds ? new Set(options.kinds) : null
+    const results: VirtualToolSearchResult<T>[] = []
+    for (const entry of this.entries.values()) {
+      if (kinds && !kinds.has(entry.kind)) continue
+      const haystack = new Set(tokenize([
+        entry.name,
+        entry.description,
+        ...(entry.keywords ?? [])
+      ].join(' ')))
+      let overlap = 0
+      for (const token of queryTokens) {
+        if (haystack.has(token)) overlap += 1
+      }
+      if (overlap === 0) continue
+      results.push({ entry, score: overlap / queryTokens.size })
+    }
+    return results
+      .sort((a, b) => (b.score - a.score) || a.entry.name.localeCompare(b.entry.name))
+      .slice(0, options.topK ?? 5)
+  }
+
+  freeze(): FrozenToolCatalogView<T> {
+    return new FrozenToolCatalogView(this)
+  }
+}
+
+export class FrozenToolCatalogView<T = unknown> {
+  readonly frozenVersion: string
+  private readonly snapshot: VirtualToolCatalog<T>
+
+  constructor(private readonly catalog: VirtualToolCatalog<T>) {
+    this.frozenVersion = catalog.currentVersion()
+    this.snapshot = new VirtualToolCatalog(catalog.list().map(cloneEntry))
+  }
+
+  pendingUpdate(): boolean {
+    return this.catalog.currentVersion() !== this.frozenVersion
+  }
+
+  size(): number {
+    return this.snapshot.size()
+  }
+
+  list(): VirtualToolEntry<T>[] {
+    return this.snapshot.list()
+  }
+
+  load(id: string): VirtualToolEntry<T> | undefined {
+    return this.snapshot.load(id)
+  }
+
+  has(id: string): boolean {
+    return this.snapshot.load(id) !== undefined
+  }
+
+  alwaysOn(): VirtualToolEntry<T>[] {
+    return this.snapshot.alwaysOn()
+  }
+
+  search(
+    query: string,
+    options?: { topK?: number; kinds?: VirtualToolKind[] }
+  ): VirtualToolSearchResult<T>[] {
+    return this.snapshot.search(query, options)
+  }
+}
+
+function cloneEntry<T>(entry: VirtualToolEntry<T>): VirtualToolEntry<T> {
+  return {
+    ...entry,
+    ...(entry.inputSchema ? { inputSchema: structuredClone(entry.inputSchema) } : {}),
+    ...(entry.keywords ? { keywords: [...entry.keywords] } : {}),
+    ...(entry.metadata !== undefined ? { metadata: structuredClone(entry.metadata) } : {})
+  }
+}
+
+function catalogVersion<T>(entries: readonly VirtualToolEntry<T>[]): string {
+  const signatures = entries.map(entrySignature).sort()
+  return createHash('sha256').update(signatures.join('\n')).digest('hex').slice(0, 16)
+}
+
+function entrySignature<T>(entry: VirtualToolEntry<T>): string {
+  return JSON.stringify(canonicalize({
+    id: entry.id,
+    name: entry.name,
+    kind: entry.kind,
+    description: entry.description,
+    inputSchema: entry.inputSchema ?? {},
+    keywords: [...(entry.keywords ?? [])].sort(),
+    alwaysOn: entry.alwaysOn === true,
+    metadata: entry.metadata
+  }))
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (!value || typeof value !== 'object') return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    const next = (value as Record<string, unknown>)[key]
+    if (next !== undefined) out[key] = canonicalize(next)
+  }
+  return out
+}
+
+function tokenize(text: string): string[] {
+  const normalized = text.normalize('NFKC').toLowerCase()
+  const tokens: string[] = []
+  for (const term of normalized.match(/[a-z0-9][a-z0-9_-]*/g) ?? []) {
+    tokens.push(term)
+    tokens.push(...term.split(/[_-]+/).filter(Boolean))
+  }
+  const han: string[] = normalized.match(/\p{Script=Han}+/gu) ?? []
+  for (const segment of han) {
+    const chars = [...segment]
+    if (chars.length === 1) {
+      tokens.push(chars[0])
+      continue
+    }
+    for (let index = 0; index < chars.length - 1; index += 1) {
+      tokens.push(chars.slice(index, index + 2).join(''))
+    }
+  }
+  return tokens
+}

--- a/kun/tests/mcp-tool-search.test.ts
+++ b/kun/tests/mcp-tool-search.test.ts
@@ -168,3 +168,81 @@ describe('MCP search provider honors workspace visibility roots', () => {
     expect(describeInside.item).toMatchObject({ kind: 'tool_result', isError: false })
   })
 })
+
+describe('MCP search provider freezes its virtual catalog per turn', () => {
+  it('defers refreshed tools and schema changes until the next turn', async () => {
+    const calls: string[] = []
+    const original = record('github', 'search_issues', calls)
+    original.descriptor.description = 'Search issues with the old schema'
+    const replacement = record('github', 'search_issues', calls)
+    replacement.descriptor.description = 'Search issues with the new schema'
+    replacement.descriptor.inputSchema = {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query']
+    }
+    const added = record('github', 'create_issue', calls)
+    const state = { records: [original] }
+    const host = new LocalToolHost({
+      registry: new CapabilityRegistry([
+        createMcpSearchProvider({
+          config: SEARCH_CONFIG,
+          state,
+          refreshCatalog: async () => {
+            state.records = [replacement, added]
+            return state.records
+          },
+          isServerAvailable: () => true
+        })
+      ])
+    })
+    const firstTurn = ctx({ turnId: 'turn_1' })
+
+    const before = await host.execute(
+      { callId: 'c0', toolName: 'mcp_describe', arguments: { toolId: 'github/search_issues' } },
+      firstTurn
+    )
+    expect(before.item.kind === 'tool_result' ? before.item.output : {}).toMatchObject({
+      description: 'Search issues with the old schema'
+    })
+
+    const refresh = await host.execute(
+      { callId: 'c1', toolName: 'mcp_refresh_catalog', arguments: {} },
+      firstTurn
+    )
+    expect(refresh.item.kind === 'tool_result' ? refresh.item.output : {}).toMatchObject({
+      totalIndexed: 2,
+      catalogUpdatePending: true
+    })
+
+    const stillFrozen = await host.execute(
+      { callId: 'c2', toolName: 'mcp_describe', arguments: { toolId: 'github/search_issues' } },
+      firstTurn
+    )
+    expect(stillFrozen.item.kind === 'tool_result' ? stillFrozen.item.output : {}).toMatchObject({
+      description: 'Search issues with the old schema'
+    })
+    const hiddenUntilNextTurn = await host.execute(
+      { callId: 'c3', toolName: 'mcp_call', arguments: { toolId: 'github/create_issue', arguments: {} } },
+      firstTurn
+    )
+    expect(hiddenUntilNextTurn.item).toMatchObject({ kind: 'tool_result', isError: true })
+    expect(calls).toEqual([])
+
+    const nextTurn = ctx({ turnId: 'turn_2' })
+    const updated = await host.execute(
+      { callId: 'c4', toolName: 'mcp_describe', arguments: { toolId: 'github/search_issues' } },
+      nextTurn
+    )
+    expect(updated.item.kind === 'tool_result' ? updated.item.output : {}).toMatchObject({
+      description: 'Search issues with the new schema',
+      inputSchema: { required: ['query'] }
+    })
+    const callable = await host.execute(
+      { callId: 'c5', toolName: 'mcp_call', arguments: { toolId: 'github/create_issue', arguments: {} } },
+      nextTurn
+    )
+    expect(callable.item).toMatchObject({ kind: 'tool_result', isError: false })
+    expect(calls).toEqual(['github/create_issue'])
+  })
+})

--- a/kun/tests/virtual-tool-catalog.test.ts
+++ b/kun/tests/virtual-tool-catalog.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  VirtualToolCatalog,
+  type VirtualToolEntry
+} from '../src/adapters/tool/virtual-tool-catalog.js'
+
+const entries: VirtualToolEntry[] = [
+  {
+    id: 'builtin:read',
+    name: 'read',
+    kind: 'builtin',
+    description: 'Read a file from disk',
+    alwaysOn: true
+  },
+  {
+    id: 'mcp:gh/create_issue',
+    name: 'create_issue',
+    kind: 'mcp',
+    description: 'Create a GitHub issue',
+    keywords: ['github', 'issue', 'tracker']
+  },
+  {
+    id: 'mcp:db/query',
+    name: 'sql_query',
+    kind: 'mcp',
+    description: 'Run a SQL query against the database',
+    keywords: ['database', 'sql', 'postgres'],
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string' } }
+    }
+  },
+  {
+    id: 'skill:pdf',
+    name: 'pdf_extract',
+    kind: 'skill',
+    description: 'Extract text from a PDF document',
+    keywords: ['pdf', 'document']
+  }
+]
+
+describe('VirtualToolCatalog', () => {
+  it('searches across names, descriptions, and keywords', () => {
+    const catalog = new VirtualToolCatalog(entries)
+    expect(catalog.search('github issue')[0]?.entry.id).toBe('mcp:gh/create_issue')
+  })
+
+  it('filters search by tool kind and exposes always-on entries', () => {
+    const catalog = new VirtualToolCatalog(entries)
+    const results = catalog.search('query database', { kinds: ['mcp'] })
+    expect(results.every((result) => result.entry.kind === 'mcp')).toBe(true)
+    expect(results[0]?.entry.id).toBe('mcp:db/query')
+    expect(catalog.alwaysOn().map((entry) => entry.id)).toEqual(['builtin:read'])
+  })
+
+  it('changes version when a same-id schema changes', () => {
+    const catalog = new VirtualToolCatalog(entries)
+    const previous = catalog.currentVersion()
+    catalog.replaceAll(entries.map((entry) =>
+      entry.id === 'mcp:db/query'
+        ? { ...entry, inputSchema: { type: 'object', required: ['query'] } }
+        : entry
+    ))
+    expect(catalog.currentVersion()).not.toBe(previous)
+  })
+
+  it('keeps a frozen view stable while reporting live catalog drift', () => {
+    const catalog = new VirtualToolCatalog(entries)
+    const frozen = catalog.freeze()
+    catalog.replaceAll([
+      ...entries,
+      {
+        id: 'connector:slack',
+        name: 'post',
+        kind: 'connector',
+        description: 'Post to a Slack channel'
+      }
+    ])
+
+    expect(frozen.pendingUpdate()).toBe(true)
+    expect(frozen.has('connector:slack')).toBe(false)
+    expect(frozen.search('slack channel')).toEqual([])
+  })
+
+  it('isolates frozen metadata from a live same-id replacement', () => {
+    const catalog = new VirtualToolCatalog(entries)
+    const frozen = catalog.freeze()
+    catalog.replaceAll(entries.map((entry) =>
+      entry.id === 'mcp:db/query'
+        ? { ...entry, description: 'Run a new parameterized query' }
+        : entry
+    ))
+
+    expect(frozen.load('mcp:db/query')?.description).toBe('Run a SQL query against the database')
+    expect(frozen.pendingUpdate()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Add a reusable virtual tool catalog and wire it into MCP search so catalog refreshes cannot change the tool/schema view in the middle of a turn.

## Changes
- add a versioned searchable virtual catalog with frozen snapshots
- freeze MCP search records per thread and turn, with bounded snapshot retention
- keep `mcp_search`, `mcp_describe`, and `mcp_call` on the same snapshot
- report pending live catalog updates after `mcp_refresh_catalog`
- activate refreshed tools and schemas on the next turn
- preserve existing BM25 ranking, workspace trust, and blocked-provider filtering

## Tests
- `npm.cmd --prefix kun test -- virtual-tool-catalog.test.ts mcp-tool-search.test.ts mcp-tool-provider.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd --prefix kun run build`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- focused ESLint
- `git diff --check`