### PR TITLE
fix(mcp): resolve nvm npx for stdio servers

### DIFF
--- a/kun/src/adapters/tool/mcp-stdio-environment.ts
+++ b/kun/src/adapters/tool/mcp-stdio-environment.ts
@@ -1,3 +1,4 @@
+import { readdirSync, statSync } from 'node:fs'
 import { posix, win32 } from 'node:path'
 import type { McpServerConfig } from '../../contracts/capabilities.js'
 
@@ -57,6 +58,7 @@ function commonMcpCommandPathEntries(
       '/opt/homebrew/bin',
       '/usr/local/bin',
       '/opt/local/bin',
+      ...nvmNodeBinPathEntries(env),
       homePath(env, '.volta/bin'),
       homePath(env, '.local/bin'),
       homePath(env, '.bun/bin')
@@ -67,6 +69,7 @@ function commonMcpCommandPathEntries(
       '/home/linuxbrew/.linuxbrew/bin',
       '/usr/local/bin',
       '/usr/bin',
+      ...nvmNodeBinPathEntries(env),
       homePath(env, '.volta/bin'),
       homePath(env, '.local/bin'),
       homePath(env, '.bun/bin')
@@ -114,6 +117,55 @@ function pathDelimiter(platform: NodeJS.Platform): string {
 
 function homePath(env: NodeJS.ProcessEnv, relativePath: string): string {
   return env.HOME ? posix.join(env.HOME, relativePath) : ''
+}
+
+function nvmNodeBinPathEntries(env: NodeJS.ProcessEnv): string[] {
+  const entries: string[] = []
+  const nvmBin = env.NVM_BIN?.trim()
+  if (nvmBin) entries.push(nvmBin)
+
+  const nvmDir = env.NVM_DIR?.trim() || homePath(env, '.nvm')
+  if (!nvmDir) return entries
+
+  const versionsDir = posix.join(nvmDir, 'versions/node')
+  for (const version of childDirectoryNames(versionsDir).sort(compareNvmVersionDescending)) {
+    const binPath = posix.join(versionsDir, version, 'bin')
+    if (isDirectory(binPath)) entries.push(binPath)
+  }
+  return entries
+}
+
+function childDirectoryNames(path: string): string[] {
+  try {
+    return readdirSync(path).filter((entry) => isDirectory(posix.join(path, entry)))
+  } catch {
+    return []
+  }
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function compareNvmVersionDescending(left: string, right: string): number {
+  const leftParts = nvmVersionParts(left)
+  const rightParts = nvmVersionParts(right)
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const diff = (rightParts[index] ?? 0) - (leftParts[index] ?? 0)
+    if (diff !== 0) return diff
+  }
+  return right.localeCompare(left)
+}
+
+function nvmVersionParts(version: string): number[] {
+  return version.replace(/^v/i, '').split(/[.-]/).map((part) => {
+    const value = Number.parseInt(part, 10)
+    return Number.isFinite(value) ? value : 0
+  })
 }
 
 function isMissingExecutableError(error: unknown, message: string): boolean {

--- a/kun/tests/mcp-tool-provider.test.ts
+++ b/kun/tests/mcp-tool-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { mkdtemp } from 'node:fs/promises'
+import { mkdir, mkdtemp } from 'node:fs/promises'
 import { createServer, get as httpGet } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
@@ -115,6 +115,22 @@ describe('MCP tool provider', () => {
       '/Users/alice/.local/bin',
       '/Users/alice/.bun/bin'
     ])
+  })
+
+  it('adds nvm node bin directories to stdio MCP environments on Linux', async () => {
+    const home = (await mkdtemp(join(tmpdir(), 'kun-nvm-home-'))).replace(/\\/g, '/')
+    const nvmBin = `${home}/.nvm/versions/node/v22.23.0/bin`
+    await mkdir(nvmBin, { recursive: true })
+
+    const env = buildMcpStdioEnvironment({}, {
+      platform: 'linux',
+      baseEnv: {
+        PATH: '/usr/bin',
+        HOME: home
+      }
+    })
+
+    expect(env.PATH).toContain(nvmBin)
   })
 
   it('keeps explicitly configured stdio MCP PATH values ahead of common paths', () => {


### PR DESCRIPTION
## Summary
- Fixes MCP stdio server startup when Kun is launched without an nvm-initialized shell PATH.
- Adds Linux/macOS discovery for `NVM_BIN` and existing `~/.nvm/versions/node/*/bin` entries before Volta/Bun fallback paths.
- Covers the nvm PATH case from #702 with a focused runtime test.

## Changes
- Extends `buildMcpStdioEnvironment` to include nvm-managed Node bin directories for GUI-launched apps.
- Keeps explicit MCP server PATH values first and continues to de-duplicate PATH entries.

## Tests
- `npm.cmd --prefix kun test -- tests/mcp-tool-provider.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `git diff --check`

Fixes #702