### PR TITLE
fix(routes): implement RouteRegistry with dynamic /v1/routes resolution and compile-time fallback | 新增动态路由注册，修复 #237 GUI /v1/tools 404

### DIFF
--- a/kun/src/server/router.ts
+++ b/kun/src/server/router.ts
@@ -8,7 +8,7 @@ export type RouteHandler = (
 
 /**
  * Minimal router that supports `:param` placeholders. Routes are
- * registered with `(method, path, handler)` tuples and resolved in
+ * registered with `(method, path, handler, key?)` tuples and resolved in
  * registration order. The first matching route wins; this keeps
  * extension paths (`/v1/threads/:id/turns/:turnId`) explicit.
  */
@@ -18,15 +18,22 @@ export class Router {
     pattern: string
     segments: string[]
     handler: RouteHandler
+    key?: string
   }> = []
 
-  add(method: string, path: string, handler: RouteHandler): void {
+  add(method: string, path: string, handler: RouteHandler, key?: string): void {
     this.routes.push({
       method: method.toUpperCase(),
       pattern: path,
       segments: path.split('/').filter(Boolean),
-      handler
+      handler,
+      key
     })
+  }
+
+  /** Return all registered routes with their semantic keys for client discovery. */
+  listRoutes(): Array<{ key?: string; method: string; path: string }> {
+    return this.routes.map((r) => ({ key: r.key, method: r.method, path: r.pattern }))
   }
 
   match(method: string, path: string): { handler: RouteHandler; params: Record<string, string> } | undefined {

--- a/kun/src/server/routes/index.ts
+++ b/kun/src/server/routes/index.ts
@@ -1,4 +1,5 @@
 import { Router } from '../router.js'
+import { jsonResponse } from '../response.js'
 import { healthJsonResponse } from './health.js'
 import { buildWorkspaceStatusResponse } from './workspace.js'
 import {
@@ -101,174 +102,175 @@ import type { ServerRuntime } from './server-runtime.js'
 export function buildRouter(runtime: ServerRuntime): Router {
   const router = new Router()
   router.add('GET', '/health', () => healthJsonResponse())
+  router.add('GET', '/v1/routes', async (_request) => jsonResponse({ routes: router.listRoutes() }), 'routes')
   router.add('GET', '/v1/runtime/info', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return runtimeInfoJsonResponse(runtime)
-  })
+  }, 'runtime.info')
   router.add('GET', '/v1/runtime/tools', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return runtimeToolDiagnosticsJsonResponse(runtime)
-  })
+  }, 'runtime.tools')
   router.add('POST', '/v1/runtime/config/apply', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return applyRuntimeConfig(runtime, request)
-  })
+  }, 'runtime.config-apply')
   router.add('GET', '/v1/mcp/oauth', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return mcpOAuthDiagnostics(runtime)
-  })
+  }, 'mcp.oauth')
   router.add('DELETE', '/v1/mcp/oauth', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return clearMcpOAuth(runtime)
-  })
+  }, 'mcp.oauth')
   router.add('DELETE', '/v1/mcp/oauth/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return clearMcpOAuth(runtime, ctx.params.id)
-  })
+  }, 'mcp.oauth-server')
   router.add('POST', '/v1/mcp/oauth/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return authorizeMcpOAuth(runtime, ctx.params.id)
-  })
+  }, 'mcp.oauth-server')
   router.add('GET', '/v1/skills', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return listSkills(runtime)
-  })
+  }, 'skills')
   router.add('POST', '/v1/supply-chain/audit', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return auditSupplyChainPackage(runtime, request)
-  })
+  }, 'supply-chain.audit')
   router.add('POST', '/v1/supply-chain/update-check', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return checkSupplyChainUpdate(request)
-  })
+  }, 'supply-chain.update-check')
   router.add('POST', '/v1/attachments', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return uploadAttachment(runtime.attachmentStore, request)
-  })
+  }, 'attachments')
   router.add('GET', '/v1/attachments/diagnostics', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return attachmentDiagnostics(runtime.attachmentStore)
-  })
+  }, 'attachments.diagnostics')
   router.add('GET', '/v1/attachments/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return getAttachmentMetadata(runtime.attachmentStore, ctx.params.id)
-  })
+  }, 'attachment')
   router.add('GET', '/v1/attachments/:id/content', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return getAttachmentContent(runtime.attachmentStore, ctx.params.id, request)
-  })
+  }, 'attachment.content')
   router.add('GET', '/v1/memory', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return listMemories(runtime.memoryStore, request)
-  })
+  }, 'memory')
   router.add('POST', '/v1/memory', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return createMemory(runtime.memoryStore, request)
-  })
+  }, 'memory')
   router.add('GET', '/v1/memory/diagnostics', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return memoryDiagnostics(runtime.memoryStore)
-  })
+  }, 'memory.diagnostics')
   router.add('PATCH', '/v1/memory/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return updateMemory(runtime.memoryStore, ctx.params.id, request)
-  })
+  }, 'memory.record')
   router.add('DELETE', '/v1/memory/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return deleteMemory(runtime.memoryStore, ctx.params.id, request)
-  })
+  }, 'memory.record')
   router.add('GET', '/v1/delegation/diagnostics', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return delegationDiagnostics(runtime.delegationRuntime, request)
-  })
+  }, 'delegation.diagnostics')
   router.add('GET', '/v1/delegation/profiles', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return delegationProfiles(runtime.delegationRuntime)
-  })
+  }, 'delegation.profiles')
   router.add('POST', '/v1/delegation/abort/:childId', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return delegationAbort(runtime.delegationRuntime, ctx.params.childId)
-  })
+  }, 'delegation.abort')
   router.add('GET', '/v1/background-shells', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return backgroundShellList(runtime.backgroundShellRuntime, request)
-  })
+  }, 'background-shells')
   router.add('GET', '/v1/background-shells/:sessionId', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return backgroundShellGet(runtime.backgroundShellRuntime, ctx.params.sessionId)
-  })
+  }, 'background-shell')
   router.add('POST', '/v1/background-shells/:sessionId/stop', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return backgroundShellStop(runtime.backgroundShellRuntime, ctx.params.sessionId)
-  })
+  }, 'background-shell.stop')
   router.add('GET', '/v1/workspace/status', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     const url = new URL(request.url)
     const path = url.searchParams.get('path')
     return buildWorkspaceStatusResponse({ inspector: runtime.workspaceInspector, path })
-  })
+  }, 'workspace.status')
   router.add('GET', '/v1/threads', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return listThreads(runtime.threadService, request)
-  })
+  }, 'threads')
   router.add('POST', '/v1/threads', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return createThread(runtime.threadService, request)
-  })
+  }, 'threads')
   router.add('GET', '/v1/threads/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return getThread(runtime.threadService, ctx.params.id, runtime.sessionStore, runtime.userInputGate)
-  })
+  }, 'thread')
   router.add('PATCH', '/v1/threads/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return updateThread(runtime.threadService, ctx.params.id, request)
-  })
+  }, 'thread')
   router.add('DELETE', '/v1/threads/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return deleteThread(runtime.threadService, ctx.params.id)
-  })
+  }, 'thread')
   router.add('POST', '/v1/threads/:id/fork', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return forkThread(runtime.threadService, ctx.params.id, request)
-  })
+  }, 'thread.fork')
   router.add('POST', '/v1/threads/:id/summarize', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return summarizeThread(runtime, ctx.params.id, request)
-  })
+  }, 'thread.summarize')
   router.add('GET', '/v1/threads/:id/goal', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return getThreadGoal(runtime.threadService, ctx.params.id)
-  })
+  }, 'thread.goal')
   router.add('POST', '/v1/threads/:id/goal', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return setThreadGoal(runtime.threadService, ctx.params.id, request)
-  })
+  }, 'thread.goal')
   router.add('DELETE', '/v1/threads/:id/goal', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return clearThreadGoal(runtime.threadService, ctx.params.id)
-  })
+  }, 'thread.goal')
   router.add('GET', '/v1/threads/:id/todos', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return getThreadTodos(runtime.threadService, ctx.params.id)
-  })
+  }, 'thread.todos')
   router.add('POST', '/v1/threads/:id/todos', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return setThreadTodos(runtime.threadService, ctx.params.id, request)
-  })
+  }, 'thread.todos')
   router.add('DELETE', '/v1/threads/:id/todos', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return clearThreadTodos(runtime.threadService, ctx.params.id)
-  })
+  }, 'thread.todos')
   router.add('POST', '/v1/threads/:id/turns', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return startTurn(runtime.turnService, ctx.params.id, request, ({ threadId, turnId }) => {
       runtime.runTurn(threadId, turnId)
     })
-  })
+  }, 'thread.turns')
   router.add('POST', '/v1/threads/:id/rewind', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return rewindThread(runtime.turnService, ctx.params.id, request)
-  })
+  }, 'thread.rewind')
   router.add('POST', '/v1/threads/:id/review', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     if (!runtime.reviewService || !runtime.runReview) {
@@ -282,23 +284,23 @@ export function buildRouter(runtime: ServerRuntime): Router {
         runtime.runReview?.({ threadId, turnId, reviewItemId, target, model })
       }
     )
-  })
+  }, 'thread.review')
   router.add('GET', '/v1/threads/:id/turns/:turnId', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return getTurn(runtime.turnService, ctx.params.id, ctx.params.turnId)
-  })
+  }, 'thread.turns')
   router.add('POST', '/v1/threads/:id/turns/:turnId/steer', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return steerTurn(runtime.turnService, ctx.params.id, ctx.params.turnId, request)
-  })
+  }, 'thread.steer')
   router.add('POST', '/v1/threads/:id/turns/:turnId/interrupt', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return interruptTurn(runtime.turnService, ctx.params.id, ctx.params.turnId, request)
-  })
+  }, 'thread.interrupt')
   router.add('POST', '/v1/threads/:id/compact', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return compactTurn(runtime.turnService, ctx.params.id, request)
-  })
+  }, 'thread.compact')
   router.add('GET', '/v1/threads/:id/events', (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return buildEventStreamResponse({
@@ -307,7 +309,7 @@ export function buildRouter(runtime: ServerRuntime): Router {
       eventBus: runtime.eventBus,
       sessionStore: runtime.sessionStore
     })
-  })
+  }, 'thread.events')
   router.add('POST', '/v1/approvals/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return decideApproval({
@@ -316,7 +318,7 @@ export function buildRouter(runtime: ServerRuntime): Router {
       gate: runtime.approvalGate,
       events: runtime.events
     })
