### PR TITLE
fix(validation): restore typecheck and timeline error tests

### DIFF
--- a/src/main/services/write-export-service.ts
+++ b/src/main/services/write-export-service.ts
@@ -626,7 +626,7 @@ function designExportSaveDialog(
 /**
  * Export a design prototype (an already-complete single-file HTML document) to
  * a standalone .html or a .pdf (rendered via a hidden BrowserWindow). Reuses the
- * write-mode renderHtmlToPdf pipeline.
+ * write-mode HTML render pipeline.
  */
 export async function exportDesignPrototype(
   payload: DesignExportPayload,
@@ -643,7 +643,7 @@ export async function exportDesignPrototype(
       ? dialogResult.filePath
       : `${dialogResult.filePath}${ext}`
     if (payload.format === 'pdf') {
-      await writeFile(targetPath, await renderHtmlToPdf(html))
+      await writeFile(targetPath, await renderHtmlDocument(html, 'pdf'))
     } else {
       await writeFile(targetPath, html, 'utf8')
     }

--- a/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
+++ b/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
@@ -444,6 +444,28 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
     expect(html).toContain('aria-expanded="false"')
   })
 
+  it('keeps an active failed-tool detail visible while the turn is running', () => {
+    const block: ChatBlock = toolBlock({
+      summary: 'Recognize image recognize_image',
+      status: 'error',
+      detail: 'model request failed with status 401',
+      meta: { toolName: 'recognize_image' }
+    })
+
+    const html = renderToStaticMarkup(
+      createElement(ProcessSectionRow, {
+        section: { id: 'execution-tool_error', kind: 'execution', blocks: [block] },
+        processing: true,
+        singleReasoningSection: false,
+        viewportRef: { current: null }
+      })
+    )
+
+    expect(html).toContain('Recognize image recognize_image')
+    expect(html).toContain('model request failed with status 401')
+    expect(html).toContain('aria-expanded="true"')
+  })
+
   it('expands active reasoning so the current process is visible', () => {
     const block: ChatBlock = {
       kind: 'reasoning',

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -549,10 +549,10 @@ function MessageTurn({
   )
   const onlyCompactionProcess = processBlocks.length > 0 && workProcessBlocks.length === 0
   const hasProcessError = workProcessBlocks.some(processBlockHasError)
-  // Error details should stay visible after completion so provider/runtime
-  // failures do not disappear into a collapsed work summary.
+  // Keep active failures visible while a turn is still running, but fold
+  // completed failures into the normal work summary until the user opens it.
   const forceExpandForError = isProcessing && hasProcessError
-  const workExpanded = forceExpandForError || (workExpandedOverride ?? (isProcessing || hasProcessError))
+  const workExpanded = forceExpandForError || (workExpandedOverride ?? isProcessing)
   const reviewBlocks = useMemo(
     () => turn.blocks.filter((block) => block.kind === 'review'),
     [turn.blocks]

--- a/src/renderer/src/components/chat/message-timeline-process.tsx
+++ b/src/renderer/src/components/chat/message-timeline-process.tsx
@@ -387,8 +387,7 @@ function ProcessStackRows({
         const autoOpenPending = processBlockIsAutoOpenPending(block, processing) || isPendingApproval(block)
         const errorTone = processBlockErrorTone(block)
         const isError = errorTone !== null
-        // Error details are visible by default but remain collapsible.
-        const defaultOpen = isError
+        const defaultOpen = processing && isError
         const forceOpen = autoOpenPending || autoOpenRequestInput
         const userClosed = closedBlockIds.has(block.id)
         const userOpened = openBlockId === block.id
@@ -503,8 +502,7 @@ function ProcessEntryRow({
   const errorTone = processBlockErrorTone(block)
   const isError = errorTone !== null
   const forceOpen = isAutoOpenPending || isAssistantProcessText || isStreamingAssistant
-  // Error details are visible by default but remain collapsible.
-  const defaultOpen = isError
+  const defaultOpen = processing && isError
   const open =
     canExpand &&
     (forceOpen || (userOpen ?? defaultOpen))


### PR DESCRIPTION
Summary
- Fix design prototype PDF export to use the existing HTML render pipeline.
- Keep completed timeline errors collapsed while preserving visible active error details.
- Add coverage for active failed tool detail visibility.

Tests
- npm run typecheck
- npm exec -- vitest run src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts