### PR TITLE
fix(memory): allow disabled records to be re-enabled

### DIFF
--- a/kun/src/memory/memory-store.test.ts
+++ b/kun/src/memory/memory-store.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { FileMemoryStore } from './memory-store.js'
+
+const tempDirs: string[] = []
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'kun-memory-store-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('FileMemoryStore', () => {
+  it('re-enables a disabled memory when updated with disabled false', async () => {
+    let tick = 0
+    const store = new FileMemoryStore({
+      rootDir: await makeTempDir(),
+      config: { enabled: true, scopes: ['workspace'], maxInjectedRecords: 8 },
+      idGenerator: () => 'mem_toggle',
+      nowIso: () => `2026-06-21T00:00:0${tick++}.000Z`
+    })
+
+    await store.create({
+      content: 'Prefer pnpm',
+      scope: 'workspace',
+      workspace: '/tmp/workspace'
+    })
+
+    const disabled = await store.update('mem_toggle', { disabled: true }, { workspace: '/tmp/workspace' })
+    expect(disabled.disabledAt).toBe('2026-06-21T00:00:01.000Z')
+    await expect(store.retrieve({
+      query: 'pnpm',
+      workspace: '/tmp/workspace',
+      limit: 8
+    })).resolves.toEqual([])
+
+    const enabled = await store.update('mem_toggle', { disabled: false }, { workspace: '/tmp/workspace' })
+    expect(enabled.disabledAt).toBeUndefined()
+    await expect(store.retrieve({
+      query: 'pnpm',
+      workspace: '/tmp/workspace',
+      limit: 8
+    })).resolves.toMatchObject([{ id: 'mem_toggle' }])
+  })
+})

--- a/src/renderer/src/agent/kun-runtime.test.ts
+++ b/src/renderer/src/agent/kun-runtime.test.ts
@@ -734,7 +734,8 @@ describe('KunRuntimeProvider', () => {
     )
   })
 
-  it('lists, disables, and deletes memory records through Kun endpoints', async () => {
+  it('lists, toggles, and deletes memory records through Kun endpoints', async () => {
+    const memoryPatches: string[] = []
     const runtimeRequest = vi.fn(async (path: string, method?: string, body?: string) => {
       if (path === '/v1/memory?workspace=%2Ftmp%2Fworkspace&include_deleted=false') {
         return {
@@ -755,7 +756,8 @@ describe('KunRuntimeProvider', () => {
         }
       }
       if (path === '/v1/memory/mem_1?workspace=%2Ftmp%2Fworkspace' && method === 'PATCH') {
-        expect(body).toBe(JSON.stringify({ disabled: true }))
+        memoryPatches.push(body ?? '')
+        const disabled = JSON.parse(body ?? '{}').disabled === true
         return {
           ok: true,
           status: 200,
@@ -764,9 +766,9 @@ describe('KunRuntimeProvider', () => {
               id: 'mem_1',
               content: 'Use pnpm',
               scope: 'workspace',
-              disabledAt: 't1',
+              ...(disabled ? { disabledAt: 't1' } : {}),
               createdAt: 't0',
-              updatedAt: 't1'
+              updatedAt: disabled ? 't1' : 't2'
             }
           })
         }
@@ -797,6 +799,14 @@ describe('KunRuntimeProvider', () => {
       id: 'mem_1',
       disabledAt: 't1'
     })
+    await expect(provider.updateMemory('mem_1', { disabled: false }, { workspace: '/tmp/workspace' })).resolves.toMatchObject({
+      id: 'mem_1',
+      updatedAt: 't2'
+    })
+    expect(memoryPatches).toEqual([
+      JSON.stringify({ disabled: true }),
+      JSON.stringify({ disabled: false })
+    ])
     await expect(provider.deleteMemory('mem_1', { workspace: '/tmp/workspace' })).resolves.toMatchObject({
       id: 'mem_1',
       deletedAt: 't2'

--- a/src/renderer/src/components/settings-section-agents.test.ts
+++ b/src/renderer/src/components/settings-section-agents.test.ts
@@ -178,6 +178,7 @@ const labels: Record<string, string> = {
   kunMemoryRecordsDesc: 'Memory records description',
   kunMemoryEmpty: 'No memories',
   kunMemoryDisable: 'Disable memory',
+  memoryRestore: 'Restore',
   kunMemoryDelete: 'Delete memory',
   kunMemoryDisabled: 'Disabled',
   skill: 'Skill',
@@ -648,7 +649,8 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
           id: 'mem_1',
           content: 'Prefer pnpm for this workspace',
           scope: 'workspace',
-          tags: ['tooling']
+          tags: ['tooling'],
+          disabledAt: '2026-06-21T01:00:00.000Z'
         }
       ]
     }
@@ -667,7 +669,8 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
     expect(html).toContain('Discovered Skills')
     expect(html).toContain('Prefer pnpm for this workspace')
     expect(html).toContain('mem_1')
-    expect(html).toContain('Disable memory')
+    expect(html).toContain('aria-label="Restore"')
+    expect(html).not.toContain('aria-label="Disable memory"')
     expect(html).toContain('Delete memory')
   })
 


### PR DESCRIPTION
## Summary

- Allow disabled memory records to be toggled back on from the memory settings list and Kun diagnostics list.
- Send a real `{ disabled: false }` update through the runtime provider when re-enabling a record.
- Add renderer and Kun memory store tests that verify disabled records are actually restored, not just restyled.

## Changes

- Memory row action now switches between disable and enable based on `disabledAt`.
- Runtime provider test now covers both disable and re-enable PATCH payloads.
- FileMemoryStore test verifies `disabledAt` is cleared and retrieval resumes after re-enable.

## Tests

- `npm run test -- src/renderer/src/components/settings-section-memory.test.ts src/renderer/src/components/settings-section-agents.test.ts src/renderer/src/agent/kun-runtime.test.ts`
- `npm --prefix kun run test -- src/memory/memory-store.test.ts`
- `npm run typecheck`
- `npm --prefix kun run typecheck`
