### PR TITLE
fix(im): normalize attachment relative paths

### DIFF
--- a/kun/src/adapters/tool/im-attachment-tool.ts
+++ b/kun/src/adapters/tool/im-attachment-tool.ts
@@ -39,8 +39,8 @@ async function resolveImAttachmentPath(
     realpath(root),
     realpath(lexicalPath)
   ])
-  const relativePath = relative(realRoot, realFile)
-  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+  const nativeRelativePath = relative(realRoot, realFile)
+  if (nativeRelativePath === '..' || nativeRelativePath.startsWith(`..${sep}`) || isAbsolute(nativeRelativePath)) {
     throw new Error(`path escapes the workspace root: ${inputPath}`)
   }
   const fileStat = await stat(realFile)
@@ -52,7 +52,7 @@ async function resolveImAttachmentPath(
   }
   return {
     absolutePath: realFile,
-    relativePath,
+    relativePath: nativeRelativePath.replaceAll(sep, '/'),
     fileName: basename(realFile),
     bytes: fileStat.size
   }


### PR DESCRIPTION
## Summary

- keep native separators for workspace escape validation
- normalize returned IM attachment `relativePath` values to forward slashes

## Root cause

`node:path.relative` returns backslashes on Windows. The attachment metadata crossed a runtime/IM boundary without normalization, so the same file produced platform-dependent payloads and failed the cross-platform contract test.

## Tests

- `npm.cmd --prefix kun test -- src/adapters/tool/im-attachment-tool.test.ts`
- `npm.cmd --prefix kun run typecheck`
- focused ESLint
- `git diff --check`
