### PR TITLE
fix(sidebar): show right rail tooltips

### DIFF
--- a/src/renderer/src/components/chat/WorkbenchTopBar.test.ts
+++ b/src/renderer/src/components/chat/WorkbenchTopBar.test.ts
@@ -1,0 +1,50 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import i18n from '../../i18n'
+import { WorkbenchSideRail } from './WorkbenchTopBar'
+
+describe('WorkbenchSideRail', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it('renders visible tooltip labels for right rail icon buttons', () => {
+    const html = renderToStaticMarkup(
+      createElement(WorkbenchSideRail, {
+        rightPanelMode: null,
+        onToggleRightPanelMode: vi.fn(),
+        planPanelEnabled: true,
+        canvasEnabled: true,
+        terminalOpen: false,
+        onToggleTerminal: vi.fn(),
+        sideChatCount: 0,
+        sideChatRunningCount: 0,
+        sideChatOpen: false,
+        sideChatEnabled: true,
+        fileTreeOpen: false,
+        fileTreeEnabled: true,
+        onToggleFileTree: vi.fn(),
+        onOpenSideChat: vi.fn()
+      })
+    )
+
+    for (const label of [
+      'Choose default editor',
+      'Open branch conversation',
+      'Todo',
+      'Plan',
+      'Changes',
+      'Terminal',
+      'Preview',
+      'Whiteboard',
+      'Subagents',
+      'Files'
+    ]) {
+      expect(html).toContain(`data-tooltip="${label}"`)
+      expect(html).toContain(`title="${label}"`)
+    }
+
+    expect(html.match(/ds-side-rail-button/g)?.length).toBeGreaterThanOrEqual(10)
+  })
+})

--- a/src/renderer/src/components/chat/WorkbenchTopBar.tsx
+++ b/src/renderer/src/components/chat/WorkbenchTopBar.tsx
@@ -53,6 +53,15 @@ type Props = {
 }
 
 const TOPBAR_ICON_CLASS = 'h-4 w-4'
