### PR TITLE
fix(runtime): clear deleted thread memory

### DIFF
--- a/kun/src/adapters/file/file-session-store.ts
+++ b/kun/src/adapters/file/file-session-store.ts
@@ -171,6 +171,11 @@ export class FileSessionStore implements SessionStore {
     this.itemsCacheVersion.clear()
   }
 
+  clearThreadMemory(threadId: string): void {
+    this.itemsCache.delete(threadId)
+    this.itemsCacheVersion.delete(threadId)
+  }
+
   private itemsVersionOf(threadId: string): number {
     return this.itemsCacheVersion.get(threadId) ?? 0
   }

--- a/kun/src/adapters/hybrid/hybrid-session-store.ts
+++ b/kun/src/adapters/hybrid/hybrid-session-store.ts
@@ -80,4 +80,8 @@ export class HybridSessionStore implements SessionStore {
   async resetMemory(): Promise<void> {
     await this.delegate.resetMemory()
   }
+
+  clearThreadMemory(threadId: string): void {
+    this.delegate.clearThreadMemory(threadId)
+  }
 }

--- a/kun/src/adapters/in-memory-event-bus.ts
+++ b/kun/src/adapters/in-memory-event-bus.ts
@@ -75,4 +75,11 @@ export class InMemoryEventBus implements EventBus {
     this.nextSeq.clear()
     this.highestSeqByThread.clear()
   }
+
+  clearThread(threadId: string): void {
+    this.events.delete(threadId)
+    this.subscribers.delete(threadId)
+    this.nextSeq.delete(threadId)
+    this.highestSeqByThread.delete(threadId)
+  }
 }

--- a/kun/src/adapters/in-memory-session-store.ts
+++ b/kun/src/adapters/in-memory-session-store.ts
@@ -119,4 +119,10 @@ export class InMemorySessionStore implements SessionStore {
     this.items.clear()
     this.sessions.clear()
   }
+
+  clearThreadMemory(threadId: string): void {
+    this.events.delete(threadId)
+    this.items.delete(threadId)
+    this.sessions.delete(threadId)
+  }
 }

--- a/kun/src/ports/session-store.ts
+++ b/kun/src/ports/session-store.ts
@@ -50,4 +50,6 @@ export interface SessionStore {
   loadLatestUsageSnapshots?(options?: { threadIds?: string[] }): Promise<SessionLatestUsageSnapshot[]>
   /** Forget the per-thread in-memory state without touching disk. */
   resetMemory(): Promise<void>
+  /** Forget cached state for a deleted thread without recreating its files. */
+  clearThreadMemory(threadId: string): void
 }

--- a/kun/src/server/runtime-factory.ts
+++ b/kun/src/server/runtime-factory.ts
@@ -193,7 +193,18 @@ export async function createKunServeRuntime(
       'system: keep the stable Kun prefix byte-stable for prompt-cache reuse'
     ]
   })
