### PR TITLE
fix(runtime): preserve compaction context outlines

### DIFF
--- a/docs/KUN_CONFIG.md
+++ b/docs/KUN_CONFIG.md
@@ -75,9 +75,9 @@ GUI 启动 Kun 时会按下面的顺序合并配置。
   "contextCompaction": {
     "defaultSoftThreshold": 96000,
     "defaultHardThreshold": 108800,
-    "summaryMode": "heuristic",
+    "summaryMode": "model",
     "summaryTimeoutMs": 15000,
-    "summaryMaxTokens": 1200,
+    "summaryMaxTokens": 2048,
     "summaryInputMaxBytes": 98304
   },
   "runtime": {
@@ -179,9 +179,9 @@ Kun 内置 DeepSeek V4 默认模型画像：
   "contextCompaction": {
     "defaultSoftThreshold": 96000,
     "defaultHardThreshold": 108800,
-    "summaryMode": "heuristic",
+    "summaryMode": "model",
     "summaryTimeoutMs": 15000,
-    "summaryMaxTokens": 1200,
+    "summaryMaxTokens": 2048,
     "summaryInputMaxBytes": 98304
   }
 }
@@ -191,7 +191,9 @@ Kun 内置 DeepSeek V4 默认模型画像：
 
 - `defaultSoftThreshold`: 未匹配到模型 profile 时，达到多少 input tokens 开始压缩。
 - `defaultHardThreshold`: 未匹配到模型 profile 时，达到多少 input tokens 强制压缩。
-- `summaryMode`: `heuristic` 使用本地摘要骨架，`model` 会尝试调用模型生成摘要。
+- `summaryMode`: GUI 管理的配置默认并归一为 `model`。手工维护 `config.json`
+  时仍可显式写 `heuristic` 使用本地摘要骨架；`model` 模式下模型摘要失败、
+  超时或返回空文本时会自动降级为本地摘要骨架。
 - `summaryTimeoutMs`: 模型摘要调用超时时间。
 - `summaryMaxTokens`: 模型摘要输出 token 上限。
 - `summaryInputMaxBytes`: 摘要输入文本最大字节数。

