### PR TITLE
fix(runtime): validate GUI and backend build identity

### DIFF
--- a/kun/package.json
+++ b/kun/package.json
@@ -56,7 +56,7 @@
     "kun": "./dist/cli/serve-entry.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node ../scripts/generate-build-identity.cjs && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/kun/src/server/routes/health.ts
+++ b/kun/src/server/routes/health.ts
@@ -1,6 +1,13 @@
 import { jsonResponse, type JsonResponse } from '../response.js'
+import { KUN_RUNTIME_BUILD_HASH, KUN_RUNTIME_VERSION } from '../../version.js'
 
 /** Build the `GET /health` response. The endpoint is unauthenticated. */
 export function healthJsonResponse(): JsonResponse {
-  return jsonResponse({ status: 'ok', service: 'kun', mode: 'serve' })
+  return jsonResponse({
+    status: 'ok',
+    service: 'kun',
+    mode: 'serve',
+    version: KUN_RUNTIME_VERSION,
+    buildHash: KUN_RUNTIME_BUILD_HASH
+  })
 }

--- a/kun/src/version.ts
+++ b/kun/src/version.ts
@@ -1,0 +1,2 @@
+export const KUN_RUNTIME_VERSION = '0.1.0'
+export const KUN_RUNTIME_BUILD_HASH = '9b9bdc94baceed433c723556a5bf11ea4c07759a'

--- a/kun/src/version.ts
+++ b/kun/src/version.ts
@@ -1,2 +1,3 @@
+// 此文件由 ../scripts/generate-build-identity.cjs 生成。
 export const KUN_RUNTIME_VERSION = '0.1.0'
-export const KUN_RUNTIME_BUILD_HASH = '9b9bdc94baceed433c723556a5bf11ea4c07759a'
+export const KUN_RUNTIME_BUILD_HASH = '4f3c34ada9afb7fe945147ffb8329cd177583a50'

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "dev": "npm run build:kun && electron-vite dev",
     "build": "npm run build:kun && electron-vite build",
-    "build:kun": "node ./scripts/ensure-kun-install.cjs && npm --prefix kun run build",
+    "build:kun": "node ./scripts/generate-build-identity.cjs && node ./scripts/ensure-kun-install.cjs && npm --prefix kun run build",
     "lint": "eslint .",
-    "test": "vitest run",
+    "test": "node ./scripts/generate-build-identity.cjs && vitest run",
     "test:watch": "vitest",
     "dist": "npm run build && npx --yes electron-builder@26.8.1 --config electron-builder.config.cjs --publish never",
     "dist:mac": "rm -f dist/Kun-*-mac-* dist/DeepSeek-GUI-*-mac-* dist/latest-mac.yml && npm run build && npm run dist:mac:x64:dmg && npm run dist:mac:x64:zip && npm run dist:mac:arm64:dmg && npm run dist:mac:arm64:zip && node ./scripts/generate-mac-latest.cjs dist",
@@ -31,7 +31,7 @@
     "postinstall": "node ./scripts/postinstall.cjs",
     "verify:apple": "node ./scripts/verify-apple-signing.cjs",
     "preview": "electron-vite preview",
-    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.node.json",
+    "typecheck": "node ./scripts/generate-build-identity.cjs && tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.node.json",
     "prepare:whisper": "node ./scripts/prepare-whisper-runner.cjs",
     "mac:unquarantine": "bash ./scripts/mac-unquarantine.sh"
   },

