### PR TITLE
fix(im): guide unavailable user input tools

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -261,9 +261,8 @@ const PLAN_READ_ONLY_TOOL_NAMES = new Set([
 /** Interactive tools allowed during the investigation phase (step 0) of a
  * Plan-mode turn so the model can ask the user a structured clarifying
  * question (with options) and continue to `create_plan` in the same turn
- * instead of stopping with a prose question. Only effective on GUI turns:
- * these tools advertise off `awaitUserInput`, so IM/headless plan turns never
- * surface them and the prose-and-stop fallback applies there. */
+ * instead of stopping with a prose question. IM/headless turns retain the
+ * stable catalog but receive an instruction not to call these tools. */
 const PLAN_INTERACTIVE_TOOL_NAMES = new Set(['user_input', 'request_user_input'])
 
 /**
@@ -615,6 +614,13 @@ function latestUserMessageText(items: readonly TurnItem[], turnId: string): stri
     }
   }
   return ''
+}
+
+function userInputUnavailableInstruction(): string {
+  return [
+    'The `user_input` and `request_user_input` tools are unavailable for this turn because the user cannot answer GUI prompts.',
+    'Do not call either tool. If information is missing, ask the question in your normal response and end the turn so the user can answer in their next message.'
+  ].join(' ')
 }
 
 function allowedToolNamesWithGuiStateTools(
@@ -1578,6 +1584,7 @@ export class AgentLoop {
       ...memoryInstructions(memories),
       ...(skillResolution.catalogInstruction ? [skillResolution.catalogInstruction] : []),
       ...skillResolution.instructions,
+      ...(userInputDisabled ? [userInputUnavailableInstruction()] : []),
       ...(toolPreferenceInstruction ? [toolPreferenceInstruction] : []),
       ...(effectiveToolSpecs.some((tool) => tool.name === 'bash') ? [shellRuntimeInstruction()] : []),
       ...(suggestVerification ? [verificationSuggestionInstruction()] : []),

--- a/kun/tests/builtin-tools.test.ts
+++ b/kun/tests/builtin-tools.test.ts
@@ -337,11 +337,11 @@ describe('Kun built-in tools', () => {
     })
   })
 
-  it('hides GUI input tools when the turn context has no user-input gate', async () => {
+  it('keeps GUI input tools in the stable catalog without a user-input gate', async () => {
     const tools = await host.listTools(buildContext(workspace))
     const names = tools.map((tool) => tool.name)
-    expect(names).not.toContain('user_input')
-    expect(names).not.toContain('request_user_input')
+    expect(names).toContain('user_input')
+    expect(names).toContain('request_user_input')
   })
 
   it('exposes pi-style coding and read-only tool groups', () => {
@@ -366,6 +366,7 @@ describe('Kun built-in tools', () => {
       'lsp',
       'read',
       'repo_map',
+      'send_im_attachment',
       'verify_changes',
       'write'
     ])
@@ -399,6 +400,7 @@ describe('Kun built-in tools', () => {
       'lsp',
       'read',
       'repo_map',
+      'send_im_attachment',
       'verify_changes',
       'write'
     ])
@@ -411,6 +413,7 @@ describe('Kun built-in tools', () => {
       'lsp',
       'read',
       'repo_map',
+      'send_im_attachment',
       'verify_changes',
       'write'
     ])

--- a/kun/tests/create-plan-tool.test.ts
+++ b/kun/tests/create-plan-tool.test.ts
@@ -100,12 +100,21 @@ describe('create_plan tool: advertisement', () => {
     expect(names).not.toEqual(expect.arrayContaining(['bash', 'edit', 'write', 'echo']))
   })
 
-  it('drops the GUI input tools from plan-mode advertisement when no user-input gate is wired', async () => {
+  it('keeps the plan-mode tool catalog stable when no user-input gate is wired', async () => {
     const host = new LocalToolHost({ tools: buildDefaultLocalTools() })
     const tools = await host.listTools(buildContext({ threadMode: 'plan' }))
     const names = tools.map((tool) => tool.name)
 
-    expect(names).toEqual(['read', 'grep', 'find', 'ls', 'repo_map', CREATE_PLAN_TOOL_NAME])
+    expect(names).toEqual([
+      'read',
+      'grep',
+      'find',
+      'ls',
+      'repo_map',
+      'user_input',
+      'request_user_input',
+      CREATE_PLAN_TOOL_NAME
+    ])
   })
 
   it('keeps the normal agent-mode default tool advertisement unchanged', async () => {

--- a/kun/tests/ports.test.ts
+++ b/kun/tests/ports.test.ts
@@ -169,21 +169,25 @@ describe('LocalToolHost', () => {
     ).rejects.toThrow(/aborted/)
   })
 
-  it('rejects user_input as unadvertised when no GUI gate is available', async () => {
+  it('returns an error when user_input has no GUI gate', async () => {
     const host = new LocalToolHost({ tools: defaultLocalTools })
-    await expect(
-      host.execute(
-        { callId: 'c1', toolName: 'user_input', arguments: { prompt: '?' } },
-        {
-          threadId: 'th',
-          turnId: 'tu',
-          workspace: '/tmp',
-          approvalPolicy: 'on-request',
-          abortSignal: new AbortController().signal,
-          awaitApproval: async () => 'allow'
-        }
-      )
-    ).rejects.toThrow(/user_input is not advertised/)
+    const result = await host.execute(
+      { callId: 'c1', toolName: 'user_input', arguments: { prompt: '?' } },
+      {
+        threadId: 'th',
+        turnId: 'tu',
+        workspace: '/tmp',
+        approvalPolicy: 'on-request',
+        abortSignal: new AbortController().signal,
+        awaitApproval: async () => 'allow'
+      }
+    )
+    expect(result.item).toMatchObject({
+      kind: 'tool_result',
+      toolName: 'user_input',
+      isError: true,
+      output: { error: 'GUI user input is not available in this runtime context' }
+    })
   })
 
   it('updates in-memory session items in place', async () => {

--- a/kun/tests/user-input-disabled.test.ts
+++ b/kun/tests/user-input-disabled.test.ts
@@ -3,7 +3,7 @@ import type { ModelRequest, ModelStreamChunk } from '../src/ports/model-client.j
 import { bootstrapThread, makeHarness } from './loop-test-harness.js'
 
 describe('agent loop: disableUserInput turns (IM bridges)', () => {
-  it('hides GUI input tools and rejects stray calls instead of blocking', async () => {
+  it('keeps a stable catalog but tells the model not to call GUI input tools', async () => {
     let calls = 0
     const seenRequests: ModelRequest[] = []
     const h = makeHarness({
@@ -32,12 +32,13 @@ describe('agent loop: disableUserInput turns (IM bridges)', () => {
     const status = await h.loop.runTurn(h.threadId, h.turnId)
 
     expect(status).toBe('completed')
-    const advertised = seenRequests[0]?.tools.map((tool) => tool.name) ?? []
-    expect(advertised).not.toContain('user_input')
-    expect(advertised).not.toContain('request_user_input')
-    expect(seenRequests[0]?.contextInstructions?.join(' ')).toMatch(
-      /Interactive user input is unavailable/
-    )
+    expect(seenRequests).toHaveLength(2)
+    for (const request of seenRequests) {
+      const advertised = request.tools.map((tool) => tool.name)
+      expect(advertised).toContain('user_input')
+      expect(advertised).toContain('request_user_input')
+      expect(request.contextInstructions?.join(' ')).toMatch(/Do not call either tool/)
+    }
 
     const result = (await h.sessionStore.loadItems(h.threadId)).find(
       (item) => item.kind === 'tool_result' && item.toolName === 'request_user_input'
@@ -69,7 +70,7 @@ describe('agent loop: disableUserInput turns (IM bridges)', () => {
     expect(advertised).toContain('user_input')
     expect(advertised).toContain('request_user_input')
     expect(seenRequests[0]?.contextInstructions?.join(' ') ?? '').not.toMatch(
-      /Interactive user input is unavailable/
+      /Do not call either tool/
     )
   })
 })


### PR DESCRIPTION
## Summary

- preserve the stable provider tool catalog across GUI and IM turns
- inject explicit per-step guidance when structured GUI input cannot be resolved
- return a deterministic tool error for stray user-input calls instead of blocking
- align plan-mode and tool-host regression tests with the stable-catalog contract

## Root cause

The IM thread-management change intentionally kept `user_input` and `request_user_input` in the model tool schema for prompt-cache stability, but removed the contextual instruction that told IM/headless models those tools could not be used. Models could therefore call an advertised tool that had no user-input gate.

## Tests

- `npm.cmd --prefix kun test -- tests/user-input-disabled.test.ts tests/create-plan-tool.test.ts tests/ports.test.ts src/loop/agent-loop.test.ts src/adapters/tool/local-tool-host.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd exec eslint -- kun/src/loop/agent-loop.ts kun/tests/user-input-disabled.test.ts kun/tests/create-plan-tool.test.ts kun/tests/ports.test.ts`
- `git diff --check`
