### PR TITLE
fix(write): bound retrieval index cache

### DIFF
--- a/src/main/services/write-retrieval-service.test.ts
+++ b/src/main/services/write-retrieval-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -80,8 +80,17 @@ function createRequest(workspaceRoot: string): WriteInlineCompletionRequest {
   }
 }
 
-afterEach(() => {
+const tempRoots: string[] = []
+
+async function createTempWorkspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'ds-gui-write-rag-'))
+  tempRoots.push(root)
+  return root
+}
+
+afterEach(async () => {
   clearWriteRetrievalCache()
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
 describe('write retrieval service', () => {
@@ -95,7 +104,7 @@ describe('write retrieval service', () => {
   })
 
   it('retrieves relevant cross-document snippets and excludes the active file', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'ds-gui-write-rag-'))
+    const workspaceRoot = await createTempWorkspace()
     await mkdir(join(workspaceRoot, 'research'), { recursive: true })
     await writeFile(
       join(workspaceRoot, 'draft.md'),
@@ -127,7 +136,7 @@ describe('write retrieval service', () => {
   })
 
   it('ignores unsupported large data files while scanning the workspace', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'ds-gui-write-rag-'))
+    const workspaceRoot = await createTempWorkspace()
     await writeFile(join(workspaceRoot, 'draft.md'), '# Draft\n\nembedding cache', 'utf8')
     await writeFile(
       join(workspaceRoot, 'notes.md'),
@@ -155,7 +164,7 @@ describe('write retrieval service', () => {
   })
 
   it('retrieves PDF chunks for assistant context with page locations', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'ds-gui-write-pdf-rag-'))
+    const workspaceRoot = await createTempWorkspace()
     const pdfPath = join(workspaceRoot, 'papers', 'study.pdf')
     await mkdir(join(workspaceRoot, 'papers'), { recursive: true })
     await writeFile(join(workspaceRoot, 'draft.md'), '# Draft\n\nExplain literature context.', 'utf8')
@@ -182,4 +191,42 @@ describe('write retrieval service', () => {
     })
     expect(result?.snippets[0].text).toContain('PDF BM25 关键词检索')
   })
+
+  it('evicts the least recently used workspace index at the cache limit', async () => {
+    const first = await createTempWorkspace()
+    await writeFile(
+      join(first, 'notes.md'),
+      'alphacachemarker provides enough document text for workspace retrieval indexing.',
+      'utf8'
+    )
+    const request = (workspaceRoot: string, query: string) => retrieveWriteContext({
+      workspaceRoot,
+      currentFilePath: join(workspaceRoot, 'draft.md'),
+      query,
+      includeCurrentFile: true
+    })
+    expect(await request(first, 'alphacachemarker')).not.toBeNull()
+
+    const others: string[] = []
+    for (let index = 0; index < 7; index += 1) {
+      const root = await createTempWorkspace()
+      others.push(root)
+      await request(root, 'empty')
+    }
+    expect(await request(first, 'alphacachemarker')).not.toBeNull()
+    await request(await createTempWorkspace(), 'overflow')
+
+    await writeFile(
+      join(others[0]!, 'notes.md'),
+      'betacachemarker provides enough document text for workspace retrieval indexing.',
+      'utf8'
+    )
+    expect(await request(others[0]!, 'betacachemarker')).not.toBeNull()
+    await writeFile(
+      join(first, 'notes.md'),
+      'betacachemarker provides enough document text for workspace retrieval indexing.',
+      'utf8'
+    )
+    expect(await request(first, 'betacachemarker')).toBeNull()
+  }, 10_000)
 })

--- a/src/main/services/write-retrieval-service.ts
+++ b/src/main/services/write-retrieval-service.ts
@@ -12,6 +12,7 @@ import { expandHomePath } from './workspace-service'
 import { readWritePdfText, type WritePdfTextPage } from './write-pdf-text-service'
 
 const INDEX_CACHE_TTL_MS = 30_000
+const INDEX_CACHE_MAX_ENTRIES = 8
 const MAX_INDEX_BUILD_MS = 250
 const MAX_ASSISTANT_INDEX_BUILD_MS = 2_500
 const MAX_SCAN_ENTRIES = 8_000
@@ -125,6 +126,17 @@ type QueryModel = {
 
 const indexCache = new Map<string, WorkspaceIndex>()
 const inFlightIndexCache = new Map<string, Promise<WorkspaceIndex>>()
+
+function pruneIndexCache(now: number): void {
+  for (const [key, index] of indexCache) {
+    if (now - index.builtAt > INDEX_CACHE_TTL_MS) indexCache.delete(key)
+  }
+  while (indexCache.size > INDEX_CACHE_MAX_ENTRIES) {
+    const oldest = indexCache.keys().next().value
+    if (oldest === undefined) break
+    indexCache.delete(oldest)
+  }
+}
 
 type WorkspaceIndexOptions = {
   includePdf: boolean
@@ -454,14 +466,21 @@ async function loadWorkspaceIndex(
   options: WorkspaceIndexOptions
 ): Promise<WorkspaceIndex> {
   const cacheKey = workspaceIndexCacheKey(workspaceRoot, options.includePdf)
+  pruneIndexCache(Date.now())
   const cached = indexCache.get(cacheKey)
-  if (cached && Date.now() - cached.builtAt <= INDEX_CACHE_TTL_MS) return cached
+  if (cached) {
+    indexCache.delete(cacheKey)
+    indexCache.set(cacheKey, cached)
+    return cached
+  }
   const existing = inFlightIndexCache.get(cacheKey)
   if (existing) return existing
 
   const build = buildWorkspaceIndex(workspaceRoot, options)
     .then((index) => {
+      indexCache.delete(cacheKey)
       indexCache.set(cacheKey, index)
+      pruneIndexCache(Date.now())
       return index
     })
     .finally(() => {


### PR DESCRIPTION
## Summary

- sweep expired Write retrieval indexes before lookup
- cap completed indexes at eight workspace/PDF-mode entries
- promote cache hits so capacity eviction is least-recently-used
- clean test workspaces after each retrieval test

## Root cause

Write retrieval indexes had a 30-second TTL check on lookup, but expired workspace keys remained in the process-wide map indefinitely. Moving across many workspaces therefore retained every large chunk/token/document-frequency index until process exit.

## Tests

- `npm.cmd test -- --run src/main/services/write-retrieval-service.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd exec eslint -- src/main/services/write-retrieval-service.ts src/main/services/write-retrieval-service.test.ts`
- `git diff --check`