--- a/scripts/generate-build-identity.cjs
+++ b/scripts/generate-build-identity.cjs
@@ -1,0 +1,64 @@
+const { execFileSync } = require('node:child_process')
+const { readFileSync, writeFileSync } = require('node:fs')
+const { join } = require('node:path')
+
+const rootDir = join(__dirname, '..')
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(rootDir, relativePath), 'utf8'))
+}
+
+function readGitHead() {
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: rootDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore']
+  }).trim()
+}
+
+function resolveBuildHash() {
+  const explicit = (process.env.KUN_BUILD_HASH || process.env.GITHUB_SHA || '').trim()
+  if (explicit) return explicit
+  return readGitHead()
+}
+
+function assertCommitHash(value) {
+  if (!/^[0-9a-f]{40}$/i.test(value)) {
+    throw new Error(`KUN_BUILD_HASH must be a 40-character git commit hash, got: ${value}`)
+  }
+  return value.toLowerCase()
+}
+
+function writeGeneratedFile(relativePath, content) {
+  writeFileSync(join(rootDir, relativePath), content, 'utf8')
+}
+
+function tsString(value) {
+  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}
+
+const guiVersion = readJson('package.json').version
+const runtimeVersion = readJson('kun/package.json').version
+const buildHash = assertCommitHash(resolveBuildHash())
+
+writeGeneratedFile(
+  'src/shared/build-identity.ts',
+  [
+    '// 此文件由 scripts/generate-build-identity.cjs 生成。',
+    `export const KUN_GUI_VERSION = ${tsString(guiVersion)}`,
+    `export const KUN_GUI_BUILD_HASH = ${tsString(buildHash)}`,
+    ''
+  ].join('\n')
+)
+
+writeGeneratedFile(
+  'kun/src/version.ts',
+  [
+    '// 此文件由 ../scripts/generate-build-identity.cjs 生成。',
+    `export const KUN_RUNTIME_VERSION = ${tsString(runtimeVersion)}`,
+    `export const KUN_RUNTIME_BUILD_HASH = ${tsString(buildHash)}`,
+    ''
+  ].join('\n')
+)
+
+console.log(`[build-identity] generated ${buildHash}`)

--- a/src/main/build-identity.test.ts
+++ b/src/main/build-identity.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { KUN_RUNTIME_BUILD_HASH } from '../../kun/src/version'
+import { KUN_GUI_BUILD_HASH } from '../shared/build-identity'
+
+describe('build identity', () => {
+  it('embeds the same git commit hash in GUI and runtime code', () => {
+    expect(KUN_GUI_BUILD_HASH).toBe(KUN_RUNTIME_BUILD_HASH)
+    expect(KUN_GUI_BUILD_HASH).toMatch(/^[0-9a-f]{40}$/)
+  })
+})

--- a/src/main/build-identity.test.ts
+++ b/src/main/build-identity.test.ts
@@ -1,10 +1,21 @@
+import { execFileSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import { KUN_RUNTIME_BUILD_HASH } from '../../kun/src/version'
-import { KUN_GUI_BUILD_HASH } from '../shared/build-identity'
+import { KUN_GUI_BUILD_HASH, KUN_GUI_VERSION } from '../shared/build-identity'
 
 describe('build identity', () => {
   it('embeds the same git commit hash in GUI and runtime code', () => {
     expect(KUN_GUI_BUILD_HASH).toBe(KUN_RUNTIME_BUILD_HASH)
     expect(KUN_GUI_BUILD_HASH).toMatch(/^[0-9a-f]{40}$/)
+
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: new URL('../..', import.meta.url),
+      encoding: 'utf8'
+    }).trim()
+    expect(KUN_GUI_BUILD_HASH).toBe(head)
+  })
+
+  it('embeds the package versions generated at build time', () => {
+    expect(KUN_GUI_VERSION).toBe('0.1.0')
   })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ import {
   JsonSettingsStore,
   devServerHintUrl
 } from './settings-store'
+import { KUN_GUI_BUILD_HASH } from '../shared/build-identity'
 import kunLogoPng from '../asset/img/kun.png?url'
 import kunMacLogoPng from '../asset/img/kun_mac.png?url'
 import kunTrayPng from '../asset/img/kun_tray.png?url'
@@ -743,7 +744,10 @@ function probeKunHealthOnce(
         headers: runtimeAuthHeaders(settings),
         signal: AbortSignal.timeout(Math.max(250, Math.min(1_000, remainingMs)))
       })
