### PR TITLE
fix(runtime): secure managed Kun runtime settings

### DIFF
--- a/docs/KUN_CONFIG.md
+++ b/docs/KUN_CONFIG.md
@@ -50,7 +50,7 @@ GUI 启动 Kun 时会按下面的顺序合并配置。
     "host": "127.0.0.1",
     "port": 18899,
     "dataDir": "~/.kun/data",
-    "runtimeToken": "",
+    "runtimeToken": "<local-access-token>",
     "apiKey": "",
     "baseUrl": "https://api.deepseek.com/beta",
     "model": "deepseek-v4-pro",
@@ -87,6 +87,8 @@ GUI 启动 Kun 时会按下面的顺序合并配置。
   }
 }
 ```
+
+GUI 管理的运行时会在 `runtimeToken` 为空时自动生成并保存本地访问令牌。
 
 ## 模型配置写在哪里
 

--- a/docs/kun-architecture.en.md
+++ b/docs/kun-architecture.en.md
@@ -157,7 +157,7 @@ Saved settings should now be just:
       "autoStart": true,
       "apiKey": "",
       "baseUrl": "https://api.deepseek.com/beta",
-      "runtimeToken": "",
+      "runtimeToken": "<generated-local-token>",
       "dataDir": "~/.kun/data",
       "model": "deepseek-v4-pro",
       "approvalPolicy": "auto",

--- a/docs/kun-architecture.md
+++ b/docs/kun-architecture.md
@@ -146,7 +146,7 @@ Renderer 只应展示 Kun。需要删除或保持删除的 UI 面包括：
       "autoStart": true,
       "apiKey": "",
       "baseUrl": "https://api.deepseek.com/beta",
-      "runtimeToken": "",
+      "runtimeToken": "<generated-local-token>",
       "dataDir": "~/.kun/data",
       "model": "deepseek-v4-pro",
       "approvalPolicy": "auto",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import {
   type ContextMenuParams,
   type MenuItemConstructorOptions
 } from 'electron'
+import { randomBytes } from 'node:crypto'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -1067,9 +1068,11 @@ async function resolveManagedKunLaunchSettings(
   settings: AppSettingsV1,
   source: string
 ): Promise<AppSettingsV1> {
-  const runtime = getKunRuntimeSettings(settings)
+  const tokenResult = await ensureManagedKunRuntimeToken(settings, source)
+  const launchSettings = tokenResult.settings
+  const runtime = getKunRuntimeSettings(launchSettings)
   const resolved = await kunRuntimeAdapter.resolveAvailablePort(runtime.port)
-  if (!resolved.changed) return settings
+  if (!resolved.changed) return launchSettings
 
   const next = await store.patch({ agents: { kun: { port: resolved.port } } })
   lastAppliedSettings = next
@@ -1081,16 +1084,44 @@ async function resolveManagedKunLaunchSettings(
   return next
 }
 
-async function ensureKunRuntime(settings: AppSettingsV1): Promise<AppSettingsV1> {
-  const runtime = getKunRuntimeSettings(settings)
-  const hasApiKey = Boolean(resolveConfiguredApiKey(settings))
+function generateKunRuntimeToken(): string {
+  return randomBytes(32).toString('base64url')
+}
 
-  const healthy = await waitForKunHealth(settings, 2_000)
+async function ensureManagedKunRuntimeToken(
+  settings: AppSettingsV1,
+  source: string
+): Promise<{ settings: AppSettingsV1; generated: boolean }> {
+  const runtime = getKunRuntimeSettings(settings)
+  if (runtime.runtimeToken.trim()) {
+    return { settings, generated: false }
+  }
+
+  const next = await store.patch({
+    agents: { kun: { runtimeToken: generateKunRuntimeToken() } }
+  })
+  lastAppliedSettings = next
+  logWarn(source, 'Generated a runtime token for the managed Kun runtime because none was configured.')
+  return { settings: next, generated: true }
+}
+
+async function ensureKunRuntime(settings: AppSettingsV1): Promise<AppSettingsV1> {
+  const tokenResult = await ensureManagedKunRuntimeToken(settings, 'runtime-start')
+  const currentSettings = tokenResult.settings
+  if (tokenResult.generated && kunRuntimeAdapter.isChildRunning()) {
+    logWarn('runtime-start', 'Restarting managed Kun to apply the generated runtime token.')
+    await kunRuntimeAdapter.stopAndWait()
+  }
+
+  const runtime = getKunRuntimeSettings(currentSettings)
+  const hasApiKey = Boolean(resolveConfiguredApiKey(currentSettings))
+
+  const healthy = await waitForKunHealth(currentSettings, 2_000)
   if (healthy) {
-    const threadApi = await probeThreadApi(settings)
+    const threadApi = await probeThreadApi(currentSettings)
     if (threadApi.ok) {
       noteRuntimeHealthy('ensure')
-      return settings
+      return currentSettings
     }
     throw runtimeJsonError(threadApi.error, threadApi.message)
   }
@@ -1123,12 +1154,12 @@ async function ensureKunRuntime(settings: AppSettingsV1): Promise<AppSettingsV1>
     if (kunRuntimeAdapter.isChildRunning()) {
       // Give a merely-busy runtime a real chance to answer before judging it
       // hung, so one long synchronous step does not cost the user their turn.
-      const recovered = await waitForKunHealth(settings, RUNTIME_HUNG_CONFIRM_MS)
+      const recovered = await waitForKunHealth(currentSettings, RUNTIME_HUNG_CONFIRM_MS)
       if (recovered) {
-        const threadApi = await probeThreadApi(settings)
+        const threadApi = await probeThreadApi(currentSettings)
         if (threadApi.ok) {
           noteRuntimeHealthy('ensure')
-          return settings
+          return currentSettings
         }
         throw runtimeJsonError(threadApi.error, threadApi.message)
       }
@@ -1140,7 +1171,7 @@ async function ensureKunRuntime(settings: AppSettingsV1): Promise<AppSettingsV1>
     }
   }
 
-  const launchSettings = await resolveManagedKunLaunchSettings(settings, 'runtime-start')
+  const launchSettings = await resolveManagedKunLaunchSettings(currentSettings, 'runtime-start')
   const adapter = kunRuntimeAdapter
   try {
     await adapter.ensureRunning(launchSettings)
@@ -1358,6 +1389,46 @@ function validateRuntimeSettingsForApply(next: AppSettingsV1): string | null {
     }
   }
   return null
+}
+
+function preserveRuntimeTokenForFullSettingsSnapshot(
+  prev: AppSettingsV1,
+  partial: AppSettingsPatch
+): AppSettingsPatch {
+  const incomingKun = partial.agents?.kun
+  if (!incomingKun || !isFullSettingsSnapshotPatch(partial)) return partial
+  if (typeof incomingKun.runtimeToken !== 'string' || incomingKun.runtimeToken.trim()) return partial
+
+  const currentToken = getKunRuntimeSettings(prev).runtimeToken.trim()
+  if (!currentToken) return partial
+
+  return {
+    ...partial,
+    agents: {
+      ...partial.agents,
+      kun: {
+        ...incomingKun,
+        runtimeToken: currentToken
+      }
+    }
+  }
+}
+
+function isFullSettingsSnapshotPatch(partial: AppSettingsPatch): boolean {
+  return partial.version !== undefined &&
+    partial.provider !== undefined &&
+    partial.agents?.kun !== undefined &&
+    partial.log !== undefined &&
+    partial.checkpointCleanup !== undefined &&
+    partial.notifications !== undefined &&
+    partial.appBehavior !== undefined &&
+    partial.keyboardShortcuts !== undefined &&
+    partial.write !== undefined &&
+    partial.claw !== undefined &&
+    partial.schedule !== undefined &&
+    partial.workflow !== undefined &&
+    partial.terminal !== undefined &&
+    partial.guiUpdate !== undefined
 }
 
 async function restartManagedRuntimeForSettingsChange(
@@ -1634,30 +1705,31 @@ app.whenReady().then(async () => {
   traceStartup('ipc registration:start')
   const applySettingsPatch = async (partial: AppSettingsPatch): Promise<AppSettingsV1> => {
     const prev = await store.load()
-    const { agents: agentsPatch, provider: providerPatch, ...restPatch } = partial
+    const effectivePartial = preserveRuntimeTokenForFullSettingsSnapshot(prev, partial)
+    const { agents: agentsPatch, provider: providerPatch, ...restPatch } = effectivePartial
     const next = normalizeAppSettings({
       ...applyKunRuntimePatch(prev, agentsPatch?.kun),
       ...restPatch,
       provider: mergeModelProviderSettings(prev.provider, providerPatch),
-      log: { ...prev.log, ...(partial.log ?? {}) },
+      log: { ...prev.log, ...(effectivePartial.log ?? {}) },
       checkpointCleanup: normalizeCheckpointCleanupSettings({
         ...prev.checkpointCleanup,
-        ...(partial.checkpointCleanup ?? {})
+        ...(effectivePartial.checkpointCleanup ?? {})
       }),
-      notifications: { ...prev.notifications, ...(partial.notifications ?? {}) },
-      appBehavior: mergeAppBehaviorSettings(prev.appBehavior, partial.appBehavior),
+      notifications: { ...prev.notifications, ...(effectivePartial.notifications ?? {}) },
+      appBehavior: mergeAppBehaviorSettings(prev.appBehavior, effectivePartial.appBehavior),
       keyboardShortcuts: normalizeKeyboardShortcuts({
         bindings: {
           ...prev.keyboardShortcuts.bindings,
-          ...(partial.keyboardShortcuts?.bindings ?? {})
+          ...(effectivePartial.keyboardShortcuts?.bindings ?? {})
         }
       }),
-      write: mergeWriteSettings(prev.write, partial.write),
-      claw: mergeClawSettings(prev.claw, partial.claw),
-      schedule: mergeScheduleSettings(prev.schedule, partial.schedule),
-      workflow: mergeWorkflowSettings(prev.workflow, partial.workflow),
-      terminal: mergeTerminalSettings(prev.terminal, partial.terminal),
-      guiUpdate: { ...prev.guiUpdate, ...(partial.guiUpdate ?? {}) }
+      write: mergeWriteSettings(prev.write, effectivePartial.write),
+      claw: mergeClawSettings(prev.claw, effectivePartial.claw),
+      schedule: mergeScheduleSettings(prev.schedule, effectivePartial.schedule),
+      workflow: mergeWorkflowSettings(prev.workflow, effectivePartial.workflow),
+      terminal: mergeTerminalSettings(prev.terminal, effectivePartial.terminal),
+      guiUpdate: { ...prev.guiUpdate, ...(effectivePartial.guiUpdate ?? {}) }
     })
     if (prev.log.enabled !== next.log.enabled || prev.log.retentionDays !== next.log.retentionDays) {
       configureLogger({ enabled: next.log.enabled, retentionDays: next.log.retentionDays })
@@ -1666,7 +1738,7 @@ app.whenReady().then(async () => {
     if (runtimeValidationError) {
       throw new Error(`Invalid runtime settings: ${runtimeValidationError}`)
     }
-    const saved = await store.patch(partial)
+    const saved = await store.patch(effectivePartial)
     await syncClawScheduleMcpConfig(saved, getClawScheduleMcpLaunchConfig()).catch((error) => {
       console.error('[claw-schedule-mcp] failed to sync config after settings change:', error)
     })
@@ -1697,7 +1769,7 @@ app.whenReady().then(async () => {
   }
 
   const saveSettingsPatch = async (partial: AppSettingsPatch): Promise<AppSettingsV1> => {
-    return store.patch(partial)
+    return store.patch(preserveRuntimeTokenForFullSettingsSnapshot(await store.load(), partial))
   }
 
   registerAppIpcHandlers({

--- a/src/renderer/src/components/SettingsView.tsx
+++ b/src/renderer/src/components/SettingsView.tsx
@@ -48,6 +48,7 @@ import { useSettingsGuiUpdate } from './use-settings-gui-update'
 import {
   DEFAULT_WORKSPACE_ROOT,
   coerceRendererSettings,
+  diffSettingsPatch,
   hasValidPort,
   listSettingsText,
   mergeSettings,
@@ -194,6 +195,7 @@ export function SettingsView(): ReactElement {
   // exits that bypass goBack() (Esc, route changes, closing settings) don't
   // drop the last edit made within the 450ms debounce window (issue #602).
   const pendingSnapshotRef = useRef<AppSettingsV1 | null>(null)
+  const persistedSettingsRef = useRef<AppSettingsV1 | null>(null)
   const flushOnUnmountRef = useRef<() => void>(() => {})
   const agentsSectionRef = useRef<HTMLDivElement | null>(null)
   const skillSectionRef = useRef<HTMLDivElement | null>(null)
@@ -247,7 +249,11 @@ export function SettingsView(): ReactElement {
     void rendererRuntimeClient
       .getSettings({ forceRefresh: true })
       .then((s) => {
-        if (!cancelled) setForm(coerceRendererSettings(s))
+        if (!cancelled) {
+          const next = coerceRendererSettings(s)
+          persistedSettingsRef.current = next
+          setForm(next)
+        }
       })
       .catch((e: unknown) => {
         if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
@@ -286,7 +292,11 @@ export function SettingsView(): ReactElement {
   useEffect(() => {
     const onSettingsChanged = (event: Event): void => {
       const next = (event as CustomEvent<AppSettingsV1>).detail
-      if (next) setForm(coerceRendererSettings(next))
+      if (next) {
+        const coerced = coerceRendererSettings(next)
+        persistedSettingsRef.current = coerced
+        setForm(coerced)
+      }
     }
     window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
     return () => window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
@@ -695,13 +705,21 @@ export function SettingsView(): ReactElement {
     setSaveError(null)
 
     try {
+      const expandedSnapshot = expandSettingsHomePathsForUse(snapshot, settingsHomeDir, settingsPlatform)
+      const expandedBase = expandSettingsHomePathsForUse(
+        persistedSettingsRef.current ?? snapshot,
+        settingsHomeDir,
+        settingsPlatform
+      )
+      const patch = diffSettingsPatch(expandedBase, expandedSnapshot)
       const next = coerceRendererSettings(
-        await rendererRuntimeClient.setSettings(
-          expandSettingsHomePathsForUse(snapshot, settingsHomeDir, settingsPlatform)
-        )
+        Object.keys(patch).length > 0
+          ? await rendererRuntimeClient.setSettings(patch)
+          : await rendererRuntimeClient.getSettings({ forceRefresh: true })
       )
       if (version !== draftVersion.current) return
 
+      persistedSettingsRef.current = next
       setForm(next)
       emitRendererSettingsChanged(next)
       await applyI18n(next.locale)
@@ -774,10 +792,18 @@ export function SettingsView(): ReactElement {
     const snapshot = pendingSnapshotRef.current
     pendingSnapshotRef.current = null
     if (!snapshot || !hasValidPort(snapshot)) return
+    const expandedSnapshot = expandSettingsHomePathsForUse(snapshot, settingsHomeDir, settingsPlatform)
+    const expandedBase = expandSettingsHomePathsForUse(
+      persistedSettingsRef.current ?? snapshot,
+      settingsHomeDir,
+      settingsPlatform
+    )
+    const patch = diffSettingsPatch(expandedBase, expandedSnapshot)
     void rendererRuntimeClient
-      .setSettings(expandSettingsHomePathsForUse(snapshot, settingsHomeDir, settingsPlatform))
+      .setSettings(patch)
       .then((saved) => {
         const next = coerceRendererSettings(saved)
+        persistedSettingsRef.current = next
         emitRendererSettingsChanged(next)
         // App-wide effects the normal save path runs, so a last-moment locale or
         // UI-token edit still takes effect immediately rather than on next start.

--- a/src/renderer/src/components/settings-section-agents.tsx
+++ b/src/renderer/src/components/settings-section-agents.tsx
@@ -695,15 +695,10 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                   />
                   <SettingRow
                     title={t('kunInsecure')}
-                    description={
-                      kun.runtimeToken.trim()
-                        ? t('kunInsecureDesc')
-                        : t('kunInsecureForcedDesc')
-                    }
+                    description={t('kunInsecureDesc')}
                     control={
                       <Toggle
                         checked={isKunRuntimeInsecure(kun)}
-                        disabled={!kun.runtimeToken.trim()}
                         onChange={(v) => updateKun({ insecure: v })}
                       />
                     }

--- a/src/renderer/src/components/settings-utils.test.ts
+++ b/src/renderer/src/components/settings-utils.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import type { AppSettingsV1, KunRuntimeSettingsV1 } from '@shared/app-settings'
+import { coerceRendererSettings, diffSettingsPatch, mergeSettings } from './settings-utils'
+
+function settings(kunPatch: Partial<KunRuntimeSettingsV1> = {}): AppSettingsV1 {
+  return coerceRendererSettings({
+    agents: {
+      kun: kunPatch
+    }
+  } as unknown as AppSettingsV1)
+}
+
+describe('diffSettingsPatch', () => {
+  it('omits an unchanged blank runtime token when another setting changes', () => {
+    const base = settings({ runtimeToken: '' })
+    const next: AppSettingsV1 = {
+      ...base,
+      theme: 'dark'
+    }
+
+    const patch = diffSettingsPatch(base, next)
+
+    expect(patch).toEqual({ theme: 'dark' })
+    expect(patch.agents).toBeUndefined()
+  })
+
+  it('preserves an explicit runtime token clear', () => {
+    const base = settings({ runtimeToken: 'generated-token' })
+    const next: AppSettingsV1 = {
+      ...base,
+      agents: {
+        kun: {
+          ...base.agents.kun,
+          runtimeToken: ''
+        }
+      }
+    }
+
+    expect(diffSettingsPatch(base, next)).toEqual({
+      agents: {
+        kun: {
+          runtimeToken: ''
+        }
+      }
+    })
+  })
+
+  it('diffs nested provider fields without sending the full settings snapshot', () => {
+    const base = settings()
+    const next: AppSettingsV1 = {
+      ...base,
+      provider: {
+        ...base.provider,
+        apiKey: 'sk-next'
+      }
+    }
+
+    expect(diffSettingsPatch(base, next)).toEqual({
+      provider: {
+        apiKey: 'sk-next'
+      }
+    })
+  })
+
+  it('preserves provider proxy siblings when applying a partial diff patch', () => {
+    const base: AppSettingsV1 = {
+      ...settings(),
+      provider: {
+        ...settings().provider,
+        proxy: {
+          enabled: true,
+          url: 'http://127.0.0.1:7890'
+        }
+      }
+    }
+    const next: AppSettingsV1 = {
+      ...base,
+      provider: {
+        ...base.provider,
+        proxy: {
+          ...base.provider.proxy,
+          url: 'http://127.0.0.1:9999'
+        }
+      }
+    }
+
+    const patch = diffSettingsPatch(base, next)
+
+    expect(patch).toEqual({
+      provider: {
+        proxy: {
+          url: 'http://127.0.0.1:9999'
+        }
+      }
+    })
+    expect(mergeSettings(base, patch).provider.proxy).toEqual({
+      enabled: true,
+      url: 'http://127.0.0.1:9999'
+    })
+  })
+})

--- a/src/renderer/src/components/settings-utils.ts
+++ b/src/renderer/src/components/settings-utils.ts
@@ -37,6 +37,7 @@ import type { GuiUpdateInfo } from '@shared/gui-update'
 
 type RendererSettingsShape = AppSettingsPatch
 type SettingsPatch = AppSettingsPatch
+const SETTINGS_DIFF_NO_CHANGE = Symbol('settings-diff-no-change')
 
 export const DEFAULT_WORKSPACE_ROOT = '~/.kun/default_workspace'
 
@@ -94,6 +95,11 @@ export function mergeSettings(current: AppSettingsV1, patch: SettingsPatch): App
   }
 }
 
+export function diffSettingsPatch(base: AppSettingsV1, next: AppSettingsV1): AppSettingsPatch {
+  const diff = diffSettingsValue(base, next)
+  return diff === SETTINGS_DIFF_NO_CHANGE ? {} : diff as AppSettingsPatch
+}
+
 export function coerceRendererSettings(settings: AppSettingsV1): AppSettingsV1 {
   const raw = settings as RendererSettingsShape
   const theme =
@@ -141,6 +147,42 @@ export function coerceRendererSettings(settings: AppSettingsV1): AppSettingsV1 {
     codePromptPrefix: typeof raw.codePromptPrefix === 'string' ? raw.codePromptPrefix : '',
     disabledSkillIds: normalizeDisabledSkillIds(raw.disabledSkillIds)
   }
+}
+
+function diffSettingsValue(base: unknown, next: unknown): unknown | typeof SETTINGS_DIFF_NO_CHANGE {
+  if (settingsValueEqual(base, next)) return SETTINGS_DIFF_NO_CHANGE
+  if (isPlainSettingsRecord(base) && isPlainSettingsRecord(next)) {
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(next).sort()) {
+      const childDiff = diffSettingsValue(base[key], next[key])
+      if (childDiff !== SETTINGS_DIFF_NO_CHANGE) out[key] = childDiff
+    }
+    return Object.keys(out).length > 0 ? out : SETTINGS_DIFF_NO_CHANGE
+  }
+  return next
+}
+
+function settingsValueEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  return stableSettingsStringify(a) === stableSettingsStringify(b)
+}
+
+function stableSettingsStringify(value: unknown): string {
+  return JSON.stringify(canonicalSettingsValue(value))
+}
+
+function canonicalSettingsValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalSettingsValue)
+  if (!isPlainSettingsRecord(value)) return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    out[key] = canonicalSettingsValue(value[key])
+  }
+  return out
+}
+
+function isPlainSettingsRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function normalizeDisabledSkillIds(value: unknown): string[] {

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -779,7 +779,7 @@
   "portDesc": "Port used by the local AI assistant service. Most users do not need to change it.",
   "portInvalid": "Port must be between 10000 and 65535.",
   "runtimeToken": "Local access token (optional)",
-  "runtimeTokenDesc": "Protects the assistant service running on this computer. Fill this only if another local program needs to connect to it.",
+  "runtimeTokenDesc": "Protects the assistant service running on this computer. Kun generates one automatically when blank; fill it only if another local program needs a fixed token.",
   "configFilePath": "External tool config path",
   "configFilePathDesc": "Path to the MCP external tool server JSON config.",
   "skillsLocation": "Skill save location",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -779,7 +779,7 @@
   "portDesc": "AI 助手后台服务使用的本机端口。一般不需要修改。",
   "portInvalid": "端口必须在 10000 到 65535 之间。",
   "runtimeToken": "本地访问令牌（可选）",
-  "runtimeTokenDesc": "用于保护本机上的助手服务。只在你需要让其他本地程序连接它时填写。",
+  "runtimeTokenDesc": "用于保护本机上的助手服务。留空时 Kun 会自动生成；只在其他本地程序需要固定令牌时填写。",
   "configFilePath": "外部工具配置路径",
   "configFilePathDesc": "MCP 外部工具服务器的 JSON 配置文件路径。",
   "skillsLocation": "技能保存位置",

--- a/src/shared/app-settings-kun.ts
+++ b/src/shared/app-settings-kun.ts
@@ -1012,7 +1012,7 @@ export function applyKunRuntimePatch(
 }
 
 export function isKunRuntimeInsecure(runtime: Pick<KunRuntimeSettingsV1, 'insecure' | 'runtimeToken'>): boolean {
-  return runtime.insecure || !runtime.runtimeToken.trim()
+  return runtime.insecure === true
 }
 
 export function getActiveAgentApiKey(settings: AppSettingsV1): string {

--- a/src/shared/app-settings-provider.ts
+++ b/src/shared/app-settings-provider.ts
@@ -135,7 +135,13 @@ export function mergeModelProviderSettings(
 ): ModelProviderSettingsV1 {
   return normalizeModelProviderSettings({
     ...current,
-    ...(patch ?? {})
+    ...(patch ?? {}),
+    proxy: patch?.proxy
+      ? {
+          ...current.proxy,
+          ...patch.proxy
+        }
+      : current.proxy
   })
 }
 

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -506,14 +506,14 @@ describe('claw settings', () => {
 })
 
 describe('isKunRuntimeInsecure', () => {
-  it('treats an empty runtime token as effectively insecure', () => {
+  it('keeps auth enabled even when the runtime token is empty', () => {
     expect(
       isKunRuntimeInsecure({
         ...defaultKunRuntimeSettings(),
         insecure: false,
         runtimeToken: ''
       })
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('keeps auth enabled when a token exists and insecure is false', () => {
@@ -524,6 +524,16 @@ describe('isKunRuntimeInsecure', () => {
         runtimeToken: 'tok-1'
       })
     ).toBe(false)
+  })
+
+  it('honors explicit insecure mode', () => {
+    expect(
+      isKunRuntimeInsecure({
+        ...defaultKunRuntimeSettings(),
+        insecure: true,
+        runtimeToken: 'tok-1'
+      })
+    ).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary / 概要

- Secures the managed Kun runtime by generating and preserving a local runtime token.
- Changes Settings saves to send focused patches so unchanged sensitive settings are not overwritten.

## Why / 背景

- The managed Kun runtime can start with an empty runtime token, which makes local runtime authentication depend on an implicit blank-token state.
- Settings saves can submit full snapshots with unchanged blank fields, causing generated runtime credentials or nested provider settings to be lost.

## Changes / 变更

- Generate and persist a managed Kun runtime token when no token is configured.
- Preserve the current runtime token when a full settings snapshot carries an unchanged blank token field.
- Save renderer settings as minimal diffs instead of full settings snapshots.
- Allow runtime auth state to depend on the explicit `insecure` setting instead of treating a blank token as forced insecure mode.
- Preserve provider proxy sibling fields when applying partial provider settings patches.
- Update settings copy and runtime configuration docs to describe generated local runtime tokens.

## Media / 截图或录屏

- Not applicable; no visual UI change.

## Tests / 测试

- Added settings diff tests for runtime token preservation and provider proxy partial patches.
- Updated runtime security settings tests for explicit insecure mode.

## Validation / 验证

- [x] I agree that this contribution is submitted under the [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md). / 我同意本贡献遵循 [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md) 提交。
- [x] `npm run test -- src/shared/app-settings.test.ts src/renderer/src/components/settings-utils.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run dev` smoke: renderer dev server reached and Electron started.
- [x] UI change: not applicable; no visual UI change.
- [x] Logic change: unit tests added or updated.

## Notes / 备注

- No linked issue.