### PR TITLE
fix(chat): compact timeline jump rail

### DIFF
--- a/src/renderer/src/components/chat/MessageTimeline.tsx
+++ b/src/renderer/src/components/chat/MessageTimeline.tsx
@@ -59,6 +59,9 @@ type CompactionTimelineBlock = Extract<ChatBlock, { kind: 'compaction' }>
 
 const TURN_PAGE_SIZE = 18
 const AUTO_COLLAPSE_THRESHOLD = 24
+const TIMELINE_JUMP_RAIL_RESERVED_PX = 84
+const TIMELINE_JUMP_RAIL_GAP_PX = 18
+const TIMELINE_JUMP_RAIL_FALLBACK_LEFT_PX = 16
 
 export function goalTimelinePaddingClass(route: 'chat' | 'claw', hasActiveGoal: boolean): string {
   return route === 'chat' && hasActiveGoal ? 'pb-32 md:pb-40' : 'pb-10'
@@ -81,6 +84,16 @@ export function activeTimelineTurnKey(
     active = position.key
   }
   return active
+}
+
+export function timelineJumpRailLeft(containerLeft: number, containerWidth: number, contentMaxWidth: number): number {
+  const contentWidth = Math.min(
+    containerWidth,
+    Math.max(0, contentMaxWidth),
+    Math.max(0, containerWidth - TIMELINE_JUMP_RAIL_RESERVED_PX)
+  )
+  const contentLeft = containerLeft + Math.max(0, (containerWidth - contentWidth) / 2)
+  return Math.max(TIMELINE_JUMP_RAIL_FALLBACK_LEFT_PX, contentLeft - TIMELINE_JUMP_RAIL_GAP_PX)
 }
 
 function blockScrollStamp(block: ChatBlock | undefined): string {
@@ -115,6 +128,20 @@ function turnPreview(turn: Turn, fallback: string): string {
   if (!text) return fallback
   const oneLine = text.replace(/\s+/g, ' ')
   return oneLine.length > 48 ? `${oneLine.slice(0, 47).trimEnd()}...` : oneLine
+}
+
+function turnPromptPreview(turn: Turn, fallback: string): string {
+  if (turn.user && isBackgroundShellNoticeBlock(turn.user)) {
+    const display = turn.user.meta?.displayText?.trim()
+    if (display) return display.replace(/\s+/g, ' ')
+  }
+  const text = turn.user?.text.trim() ?? ''
+  if (!text) return fallback
+  return text.replace(/\s+/g, ' ')
+}
+
+export function timelineJumpWaveLevel(index: number): number {
+  return [2, 4, 5, 3, 1][index % 5] ?? 3
 }
 
 function processBlockHasError(block: ChatBlock): boolean {
@@ -198,6 +225,12 @@ export function MessageTimeline({
   const containerRef = useRef<HTMLDivElement>(null)
   const turnRefMap = useRef(new Map<string, HTMLDivElement>())
   const [activeTurnKey, setActiveTurnKey] = useState<string | null>(null)
+  const [jumpRailLeft, setJumpRailLeft] = useState<number | null>(null)
+  const [jumpRailPreview, setJumpRailPreview] = useState<{
+    title: string
+    prompt: string
+    top: number
+  } | null>(null)
 
   const turns = useMemo(() => groupTurns(blocks), [blocks])
   const latestBlock = blocks[blocks.length - 1]
@@ -234,7 +267,7 @@ export function MessageTimeline({
   )
   const visibleTurnAnchors = useMemo(
     () => {
-      const anchors: { key: string; label: string; title: string }[] = []
+      const anchors: { key: string; label: string; title: string; prompt: string; waveLevel: number }[] = []
       let questionIndex = turns
         .slice(0, hiddenTurnCount)
         .filter((turn) => turn.user)
@@ -248,7 +281,9 @@ export function MessageTimeline({
         anchors.push({
           key,
           label: String(questionIndex),
-          title: turnPreview(turn, t('timelineJumpTurn', { index: questionIndex }))
+          title: turnPreview(turn, t('timelineJumpTurn', { index: questionIndex })),
+          prompt: turnPromptPreview(turn, t('timelineJumpTurn', { index: questionIndex })),
+          waveLevel: timelineJumpWaveLevel(anchors.length)
         })
       })
       return anchors
@@ -294,6 +329,29 @@ export function MessageTimeline({
     }
   }, [visibleTurnAnchors])
 
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || visibleTurnAnchors.length <= 2) {
+      setJumpRailLeft(null)
+      return
+    }
+    const update = (): void => {
+      const rect = container.getBoundingClientRect()
+      const rawMaxWidth = window.getComputedStyle(document.documentElement).getPropertyValue('--ds-chat-content-max-width')
+      const parsedMaxWidth = Number.parseFloat(rawMaxWidth)
+      const contentMaxWidth = Number.isFinite(parsedMaxWidth) ? parsedMaxWidth : 896
+      setJumpRailLeft(timelineJumpRailLeft(rect.left, rect.width, contentMaxWidth))
+    }
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(container)
+    window.addEventListener('resize', update)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', update)
+    }
+  }, [visibleTurnAnchors.length])
+
   // Tick a clock while a turn is running so the live "Worked for Xs" updates.
   const [tickNow, setTickNow] = useState(() => Date.now())
   useEffect(() => {
@@ -310,6 +368,18 @@ export function MessageTimeline({
     target.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
 
+  const showJumpRailPreview = (
+    anchor: { label: string; title: string; prompt: string },
+    node: HTMLButtonElement
+  ): void => {
+    const rect = node.getBoundingClientRect()
+    setJumpRailPreview({
+      title: t('timelineJumpTurn', { index: anchor.label }),
+      prompt: anchor.prompt || anchor.title,
+      top: rect.top + rect.height / 2
+    })
+  }
+
   return (
     <InjectedMemoryLookupProvider workspaceRoot={workspaceRoot}>
     <div ref={containerRef} className="ds-no-drag relative flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden">
@@ -317,21 +387,38 @@ export function MessageTimeline({
         <nav
           aria-label={t('timelineJumpRailLabel')}
           className="timeline-jump-rail"
+          style={jumpRailLeft === null ? undefined : { left: `${jumpRailLeft}px` }}
         >
           {visibleTurnAnchors.map((anchor) => (
             <button
               key={anchor.key}
               type="button"
               className={`timeline-jump-rail-button${activeTurnKey === anchor.key ? ' is-active' : ''}`}
+              data-wave-level={anchor.waveLevel}
               title={anchor.title}
               aria-label={anchor.title}
               aria-current={activeTurnKey === anchor.key ? 'true' : undefined}
+              onMouseEnter={(event) => showJumpRailPreview(anchor, event.currentTarget)}
+              onFocus={(event) => showJumpRailPreview(anchor, event.currentTarget)}
+              onMouseLeave={() => setJumpRailPreview(null)}
+              onBlur={() => setJumpRailPreview(null)}
               onClick={() => jumpToTurn(anchor.key)}
-            >
-              {anchor.label}
-            </button>
+            />
           ))}
         </nav>
+      ) : null}
+      {jumpRailPreview ? (
+        <div
+          className="timeline-jump-rail-preview"
+          style={{
+            left: `${Math.max(TIMELINE_JUMP_RAIL_FALLBACK_LEFT_PX, (jumpRailLeft ?? TIMELINE_JUMP_RAIL_FALLBACK_LEFT_PX) + 34)}px`,
+            top: `${jumpRailPreview.top}px`
+          }}
+          role="tooltip"
+        >
+          <div className="timeline-jump-rail-preview-title">{jumpRailPreview.title}</div>
+          <div className="timeline-jump-rail-preview-text">{jumpRailPreview.prompt}</div>
+        </div>
       ) : null}
       <div className={`ds-message-timeline-content ds-chat-column-inset ds-chat-content-max-width mx-auto flex w-full min-w-0 flex-col gap-8 pt-8 ${
         goalTimelinePaddingClass(heroRoute, Boolean(activeThreadGoal))

--- a/src/renderer/src/components/chat/MessageTimeline.turn-rail.test.ts
+++ b/src/renderer/src/components/chat/MessageTimeline.turn-rail.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { activeTimelineTurnKey } from './MessageTimeline'
+import { activeTimelineTurnKey, timelineJumpRailLeft, timelineJumpWaveLevel } from './MessageTimeline'
 
 describe('activeTimelineTurnKey', () => {
   const positions = [
@@ -21,5 +21,21 @@ describe('activeTimelineTurnKey', () => {
 
   it('returns null for an empty timeline', () => {
     expect(activeTimelineTurnKey([])).toBeNull()
+  })
+})
+
+describe('timelineJumpWaveLevel', () => {
+  it('cycles compact rail items through a wave pattern', () => {
+    expect(Array.from({ length: 7 }, (_, index) => timelineJumpWaveLevel(index))).toEqual([2, 4, 5, 3, 1, 2, 4])
+  })
+})
+
+describe('timelineJumpRailLeft', () => {
+  it('keeps the rail beside the content when the content width is capped', () => {
+    expect(timelineJumpRailLeft(300, 1000, 800)).toBe(382)
+  })
+
+  it('reserves space when the requested content width is wider than the stage', () => {
+    expect(timelineJumpRailLeft(300, 1000, 1200)).toBe(324)
   })
 })

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -2850,40 +2850,42 @@ pre {
 }
 
 .ds-chat-column-inset {
-  padding-inline: clamp(0.75rem, calc((100% - var(--ds-chat-content-max-width, 56rem)) / 2 + 1rem), 2rem);
+  padding-inline: clamp(0.75rem, calc((100% - var(--ds-chat-content-effective-max-width, var(--ds-chat-content-max-width, 56rem))) / 2 + 1rem), 2rem);
 }
 
 .ds-chat-content-max-width {
-  max-width: var(--ds-chat-content-max-width, 56rem);
+  max-width: var(--ds-chat-content-effective-max-width, var(--ds-chat-content-max-width, 56rem));
 }
 
 .ds-chat-stage {
   container-type: inline-size;
+  --ds-chat-side-rail-reserve: 5.25rem;
+  --ds-chat-content-effective-max-width: min(
+    var(--ds-chat-content-max-width, 56rem),
+    max(0px, calc(100cqw - var(--ds-chat-side-rail-reserve)))
+  );
 }
 
 .timeline-jump-rail {
   position: fixed;
-  top: 7.6rem;
-  right: 1.55rem;
+  top: 50%;
+  left: 1rem;
   z-index: 15;
   display: flex;
   box-sizing: border-box;
-  width: 2.4rem;
-  min-width: 2.4rem;
-  max-height: min(48vh, 22rem);
+  width: 1.85rem;
+  min-width: 1.85rem;
+  max-height: min(54vh, 25rem);
   flex-direction: column;
-  align-items: center;
-  gap: 0.3rem;
+  align-items: flex-start;
+  gap: 0.22rem;
   overflow-y: auto;
-  border: 1px solid color-mix(in srgb, var(--ds-border) 82%, transparent);
+  border: 0;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--ds-surface-card) 96%, transparent);
-  padding: 0.34rem;
-  box-shadow:
-    0 12px 34px rgba(15, 23, 42, 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
-  backdrop-filter: blur(20px);
+  background: transparent;
+  padding: 0.28rem 0.18rem;
   scrollbar-width: none;
+  transform: translateY(-50%);
 }
 
 .timeline-jump-rail::-webkit-scrollbar {
@@ -2891,37 +2893,97 @@ pre {
 }
 
 .timeline-jump-rail-button {
-  display: inline-flex;
+  display: block;
   box-sizing: border-box;
-  width: 1.7rem;
-  min-width: 1.7rem;
-  height: 1.7rem;
-  align-items: center;
-  justify-content: center;
+  width: calc(0.22rem + var(--timeline-wave-width, 0.55rem));
+  min-width: 0;
+  height: 0.18rem;
+  min-height: 0.18rem;
+  margin-left: 0;
   padding: 0;
   border: 0;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--ds-text) 7%, transparent);
-  color: var(--ds-text-muted);
-  font-size: 0.76rem;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-  white-space: nowrap;
-  text-align: center;
+  background: color-mix(in srgb, var(--ds-text-muted) 52%, transparent);
   transition:
-    background 140ms ease,
-    color 140ms ease,
-    transform 140ms ease;
+    background-color 140ms ease,
+    box-shadow 140ms ease,
+    opacity 140ms ease,
+    transform 140ms ease,
+    width 140ms ease;
+}
+
+.timeline-jump-rail-button[data-wave-level='1'] {
+  --timeline-wave-width: 0.32rem;
+}
+
+.timeline-jump-rail-button[data-wave-level='2'] {
+  --timeline-wave-width: 0.5rem;
+}
+
+.timeline-jump-rail-button[data-wave-level='3'] {
+  --timeline-wave-width: 0.72rem;
+}
+
+.timeline-jump-rail-button[data-wave-level='4'] {
+  --timeline-wave-width: 0.95rem;
+}
+
+.timeline-jump-rail-button[data-wave-level='5'] {
+  --timeline-wave-width: 1.18rem;
 }
 
 .timeline-jump-rail-button:hover,
 .timeline-jump-rail-button:focus-visible,
 .timeline-jump-rail-button.is-active {
-  background: var(--ds-accent-soft);
-  color: var(--ds-accent);
-  transform: translateY(-1px);
+  width: 1.28rem;
+  background: var(--ds-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ds-accent) 12%, transparent);
+  opacity: 1;
+  transform: none;
   outline: none;
+}
+
+.timeline-jump-rail-preview {
+  position: fixed;
+  z-index: 45;
+  box-sizing: border-box;
+  width: min(26rem, calc(100vw - 5.5rem));
+  max-height: min(15rem, calc(100vh - 2rem));
+  overflow: hidden;
+  transform: translateY(-50%);
+  border: 1px solid color-mix(in srgb, var(--ds-border) 82%, transparent);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--ds-surface-card) 94%, rgba(20, 20, 22, 0.9));
+  padding: 0.9rem 1rem;
+  color: var(--ds-text);
+  box-shadow:
+    0 18px 46px rgba(15, 23, 42, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(20px);
+  pointer-events: none;
+}
+
+.timeline-jump-rail-preview-title {
+  overflow: hidden;
+  color: var(--ds-text);
+  font-size: 0.92rem;
+  font-weight: 750;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeline-jump-rail-preview-text {
+  display: -webkit-box;
+  margin-top: 0.5rem;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  color: var(--ds-text-muted);
+  font-size: 0.86rem;
+  font-weight: 600;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
 }
 
 .ds-plan-panel-overlay {
@@ -2959,6 +3021,10 @@ pre {
 
 @media (max-width: 720px) {
   .timeline-jump-rail {
+    display: none;
+  }
+
+  .timeline-jump-rail-preview {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- Replace the large numbered timeline jump rail with a compact left-side wave rail.
- Show the full prompt preview on hover/focus without jumping to the turn.
- Reserve left-side rail space so chat width settings cannot cover the rail.

## Changes
- Added prompt preview and dynamic left-positioning for timeline jump anchors.
- Updated timeline rail CSS to use left-aligned wave bars centered vertically.
- Added tests for active turn selection, wave cycling, and rail positioning with wide chat content.

## Tests
- npm run test -- src/renderer/src/components/chat/MessageTimeline.turn-rail.test.ts
- npm run typecheck
- npm run lint (passes with existing hook dependency warnings)
- npm run dist
