### PR TITLE
fix(tools): bound repo map cache

### DIFF
--- a/kun/src/adapters/tool/builtin-repo-map-tool.test.ts
+++ b/kun/src/adapters/tool/builtin-repo-map-tool.test.ts
@@ -39,6 +39,12 @@ async function createFixture(): Promise<string> {
   return root
 }
 
+async function createEmptyFixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'kun-repo-map-cache-'))
+  tempRoots.push(root)
+  return root
+}
+
 function context(workspace: string): ToolHostContext {
   return {
     threadId: 'thread_repo_map',
@@ -95,4 +101,23 @@ describe('repo_map tool', () => {
     expect((cached.output as { cache: { hit: boolean } }).cache.hit).toBe(true)
     expect(SUBAGENT_READ_ONLY_TOOL_NAMES).toContain('repo_map')
   })
+
+  it('evicts the least recently used workspace when the cache reaches its limit', async () => {
+    const first = await createEmptyFixture()
+    const tool = createRepoMapLocalTool()
+    await tool.execute({}, context(first))
+
+    const others: string[] = []
+    for (let index = 0; index < 7; index += 1) {
+      const root = await createEmptyFixture()
+      others.push(root)
+      await tool.execute({}, context(root))
+    }
+    expect((await tool.execute({}, context(first))).output).toMatchObject({ cache: { hit: true } })
+    await tool.execute({}, context(await createEmptyFixture()))
+
+    expect((await tool.execute({}, context(first))).output).toMatchObject({ cache: { hit: true } })
+    const rebuilt = await tool.execute({}, context(others[0]!))
+    expect((rebuilt.output as { cache: { hit: boolean } }).cache.hit).toBe(false)
+  }, 10_000)
 })

--- a/kun/src/adapters/tool/builtin-repo-map-tool.ts
+++ b/kun/src/adapters/tool/builtin-repo-map-tool.ts
@@ -16,6 +16,7 @@ const DEFAULT_REPO_MAP_MAX_FILES = 20
 const DEFAULT_REPO_MAP_MAX_SYMBOLS = 12
 const DEFAULT_REPO_MAP_SCAN_LIMIT = 2500
 const REPO_MAP_CACHE_TTL_MS = 30_000
+const REPO_MAP_CACHE_MAX_ENTRIES = 8
 const MAX_SYMBOL_BYTES = 512 * 1024
 const MAX_GIT_RECENT_FILES = 250
 const INDEX_CONCURRENCY = 12
@@ -99,6 +100,17 @@ type RepoMapCacheEntry = {
 
 const repoMapCache = new Map<string, RepoMapCacheEntry>()
 
+function pruneRepoMapCache(now: number): void {
+  for (const [key, entry] of repoMapCache) {
+    if (entry.expiresAt <= now) repoMapCache.delete(key)
+  }
+  while (repoMapCache.size > REPO_MAP_CACHE_MAX_ENTRIES) {
+    const oldest = repoMapCache.keys().next().value
+    if (oldest === undefined) break
+    repoMapCache.delete(oldest)
+  }
+}
+
 export function createRepoMapLocalTool(): LocalTool {
   return {
     name: 'repo_map',
@@ -148,8 +160,9 @@ export function createRepoMapLocalTool(): LocalTool {
       const { workspaceRoot, absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       const cacheKey = `${workspaceRoot}\0${absolutePath}`
       const gitHead = await gitHeadForWorkspace(workspaceRoot)
-      const cached = repoMapCache.get(cacheKey)
       const now = Date.now()
+      pruneRepoMapCache(now)
+      const cached = repoMapCache.get(cacheKey)
       const cacheHit = Boolean(
         cached &&
         !refresh &&
@@ -167,11 +180,16 @@ export function createRepoMapLocalTool(): LocalTool {
             signal: context.abortSignal
           })
       if (!cacheHit) {
+        repoMapCache.delete(cacheKey)
         repoMapCache.set(cacheKey, {
           index,
           expiresAt: now + REPO_MAP_CACHE_TTL_MS,
           scanLimit: maxScanFiles
         })
+        pruneRepoMapCache(now)
+      } else {
+        repoMapCache.delete(cacheKey)
+        repoMapCache.set(cacheKey, cached!)
       }
 
       const ranked = rankRepoMapFiles(index.files, query, index.recentFiles)


### PR DESCRIPTION
## Summary

- remove expired repo-map indexes opportunistically before lookup
- cap the process-wide cache at eight workspace/target indexes
- promote cache hits so capacity eviction follows least-recently-used order
- cover eviction with real multi-workspace tool executions

## Root cause

Repo-map entries had a 30-second expiry timestamp, but expired keys were only replaced when the same workspace was queried again. Visiting many workspaces therefore retained every large file/symbol index for the lifetime of the process.

## Tests

- `npm.cmd --prefix kun test -- src/adapters/tool/builtin-repo-map-tool.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd exec eslint -- kun/src/adapters/tool/builtin-repo-map-tool.ts kun/src/adapters/tool/builtin-repo-map-tool.test.ts`
- `git diff --check`
