### PR TITLE
fix(tools): normalize relative path output

### DIFF
--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -75,7 +75,7 @@ export async function resolveWorkspacePath(inputPath: string, context: ToolHostC
     return {
       workspaceRoot: root,
       absolutePath: resolve(lexicalAbsolutePath),
-      relativePath: relative(root, resolve(lexicalAbsolutePath)) || '.'
+      relativePath: normalizeToolPath(relative(root, resolve(lexicalAbsolutePath)) || '.')
     }
   }
   // In full-access mode the workspace boundary is not enforced: the user has
@@ -88,7 +88,7 @@ export async function resolveWorkspacePath(inputPath: string, context: ToolHostC
     return {
       workspaceRoot: root,
       absolutePath: lexicalAbsolutePath,
-      relativePath: relative(root, lexicalAbsolutePath) || '.'
+      relativePath: normalizeToolPath(relative(root, lexicalAbsolutePath) || '.')
     }
   }
   const resolvedRoot = await safeRealpath(root)
@@ -110,7 +110,7 @@ export async function resolveWorkspacePath(inputPath: string, context: ToolHostC
   return {
     workspaceRoot: root,
     absolutePath: lexicalAbsolutePath,
-    relativePath: relative(root, lexicalAbsolutePath) || '.'
+    relativePath: normalizeToolPath(relative(root, lexicalAbsolutePath) || '.')
   }
 }
 


### PR DESCRIPTION
## Summary

- normalize every `resolveWorkspacePath.relativePath` result to forward slashes
- retain native paths for absolute filesystem access and workspace escape checks

## Root cause

The shared file-tool resolver returned `node:path.relative` directly. Read/write tools therefore emitted backslashes on Windows while find/grep/ls already normalized their wire-facing relative paths, producing inconsistent tool results.

## Tests

- `npm.cmd --prefix kun test -- tests/builtin-tools.test.ts -t "writes, reads, edits"`
- `npm.cmd --prefix kun run typecheck`
- focused ESLint
- `git diff --check`

The separate Windows symlink privilege failures are covered by #760.
