### PR TITLE
fix(tests): stabilize Windows test runs

### DIFF
--- a/scripts/mac-notarize.cjs
+++ b/scripts/mac-notarize.cjs
@@ -48,7 +48,10 @@ function isBundleLike(path) {
 
 function isLikelySignedFile(path, info) {
   if (/\.(dylib|node|so)$/i.test(path)) return true
-  return info.isFile() && (info.mode & 0o111) !== 0 && /\/Contents\/(?:MacOS|Frameworks)\//.test(path)
+  const normalizedPath = path.replace(/\\/g, '/')
+  if (!info.isFile()) return false
+  if (/\/Contents\/MacOS\//.test(normalizedPath)) return true
+  return (info.mode & 0o111) !== 0 && /\/Contents\/Frameworks\//.test(normalizedPath)
 }
 
 function collectSignedCodeCandidates(appBundle) {

--- a/src/main/services/git-checkpoint-service.test.ts
+++ b/src/main/services/git-checkpoint-service.test.ts
@@ -22,6 +22,8 @@ beforeEach(async () => {
   execFileSync('git', ['init', '-b', 'main', repoRoot], { stdio: 'pipe' })
   execFileSync('git', ['-C', repoRoot, 'config', 'user.email', 'test@example.com'], { stdio: 'pipe' })
   execFileSync('git', ['-C', repoRoot, 'config', 'user.name', 'Test'], { stdio: 'pipe' })
+  execFileSync('git', ['-C', repoRoot, 'config', 'core.autocrlf', 'false'], { stdio: 'pipe' })
+  execFileSync('git', ['-C', repoRoot, 'config', 'core.eol', 'lf'], { stdio: 'pipe' })
   await writeFile(join(repoRoot, 'tracked.txt'), 'base\n')
   await writeFile(join(repoRoot, 'staged.txt'), 'staged base\n')
   execFileSync('git', ['-C', repoRoot, 'add', '.'], { stdio: 'pipe' })

--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
 import { access, mkdir, realpath } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { basename, join } from 'node:path'
+import { basename, join, normalize } from 'node:path'
 import { promisify } from 'node:util'
 import type {
   GitBranchesResult,
@@ -77,6 +77,10 @@ function resolveBranchWorktreeRoot(worktreeRoot?: string): string {
   return worktreeRoot?.trim() || join(homedir(), '.kun', 'worktrees')
 }
 
+function normalizeGitPath(path: string): string {
+  return normalize(path)
+}
+
 async function allocateBranchWorktreePath(
   sourceRepositoryRoot: string,
   worktreeRoot?: string
@@ -96,7 +100,7 @@ async function getPrimaryWorktreeRoot(cwd: string, fallback: string): Promise<st
     const { stdout } = await runGit(cwd, ['worktree', 'list', '--porcelain'])
     const line = stdout.split('\n').find((item) => item.startsWith('worktree '))
     const root = line?.slice('worktree '.length).trim()
-    return root || fallback
+    return root ? normalizeGitPath(root) : fallback
   } catch {
     return fallback
   }
@@ -120,7 +124,7 @@ function parseWorktreeListPorcelain(stdout: string): GitBranchWorktreeRow[] {
   let branch: string | null = null
   let head = ''
   const flush = (): void => {
-    if (path) rows.push({ path, branch, head })
+    if (path) rows.push({ path: normalizeGitPath(path), branch, head })
     path = ''
     branch = null
     head = ''
@@ -171,7 +175,7 @@ export async function getGitBranches(workspaceRoot: string): Promise<GitBranches
     return { ok: false, reason: 'no_workspace', message: 'No working directory selected.' }
   }
   try {
-    const repositoryRoot = (await runGit(cwd, ['rev-parse', '--show-toplevel'])).stdout.trim()
+    const repositoryRoot = normalizeGitPath((await runGit(cwd, ['rev-parse', '--show-toplevel'])).stdout.trim())
     const currentRaw = (await runGit(cwd, ['branch', '--show-current'])).stdout.trim()
     const currentBranch = currentRaw || null
     const branchLines = (await runGit(cwd, ['branch', '--format=%(refname:short)'])).stdout
@@ -261,7 +265,7 @@ export async function checkoutGitBranchWorktree(
   if (!cwd) return { ok: false, reason: 'no_workspace', message: 'No working directory selected.' }
   if (!branch) return { ok: false, reason: 'error', message: 'Branch name is required.' }
   try {
-    const currentRepositoryRoot = (await runGit(cwd, ['rev-parse', '--show-toplevel'])).stdout.trim()
+    const currentRepositoryRoot = normalizeGitPath((await runGit(cwd, ['rev-parse', '--show-toplevel'])).stdout.trim())
     const sourceRepositoryRoot = await getPrimaryWorktreeRoot(cwd, currentRepositoryRoot)
     const wtPath = await allocateBranchWorktreePath(sourceRepositoryRoot, worktreeRoot)
     const worktreeBranch = await allocateDerivedWorktreeBranch(cwd)
@@ -286,7 +290,7 @@ export async function createGitBranchWorktree(
   if (!branch) return { ok: false, reason: 'error', message: 'Branch name is required.' }
   try {
     await runGit(cwd, ['check-ref-format', '--branch', branch])
-    const currentRepositoryRoot = (await runGit(cwd, ['rev-parse', '--show-toplevel'])).stdout.trim()
+    const currentRepositoryRoot = normalizeGitPath((await runGit(cwd, ['rev-parse', '--show-toplevel'])).stdout.trim())
     const sourceRepositoryRoot = await getPrimaryWorktreeRoot(cwd, currentRepositoryRoot)
     const wtPath = await allocateBranchWorktreePath(sourceRepositoryRoot, worktreeRoot)
     await mkdir(join(wtPath, '..'), { recursive: true })
@@ -304,13 +308,15 @@ export async function listGitBranchWorktrees(
   const cwd = await resolveGitCwd(workspaceRoot)
   if (!cwd) return { ok: false, reason: 'no_workspace', message: 'No working directory selected.' }
   try {
-    const currentRepositoryRoot = (await runGit(cwd, ['rev-parse', '--show-toplevel'])).stdout.trim()
+    const currentRepositoryRoot = normalizeGitPath((await runGit(cwd, ['rev-parse', '--show-toplevel'])).stdout.trim())
     const sourceRepositoryRoot = await getPrimaryWorktreeRoot(cwd, currentRepositoryRoot)
-    const root = await realpath(resolveBranchWorktreeRoot(worktreeRoot)).catch(() => resolveBranchWorktreeRoot(worktreeRoot))
+    const root = normalizeGitPath(
+      await realpath(resolveBranchWorktreeRoot(worktreeRoot)).catch(() => resolveBranchWorktreeRoot(worktreeRoot))
+    )
     const { stdout } = await runGit(cwd, ['worktree', 'list', '--porcelain'])
     const worktrees = parseWorktreeListPorcelain(stdout)
       .filter((row) => row.path !== sourceRepositoryRoot)
-      .filter((row) => row.path === root || row.path.startsWith(`${root}/`))
+      .filter((row) => row.path === root || row.path.startsWith(`${root}\\`) || row.path.startsWith(`${root}/`))
     return {
       ok: true,
       repositoryRoot: sourceRepositoryRoot,

--- a/src/main/services/workspace-editors.ts
+++ b/src/main/services/workspace-editors.ts
@@ -2,7 +2,7 @@ import { app, nativeImage, shell } from 'electron'
 import { execFile } from 'node:child_process'
 import { readFile, stat, unlink } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
-import { basename, dirname, extname, isAbsolute, join } from 'node:path'
+import { basename, dirname, extname, isAbsolute, join, posix } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { promisify } from 'node:util'
 import type {
@@ -356,11 +356,11 @@ function linuxIconNamePaths(iconName: string): string[] {
   ]
   const themed = roots.flatMap((root) =>
     LINUX_ICON_SIZES.flatMap((size) =>
-      ICON_IMAGE_EXTENSIONS.map((extension) => join(root, size, 'apps', `${iconName}${extension}`))
+      ICON_IMAGE_EXTENSIONS.map((extension) => posix.join(root, size, 'apps', `${iconName}${extension}`))
     )
   )
   const pixmaps = ['/usr/share/pixmaps', '/usr/local/share/pixmaps'].flatMap((root) =>
-    ICON_IMAGE_EXTENSIONS.map((extension) => join(root, `${iconName}${extension}`))
+    ICON_IMAGE_EXTENSIONS.map((extension) => posix.join(root, `${iconName}${extension}`))
   )
 
   return [...themed, ...pixmaps]
@@ -376,7 +376,7 @@ function linuxDesktopFilePaths(desktopIds: string[]): string[] {
     join(home, '.local', 'share', 'flatpak', 'exports', 'share', 'applications')
   ]
 
-  return roots.flatMap((root) => desktopIds.map((desktopId) => join(root, `${desktopId}.desktop`)))
+  return roots.flatMap((root) => desktopIds.map((desktopId) => posix.join(root, `${desktopId}.desktop`)))
 }
 
 async function linuxDesktopIconNames(desktopIds: string[] = []): Promise<string[]> {

--- a/src/main/workflow-runtime.ts
+++ b/src/main/workflow-runtime.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { randomBytes, randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { isAbsolute, join, resolve } from 'node:path'
@@ -450,6 +451,24 @@ const COMMAND_TIMEOUT_MS = 30_000
 const PYTHON_BIN = process.env.WORKFLOW_PYTHON_BIN?.trim() || 'python3'
 const MAX_SUBWORKFLOW_DEPTH = 5
 
+function resolveBashBin(): string {
+  const configured = process.env.WORKFLOW_BASH_BIN?.trim()
+  if (configured) return configured
+  if (process.platform !== 'win32') return 'bash'
+
+  const candidates = [
+    join(process.env.PROGRAMFILES || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'),
+    join(process.env.PROGRAMFILES || 'C:\\Program Files', 'Git', 'usr', 'bin', 'bash.exe'),
+    join(process.env['PROGRAMFILES(X86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe')
+  ]
+  if (process.env.LOCALAPPDATA) {
+    candidates.push(join(process.env.LOCALAPPDATA, 'Programs', 'Git', 'bin', 'bash.exe'))
+  }
+  return candidates.find((candidate) => existsSync(candidate)) ?? 'bash'
+}
+
+const BASH_BIN = resolveBashBin()
+
 function runCodeNode(
   code: string,
   payload: WorkflowPayload,
@@ -488,7 +507,7 @@ function runCommandNode(
   payload: WorkflowPayload,
   fields: Record<string, unknown> = {}
 ): Promise<NodeOutcome> {
-  const bin = language === 'python' ? PYTHON_BIN : 'bash'
+  const bin = language === 'python' ? PYTHON_BIN : BASH_BIN
   return new Promise((resolve, reject) => {
     const child = spawn(bin, ['-c', code], {
       env: {
@@ -616,7 +635,7 @@ export function checkWorkflowCode(language: WorkflowCodeLanguage, code: string):
       return Promise.resolve({ status: 'error', message: error instanceof Error ? error.message : String(error) })
     }
   }
-  const bin = language === 'python' ? PYTHON_BIN : 'bash'
+  const bin = language === 'python' ? PYTHON_BIN : BASH_BIN
   const args = language === 'python' ? ['-c', 'import ast, sys; ast.parse(sys.stdin.read())'] : ['-n']
   return new Promise((resolveResult) => {
     let settled = false


### PR DESCRIPTION
## Summary / 概要

- Stabilizes Windows test runs by removing platform-specific path, line-ending, executable-bit, and shell-resolution assumptions.

## Why / 背景

- Windows test runs were failing because several tests and supporting paths assumed POSIX separators, LF-only Git behavior, executable mode bits, or WSL-compatible `bash` environment inheritance.

## Changes / 变更

- Normalize Git repository and worktree paths before returning or comparing them.
- Use POSIX joins for Linux desktop/icon lookup paths.
- Force LF behavior in temporary Git checkpoint test repositories.
- Prefer Git Bash for workflow shell execution on Windows while preserving `WORKFLOW_BASH_BIN`.
- Normalize mac bundle candidate paths and avoid relying on executable bits for `Contents/MacOS` files on Windows.

## Media / 截图或录屏

- Not applicable; no UI changes.

## Tests / 测试

- Existing Windows-sensitive tests now pass; updated test setup for Git line-ending behavior.

## Validation / 验证

- [x] I agree that this contribution is submitted under the [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md). / 我同意本贡献遵循 [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md) 提交。
- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run dev` smoke: renderer dev server reached and Electron started.
- [x] UI change: not applicable; no UI changes.
- [x] Logic change: existing unit tests updated and passing.

## Notes / 备注

- No linked issue.