--- a/kun/src/loop/compaction-summary.ts
+++ b/kun/src/loop/compaction-summary.ts
@@ -20,7 +20,14 @@ export const DEFAULT_COMPACTION_SUMMARY_INPUT_MAX_BYTES = 96 * 1024
 export const COMPACTION_SYSTEM_PROMPT = [
   'You are summarizing a long coding-agent conversation so the work can continue past the context window.',
   '',
-  'Provide a detailed but concise summary. Focus on information that would be helpful for continuing the work, including:',
+  'Write a structured handoff summary with these sections:',
+  '## Goal',
+  '## Durable Context',
+  '## Completed and Decisions',
+  '## Files, Commands, and Results',
+  '## Open Issues and Next Steps',
+  '',
+  'Focus on information that would be helpful for continuing the work, including:',
   '- What was requested and the overall goal',
   '- What has been done and the decisions that were made (and why)',
   '- Which files are being created, edited, or inspected (with their paths)',
@@ -28,6 +35,7 @@ export const COMPACTION_SYSTEM_PROMPT = [
   '- What still needs to be done next',
   '- User requests, constraints, and preferences that must persist',
   '',
+  'If the conversation contains a numbered or bulleted list of issues, tasks, TODOs, problems, requirements, or user findings, preserve every item that is still relevant. Do not collapse middle items into a range, "etc.", or an omitted-count line.',
   'Preserve concrete identifiers verbatim: file paths, function and variable names, commands, URLs, IDs, and error messages.',
   'Do not invent facts and do not add generic advice. Write in the same language as the conversation.',
   'Your summary should be comprehensive enough to provide full context but concise enough to be quickly understood.'
@@ -45,7 +53,8 @@ export function buildCompactionContinuationMessage(pinnedConstraints?: readonly 
     'Provide a detailed summary of our conversation above, written so a new session with no access to ' +
       'this history can continue the work seamlessly. Cover what we set out to do, what has been done, ' +
       'which files and locations are involved, the key findings and decisions, and what remains to be done next. ' +
-      'Preserve concrete identifiers (file paths, function/variable names, commands, URLs, IDs, error messages) verbatim.'
+      'Preserve concrete identifiers (file paths, function/variable names, commands, URLs, IDs, error messages) verbatim. ' +
+      'If there are numbered or bulleted issue/task/problem/TODO/requirement lists, keep every still-relevant item rather than summarizing them as a range or omitted middle.'
   ]
   const pins = (pinnedConstraints ?? []).map((pin) => pin.trim()).filter((pin) => pin.length > 0)
   if (pins.length > 0) {

--- a/kun/src/loop/context-compactor.test.ts
+++ b/kun/src/loop/context-compactor.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { createImmutablePrefix } from '../cache/immutable-prefix.js'
+import type { TurnItem } from '../contracts/items.js'
+import { makeAssistantTextItem, makeUserItem } from '../domain/item.js'
+import { ContextCompactor } from './context-compactor.js'
+
+describe('ContextCompactor', () => {
+  it('preserves numbered problem outlines when heuristic compaction is the fallback', () => {
+    const threadId = 'thr_compaction_outline'
+    const turnId = 'turn_compaction_outline'
+    const problems = Array.from(
+      { length: 80 },
+      (_, index) => `Problem ${index + 1}: preserve finding ${index + 1}`
+    )
+    const history: TurnItem[] = [
+      makeUserItem({
+        id: 'item_user_start',
+        threadId,
+        turnId,
+        text: 'Please keep the complete issue list when compacting.'
+      }),
+      makeAssistantTextItem({
+        id: 'item_problem_list',
+        threadId,
+        turnId,
+        status: 'completed',
+        text: ['Current problem list:', ...problems].join('\n')
+      }),
+      ...Array.from({ length: 50 }, (_, index) =>
+        makeAssistantTextItem({
+          id: `item_filler_${index}`,
+          threadId,
+          turnId,
+          status: 'completed',
+          text: `Routine progress note ${index + 1}.`
+        })
+      ),
+      makeUserItem({
+        id: 'item_recent_tail',
+        threadId,
+        turnId,
+        text: 'Recent tail request kept verbatim.'
+      })
+    ]
+
+    const result = new ContextCompactor().compact({
+      threadId,
+      turnId,
+      history,
+      prefix: createImmutablePrefix({
+        pinnedConstraints: ['system: preserve user intent across compaction']
+      }),
+      keepRecent: 1,
+      reason: 'test forced fallback summary'
+    })
+
+    expect(result.summaryItem.kind).toBe('compaction')
+    if (result.summaryItem.kind !== 'compaction') return
+    expect(result.summaryItem.summary).toContain('Problem 1: preserve finding 1')
+    expect(result.summaryItem.summary).toContain('Problem 42: preserve finding 42')
+    expect(result.summaryItem.summary).toContain('Problem 80: preserve finding 80')
+    expect(result.summaryItem.summary).not.toContain('middle item(s) omitted from this compact summary')
+  })
+})

--- a/kun/src/loop/context-compactor.ts
+++ b/kun/src/loop/context-compactor.ts
@@ -347,10 +347,21 @@ function buildCompactionSummary(input: {
   lines.push(
     `Summarized ${input.history.length} item(s); ${input.tail.length} recent item(s) are also kept verbatim for the current request.`
   )
+  const durableOutlineLines = fitLinesToBudget(
+    extractDurableOutlineLines(input.history),
+    Math.floor(contentBudget * 0.75)
+  )
+  if (durableOutlineLines.length > 0) {
+    lines.push('Durable outline and open items:')
+    lines.push(...durableOutlineLines)
+    lines.push('')
+  }
   lines.push('Conversation and work summary:')
+  const usedBudget = lines.join('\n').length
+  const remainingBudget = Math.max(1_200, contentBudget - usedBudget)
   const summaryLines = fitLinesToBudget(
     selectSummaryLines(input.history.map(summarizeItem).filter((line) => line.length > 0)),
-    contentBudget
+    remainingBudget
   )
   if (summaryLines.length === 0) {
     lines.push('- No user-visible content before compaction.')
@@ -376,8 +387,102 @@ function extractSkillPins(history: TurnItem[]): string[] {
 }
 
 function summaryCharBudget(budgetTokens: number | undefined): number {
-  if (budgetTokens === undefined) return 4_000
-  return Math.max(1_200, Math.min(12_000, budgetTokens * 4))
+  if (budgetTokens === undefined) return 12_000
+  return Math.max(1_200, Math.min(24_000, budgetTokens * 4))
+}
+
+function extractDurableOutlineLines(history: TurnItem[]): string[] {
+  const lines: string[] = []
+  for (const item of history) {
+    switch (item.kind) {
+      case 'user_message':
+        lines.push(...durableTextLines('User request', item.text, { fallback: true }))
+        break
+      case 'assistant_text':
+        lines.push(...durableTextLines('Assistant finding', item.text))
+        break
+      case 'compaction':
+        if (item.replacedTokens > 0) {
+          lines.push(...durableTextLines('Earlier compaction', item.summary))
+        }
+        break
+      case 'tool_call': {
+        const text = item.summary || stringifyCompact(item.arguments)
+        if (isDurableTextLine(text)) {
+          lines.push(`- Tool call ${item.toolName}: ${clipText(text, 520)}`)
+        }
+        break
+      }
+      case 'tool_result': {
+        const text = stringifyCompact(item.output)
+        if (item.isError || isDurableTextLine(text)) {
+          lines.push(`- Tool result ${item.toolName}${item.isError ? ' error' : ''}: ${clipText(text, 520)}`)
+        }
+        break
+      }
+      case 'approval':
+        if (item.status !== 'allowed') {
+          lines.push(`- Approval ${item.status} for ${item.toolName}: ${clipText(item.summary, 520)}`)
+        }
+        break
+      case 'user_input':
+        lines.push(`- User input ${item.status}: ${clipText(item.prompt, 520)}`)
+        break
+      case 'review':
+        lines.push(...durableTextLines('Review', item.reviewText || stringifyCompact(item.output)))
+        break
+      case 'error':
+        lines.push(`- Error${item.code ? ` ${item.code}` : ''}: ${clipText(item.message, 520)}`)
+        break
+      case 'assistant_reasoning':
+        break
+    }
+  }
+  return dedupeLines(lines)
+}
+
+function durableTextLines(
+  label: string,
+  text: string,
+  options?: { fallback?: boolean }
+): string[] {
+  const rawLines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  const selected = rawLines.filter(isDurableTextLine)
+  if (selected.length === 0 && options?.fallback) {
+    const clipped = clipText(text, 520)
+    return clipped ? [`- ${label}: ${clipped}`] : []
+  }
+  return selected.map((line) => `- ${label}: ${clipText(line, 520)}`)
+}
+
+const DURABLE_OUTLINE_LINE =
+  /^(?:#{1,6}\s+|[-*+]\s+(?:\[[ xX-]\]\s*)?|\d{1,4}[.)]\s+|[A-Za-z][.)]\s+|(?:problems?|issues?|tasks?|todos?|bugs?|fixes?|steps?)\s*#?\d{0,4}\b)/i
+const DURABLE_KEYWORD_LINE =
+  /\b(?:issue|bug|problem|task|todo|open|done|next|remaining|scope|constraint|requirement|decision|root cause|fix|blocked|error|exception|failed|failing|command|test|file|path|must|need|expected|actual)\b/i
+const DURABLE_IDENTIFIER_LINE =
+  /(?:https?:\/\/|#[0-9]+\b|`[^`]+`|(?:^|[ ./])[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|py|go|rs|java|c|cpp|h|hpp|css|scss|html|yml|yaml)\b|\/[\w./-]+)/
+
+function isDurableTextLine(text: string): boolean {
+  const line = text.trim()
+  if (!line) return false
+  if (DURABLE_OUTLINE_LINE.test(line)) return true
+  if (DURABLE_KEYWORD_LINE.test(line)) return true
+  return DURABLE_IDENTIFIER_LINE.test(line)
+}
+
+function dedupeLines(lines: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const line of lines) {
+    const key = line.replace(/\s+/g, ' ').trim().toLowerCase()
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    out.push(line)
+  }
+  return out
 }
 
 function summarizeItem(item: TurnItem): string {
@@ -408,14 +513,28 @@ function summarizeItem(item: TurnItem): string {
 }
 
 function selectSummaryLines(lines: string[]): string[] {
-  if (lines.length <= 20) return lines
-  const start = lines.slice(0, 4)
-  const end = lines.slice(-14)
-  return [
-    ...start,
-    `- ${lines.length - start.length - end.length} middle item(s) omitted from this compact summary.`,
-    ...end
-  ]
+  if (lines.length <= 40) return lines
+  const start = lines.slice(0, 6)
+  const end = lines.slice(-18)
+  const middle = lines.slice(start.length, lines.length - end.length)
+  const criticalMiddle = middle.filter(isCriticalSummaryLine)
+  const selected = dedupeLines([...start, ...criticalMiddle, ...end])
+  const omitted = lines.length - selected.length
+  if (omitted > 0) {
+    selected.splice(
+      Math.min(start.length + criticalMiddle.length, selected.length),
+      0,
+      `- ${omitted} lower-priority transcript line(s) omitted after preserving detected user requests, task lists, errors, paths, and decisions.`
+    )
+  }
+  return selected
+}
+
+function isCriticalSummaryLine(line: string): boolean {
+  if (/^- User:/.test(line)) return true
+  if (/\b(?:error|failed|failing|exception|denied|cancelled)\b/i.test(line)) return true
+  const content = line.replace(/^- [^:]+:\s*/, '')
+  return isDurableTextLine(content)
 }
 
 function fitLinesToBudget(lines: string[], budget: number): string[] {

--- a/src/shared/app-settings-kun.ts
+++ b/src/shared/app-settings-kun.ts
@@ -321,7 +321,7 @@ export function defaultKunContextCompactionSettings(): KunContextCompactionSetti
     // Falls back to the heuristic summary automatically on timeout/failure.
     summaryMode: 'model',
     summaryTimeoutMs: 15_000,
-    summaryMaxTokens: 1_200,
+    summaryMaxTokens: 2_048,
     summaryInputMaxBytes: 96 * 1024
   }
 }

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -298,7 +298,7 @@ describe('kun defaults', () => {
         defaultHardThreshold: 108800,
         summaryMode: 'model',
         summaryTimeoutMs: 15000,
-        summaryMaxTokens: 1200,
+        summaryMaxTokens: 2048,
         summaryInputMaxBytes: 98304
       },
       runtimeTuning: {


### PR DESCRIPTION
## Summary

Fixes #747.

This PR makes context compaction preserve durable task context instead of collapsing long middle sections into an unusable omitted-count summary.

## Changes

- Add durable outline extraction to heuristic compaction fallback so user requests, numbered issue/task/TODO lists, errors, paths, decisions, and pending interaction state survive compaction.
- Strengthen the model compaction prompt to produce structured handoff summaries and preserve every still-relevant numbered/bulleted item.
- Raise the default compaction summary output budget from 1200 to 2048 tokens and update Kun config docs.
- Add a regression test covering a long middle `Problem N` list that must survive fallback compaction.

## Tests

- `npm test`
- `npm run typecheck`
- `npm run build:kun`
- `npm run lint` (0 errors; existing React hooks warnings remain)
- `npm --prefix kun test -- src/loop/context-compactor.test.ts src/services/turn-service.test.ts`
- `npm --prefix kun run typecheck`
- `npm test -- src/shared/app-settings.test.ts`

Note: full `npm --prefix kun test` currently reports unrelated baseline failures in user_input/tool advertisement, send_im_attachment tool-list expectations, and transient retry coverage; the compaction-specific Kun tests above pass.
