### PR TITLE
fix(chat): use thread workspace for file previews

### DIFF
--- a/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
+++ b/src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts
@@ -3,9 +3,19 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ChatBlock, NormalizedThread, ToolBlock } from '../../agent/types'
 import { useChatStore } from '../../store/chat-store'
-import { MessageTimeline, goalTimelinePaddingClass, liveTurnProgressClass, summarizeToolBlock } from './MessageTimeline'
+import {
+  MessageTimeline,
+  goalTimelinePaddingClass,
+  liveTurnProgressClass,
+  summarizeToolBlock
+} from './MessageTimeline'
 import { GeneratedFilesPanel, MessageBubble } from './message-timeline-bubbles'
 import { ProcessSectionRow } from './message-timeline-process'
+import {
+  TimelineFilePreviewWorkspaceProvider,
+  timelineFilePreviewWorkspaceRoot,
+  useTimelineFilePreviewWorkspaceRoot
+} from './timeline-file-preview-workspace'
 
 const labels: Record<string, string> = {
   toolActionCommand: 'Ran command',
@@ -43,6 +53,36 @@ function toolBlock(overrides: Partial<ToolBlock>): ToolBlock {
 }
 
 describe('MessageTimeline tool summaries', () => {
+  function WorkspaceConsumer() {
+    return createElement('span', null, useTimelineFilePreviewWorkspaceRoot())
+  }
+
+  it('uses the active thread workspace for file previews before falling back to the global workspace', () => {
+    expect(timelineFilePreviewWorkspaceRoot(
+      { workspace: ' /tmp/thread-workspace ' },
+      '/tmp/global-workspace'
+    )).toBe('/tmp/thread-workspace')
+
+    expect(timelineFilePreviewWorkspaceRoot(
+      { workspace: '   ' },
+      '/tmp/global-workspace'
+    )).toBe('/tmp/global-workspace')
+  })
+
+  it('provides the timeline workspace through context instead of the global active thread', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        TimelineFilePreviewWorkspaceProvider,
+        {
+          workspaceRoot: '/tmp/embedded-thread',
+          children: createElement(WorkspaceConsumer)
+        }
+      )
+    )
+
+    expect(html).toContain('/tmp/embedded-thread')
+  })
+
   it('summarizes built-in read/write/edit tools with their file path', () => {
     expect(
       summarizeToolBlock(
@@ -378,6 +418,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-tool_1', kind: 'execution', blocks: [block] },
         processing: false,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -404,6 +445,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-tool_1', kind: 'execution', blocks: [block] },
         processing: true,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -429,6 +471,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-tool_error', kind: 'execution', blocks: [block] },
         processing: false,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -457,6 +500,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-tool_error', kind: 'execution', blocks: [block] },
         processing: true,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -478,6 +522,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'reasoning', kind: 'reasoning', blocks: [block] },
         processing: true,
         singleReasoningSection: true,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -508,6 +553,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-batch', kind: 'execution', blocks: [readBlock, grepBlock] },
         processing: false,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -553,6 +599,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-batch', kind: 'execution', blocks: [readBlock, inputBlock] },
         processing: true,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -585,6 +632,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-batch', kind: 'execution', blocks: [readBlock, approvalBlock] },
         processing: true,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -619,6 +667,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-input', kind: 'execution', blocks: [inputBlock] },
         processing: true,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )
@@ -654,6 +703,7 @@ describe('MessageTimeline Kun runtime metadata smoke', () => {
         section: { id: 'execution-input', kind: 'execution', blocks: [inputBlock] },
         processing: true,
         singleReasoningSection: false,
+        workspaceRoot: '/tmp/project',
         viewportRef: { current: null }
       })
     )

--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -32,6 +32,10 @@ import {
 import { extractPlanMetadataFromBlock } from '../../plan/plan-tool'
 import { InjectedMemoryLookupProvider } from './injected-memory-lookup'
 import { planDisplayNameFromRelativePath } from '../../plan/plan-path'
+import {
+  TimelineFilePreviewWorkspaceProvider,
+  timelineFilePreviewWorkspaceRoot
+} from './timeline-file-preview-workspace'
 
 export { summarizeToolBlock } from './message-timeline-process'
 
@@ -263,6 +267,7 @@ export function MessageTimeline({
     typeof activeThread?.forkedFromTurnCount === 'number'
       ? Math.max(0, activeThread.forkedFromTurnCount)
       : undefined
+  const filePreviewWorkspaceRoot = timelineFilePreviewWorkspaceRoot(activeThread, workspaceRoot)
 
   useEffect(() => {
     const container = containerRef.current
@@ -314,6 +319,7 @@ export function MessageTimeline({
   }
 
   return (
+    <TimelineFilePreviewWorkspaceProvider workspaceRoot={filePreviewWorkspaceRoot}>
     <InjectedMemoryLookupProvider workspaceRoot={workspaceRoot}>
     <div ref={containerRef} className="ds-no-drag relative flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden">
       {visibleTurnAnchors.length > 2 ? (
@@ -418,6 +424,7 @@ export function MessageTimeline({
                 onBuildPlan={onBuildPlan}
                 onOpenPlan={onOpenPlan}
                 onOpenChildThread={onOpenChildThread}
+                filePreviewWorkspaceRoot={filePreviewWorkspaceRoot}
                 viewportRef={containerRef}
                 compactCards={compactCards}
               />
@@ -452,6 +459,7 @@ export function MessageTimeline({
             liveReasoning={liveReasoning}
             live={live}
             devPreviewCard={devPreviewCard}
+            filePreviewWorkspaceRoot={filePreviewWorkspaceRoot}
             viewportRef={containerRef}
             onOpenChildThread={onOpenChildThread}
             compactCards={compactCards}
@@ -473,6 +481,7 @@ export function MessageTimeline({
       </div>
     </div>
     </InjectedMemoryLookupProvider>
+    </TimelineFilePreviewWorkspaceProvider>
   )
 }
 
@@ -488,6 +497,7 @@ function MessageTurn({
   onBuildPlan,
   onOpenPlan,
   onOpenChildThread,
+  filePreviewWorkspaceRoot,
   viewportRef,
   compactCards = false
 }: {
@@ -502,10 +512,10 @@ function MessageTurn({
   onBuildPlan?: () => void
   onOpenPlan?: () => void
   onOpenChildThread?: OpenChildThreadHandler
+  filePreviewWorkspaceRoot: string
   viewportRef: RefObject<HTMLDivElement | null>
   compactCards?: boolean
 }): ReactElement {
-  const workspaceRoot = useChatStore((s) => s.workspaceRoot)
   const activeThreadGoal = useChatStore((s) => s.activeThreadGoal)
   const forkThreadFromTurn = useChatStore((s) => s.forkThreadFromTurn)
   const rollbackWorkspaceToCheckpoint = useChatStore((s) => s.rollbackWorkspaceToCheckpoint)
@@ -535,9 +545,9 @@ function MessageTurn({
         isProcessing,
         liveProcessText,
         liveContent,
-        workspaceRoot
+        workspaceRoot: filePreviewWorkspaceRoot
       }),
-    [turn, isProcessing, liveProcessText, liveContent, workspaceRoot]
+    [turn, isProcessing, liveProcessText, liveContent, filePreviewWorkspaceRoot]
   )
   const compactionBlocks = useMemo(
     () => processBlocks.filter((block): block is CompactionTimelineBlock => block.kind === 'compaction'),
@@ -640,6 +650,7 @@ function MessageTurn({
                   processing={isProcessing}
                   reasoningDurationMs={reasoningDurationMs}
                   singleReasoningSection={reasoningSectionCount === 1}
+                  workspaceRoot={filePreviewWorkspaceRoot}
                   viewportRef={viewportRef}
                   onOpenChildThread={onOpenChildThread}
                 />

--- a/src/renderer/src/components/chat/StreamdownAssistant.tsx
+++ b/src/renderer/src/components/chat/StreamdownAssistant.tsx
@@ -8,9 +8,9 @@ import { parseFileReferenceHref, rehypeFileReferences } from '../../lib/file-ref
 import { useValidatedFileReference } from '../../lib/file-reference-validation'
 import { openWorkspacePathInEditor } from '../../lib/open-workspace-path'
 import { previewWorkspaceFile } from '../../lib/workspace-file-preview'
-import { useChatStore } from '../../store/chat-store'
 import { sanitizeAssistantCanvasToolDisplay } from '../../design/canvas/strip-canvas-tool-display'
 import { StreamdownCode } from './StreamdownCode'
+import { useTimelineFilePreviewWorkspaceRoot } from './timeline-file-preview-workspace'
 import { createMathPlugin } from '@streamdown/math'
 import 'katex/dist/katex.min.css'
 
@@ -137,7 +137,7 @@ function StreamdownLink({
   className,
   title
 }: StreamdownLinkProps): ReactElement {
-  const workspaceRoot = useChatStore((s) => s.workspaceRoot)
+  const workspaceRoot = useTimelineFilePreviewWorkspaceRoot()
   const fileTarget = parseFileReferenceHref(href)
   const validation = useValidatedFileReference(fileTarget, workspaceRoot)
   const isExternal = href ? /^(https?:|mailto:)/i.test(href) : false

--- a/src/renderer/src/components/chat/StreamdownCode.tsx
+++ b/src/renderer/src/components/chat/StreamdownCode.tsx
@@ -33,7 +33,7 @@ import {
   highlightCodeHtml,
   renderFallbackCodeHtml
 } from '../../lib/code-highlighting'
-import { useChatStore } from '../../store/chat-store'
+import { useTimelineFilePreviewWorkspaceRoot } from './timeline-file-preview-workspace'
 
 const LANGUAGE_REGEX = /language-([^\s]+)/
 const TRAILING_NEWLINES_REGEX = /\n+$/
@@ -154,7 +154,7 @@ function InlineFileReferenceCode({
   target: FileReferenceTarget
   className?: string
 }): ReactNode {
-  const workspaceRoot = useChatStore((s) => s.workspaceRoot)
+  const workspaceRoot = useTimelineFilePreviewWorkspaceRoot()
   const validation = useValidatedFileReference(target, workspaceRoot)
 
   if (validation.status !== 'valid') {

--- a/src/renderer/src/components/chat/message-timeline-process.tsx
+++ b/src/renderer/src/components/chat/message-timeline-process.tsx
@@ -22,7 +22,6 @@ import { extractUnifiedDiffText } from '../../lib/diff-stats'
 import { useDeferredRender } from '../../hooks/use-deferred-render'
 import { openWorkspacePathInEditor } from '../../lib/open-workspace-path'
 import { previewWorkspaceFile } from '../../lib/workspace-file-preview'
-import { useChatStore } from '../../store/chat-store'
 import { DiffView } from '../DiffView'
 import { AssistantMarkdown } from './AssistantMarkdown'
 import { MessageBubble } from './message-timeline-bubbles'
@@ -204,6 +203,7 @@ export function ProcessSectionRow({
   processing,
   reasoningDurationMs,
   singleReasoningSection,
+  workspaceRoot,
   viewportRef,
   onOpenChildThread
 }: {
@@ -211,6 +211,7 @@ export function ProcessSectionRow({
   processing: boolean
   reasoningDurationMs?: number
   singleReasoningSection: boolean
+  workspaceRoot: string
   viewportRef: RefObject<HTMLDivElement | null>
   onOpenChildThread?: OpenChildThreadHandler
 }): ReactElement {
@@ -257,7 +258,7 @@ export function ProcessSectionRow({
   if (section.kind === 'execution' && section.blocks.length === 1) {
     const [block] = section.blocks
     if (block) {
-      return <ProcessEntryRow block={block} processing={processing} />
+      return <ProcessEntryRow block={block} processing={processing} workspaceRoot={workspaceRoot} />
     }
   }
 
@@ -331,7 +332,7 @@ export function ProcessSectionRow({
               <AssistantMarkdown text={reasoningText} streaming={active && processing} />
             </div>
           ) : (
-            <ProcessStackRows blocks={section.blocks} processing={processing} />
+            <ProcessStackRows blocks={section.blocks} processing={processing} workspaceRoot={workspaceRoot} />
           )
           ) : null}
         </div>
@@ -367,10 +368,12 @@ function processBlockHasError(block: ChatBlock): boolean {
 
 function ProcessStackRows({
   blocks,
-  processing
+  processing,
+  workspaceRoot
 }: {
   blocks: ChatBlock[]
   processing: boolean
+  workspaceRoot: string
 }): ReactElement {
   const { t } = useTranslation('common')
   const [openBlockId, setOpenBlockId] = useState<string | null>(null)
@@ -443,7 +446,7 @@ function ProcessStackRows({
             >
               {RowIcon ? <ProcessGlyph Icon={RowIcon} /> : null}
               <span className={`min-w-0 flex-1 truncate ${rowActive && !isError ? 'ds-shiny-text' : ''}`}>
-                <ProcessSummaryText block={block} summary={summary} />
+                <ProcessSummaryText block={block} summary={summary} workspaceRoot={workspaceRoot} />
               </span>
               {canExpand ? (
                 <button
@@ -485,10 +488,12 @@ function ProcessStackRows({
 /** One line inside an execution section. */
 function ProcessEntryRow({
   block,
-  processing
+  processing,
+  workspaceRoot
 }: {
   block: ChatBlock
   processing: boolean
+  workspaceRoot: string
 }): ReactElement {
   const { t } = useTranslation('common')
   const [userOpen, setUserOpen] = useState<boolean | null>(null)
@@ -558,7 +563,7 @@ function ProcessEntryRow({
           </span>
           {rest ? (
             <span className="ml-1.5 font-mono text-[13px]">
-              <ProcessSummaryText block={block} summary={rest} />
+              <ProcessSummaryText block={block} summary={rest} workspaceRoot={workspaceRoot} />
             </span>
           ) : null}
         </span>
@@ -794,13 +799,14 @@ function toolFilePath(block: ToolBlock): string | undefined {
 
 function ProcessFileReference({
   path,
+  workspaceRoot,
   children
 }: {
   path: string
+  workspaceRoot: string
   children: string
 }): ReactElement {
   const { t } = useTranslation('common')
-  const workspaceRoot = useChatStore((s) => s.workspaceRoot)
 
   const stopRowToggle = (event: ReactMouseEvent<HTMLElement>): void => {
     event.stopPropagation()
@@ -841,10 +847,12 @@ function ProcessFileReference({
 
 function ProcessSummaryText({
   block,
-  summary
+  summary,
+  workspaceRoot
 }: {
   block: ChatBlock
   summary: string
+  workspaceRoot: string
 }): ReactElement {
   if (block.kind !== 'tool') return <>{summary}</>
   const path = toolFilePath(block)
@@ -856,7 +864,7 @@ function ProcessSummaryText({
   return (
     <>
       {before}
-      <ProcessFileReference path={path}>{path}</ProcessFileReference>
+      <ProcessFileReference path={path} workspaceRoot={workspaceRoot}>{path}</ProcessFileReference>
       {after}
     </>
   )

--- a/src/renderer/src/components/chat/timeline-file-preview-workspace.tsx
+++ b/src/renderer/src/components/chat/timeline-file-preview-workspace.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type ReactNode } from 'react'
+
+export function timelineFilePreviewWorkspaceRoot(
+  activeThread: { workspace?: string | null } | null | undefined,
+  workspaceRoot: string
+): string {
+  return activeThread?.workspace?.trim() || workspaceRoot
+}
+
+const TimelineFilePreviewWorkspaceContext = createContext('')
+
+export function TimelineFilePreviewWorkspaceProvider({
+  workspaceRoot,
+  children
+}: {
+  workspaceRoot: string
+  children: ReactNode
+}) {
+  return (
+    <TimelineFilePreviewWorkspaceContext.Provider value={workspaceRoot}>
+      {children}
+    </TimelineFilePreviewWorkspaceContext.Provider>
+  )
+}
+
+export function useTimelineFilePreviewWorkspaceRoot(): string {
+  return useContext(TimelineFilePreviewWorkspaceContext)
+}


### PR DESCRIPTION
Summary
- Fix timeline file previews to resolve paths against the active thread workspace instead of the currently selected global workspace.
- Thread workspace context now flows through markdown file links and process/tool file references.
- Add regression coverage for previews when the selected workspace differs from the thread workspace.

Changes
- Add a timeline file-preview workspace provider derived from the active thread.
- Pass the derived workspace root into process-section file reference previews and editor opens.
- Keep existing global workspace behavior as a fallback when no thread workspace is available.

Tests
- npm run typecheck
- npm exec -- vitest run src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts

Fixes #708