### PR TITLE
fix(chat): isolate per-turn provider routing

### DIFF
--- a/kun/src/contracts/review.ts
+++ b/kun/src/contracts/review.ts
@@ -50,7 +50,8 @@ export type ReviewTarget = z.infer<typeof ReviewTargetSchema>
 
 export const StartReviewRequest = z.object({
   target: ReviewTargetSchema,
-  model: z.string().trim().min(1).optional()
+  model: z.string().trim().min(1).optional(),
+  providerId: z.string().trim().min(1).optional()
 })
 export type StartReviewRequest = z.infer<typeof StartReviewRequest>
 

--- a/kun/src/contracts/turns.ts
+++ b/kun/src/contracts/turns.ts
@@ -62,6 +62,7 @@ export const TurnSchema = z.object({
   status: TurnStatus,
   prompt: z.string(),
   model: z.string().optional(),
+  providerId: z.string().optional(),
   reasoningEffort: TurnReasoningEffortSchema.optional(),
   /** Steered text queued by the user mid-turn. Cleared on completion. */
   steering: z.array(z.string()).default([]),
@@ -100,6 +101,7 @@ export const StartTurnRequest = z.object({
   displayText: z.string().optional(),
   messageSource: UserMessageSource.optional(),
   model: z.string().optional(),
+  providerId: z.string().optional(),
   reasoningEffort: TurnReasoningEffortSchema.optional(),
   approvalPolicy: ApprovalPolicySchema.optional(),
   sandboxMode: SandboxModeSchema.optional(),

--- a/kun/src/domain/turn.ts
+++ b/kun/src/domain/turn.ts
@@ -9,6 +9,7 @@ export function createTurnRecord(input: {
   threadId: string
   prompt: string
   model?: string
+  providerId?: string
   reasoningEffort?: TurnReasoningEffort
   attachmentIds?: string[]
   guiPlan?: GuiPlanContextJson
@@ -19,6 +20,7 @@ export function createTurnRecord(input: {
   status?: TurnStatus
 }): TurnEntity {
   const model = input.model?.trim()
+  const providerId = input.providerId?.trim()
   const reasoningEffort = normalizeReasoningEffort(input.reasoningEffort)
   return {
     id: input.id,
@@ -32,6 +34,7 @@ export function createTurnRecord(input: {
     injectedMemoryIds: [],
     injectedMemorySummaries: [],
     ...(model ? { model } : {}),
+    ...(providerId ? { providerId } : {}),
     ...(reasoningEffort ? { reasoningEffort } : {}),
     ...(input.guiPlan ? { guiPlan: input.guiPlan } : {}),
     ...(input.mode ? { mode: input.mode } : {}),

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -1572,7 +1572,9 @@ export class AgentLoop {
       threadId,
       turnId,
       model,
-      ...(thread?.providerId?.trim() ? { providerId: thread.providerId.trim() } : {}),
+      ...((turn?.providerId?.trim() || thread?.providerId?.trim())
+        ? { providerId: turn?.providerId?.trim() || thread?.providerId?.trim() }
+        : {}),
       // Thread-level systemPrompt (primary-agent persona snapshot) is
       // appended to the runtime base — same augment strategy as child agents
       // (child-agent-executor) — so the agent keeps kun's tool/safety

--- a/kun/src/server/routes/index.ts
+++ b/kun/src/server/routes/index.ts
@@ -262,8 +262,8 @@ export function buildRouter(runtime: ServerRuntime): Router {
       runtime.turnService,
       ctx.params.id,
       request,
-      ({ threadId, turnId, reviewItemId }, target, model) => {
-        runtime.runReview?.({ threadId, turnId, reviewItemId, target, model })
+      ({ threadId, turnId, reviewItemId }, target, model, providerId) => {
+        runtime.runReview?.({ threadId, turnId, reviewItemId, target, model, providerId })
       }
     )
   })

--- a/kun/src/server/routes/review.ts
+++ b/kun/src/server/routes/review.ts
@@ -14,7 +14,12 @@ export async function startReview(
   turns: TurnService,
   threadId: string,
   request: Request,
-  onStarted?: (response: StartReviewResponse, target: StartReviewRequest['target'], model?: string) => void
+  onStarted?: (
+    response: StartReviewResponse,
+    target: StartReviewRequest['target'],
+    model?: string,
+    providerId?: string
+  ) => void
 ): Promise<JsonResponse | Response> {
   const body = await readJsonBody(request)
   if (!body.ok) return body.response
@@ -30,6 +35,7 @@ export async function startReview(
         prompt: reviewTargetPrompt(parsed.data.target),
         displayText: title,
         model: parsed.data.model,
+        providerId: parsed.data.providerId,
         mode: 'agent'
       }
     })
@@ -49,7 +55,7 @@ export async function startReview(
       ...started,
       reviewItemId
     }
-    onStarted?.(response, parsed.data.target, parsed.data.model)
+    onStarted?.(response, parsed.data.target, parsed.data.model, parsed.data.providerId)
     return jsonResponse(response, 202)
   } catch (error) {
     if (error instanceof Error && /not found/i.test(error.message)) {

--- a/kun/src/server/routes/server-runtime.ts
+++ b/kun/src/server/routes/server-runtime.ts
@@ -110,6 +110,7 @@ export type ServerRuntime = {
     reviewItemId: string
     target: ReviewTarget
     model?: string
+    providerId?: string
   }): Promise<'completed' | 'failed' | 'aborted'> | void
   runtimeToken: string
   insecure: boolean

--- a/kun/src/services/review-service.ts
+++ b/kun/src/services/review-service.ts
@@ -57,6 +57,7 @@ export class ReviewService {
     reviewItemId: string
     target: ReviewTarget
     model?: string
+    providerId?: string
   }): Promise<'completed' | 'failed' | 'aborted'> {
     const signal = this.deps.turns.getAbortController(input.turnId)
     if (!signal) {
@@ -82,6 +83,7 @@ export class ReviewService {
         prompt: resolved.prompt,
         workspace: thread.workspace ?? '',
         model: input.model?.trim() || thread.model || this.deps.defaultModel,
+        providerId: input.providerId?.trim() || thread.providerId,
         signal
       })
       if (signal.aborted) {
@@ -118,6 +120,7 @@ export class ReviewService {
     prompt: string
     workspace: string
     model: string
+    providerId?: string
     signal: AbortSignal
   }): Promise<string> {
     const nowIso = this.deps.nowIso
@@ -189,6 +192,7 @@ export class ReviewService {
       title: 'Review',
       workspace: input.workspace || '~',
       model: input.model,
+      ...(input.providerId ? { providerId: input.providerId } : {}),
       mode: 'agent',
       approvalPolicy: 'auto'
     })
@@ -197,6 +201,7 @@ export class ReviewService {
       request: {
         prompt: input.prompt,
         model: input.model,
+        ...(input.providerId ? { providerId: input.providerId } : {}),
         mode: 'agent',
         reasoningEffort: normalizeRoleReasoningEffort(this.deps.reasoningEffort)
       }

--- a/kun/src/services/turn-service.ts
+++ b/kun/src/services/turn-service.ts
@@ -75,6 +75,7 @@ export class TurnService {
       threadId: input.threadId,
       prompt: input.request.prompt,
       model: input.request.model,
+      providerId: input.request.providerId,
       reasoningEffort: input.request.reasoningEffort,
       attachmentIds: input.request.attachmentIds ?? [],
       guiPlan: input.request.guiPlan,

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -268,6 +268,7 @@ export class KunRuntimeProvider implements AgentProvider {
     options?: {
       mode?: KunThreadMode
       model?: string
+      providerId?: string
       reasoningEffort?: string
       displayText?: string
       guiPlan?: {
@@ -288,6 +289,7 @@ export class KunRuntimeProvider implements AgentProvider {
     const body: Record<string, unknown> = {
       prompt: text,
       model: options?.model,
+      providerId: options?.providerId,
       approvalPolicy: runtime.approvalPolicy,
       sandboxMode: runtime.sandboxMode
     }
@@ -353,11 +355,14 @@ export class KunRuntimeProvider implements AgentProvider {
   async reviewThread(
     threadId: string,
     target: ReviewTarget,
-    options?: { model?: string }
+    options?: { model?: string; providerId?: string }
   ): Promise<{ turnId: string; threadId: string; userMessageItemId?: string; reviewItemId?: string }> {
     const body: Record<string, unknown> = { target }
     if (options?.model?.trim()) {
       body.model = options.model.trim()
+    }
+    if (options?.providerId?.trim()) {
+      body.providerId = options.providerId.trim()
     }
     const response = await rendererRuntimeClient.runtimeRequest(
       kunThreadReviewPath(threadId),

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -478,6 +478,7 @@ export interface AgentProvider {
     options?: {
       mode?: string
       model?: string
+      providerId?: string
       reasoningEffort?: string
       displayText?: string
       guiPlan?: {
@@ -497,7 +498,7 @@ export interface AgentProvider {
   reviewThread?(
     threadId: string,
     target: ReviewTarget,
-    options?: { model?: string }
+    options?: { model?: string; providerId?: string }
   ): Promise<{ turnId: string; threadId: string; userMessageItemId?: string; reviewItemId?: string }>
   getRuntimeInfo?(): Promise<CoreRuntimeInfoJson>
   getToolDiagnostics?(): Promise<CoreRuntimeToolDiagnosticsJson>

--- a/src/renderer/src/store/chat-store-thread-action-helpers.ts
+++ b/src/renderer/src/store/chat-store-thread-action-helpers.ts
@@ -1,11 +1,5 @@
 import type { AgentProvider, NormalizedThread, ThreadEventSink } from '../agent/types'
-import { getProvider } from '../agent/registry'
-import { rendererRuntimeClient } from '../agent/runtime-client'
-import {
-  DEFAULT_MODEL_PROVIDER_ID,
-  getKunRuntimeSettings
-} from '@shared/app-settings'
-import type { ChatState, ChatStoreGet, ChatStoreSet } from './chat-store-types'
+import type { ChatState, ChatStoreGet } from './chat-store-types'
 import {
   composerModelSelectable,
   providerIdForComposerModel,
@@ -20,28 +14,10 @@ export function fallbackComposerProviderIdForSend(state: ChatState): string {
 export async function ensureRuntimeProviderForSend(input: {
   providerId?: string
   model?: string
-  set: ChatStoreSet
-  get: ChatStoreGet
 }): Promise<void> {
   const providerId = input.providerId?.trim()
   const model = input.model?.trim()
   if (!providerId || !model || model.toLowerCase() === 'auto') return
-  const settings = await rendererRuntimeClient.getSettings({ forceRefresh: true })
-  const runtime = getKunRuntimeSettings(settings)
-  const activeProviderId = runtime.providerId?.trim() || DEFAULT_MODEL_PROVIDER_ID
-  if (activeProviderId === providerId) return
-  input.set({ runtimeConnection: 'checking', error: null, runtimeErrorDetail: null })
-  try {
-    await window.kunGui.saveSettingsSilent({ agents: { kun: { providerId, model } } })
-    rendererRuntimeClient.invalidateSettings()
-    await rendererRuntimeClient.restartRuntime()
-    await getProvider().connect()
-    input.set({ runtimeConnection: 'ready', error: null, runtimeErrorDetail: null })
-    void input.get().loadComposerModels()
-  } catch (error) {
-    input.set({ runtimeConnection: 'offline' })
-    throw error
-  }
 }
 
 export function composerSelectionForThread(

--- a/src/renderer/src/store/chat-store-thread-actions.test.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.test.ts
@@ -35,6 +35,7 @@ function buildHarness(): {
     blocks: [],
     busy: true,
     clawChannels: [],
+    codeWorkspaceRoots: [],
     composerModel: '',
     composerProviderId: '',
     currentTurnId: null,
@@ -153,7 +154,7 @@ describe('chat-store-thread-actions queued messages', () => {
     })
   })
 
-  it('applies the selected composer provider before sending a turn', async () => {
+  it('sends the selected composer provider with the turn without switching the global runtime provider', async () => {
     const provider = {
       connect: vi.fn(async () => undefined),
       sendUserMessage: vi.fn(async () => ({
@@ -187,19 +188,17 @@ describe('chat-store-thread-actions queued messages', () => {
 
     await expect(actions.sendMessage('hello', 'agent')).resolves.toBe(true)
 
-    expect(saveSettingsSilent).toHaveBeenCalledWith({
-      agents: { kun: { providerId: 'xiaomi-token-plan', model: 'mimo-v2.5' } }
-    })
-    expect(restartRuntime).toHaveBeenCalledTimes(1)
-    expect(provider.connect).toHaveBeenCalledTimes(1)
+    expect(saveSettingsSilent).not.toHaveBeenCalled()
+    expect(restartRuntime).not.toHaveBeenCalled()
+    expect(provider.connect).not.toHaveBeenCalled()
     expect(provider.sendUserMessage).toHaveBeenCalledWith(
       'thr_existing',
       'hello',
-      expect.objectContaining({ model: 'mimo-v2.5' })
+      expect.objectContaining({ model: 'mimo-v2.5', providerId: 'xiaomi-token-plan' })
     )
   })
 
-  it('applies an override provider before sending from the write route', async () => {
+  it('sends an override provider from the write route without switching the global runtime provider', async () => {
     const provider = {
       connect: vi.fn(async () => undefined),
       sendUserMessage: vi.fn(async () => ({
@@ -236,15 +235,64 @@ describe('chat-store-thread-actions queued messages', () => {
       providerId: 'minimax-token-plan'
     })).resolves.toBe(true)
 
-    expect(saveSettingsSilent).toHaveBeenCalledWith({
-      agents: { kun: { providerId: 'minimax-token-plan', model: 'MiniMax-M3' } }
-    })
-    expect(restartRuntime).toHaveBeenCalledTimes(1)
-    expect(provider.connect).toHaveBeenCalledTimes(1)
+    expect(saveSettingsSilent).not.toHaveBeenCalled()
+    expect(restartRuntime).not.toHaveBeenCalled()
+    expect(provider.connect).not.toHaveBeenCalled()
     expect(provider.sendUserMessage).toHaveBeenCalledWith(
       'thr_existing',
       'make a prototype',
-      expect.objectContaining({ model: 'MiniMax-M3' })
+      expect.objectContaining({ model: 'MiniMax-M3', providerId: 'minimax-token-plan' })
+    )
+  })
+
+  it('snapshots the selected composer provider when creating the first thread', async () => {
+    const provider = {
+      connect: vi.fn(async () => undefined),
+      createThread: vi.fn(async () => ({
+        id: 'thr_new',
+        title: 'hello',
+        updatedAt: '2026-06-09T00:00:00.000Z',
+        model: 'MiniMax-M3',
+        providerId: 'minimax-token-plan',
+        mode: 'agent',
+        workspace: '/workspace/deepseek-gui',
+        status: 'idle'
+      })),
+      sendUserMessage: vi.fn(async () => ({
+        threadId: 'thr_new',
+        turnId: 'turn_1',
+        userMessageItemId: 'user_1'
+      })),
+      subscribeThreadEvents: vi.fn(async () => undefined)
+    }
+    registryMock.getProvider.mockReturnValue(provider)
+    vi.stubGlobal('window', {
+      kunGui: {
+        getSettings: vi.fn(async () => ({
+          workspaceRoot: '/workspace/deepseek-gui',
+          agents: { kun: { providerId: 'deepseek', model: 'deepseek-v4-pro' } },
+          codePromptPrefix: ''
+        })),
+        logError: vi.fn(async () => undefined)
+      }
+    })
+    const { actions, state } = buildHarness()
+    state.activeThreadId = null
+    state.threads = []
+    state.busy = false
+    state.composerModel = 'MiniMax-M3'
+    state.composerProviderId = 'minimax-token-plan'
+
+    await expect(actions.sendMessage('hello', 'agent')).resolves.toBe(true)
+
+    expect(provider.createThread).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'MiniMax-M3',
+      providerId: 'minimax-token-plan'
+    }))
+    expect(provider.sendUserMessage).toHaveBeenCalledWith(
+      'thr_new',
+      'hello',
+      expect.objectContaining({ model: 'MiniMax-M3', providerId: 'minimax-token-plan' })
     )
   })
 })

--- a/src/renderer/src/store/chat-store-thread-actions.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.ts
@@ -786,6 +786,8 @@ export function createThreadActions(
                 title: generatedTitle,
                 // Provisional first-message title; let the backend LLM titler upgrade it.
                 titleAuto: true,
+                ...(composerModel ? { model: composerModel } : {}),
+                ...(composerProviderId ? { providerId: composerProviderId } : {}),
                 mode: mode ?? 'agent'
               })
             : null
@@ -847,9 +849,7 @@ export function createThreadActions(
       }
       await ensureRuntimeProviderForSend({
         providerId: channel ? undefined : composerProviderId,
-        model: composerModel,
-        set,
-        get
+        model: composerModel
       })
       const settings = await rendererRuntimeClient.getSettings()
       let workspaceCheckpointId: string | undefined
@@ -898,6 +898,7 @@ export function createThreadActions(
       const { turnId, userMessageItemId } = await p.sendUserMessage(activeThreadId, runtimeText, {
         mode,
         ...(composerModel ? { model: composerModel } : {}),
+        ...(composerProviderId ? { providerId: composerProviderId } : {}),
         ...(reasoningEffort ? { reasoningEffort } : {}),
         ...(runtimeDisplayText ? { displayText: runtimeDisplayText } : {}),
         ...((queued?.guiPlan ?? overrides?.guiPlan) ? { guiPlan: queued?.guiPlan ?? overrides?.guiPlan } : {}),
@@ -1056,6 +1057,8 @@ export function createThreadActions(
       set({ error: i18n.t('common:composerQueuePlaceholder') })
       return false
     }
+    const composerModel = get().composerModel.trim()
+    const composerProviderId = get().composerProviderId.trim()
     let activeThreadId = get().activeThreadId
     try {
       if (!activeThreadId) {
@@ -1078,6 +1081,8 @@ export function createThreadActions(
             ? await p.createThread({
                 workspace: workspaceRoot,
                 title: i18n.t('common:slashCommandReviewTitle'),
+                ...(composerModel ? { model: composerModel } : {}),
+                ...(composerProviderId ? { providerId: composerProviderId } : {}),
                 mode: 'agent'
               })
             : null
@@ -1095,8 +1100,6 @@ export function createThreadActions(
         }))
       }
       const threadSnap = get().threads.find((thread) => thread.id === activeThreadId)
-      const composerModel = get().composerModel.trim()
-      const composerProviderId = get().composerProviderId.trim()
       const userModelChip = optimisticUserModelLabel(composerModel, threadSnap?.model)
       const seqAtSend = get().lastSeq
       resetBusyRecoveryAttempts()
@@ -1113,12 +1116,11 @@ export function createThreadActions(
       })
       await ensureRuntimeProviderForSend({
         providerId: composerProviderId,
-        model: composerModel,
-        set,
-        get
+        model: composerModel
       })
       const { turnId, userMessageItemId } = await p.reviewThread(activeThreadId, target, {
-        ...(composerModel ? { model: composerModel } : {})
+        ...(composerModel ? { model: composerModel } : {}),
+        ...(composerProviderId ? { providerId: composerProviderId } : {})
       })
       if (userMessageItemId && userModelChip) {
         rememberTurnModel(activeThreadId, userMessageItemId, userModelChip)


### PR DESCRIPTION
## Summary
- Snapshot the selected composer model/provider when creating a new thread.
- Carry providerId through turn and review requests so routing is per-turn/per-thread instead of global.
- Stop switching the global Kun runtime provider before sending a turn.

## Changes
- Added providerId to turn and review contracts, persisted turn records, and runtime model requests.
- Updated renderer send/review paths to pass providerId alongside model.
- Added regression coverage for first-thread creation and per-turn provider routing.

## Tests
- npm ci
- npm run typecheck
- npm run test -- src/renderer/src/store/chat-store-thread-actions.test.ts src/main/workflow-runtime.nodes.test.ts kun/src/server/routes/turns.test.ts kun/src/services/turn-service.test.ts
