### PR TITLE
test(provider): align retry coverage with defaults

### DIFF
--- a/kun/src/adapters/model/compat-model-client.retry.test.ts
+++ b/kun/src/adapters/model/compat-model-client.retry.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { CompatModelClient } from './compat-model-client.js'
+import type { ModelRequestRetryConfig } from '../../config/kun-config.js'
 import type { ModelRequest, ModelStreamChunk } from '../../ports/model-client.js'
 
-// Transient upstream gateway failures (502/503/504 from a load balancer) are
-// momentary backend hiccups, not request errors. The client retries them a few
-// times before failing the turn — see streamInner's transient-retry loop.
+// Retry behavior is opt-in and provider-configurable. Keep the status list and
+// delays explicit so these tests match the runtime contract.
 
 function request(signal?: AbortSignal): ModelRequest {
   return {
@@ -40,13 +40,14 @@ function gatewayError(status: number): Response {
   )
 }
 
-function client(fetchImpl: typeof fetch): CompatModelClient {
+function client(fetchImpl: typeof fetch, retry?: ModelRequestRetryConfig): CompatModelClient {
   return new CompatModelClient({
     baseUrl: 'https://provider.example/v1',
     apiKey: 'sk-test',
     model: 'glm-5.1',
     endpointFormat: 'chat_completions',
     nonStreaming: true,
+    retry,
     fetchImpl
   })
 }
@@ -59,19 +60,22 @@ describe('CompatModelClient transient gateway retry', () => {
       return calls === 1 ? gatewayError(502) : okJson()
     }) as unknown as typeof fetch
 
-    const chunks = await drain(client(fetchImpl).stream(request()))
+    const chunks = await drain(
+      client(fetchImpl, { maxAttempts: 1, initialDelayMs: 0, httpStatusCodes: [502] }).stream(request())
+    )
 
     expect(calls).toBe(2)
+    expect(chunks).toContainEqual({ kind: 'retrying', status: 502, attempt: 1, maxAttempts: 1, delayMs: 0 })
     expect(chunks.some((c) => c.kind === 'assistant_text_delta')).toBe(true)
     expect(chunks.at(-1)).toEqual({ kind: 'completed', stopReason: 'stop' })
     expect(chunks.some((c) => c.kind === 'error')).toBe(false)
   })
 
-  it('does not retry a non-transient 500', async () => {
+  it('does not retry by default', async () => {
     let calls = 0
     const fetchImpl = (async () => {
       calls += 1
-      return gatewayError(500)
+      return gatewayError(502)
     }) as unknown as typeof fetch
 
     const chunks = await drain(client(fetchImpl).stream(request()))
@@ -116,7 +120,11 @@ describe('CompatModelClient transient gateway retry', () => {
       return gatewayError(503)
     }) as unknown as typeof fetch
 
-    const chunks = await drain(client(fetchImpl).stream(request(controller.signal)))
+    const chunks = await drain(
+      client(fetchImpl, { maxAttempts: 1, initialDelayMs: 1_000, httpStatusCodes: [503] }).stream(
+        request(controller.signal)
+      )
+    )
 
     expect(calls).toBe(1)
     expect(chunks.some((c) => c.kind === 'error')).toBe(true)


### PR DESCRIPTION
## Summary

- make the compatibility client retry test opt in to the provider retry configuration
- verify the default configuration performs no retry
- keep the abort-during-backoff test on the actual retry path

## Root cause

Provider retries became configurable and default to disabled, but the older gateway test still expected an implicit retry for HTTP 502. The abort test also stopped exercising backoff because no retry configuration was supplied.

## Tests

- `npm.cmd --prefix kun test -- src/adapters/model/compat-model-client.retry.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd exec eslint -- kun/src/adapters/model/compat-model-client.retry.test.ts`
- `git diff --check`