+const SIDE_RAIL_BUTTON_BASE =
+  'ds-side-rail-button inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]'
+const SIDE_RAIL_BUTTON_ACTIVE = 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
+const SIDE_RAIL_BUTTON_IDLE =
+  'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
+
+function sideRailButtonClass(active: boolean, extra?: string): string {
+  return `${SIDE_RAIL_BUTTON_BASE} ${active ? SIDE_RAIL_BUTTON_ACTIVE : SIDE_RAIL_BUTTON_IDLE}${extra ? ` ${extra}` : ''}`
+}
 
 export function WorkbenchSideRail({
   rightPanelMode,
@@ -90,6 +99,9 @@ export function WorkbenchSideRail({
     () => editors.find((editor) => editor.id === selectedEditorId) ?? editors[0],
     [editors, selectedEditorId]
   )
+  const editorButtonTitle = selectedEditor
+    ? t('editorPickerTitleWithEditor', { editor: selectedEditor.label })
+    : t('editorPickerTitle')
 
   useEffect(() => {
     let cancelled = false
@@ -280,7 +292,8 @@ export function WorkbenchSideRail({
           type="button"
           onClick={() => void runGuiUpdateAction()}
           disabled={guiUpdateBusy}
-          className="relative inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border border-amber-300/75 bg-amber-50/92 text-amber-950 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] transition hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-700/70 dark:bg-amber-950/35 dark:text-amber-100 dark:hover:bg-amber-900/45"
+          className="ds-side-rail-button relative inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border border-amber-300/75 bg-amber-50/92 text-amber-950 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] transition hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-700/70 dark:bg-amber-950/35 dark:text-amber-100 dark:hover:bg-amber-900/45"
+          data-tooltip={guiUpdateBusy ? guiUpdateLabel : guiUpdateTitle}
           aria-label={guiUpdateBusy ? guiUpdateLabel : guiUpdateTitle}
           title={guiUpdateBusy ? guiUpdateLabel : guiUpdateTitle}
         >
@@ -295,14 +308,11 @@ export function WorkbenchSideRail({
         <button
           type="button"
           onClick={() => setEditorMenuOpen((value) => !value)}
-          className="inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border border-transparent bg-white/38 text-ds-faint opacity-90 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] dark:hover:bg-white/8"
+          className={sideRailButtonClass(false)}
+          data-tooltip={editorButtonTitle}
           aria-label={t('editorPickerTitle')}
           aria-expanded={editorMenuOpen}
-          title={
-            selectedEditor
-              ? t('editorPickerTitleWithEditor', { editor: selectedEditor.label })
-              : t('editorPickerTitle')
-          }
+          title={editorButtonTitle}
         >
           {renderEditorIcon(selectedEditor, 'h-4 w-4')}
         </button>
@@ -345,11 +355,8 @@ export function WorkbenchSideRail({
           type="button"
           onClick={onOpenSideChat}
           disabled={!sideChatEnabled}
-          className={`relative inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition disabled:cursor-not-allowed disabled:opacity-45 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
-            sideChatOpen
-              ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
-              : 'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
-          }`}
+          className={sideRailButtonClass(sideChatOpen, 'relative disabled:cursor-not-allowed disabled:opacity-45')}
+          data-tooltip={t('sidePanelOpen')}
           aria-label={t('sidePanelOpen')}
           aria-pressed={sideChatOpen}
           title={t('sidePanelOpen')}
@@ -375,11 +382,8 @@ export function WorkbenchSideRail({
             <button
               type="button"
               onClick={() => onToggleRightPanelMode(item.mode)}
-              className={`inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
-                active
-                  ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
-                  : 'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
-              }`}
+              className={sideRailButtonClass(active)}
+              data-tooltip={item.label}
               aria-label={item.label}
               aria-pressed={active}
               title={item.label}
@@ -390,11 +394,8 @@ export function WorkbenchSideRail({
               <button
                 type="button"
                 onClick={onToggleTerminal}
-                className={`inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
-                  terminalOpen
-                    ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
-                    : 'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
-                }`}
+                className={sideRailButtonClass(terminalOpen)}
+                data-tooltip={t('rightPanelTerminal')}
                 aria-label={t('rightPanelTerminal')}
                 aria-pressed={terminalOpen}
                 title={t('rightPanelTerminal')}
@@ -411,11 +412,8 @@ export function WorkbenchSideRail({
           type="button"
           onClick={onToggleFileTree}
           disabled={!fileTreeEnabled}
-          className={`inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition disabled:cursor-not-allowed disabled:opacity-45 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ${
-            fileTreeOpen
-              ? 'border-ds-border-strong bg-white/70 text-ds-ink dark:bg-white/10'
-              : 'border-transparent bg-white/38 text-ds-faint opacity-90 hover:border-ds-border-muted hover:bg-white/55 hover:text-ds-ink hover:opacity-100 dark:bg-white/4 dark:hover:bg-white/8'
-          }`}
+          className={sideRailButtonClass(fileTreeOpen, 'disabled:cursor-not-allowed disabled:opacity-45')}
+          data-tooltip={t('rightPanelFiles')}
           aria-label={t('rightPanelFiles')}
           aria-pressed={fileTreeOpen}
           title={t('rightPanelFiles')}

--- a/src/renderer/src/styles/base-shell.css
+++ b/src/renderer/src/styles/base-shell.css
@@ -3087,6 +3087,67 @@ pre {
   flex: 0 0 auto;
 }
 
+.ds-side-rail-button {
+  position: relative;
+}
+
+.ds-side-rail-button::before,
+.ds-side-rail-button::after {
+  pointer-events: none;
+  position: absolute;
+  right: calc(100% + 8px);
+  top: 50%;
+  z-index: 70;
+  opacity: 0;
+  transform: translateY(-50%) translateX(4px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+
+.ds-side-rail-button::before {
+  content: '';
+  border: 5px solid transparent;
+  border-left-color: rgba(15, 23, 42, 0.9);
+}
+
+.ds-side-rail-button::after {
+  content: attr(data-tooltip);
+  margin-right: 9px;
+  max-width: min(220px, calc(100vw - 6rem));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.94);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.22);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  padding: 7px 9px;
+}
+
+.ds-side-rail-button:hover::before,
+.ds-side-rail-button:hover::after,
+.ds-side-rail-button:focus-visible::before,
+.ds-side-rail-button:focus-visible::after {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+[data-theme='dark'] .ds-side-rail-button::before {
+  border-left-color: rgba(248, 250, 252, 0.92);
+}
+
+[data-theme='dark'] .ds-side-rail-button::after {
+  border-color: rgba(15, 23, 42, 0.14);
+  background: rgba(248, 250, 252, 0.95);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  color: #111827;
+}
+
 .session-header-compact-meta {
   overflow: hidden;
 }


### PR DESCRIPTION
Summary
- Add in-app hover/focus tooltips to the right-side action rail buttons.
- Keep native titles and accessibility labels while sharing the right rail button styling through a small helper.

Changes
- Adds data-tooltip labels to editor, branch conversation, todo, changes, terminal, preview, whiteboard, subagents, and files rail buttons.
- Adds CSS pseudo-element tooltip rendering to show labels to the left of the right rail.
- Adds a WorkbenchSideRail static render test for the tooltip labels.

Effect
- User-provided effect image shows the right rail tooltip label, for example 变更, displayed next to the active right rail icon. The chat image was not available as a local uploadable file for gh CLI attachment.

Tests
- npm test -- src/renderer/src/components/chat/WorkbenchTopBar.test.ts
- npm run typecheck
- git diff --check