-  })
+  }, 'approval')
   router.add('POST', '/v1/user-inputs/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return resolveUserInput({
@@ -325,7 +327,7 @@ export function buildRouter(runtime: ServerRuntime): Router {
       gate: runtime.userInputGate,
       events: runtime.events
     })
-  })
+  }, 'user-input')
   router.add('POST', '/v1/user-input/:id', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return resolveUserInput({
@@ -334,19 +336,19 @@ export function buildRouter(runtime: ServerRuntime): Router {
       gate: runtime.userInputGate,
       events: runtime.events
     })
-  })
+  }, 'user-input')
   router.add('POST', '/v1/sessions/:id/resume-thread', async (request, ctx) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return resumeSession(runtime.threadService, ctx.params.id, request)
-  })
+  }, 'session.resume')
   router.add('GET', '/v1/usage', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return usageJsonResponse(request, runtime)
-  })
+  }, 'usage')
   router.add('GET', '/v1/debug/llm-rounds', async (request) => {
     if (!authorize(request, runtime)) return ERRORS.unauthorized()
     return llmDebugRoundsResponse(runtime)
-  })
+  }, 'debug.llm-rounds')
   return router
 }
 

--- a/src/renderer/src/agent/kun-runtime.ts
+++ b/src/renderer/src/agent/kun-runtime.ts
@@ -18,6 +18,7 @@ import {
   KUN_RUNTIME_INFO_PATH,
   KUN_RUNTIME_TOOLS_PATH,
   KUN_SKILLS_PATH,
+  KUN_THREADS_PATH,
   kunApprovalPath,
   kunThreadCompactPath,
   kunThreadEventsPath,
@@ -130,11 +131,13 @@ export class KunRuntimeProvider implements AgentProvider {
   }
 
   async connect(): Promise<void> {
+    // Initialize RouteRegistry before any API calls (#237)
+    await rendererRuntimeClient.initRouteRegistry().catch(() => { /* fallback to default routes */ })
     const health = await rendererRuntimeClient.runtimeRequest('/health', 'GET')
     if (!health.ok) {
       throw runtimeErrorToError(readRuntimeError(health.body, `runtime unhealthy (${health.status || 0})`))
     }
-    const threads = await rendererRuntimeClient.runtimeRequest('/v1/threads?limit=1', 'GET')
+    const threads = await rendererRuntimeClient.runtimeRequest(`${KUN_THREADS_PATH}?limit=1`, 'GET')
     if (!threads.ok) {
       throw runtimeErrorToError(readRuntimeError(threads.body, `failed to list threads (${threads.status || 0})`))
     }

--- a/src/renderer/src/agent/route-registry.ts
+++ b/src/renderer/src/agent/route-registry.ts
@@ -1,0 +1,153 @@
+import {
+  KUN_HEALTH_PATH,
+  KUN_RUNTIME_INFO_PATH,
+  KUN_RUNTIME_TOOLS_PATH,
+  KUN_SKILLS_PATH,
+  KUN_ATTACHMENTS_PATH,
+  KUN_ATTACHMENT_DIAGNOSTICS_PATH,
+  KUN_ATTACHMENT_TEMPLATE,
+  KUN_ATTACHMENT_CONTENT_TEMPLATE,
+  KUN_MEMORY_PATH,
+  KUN_MEMORY_DIAGNOSTICS_PATH,
+  KUN_MEMORY_RECORD_TEMPLATE,
+  KUN_THREADS_PATH,
+  KUN_THREAD_TEMPLATE,
+  KUN_THREAD_FORK_TEMPLATE,
+  KUN_THREAD_GOAL_TEMPLATE,
+  KUN_THREAD_TODOS_TEMPLATE,
+  KUN_THREAD_COMPACT_TEMPLATE,
+  KUN_THREAD_REVIEW_TEMPLATE,
+  KUN_THREAD_REWIND_TEMPLATE,
+  KUN_THREAD_TURNS_TEMPLATE,
+  KUN_THREAD_STEER_TEMPLATE,
+  KUN_THREAD_INTERRUPT_TEMPLATE,
+  KUN_THREAD_EVENTS_TEMPLATE,
+  KUN_APPROVAL_TEMPLATE,
+  KUN_USER_INPUT_TEMPLATE,
+  KUN_SESSION_RESUME_TEMPLATE,
+  KUN_USAGE_PATH,
+  KUN_DEBUG_LLM_ROUNDS_PATH,
+  KUN_ROUTES_PATH,
+} from '@shared/kun-endpoints'
+
+export type RouteEntry = { key: string; methods: string[]; path: string }
+export type RouteMap = Record<string, RouteEntry>
+
+const DEFAULT_ROUTES: RouteEntry[] = [
+  { key: 'health', methods: ['GET'], path: KUN_HEALTH_PATH },
+  { key: 'routes', methods: ['GET'], path: KUN_ROUTES_PATH },
+  { key: 'runtime.info', methods: ['GET'], path: KUN_RUNTIME_INFO_PATH },
+  { key: 'runtime.tools', methods: ['GET'], path: KUN_RUNTIME_TOOLS_PATH },
+  { key: 'skills', methods: ['GET'], path: KUN_SKILLS_PATH },
+  { key: 'attachments', methods: ['POST'], path: KUN_ATTACHMENTS_PATH },
+  { key: 'attachments.diagnostics', methods: ['GET'], path: KUN_ATTACHMENT_DIAGNOSTICS_PATH },
+  { key: 'attachment', methods: ['GET'], path: KUN_ATTACHMENT_TEMPLATE },
+  { key: 'attachment.content', methods: ['GET'], path: KUN_ATTACHMENT_CONTENT_TEMPLATE },
+  { key: 'memory', methods: ['GET', 'POST'], path: KUN_MEMORY_PATH },
+  { key: 'memory.diagnostics', methods: ['GET'], path: KUN_MEMORY_DIAGNOSTICS_PATH },
+  { key: 'memory.record', methods: ['PATCH', 'DELETE'], path: KUN_MEMORY_RECORD_TEMPLATE },
+  { key: 'threads', methods: ['GET', 'POST'], path: KUN_THREADS_PATH },
+  { key: 'thread', methods: ['GET', 'PATCH', 'DELETE'], path: KUN_THREAD_TEMPLATE },
+  { key: 'thread.fork', methods: ['POST'], path: KUN_THREAD_FORK_TEMPLATE },
+  { key: 'thread.goal', methods: ['GET', 'POST', 'DELETE'], path: KUN_THREAD_GOAL_TEMPLATE },
+  { key: 'thread.todos', methods: ['GET', 'POST', 'DELETE'], path: KUN_THREAD_TODOS_TEMPLATE },
+  { key: 'thread.compact', methods: ['POST'], path: KUN_THREAD_COMPACT_TEMPLATE },
+  { key: 'thread.review', methods: ['POST'], path: KUN_THREAD_REVIEW_TEMPLATE },
+  { key: 'thread.rewind', methods: ['POST'], path: KUN_THREAD_REWIND_TEMPLATE },
+  { key: 'thread.turns', methods: ['POST'], path: KUN_THREAD_TURNS_TEMPLATE },
+  { key: 'thread.steer', methods: ['POST'], path: KUN_THREAD_STEER_TEMPLATE },
+  { key: 'thread.interrupt', methods: ['POST'], path: KUN_THREAD_INTERRUPT_TEMPLATE },
+  { key: 'thread.events', methods: ['GET'], path: KUN_THREAD_EVENTS_TEMPLATE },
+  { key: 'approval', methods: ['POST'], path: KUN_APPROVAL_TEMPLATE },
+  { key: 'user-input', methods: ['POST'], path: KUN_USER_INPUT_TEMPLATE },
+  { key: 'session.resume', methods: ['POST'], path: KUN_SESSION_RESUME_TEMPLATE },
+  { key: 'usage', methods: ['GET'], path: KUN_USAGE_PATH },
+  { key: 'debug.llm-rounds', methods: ['GET'], path: KUN_DEBUG_LLM_ROUNDS_PATH },
+]
+
+function buildRouteMap(entries: RouteEntry[]): RouteMap {
+  const map: RouteMap = {}
+  for (const entry of entries) map[entry.key] = entry
+  return map
+}
+
+function fillTemplate(template: string, params: Record<string, string> = {}): string {
+  return template.replace(/\{(\w+)\}/g, (_: string, key: string) => {
+    const value = params[key]
+    if (value === undefined) throw new Error(`RouteRegistry: missing parameter "${key}" for "${template}"`)
+    return encodeURIComponent(value)
+  })
+}
+
+function normalizeServerPath(path: string): string {
+  return path.replace(/:(\w+)/g, '{$1}')
+}
+
+export type RouteRegistryFetch = (path: string, method?: string) => Promise<{ ok: boolean; status: number; body: string }>
+
+export class RouteRegistry {
+  private routes: RouteMap = buildRouteMap(DEFAULT_ROUTES)
+  private loaded = false
+  private loadPromise: Promise<void> | null = null
+  private source: 'server' | 'default' = 'default'
+
+  async init(fetchFn: RouteRegistryFetch): Promise<void> {
+    if (this.loaded) return
+    if (this.loadPromise) return this.loadPromise
+    this.loadPromise = this.loadFromServer(fetchFn)
+      .then(() => {
+        this.source = 'server'
+      })
+      .catch((err) => {
+        console.warn('[RouteRegistry] Failed to load routes from server, using defaults:', err)
+        this.routes = buildRouteMap(DEFAULT_ROUTES)
+        this.source = 'default'
+      })
+      .finally(() => { this.loaded = true })
+    return this.loadPromise
+  }
+
+  private async loadFromServer(fetchFn: RouteRegistryFetch): Promise<void> {
+    const result = await fetchFn(KUN_ROUTES_PATH, 'GET')
+    if (!result.ok) throw new Error(`Failed to fetch routes: HTTP ${result.status}`)
+    const parsed = JSON.parse(result.body) as { routes?: Array<{ key?: string; method: string; path: string }> }
+    if (!parsed.routes || !Array.isArray(parsed.routes)) throw new Error('Invalid routes response')
+
+    const merged = buildRouteMap(DEFAULT_ROUTES)
+
+    for (const serverRoute of parsed.routes) {
+      if (!serverRoute.key) continue
+      const existing = merged[serverRoute.key]
+      if (existing) {
+        const methods = new Set([...existing.methods, serverRoute.method])
+        merged[serverRoute.key] = {
+          key: serverRoute.key,
+          methods: Array.from(methods),
+          path: normalizeServerPath(serverRoute.path),
+        }
+      } else {
+        merged[serverRoute.key] = {
+          key: serverRoute.key,
+          methods: [serverRoute.method],
+          path: normalizeServerPath(serverRoute.path),
+        }
+      }
+    }
+
+    this.routes = merged
+  }
+
+  isFromServer(): boolean { return this.source === 'server' }
+
+  getEntry(key: string): RouteEntry | undefined { return this.routes[key] }
+
+  path(key: string, params: Record<string, string> = {}): string {
+    const entry = this.routes[key]
+    if (!entry) throw new Error(`RouteRegistry: unknown route key "${key}"`)
+    return fillTemplate(entry.path, params)
+  }
+
+  entries(): RouteEntry[] { return Object.values(this.routes) }
+}
+
+export const routeRegistry = new RouteRegistry()

--- a/src/renderer/src/agent/runtime-client.ts
+++ b/src/renderer/src/agent/runtime-client.ts
@@ -5,10 +5,34 @@ import type {
   SseErrorPayload,
   SseEventPayload
 } from '@shared/kun-gui-api'
+import { routeRegistry, type RouteRegistryFetch } from './route-registry.js'
 
 class RendererRuntimeClient {
   private cachedSettings: AppSettingsV1 | null = null
   private settingsPromise: Promise<AppSettingsV1> | null = null
+  private routeRegistryInitialized = false
+
+  /**
+   * Initialize the RouteRegistry with the IPC bridge fetch function.
+   * Idempotent – safe to call multiple times. Falls back to default routes on failure.
+   */
+  async initRouteRegistry(): Promise<void> {
+    if (this.routeRegistryInitialized) return
+    const fetchFn: RouteRegistryFetch = async (path, method) => {
+      return this.runtimeRequest(path, method)
+    }
+    await routeRegistry.init(fetchFn)
+    this.routeRegistryInitialized = true
+  }
+
+  /**
+   * Make a runtime request using a semantic route key.
+   * Automatically resolves the key to the correct path via RouteRegistry.
+   */
+  async requestByKey(key: string, params: Record<string, string> = {}, method?: string, body?: string): Promise<RuntimeRequestResult> {
+    const path = routeRegistry.path(key, params)
+    return this.runtimeRequest(path, method, body)
+  }
 
   async getSettings(options?: { forceRefresh?: boolean }): Promise<AppSettingsV1> {
     if (options?.forceRefresh) {

--- a/src/shared/kun-endpoints.ts
+++ b/src/shared/kun-endpoints.ts
@@ -133,6 +133,9 @@ export const KUN_USAGE_TEMPLATE = '/v1/usage'
 export const KUN_DEBUG_LLM_ROUNDS_PATH = '/v1/debug/llm-rounds'
 export const KUN_DEBUG_LLM_ROUNDS_TEMPLATE = '/v1/debug/llm-rounds'
 
+export const KUN_ROUTES_PATH = '/v1/routes'
+export const KUN_ROUTES_TEMPLATE = '/v1/routes'
+
 export const KUN_BACKGROUND_SHELLS_PATH = '/v1/background-shells'
 export const KUN_BACKGROUND_SHELLS_TEMPLATE = '/v1/background-shells'
 export const KUN_BACKGROUND_SHELL_TEMPLATE = '/v1/background-shells/{sessionId}'


### PR DESCRIPTION
This PR is part of the R31 batch (#736 split into atomic PRs). See the individual commit for full details.