-  const threadService = new ThreadService({ threadStore, sessionStore, events, ids, nowIso })
+  const threadService = new ThreadService({
+    threadStore,
+    sessionStore,
+    events,
+    ids,
+    nowIso,
+    onDeleted: (threadId) => {
+      usageService.reset(threadId)
+      events.clearThread(threadId)
+      eventBus.clearThread(threadId)
+    }
+  })
   const artifactStore = new FileArtifactStore(join(activeOptions.dataDir, 'artifacts'), nowIso)
   let modelProfiles = modelContextProfilesFromConfig({
     contextCompaction: activeOptions.contextCompaction,

--- a/kun/src/services/runtime-event-recorder.ts
+++ b/kun/src/services/runtime-event-recorder.ts
@@ -78,4 +78,8 @@ export class RuntimeEventRecorder {
     const current = this.lastIssuedSeq.get(threadId) ?? 0
     if (seq > current) this.lastIssuedSeq.set(threadId, seq)
   }
+
+  clearThread(threadId: string): void {
+    this.lastIssuedSeq.delete(threadId)
+  }
 }

--- a/kun/src/services/thread-service.ts
+++ b/kun/src/services/thread-service.ts
@@ -43,6 +43,7 @@ export type ThreadServiceOptions = {
   events: RuntimeEventRecorder
   ids: IdGenerator
   nowIso: () => string
+  onDeleted?: (threadId: string) => void
 }
 
 export type ListThreadsOptions = ThreadStoreListOptions
@@ -78,6 +79,7 @@ export class ThreadService {
   private readonly events: RuntimeEventRecorder
   private readonly ids: IdGenerator
   private readonly nowIso: () => string
+  private readonly onDeleted?: (threadId: string) => void
 
   constructor(options: ThreadServiceOptions) {
     this.threadStore = options.threadStore
@@ -85,6 +87,7 @@ export class ThreadService {
     this.events = options.events
     this.ids = options.ids
     this.nowIso = options.nowIso
+    this.onDeleted = options.onDeleted
   }
 
   async list(options: ListThreadsOptions = {}): Promise<ThreadSummary[]> {
@@ -377,6 +380,8 @@ export class ThreadService {
   async delete(threadId: string): Promise<boolean> {
     const ok = await this.threadStore.delete(threadId)
     if (!ok) return false
+    this.sessionStore.clearThreadMemory(threadId)
+    this.onDeleted?.(threadId)
     return true
   }
 

--- a/kun/tests/file-session-store.test.ts
+++ b/kun/tests/file-session-store.test.ts
@@ -107,4 +107,24 @@ describe('FileSessionStore', () => {
     expect(items.map((entry) => entry.id)).toEqual(['a', 'c', 'b'])
     expect(items.find((entry) => entry.id === 'b')).toMatchObject({ text: 'B-updated' })
   })
+
+  it('forgets cached items for a deleted thread', async () => {
+    const sessionStore = new FileSessionStore({ dataDir })
+    await sessionStore.appendItem('thr_deleted', {
+      id: 'item_1',
+      kind: 'assistant_text',
+      turnId: 'turn_1',
+      threadId: 'thr_deleted',
+      role: 'assistant',
+      status: 'completed',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      text: 'cached'
+    })
+    expect(await sessionStore.loadItems('thr_deleted')).toHaveLength(1)
+    await rm(join(dataDir, 'threads', 'thr_deleted'), { recursive: true, force: true })
+
+    sessionStore.clearThreadMemory('thr_deleted')
+
+    expect(await sessionStore.loadItems('thr_deleted')).toEqual([])
+  })
 })

--- a/kun/tests/ports.test.ts
+++ b/kun/tests/ports.test.ts
@@ -27,6 +27,20 @@ describe('InMemoryEventBus', () => {
     bus.publish({ kind: 'heartbeat', seq: 2, timestamp: 't', threadId: 'a' })
     expect(received).toEqual([1])
   })
+
+  it('clears retained state for only the deleted thread', () => {
+    const bus = new InMemoryEventBus()
+    bus.publish({ kind: 'heartbeat', seq: 1, timestamp: 't', threadId: 'a' })
+    bus.publish({ kind: 'heartbeat', seq: 1, timestamp: 't', threadId: 'b' })
+
+    bus.clearThread('a')
+
+    expect(bus.snapshotSince('a', 0)).toEqual([])
+    expect(bus.highestSeq('a')).toBe(0)
+    expect(bus.allocateSeq('a')).toBe(1)
+    expect(bus.snapshotSince('b', 0)).toHaveLength(1)
+    expect(bus.highestSeq('b')).toBe(1)
+  })
 })
 
 describe('InMemoryApprovalGate', () => {

--- a/kun/tests/runtime-factory.test.ts
+++ b/kun/tests/runtime-factory.test.ts
@@ -146,4 +146,45 @@ describe('runtime factory usage carryover', () => {
       await runtime.shutdown?.()
     }
   })
+
+  it('clears per-thread runtime memory when a thread is deleted', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'kun-runtime-delete-'))
+    tempDirs.push(dataDir)
+    const runtime = await createKunServeRuntime({
+      host: '127.0.0.1',
+      port: 0,
+      dataDir,
+      runtimeToken: 'tok',
+      apiKey: 'sk-default',
+      baseUrl: 'https://api.example.test/v1',
+      model: 'model-before',
+      approvalPolicy: 'auto',
+      sandboxMode: 'danger-full-access',
+      tokenEconomyMode: false,
+      insecure: false,
+      storage: { backend: 'file' },
+      capabilities: KunCapabilitiesConfig.parse({})
+    })
+
+    try {
+      const threadId = 'thr_deleted'
+      await runtime.threadService.create(
+        { workspace: '/tmp/workspace', model: 'model-before', mode: 'agent' },
+        { id: threadId }
+      )
+      runtime.usageService.record(threadId, usage({ promptTokens: 10, completionTokens: 5 }))
+
+      expect(await runtime.threadService.delete(threadId)).toBe(true)
+      expect(runtime.eventBus.snapshotSince(threadId, 0)).toEqual([])
+      expect(runtime.usageService.forThread(threadId).totalTokens).toBe(0)
+
+      await runtime.threadService.create(
+        { workspace: '/tmp/workspace', model: 'model-before', mode: 'agent' },
+        { id: threadId }
+      )
+      expect(runtime.eventBus.snapshotSince(threadId, 0).map((event) => event.seq)).toEqual([1])
+    } finally {
+      await runtime.shutdown?.()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- clear per-thread session-store caches after successful thread deletion
- remove retained EventBus events, subscribers, and sequence counters
- clear RuntimeEventRecorder sequence state and UsageService telemetry
- verify that recreating the same thread ID starts with clean runtime state

## Root cause

Thread deletion removed the persisted thread directory and index row, but several process-local maps retained the deleted thread. FileSessionStore could continue returning cached items, usage remained queryable, and event sequence caches survived a later recreation of the same ID.

## Tests

- `npm.cmd --prefix kun test -- tests/runtime-factory.test.ts tests/runtime-event-recorder.test.ts tests/thread-service.test.ts tests/hybrid-store.test.ts tests/file-session-store.test.ts`
- `npm.cmd --prefix kun test -- tests/ports.test.ts -t "clears retained state for only the deleted thread"`
- `npm.cmd --prefix kun run typecheck`
- focused ESLint on changed files
- `git diff --check`

The full `tests/ports.test.ts` file still contains the unrelated stale IM user-input assertion fixed separately by #754.
