### PR TITLE
fix(design): recover malformed design systems

### DIFF
--- a/src/renderer/src/design/canvas/design-system-persistence.test.ts
+++ b/src/renderer/src/design/canvas/design-system-persistence.test.ts
@@ -5,6 +5,7 @@ import {
   persistDesignSystem,
   serializeDesignSystem
 } from './design-system-persistence'
+import { createDefaultShape } from './canvas-types'
 import { createEmptyDesignSystem, type DesignSystem } from './design-system-types'
 
 describe('design-system-persistence', () => {
@@ -30,6 +31,10 @@ describe('design-system-persistence', () => {
   })
 
   it('repairs missing names and discards malformed persisted entries', () => {
+    const componentRoot = createDefaultShape('frame', 0, 0)
+    componentRoot.id = 'component-card-root'
+    componentRoot.name = 'Card Root'
+
     expect(
       parseDesignSystem(
         JSON.stringify({
@@ -38,7 +43,14 @@ describe('design-system-persistence', () => {
             broken: null
           },
           components: {
-            Card: { id: 'component-card', version: 1, tree: [], slots: [] },
+            Card: {
+              id: 'component-card',
+              version: 1,
+              tree: [componentRoot],
+              slots: [{ path: 'Title', kind: 'text' }]
+            },
+            EmptyTree: { id: 'empty-tree', version: 1, tree: [], slots: [] },
+            BrokenSlot: { id: 'broken-slot', version: 1, tree: [componentRoot], slots: [null] },
             broken: { name: 'Broken' }
           }
         })
@@ -48,7 +60,13 @@ describe('design-system-persistence', () => {
         'brand/primary': { name: 'brand/primary', kind: 'color', value: '#3b82d8' }
       },
       components: {
-        Card: { id: 'component-card', name: 'Card', version: 1, tree: [], slots: [] }
+        Card: {
+          id: 'component-card',
+          name: 'Card',
+          version: 1,
+          tree: [componentRoot],
+          slots: [{ path: 'Title', kind: 'text' }]
+        }
       }
     })
   })

--- a/src/renderer/src/design/canvas/design-system-persistence.test.ts
+++ b/src/renderer/src/design/canvas/design-system-persistence.test.ts
@@ -29,6 +29,30 @@ describe('design-system-persistence', () => {
     expect(parseDesignSystem('{}')).toEqual(createEmptyDesignSystem())
   })
 
+  it('repairs missing names and discards malformed persisted entries', () => {
+    expect(
+      parseDesignSystem(
+        JSON.stringify({
+          tokens: {
+            'brand/primary': { kind: 'color', value: '#3b82d8' },
+            broken: null
+          },
+          components: {
+            Card: { id: 'component-card', version: 1, tree: [], slots: [] },
+            broken: { name: 'Broken' }
+          }
+        })
+      )
+    ).toEqual({
+      tokens: {
+        'brand/primary': { name: 'brand/primary', kind: 'color', value: '#3b82d8' }
+      },
+      components: {
+        Card: { id: 'component-card', name: 'Card', version: 1, tree: [], slots: [] }
+      }
+    })
+  })
+
   describe('debounced save', () => {
     afterEach(() => {
       vi.useRealTimers()

--- a/src/renderer/src/design/canvas/design-system-persistence.ts
+++ b/src/renderer/src/design/canvas/design-system-persistence.ts
@@ -5,8 +5,21 @@
  * canvas-persistence (debounced save, lenient load).
  */
 import type { DesignSystem } from './design-system-types'
+import type { CanvasShape, ShapeType } from './canvas-types'
 
 const DESIGN_DIR = '.kun-design'
+const CANVAS_SHAPE_TYPES = new Set<ShapeType>([
+  'rect',
+  'ellipse',
+  'text',
+  'image',
+  'frame',
+  'group',
+  'arrow',
+  'line',
+  'draw'
+])
+const COMPONENT_SLOT_KINDS = new Set(['text', 'image', 'color', 'visible'])
 
 export function designSystemPath(baseDir: string = DESIGN_DIR): string {
   return `${baseDir}/design-system.json`
@@ -16,14 +29,64 @@ export function serializeDesignSystem(system: DesignSystem): string {
   return JSON.stringify(system, null, 2)
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isStringOrNull(value: unknown): boolean {
+  return value === null || typeof value === 'string'
+}
+
+function isCornerRadius(value: unknown): boolean {
+  return (
+    typeof value === 'number' ||
+    (Array.isArray(value) && value.length === 4 && value.every((item) => typeof item === 'number'))
+  )
+}
+
+function isCanvasShapeLike(value: unknown): value is CanvasShape {
+  if (!isRecord(value)) return false
+  return (
+    typeof value.id === 'string' &&
+    typeof value.type === 'string' &&
+    CANVAS_SHAPE_TYPES.has(value.type as ShapeType) &&
+    typeof value.name === 'string' &&
+    isStringOrNull(value.parentId) &&
+    isStringOrNull(value.frameId) &&
+    typeof value.x === 'number' &&
+    typeof value.y === 'number' &&
+    typeof value.width === 'number' &&
+    typeof value.height === 'number' &&
+    typeof value.rotation === 'number' &&
+    typeof value.opacity === 'number' &&
+    typeof value.visible === 'boolean' &&
+    typeof value.locked === 'boolean' &&
+    Array.isArray(value.fills) &&
+    Array.isArray(value.strokes) &&
+    isCornerRadius(value.cornerRadius) &&
+    Array.isArray(value.children) &&
+    value.children.every((child) => typeof child === 'string')
+  )
+}
+
+function isComponentSlotLike(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.path === 'string' &&
+    typeof value.kind === 'string' &&
+    COMPONENT_SLOT_KINDS.has(value.kind) &&
+    (value.label === undefined || typeof value.label === 'string')
+  )
+}
+
 function parseNamedEntries<T extends { name: string }>(
   value: unknown,
   isEntry: (value: Record<string, unknown>) => boolean
 ): Record<string, T> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  if (!isRecord(value)) return {}
   const entries: Record<string, T> = {}
   for (const [key, entry] of Object.entries(value)) {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+    if (!isRecord(entry)) continue
     const record = entry as Record<string, unknown>
     if (!isEntry(record)) continue
     const name = typeof record.name === 'string' && record.name.trim() ? record.name : key
@@ -47,7 +110,10 @@ export function parseDesignSystem(raw: string): DesignSystem | null {
         typeof entry.id === 'string' &&
         typeof entry.version === 'number' &&
         Array.isArray(entry.tree) &&
-        Array.isArray(entry.slots)
+        entry.tree.length > 0 &&
+        entry.tree.every(isCanvasShapeLike) &&
+        Array.isArray(entry.slots) &&
+        entry.slots.every(isComponentSlotLike)
     )
     return { tokens, components }
   } catch {

--- a/src/renderer/src/design/canvas/design-system-persistence.ts
+++ b/src/renderer/src/design/canvas/design-system-persistence.ts
@@ -16,17 +16,39 @@ export function serializeDesignSystem(system: DesignSystem): string {
   return JSON.stringify(system, null, 2)
 }
 
+function parseNamedEntries<T extends { name: string }>(
+  value: unknown,
+  isEntry: (value: Record<string, unknown>) => boolean
+): Record<string, T> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const entries: Record<string, T> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+    const record = entry as Record<string, unknown>
+    if (!isEntry(record)) continue
+    const name = typeof record.name === 'string' && record.name.trim() ? record.name : key
+    entries[key] = { ...record, name } as T
+  }
+  return entries
+}
+
 export function parseDesignSystem(raw: string): DesignSystem | null {
   try {
     const parsed = JSON.parse(raw) as unknown
     if (!parsed || typeof parsed !== 'object') return null
     const obj = parsed as { tokens?: unknown; components?: unknown }
-    const tokens =
-      obj.tokens && typeof obj.tokens === 'object' ? (obj.tokens as DesignSystem['tokens']) : {}
-    const components =
-      obj.components && typeof obj.components === 'object'
-        ? (obj.components as DesignSystem['components'])
-        : {}
+    const tokens = parseNamedEntries<DesignSystem['tokens'][string]>(
+      obj.tokens,
+      (entry) => typeof entry.kind === 'string' && 'value' in entry
+    )
+    const components = parseNamedEntries<DesignSystem['components'][string]>(
+      obj.components,
+      (entry) =>
+        typeof entry.id === 'string' &&
+        typeof entry.version === 'number' &&
+        Array.isArray(entry.tree) &&
+        Array.isArray(entry.slots)
+    )
     return { tokens, components }
   } catch {
     return null


### PR DESCRIPTION
## Summary

- validate persisted design-system entries before loading them into renderer state
- recover missing token and component names from their record keys
- discard unusable persisted entries instead of crashing the Design workspace

## Root cause

`parseDesignSystem` previously cast arbitrary JSON records directly to `DesignSystem`. A legacy or incomplete token/component without `name` reached `summarizeDesignSystemForGraph`, whose sort comparator called `undefined.localeCompare()` during Design workspace rendering.

## Tests

- `npm.cmd test -- --run src/renderer/src/design/canvas/design-system-persistence.test.ts src/renderer/src/design/graph/design-graph.test.ts`
- `npm.cmd exec eslint -- src/renderer/src/design/canvas/design-system-persistence.ts src/renderer/src/design/canvas/design-system-persistence.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `git diff --check`

Fixes #751
