### PR TITLE
fix(sidebar): strengthen active pin action background

### DIFF
--- a/src/renderer/src/components/chat/SidebarProjectsSection.test.ts
+++ b/src/renderer/src/components/chat/SidebarProjectsSection.test.ts
@@ -457,6 +457,7 @@ describe('ThreadRow', () => {
 
     expect(html).toContain('sidebarThreadPinned')
     expect(html).toContain('sidebarThreadUnpin')
+    expect(html).toContain('bg-[color-mix(in_srgb,var(--ds-sidebar-row-active)_72%,var(--ds-accent)_28%)]')
   })
 })
 

--- a/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
+++ b/src/renderer/src/components/sidebar/SidebarPrimitives.tsx
@@ -216,7 +216,7 @@ export function SidebarIconButton({
       }}
       className={cx(
         'ds-no-drag inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-transparent text-[#9a9a9a] transition disabled:cursor-not-allowed disabled:opacity-40 dark:text-white/45',
-        active ? 'bg-[var(--ds-sidebar-row-active)] text-[#1f1f1f] shadow-[inset_0_0_0_1px_var(--ds-sidebar-row-ring)] dark:text-white' : toneClass,
+        active ? 'bg-[color-mix(in_srgb,var(--ds-sidebar-row-active)_72%,var(--ds-accent)_28%)] text-[#1f1f1f] shadow-[inset_0_0_0_1px_var(--ds-sidebar-row-ring)] dark:text-white' : toneClass,
         className
       )}
       title={title}


### PR DESCRIPTION
Summary
- Make the selected sidebar pin action background less transparent so it masks the thread title underneath more clearly.
- Revert the previous row padding approach and keep the thread row layout unchanged.

Changes
- Active sidebar icon buttons now blend the active row color with the theme accent for a stronger selected background.
- Updated SidebarProjectsSection coverage for the pinned action active background.

Tests
- npm run test -- SidebarProjectsSection.test.ts