-      const healthy = res.ok && isKunHealthResponseBody(await res.text())
+      const healthy = res.ok && isKunHealthResponseBody(await res.text(), {
+        expectedVersion: app.getVersion(),
+        expectedBuildHash: KUN_GUI_BUILD_HASH
+      })
       return { healthy, error: healthy ? '' : `unexpected status ${res.status}` }
     } catch (error) {
       return {

--- a/src/main/kun-health.test.ts
+++ b/src/main/kun-health.test.ts
@@ -6,8 +6,45 @@ describe('isKunHealthResponseBody', () => {
     expect(isKunHealthResponseBody(JSON.stringify({
       status: 'ok',
       service: 'kun',
-      mode: 'serve'
+      mode: 'serve',
+      version: '0.1.0',
+      buildHash: 'hash-1'
     }))).toBe(true)
+  })
+
+  it('requires the expected runtime version when provided', () => {
+    const body = JSON.stringify({
+      status: 'ok',
+      service: 'kun',
+      mode: 'serve',
+      version: '0.1.0',
+      buildHash: 'hash-1'
+    })
+    expect(isKunHealthResponseBody(body, { expectedVersion: '0.1.0' })).toBe(true)
+    expect(isKunHealthResponseBody(body, { expectedVersion: '0.1.1' })).toBe(false)
+    expect(isKunHealthResponseBody(JSON.stringify({
+      status: 'ok',
+      service: 'kun',
+      mode: 'serve'
+    }), { expectedVersion: '0.1.0' })).toBe(false)
+  })
+
+  it('requires the expected build hash when provided', () => {
+    const body = JSON.stringify({
+      status: 'ok',
+      service: 'kun',
+      mode: 'serve',
+      version: '0.1.0',
+      buildHash: 'hash-1'
+    })
+    expect(isKunHealthResponseBody(body, { expectedBuildHash: 'hash-1' })).toBe(true)
+    expect(isKunHealthResponseBody(body, { expectedBuildHash: 'hash-2' })).toBe(false)
+    expect(isKunHealthResponseBody(JSON.stringify({
+      status: 'ok',
+      service: 'kun',
+      mode: 'serve',
+      version: '0.1.0'
+    }), { expectedBuildHash: 'hash-1' })).toBe(false)
   })
 
   it('rejects generic or legacy runtime health responses', () => {

--- a/src/main/kun-health.ts
+++ b/src/main/kun-health.ts
@@ -1,4 +1,9 @@
-export function isKunHealthResponseBody(body: string): boolean {
+export type KunHealthExpectation = {
+  expectedVersion?: string
+  expectedBuildHash?: string
+}
+
+export function isKunHealthResponseBody(body: string, expectation: KunHealthExpectation = {}): boolean {
   let parsed: unknown
   try {
     parsed = JSON.parse(body) as unknown
@@ -7,5 +12,14 @@ export function isKunHealthResponseBody(body: string): boolean {
   }
   if (!parsed || typeof parsed !== 'object') return false
   const record = parsed as Record<string, unknown>
-  return record.status === 'ok' && record.service === 'kun' && record.mode === 'serve'
+  if (record.status !== 'ok' || record.service !== 'kun' || record.mode !== 'serve') return false
+  const expectedVersion = expectation.expectedVersion?.trim()
+  if (expectedVersion && record.version !== expectedVersion) {
+    return false
+  }
+  const expectedBuildHash = expectation.expectedBuildHash?.trim()
+  if (expectedBuildHash && record.buildHash !== expectedBuildHash) {
+    return false
+  }
+  return true
 }

--- a/src/renderer/src/agent/kun-runtime.test.ts
+++ b/src/renderer/src/agent/kun-runtime.test.ts
@@ -11,6 +11,7 @@ import {
   defaultTerminalSettings,
   type AppSettingsV1
 } from '@shared/app-settings'
+import { KUN_GUI_BUILD_HASH } from '@shared/build-identity'
 import { KunRuntimeProvider } from './kun-runtime'
 import { getProvider, resetProviderCacheForTests } from './registry'
 import { rendererRuntimeClient } from './runtime-client'
@@ -50,6 +51,7 @@ function installDsGui(overrides: Partial<Window['kunGui']>): void {
   vi.stubGlobal('window', {
     kunGui: {
       getSettings: vi.fn(async () => settings()),
+      getAppVersion: vi.fn(async () => '0.1.0'),
       runtimeRequest: vi.fn(async () => ({ ok: true, status: 200, body: '{}' })),
       startSse: vi.fn(async (_threadId: string, _sinceSeq: number, streamId?: string) => ({
         streamId: streamId ?? 'stream-1'
@@ -81,6 +83,52 @@ describe('KunRuntimeProvider', () => {
     expect(caps.stream).toBe(true)
     expect(caps.interrupt).toBe(true)
     expect(caps.approvals).toBe(true)
+  })
+
+  it('rejects a runtime whose build hash does not match the GUI', async () => {
+    const runtimeRequest = vi.fn(async (path: string) => {
+      if (path === '/health') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            status: 'ok',
+            service: 'kun',
+            mode: 'serve',
+            version: '0.1.0',
+            buildHash: 'different-build'
+          })
+        }
+      }
+      return { ok: true, status: 200, body: JSON.stringify({ threads: [] }) }
+    })
+    installDsGui({ runtimeRequest, getAppVersion: vi.fn(async () => '0.1.0') })
+
+    await expect(new KunRuntimeProvider().connect()).rejects.toThrow('runtime_build_mismatch')
+    expect(runtimeRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a runtime whose version does not match the GUI after build hash passes', async () => {
+    const runtimeRequest = vi.fn(async (path: string) => {
+      if (path === '/health') {
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            status: 'ok',
+            service: 'kun',
+            mode: 'serve',
+            version: '0.0.9',
+            buildHash: KUN_GUI_BUILD_HASH
+          })
+        }
+      }
+      return { ok: true, status: 200, body: JSON.stringify({ threads: [] }) }
+    })
+    installDsGui({ runtimeRequest, getAppVersion: vi.fn(async () => '0.1.0') })
+
+    await expect(new KunRuntimeProvider().connect()).rejects.toThrow('runtime_version_mismatch')
+    expect(runtimeRequest).toHaveBeenCalledTimes(1)
   })
 
   it('reports invalid runtime JSON responses with a stable error message', async () => {

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -9,6 +9,7 @@ import type {
   UserInputAnswer
 } from './types'
 import { getKunRuntimeSettings } from '@shared/app-settings'
+import { KUN_GUI_BUILD_HASH } from '@shared/build-identity'
 import {
   KUN_ATTACHMENT_DIAGNOSTICS_PATH,
   KUN_ATTACHMENTS_PATH,
@@ -108,6 +109,28 @@ function readRuntimeJson<T>(body: string, fallback: string): T {
   }
 }
 
+function readHealthVersion(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as unknown
+    if (!parsed || typeof parsed !== 'object') return ''
+    const version = (parsed as Record<string, unknown>).version
+    return typeof version === 'string' ? version.trim() : ''
+  } catch {
+    return ''
+  }
+}
+
+function readHealthBuildHash(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as unknown
+    if (!parsed || typeof parsed !== 'object') return ''
+    const buildHash = (parsed as Record<string, unknown>).buildHash
+    return typeof buildHash === 'string' ? buildHash.trim() : ''
+  } catch {
+    return ''
+  }
+}
+
 /**
  * GUI-side adapter for the Kun HTTP/SSE contract.
  *
@@ -133,6 +156,23 @@ export class KunRuntimeProvider implements AgentProvider {
     const health = await rendererRuntimeClient.runtimeRequest('/health', 'GET')
     if (!health.ok) {
       throw runtimeErrorToError(readRuntimeError(health.body, `runtime unhealthy (${health.status || 0})`))
+    }
+    const runtimeVersion = readHealthVersion(health.body)
+    const appVersion = (await rendererRuntimeClient.getAppVersion().catch(() => '')).trim()
+    const runtimeBuildHash = readHealthBuildHash(health.body)
+    if (runtimeBuildHash !== KUN_GUI_BUILD_HASH) {
+      throw runtimeErrorToError({
+        code: 'runtime_build_mismatch',
+        message: `Kun runtime build ${runtimeBuildHash || 'unknown'} does not match GUI build ${KUN_GUI_BUILD_HASH}. Restart Kun or reinstall the app.`,
+        details: { runtimeBuildHash, appBuildHash: KUN_GUI_BUILD_HASH }
+      })
+    }
+    if (appVersion && runtimeVersion !== appVersion) {
+      throw runtimeErrorToError({
+        code: 'runtime_version_mismatch',
+        message: `Kun runtime version ${runtimeVersion || 'unknown'} does not match GUI version ${appVersion}. Restart Kun or reinstall the app.`,
+        details: { runtimeVersion, appVersion }
+      })
     }
     const threads = await rendererRuntimeClient.runtimeRequest('/v1/threads?limit=1', 'GET')
     if (!threads.ok) {

--- a/src/renderer/src/agent/runtime-client.ts
+++ b/src/renderer/src/agent/runtime-client.ts
@@ -50,6 +50,10 @@ class RendererRuntimeClient {
     return window.kunGui.restartRuntime()
   }
 
+  getAppVersion(): Promise<string> {
+    return window.kunGui.getAppVersion()
+  }
+
   startSse(threadId: string, sinceSeq: number, streamId?: string): Promise<{ streamId: string }> {
     return window.kunGui.startSse(threadId, sinceSeq, streamId)
   }

--- a/src/renderer/src/lib/format-runtime-error.ts
+++ b/src/renderer/src/lib/format-runtime-error.ts
@@ -113,6 +113,10 @@ function localizedRuntimeSummary(code: string | null, text: string): string | nu
     return i18n.t('common:runtimeUnhealthy')
   }
 
+  if (code === 'runtime_build_mismatch' || code === 'runtime_version_mismatch') {
+    return i18n.t('common:runtimeVersionMismatch')
+  }
+
   if (code === 'turn_in_progress' || lowered.includes('active turn')) {
     return i18n.t('common:runtimeActiveTurn')
   }

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1916,6 +1916,7 @@
   "runtimeMissingApiKey": "DeepSeek API Key is missing. Open Settings and add it before the GUI can start the local runtime.",
   "runtimeAutoStartDisabled": "Kun is offline. Enable automatic startup in Settings, or start `kun serve` manually.",
   "runtimeUnhealthy": "The local runtime is currently unavailable. Check the port, token, or runtime status.",
+  "runtimeVersionMismatch": "The local runtime version does not match this GUI version. Fully quit and restart Kun; if the problem continues, reinstall the app.",
   "runtimeAuthRequired": "The local runtime requires a bearer token for thread APIs. Add the runtime token in Settings, or restart the GUI so it can manage the local runtime again.",
   "runtimePortConflict": "The runtime port is already in use. Free that port, or choose another port in Settings.",
   "runtimeRequestFailed": "Runtime request failed. Please try again.",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1916,6 +1916,7 @@
   "runtimeMissingApiKey": "尚未配置 DeepSeek API Key。请先打开设置填写，然后 GUI 才能自动启动本地运行时。",
   "runtimeAutoStartDisabled": "Kun 当前未启动。请在设置中开启自动启动，或手动执行 `kun serve`。",
   "runtimeUnhealthy": "本地运行时当前不可用。请检查端口、令牌或运行状态。",
+  "runtimeVersionMismatch": "本地运行时版本与当前前端版本不一致。请完全退出并重启 Kun；如果仍然出现此问题，请重新安装。",
   "runtimeAuthRequired": "本地运行时要求 Bearer Token 才能访问会话接口。请在设置中填写运行时令牌，或重启 GUI 让它重新管理本地运行时。",
   "runtimePortConflict": "运行时端口已被占用。请释放该端口，或在设置中更换端口。",
   "runtimeRequestFailed": "运行时请求失败。请稍后重试。",

--- a/src/shared/build-identity.ts
+++ b/src/shared/build-identity.ts
@@ -1,0 +1,1 @@
+export const KUN_GUI_BUILD_HASH = '9b9bdc94baceed433c723556a5bf11ea4c07759a'

--- a/src/shared/build-identity.ts
+++ b/src/shared/build-identity.ts
@@ -1,1 +1,3 @@
-export const KUN_GUI_BUILD_HASH = '9b9bdc94baceed433c723556a5bf11ea4c07759a'
+// 此文件由 scripts/generate-build-identity.cjs 生成。
+export const KUN_GUI_VERSION = '0.1.0'
+export const KUN_GUI_BUILD_HASH = '4f3c34ada9afb7fe945147ffb8329cd177583a50'

--- a/src/shared/runtime-error.ts
+++ b/src/shared/runtime-error.ts
@@ -40,6 +40,8 @@ export type LegacyMainGuardCode =
   | 'runtime_offline'
   | 'runtime_port_conflict'
   | 'runtime_unhealthy'
+  | 'runtime_build_mismatch'
+  | 'runtime_version_mismatch'
   | 'runtime_request_user_input_unsupported'
   | 'missing_api_key'
 
@@ -78,6 +80,8 @@ const KNOWN_LEGACY_CODES: ReadonlySet<LegacyMainGuardCode> = new Set<LegacyMainG
   'runtime_offline',
   'runtime_port_conflict',
   'runtime_unhealthy',
+  'runtime_build_mismatch',
+  'runtime_version_mismatch',
   'runtime_request_user_input_unsupported',
   'missing_api_key'
 ])


### PR DESCRIPTION
## Summary

- Add a build identity hash to both the GUI bundle and Kun runtime.
- Include runtime version and build hash in `/health`.
- Reject local runtime connections when the backend build hash or version does not match the GUI.

## Changes

- Adds shared GUI/runtime build identity constants.
- Extends main-process health probing with version and build hash expectations.
- Adds renderer-side connection guard and localized mismatch messaging.
- Covers hash/version mismatch behavior with targeted tests.

## Tests

- `npm run test -- src/main/kun-health.test.ts src/renderer/src/agent/kun-runtime.test.ts src/main/build-identity.test.ts`
- `npm run typecheck`
- `npm run build:kun`
- `git diff --check`
