### PR TITLE
fix(feishu): close streaming race windows

### DIFF
--- a/src/main/claw-runtime-helpers.test.ts
+++ b/src/main/claw-runtime-helpers.test.ts
@@ -4,11 +4,30 @@ import {
   finalAssistantReplyText,
   imCompletionReplyForPush,
   IM_COMPLETED_NO_TEXT_REPLY,
+  createDeferredCloseHandle,
   subscribeRuntimeThreadEvents,
   type RuntimeSseEvent,
   type ThreadDetailJson,
   type TurnItemJson
 } from './claw-runtime-helpers'
+
+describe('createDeferredCloseHandle', () => {
+  it('closes a subscription that resolves after the caller already closed', async () => {
+    let resolveSetup!: (handle: { close: () => void }) => void
+    const setup = new Promise<{ close: () => void }>((resolve) => {
+      resolveSetup = resolve
+    })
+    const close = vi.fn()
+    const handle = createDeferredCloseHandle(setup, vi.fn())
+
+    handle.close()
+    resolveSetup({ close })
+    await setup
+    await Promise.resolve()
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+})
 
 // Global fetch mock for subscribeRuntimeThreadEvents
 const originalFetch = globalThis.fetch

--- a/src/main/claw-runtime-helpers.ts
+++ b/src/main/claw-runtime-helpers.ts
@@ -595,6 +595,32 @@ export async function readRequestBody(req: IncomingMessage): Promise<string> {
 
 export type SseSubscriber = (signal: AbortSignal) => { close: () => void }
 
+export function createDeferredCloseHandle(
+  setup: Promise<{ close: () => void }>,
+  onError: (error: unknown) => void
+): { close: () => void } {
+  let handle: { close: () => void } | null = null
+  let closed = false
+  void setup.then(
+    (resolved) => {
+      if (closed) {
+        resolved.close()
+        return
+      }
+      handle = resolved
+    },
+    onError
+  )
+  return {
+    close: () => {
+      if (closed) return
+      closed = true
+      handle?.close()
+      handle = null
+    }
+  }
+}
+
 export type RuntimeSseEvent = { kind: string; turnId?: string; item?: { text?: unknown }; seq?: number; [key: string]: unknown }
 
 /**

--- a/src/main/claw-runtime.ts
+++ b/src/main/claw-runtime.ts
@@ -71,6 +71,7 @@ import {
   type RunPromptOptions,
   type ThreadDetailJson,
   type ThreadRecordJson,
+  createDeferredCloseHandle,
   type SseSubscriber,
   subscribeRuntimeThreadEvents
 } from './claw-runtime-helpers'
@@ -1244,10 +1245,8 @@ export class ClawRuntime {
       // setup; if the setup itself throws (e.g. no base URL) we log via
       // deps.logError and continue with a no-op close. The streamer will
       // still rely on its own responseTimeoutMs abort as a backstop.
-      const setup = this.subscribeSse(settings, threadId, streamer, signal)
-      let close = (): void => undefined
-      void setup.then(
-        (handle) => { close = handle.close },
+      return createDeferredCloseHandle(
+        this.subscribeSse(settings, threadId, streamer, signal),
         (error) => {
           this.deps.logError('claw-feishu-stream', 'SSE subscription setup failed', {
             message: error instanceof Error ? error.message : String(error),
@@ -1255,7 +1254,6 @@ export class ClawRuntime {
           })
         }
       )
-      return { close: () => close() }
     }
   }
 

--- a/src/main/feishu-streamer.test.ts
+++ b/src/main/feishu-streamer.test.ts
@@ -47,6 +47,27 @@ function makeSubscriber(
 }
 
 describe('FeishuStreamer', () => {
+  it('buffers synchronous events until the stream controller is ready', async () => {
+    const { bridge, controller, messageId } = makeBridge()
+    const streamer = new FeishuStreamer({
+      bridge, chatId: 'oc_chat_1', turnId: 'turn_1', threadId: 'thr_1',
+      replyOptions: {}, logger: vi.fn()
+    })
+    const close = vi.fn()
+    const subscribe: SseSubscriber = () => {
+      streamer.onSseEvent({ kind: 'assistant_text_delta', turnId: 'turn_1', item: { text: 'early' } })
+      streamer.onSseEvent({ kind: 'turn_completed', turnId: 'turn_1' })
+      return { close }
+    }
+
+    const result = await streamer.start({ subscribe })
+
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(controller.append).toHaveBeenCalledWith('early')
+    expect(controller.setContent).toHaveBeenCalledWith('early')
+    expect(result).toEqual({ ok: true, messageId, finalText: 'early', fellBack: false })
+  })
+
   it('streams assistant_text_delta in order, calls setContent once on turn_completed, resolves with messageId', async () => {
     const { bridge, controller, messageId } = makeBridge()
     const streamer = new FeishuStreamer({

--- a/src/main/feishu-streamer.ts
+++ b/src/main/feishu-streamer.ts
@@ -30,6 +30,7 @@ export class FeishuStreamer {
   private subscription: { close: () => void } | null = null
   private startAbortController: AbortController | null = null
   private failed = false
+  private ended = false
 
   constructor(opts: FeishuStreamerOptions) {
     this.opts = opts
@@ -40,6 +41,7 @@ export class FeishuStreamer {
       const controller = new AbortController()
       this.startAbortController = controller
       this.failed = false
+      this.ended = false
       let resolved = false
       const onComplete = (result: FeishuStreamerResult): void => {
         if (resolved) return
@@ -99,7 +101,9 @@ export class FeishuStreamer {
         }
       }
 
-      this.subscription = input.subscribe(controller.signal)
+      const subscription = input.subscribe(controller.signal)
+      if (this.ended || controller.signal.aborted) subscription.close()
+      else this.subscription = subscription
       const onAbort = (): void => {
         this.state = 'closed'
         this.subscription?.close()
@@ -134,7 +138,7 @@ export class FeishuStreamer {
   }
 
   onSseEvent(event: Record<string, unknown>): void {
-    if (this.state !== 'streaming') return
+    if (this.state === 'closed' || this.ended) return
     const kind = event.kind
     // 关键：读 event.item.text,不是 event.item.delta
     if (kind === 'assistant_text_delta' && event.turnId === this.opts.turnId) {
@@ -152,6 +156,7 @@ export class FeishuStreamer {
       event.turnId === this.opts.turnId
     ) {
       if (kind === 'turn_failed') this.failed = true
+      this.ended = true
       this.subscription?.close()
       this.subscription = null
       this.push(null)


### PR DESCRIPTION
## Summary

- buffer Feishu SSE deltas and terminal events that arrive before the markdown stream controller starts
- close subscriptions whose handles are returned after the streamer has already disposed
- close synchronously completed subscriptions even when their handle has not yet been assigned
- add deterministic regression coverage for pending-event and late-close timing

## Root cause

The SSE subscription starts before `bridge.stream` invokes its markdown producer. Events received while the streamer was still `pending` were discarded. Separately, the async SSE setup was adapted to a synchronous close contract with a temporary no-op function, so disposing before setup completed leaked the eventual subscription.

## Tests

- `npm.cmd test -- --run src/main/feishu-streamer.test.ts src/main/claw-runtime-helpers.test.ts src/main/claw-runtime.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd exec eslint -- src/main/feishu-streamer.ts src/main/feishu-streamer.test.ts src/main/claw-runtime.ts src/main/claw-runtime-helpers.ts src/main/claw-runtime-helpers.test.ts`
- `npm.cmd run build`
- `git diff --check`
