### PR TITLE
test(tools): gate POSIX fd fixture

### DIFF
--- a/kun/tests/builtin-tools.test.ts
+++ b/kun/tests/builtin-tools.test.ts
@@ -514,7 +514,9 @@ describe('Kun built-in tools', () => {
     expect(String(output.output)).toContain('hello local bash')
   })
 
-  it('prefers the fd backend path when an fd executable candidate is provided', async () => {
+  it.skipIf(process.platform === 'win32')(
+    'prefers the fd backend path when a POSIX executable candidate is provided',
+    async () => {
     await mkdir(join(workspace, 'notes'), { recursive: true })
     await writeFile(join(workspace, 'notes', 'demo.txt'), 'demo\n', 'utf8')
     const fdHost = new LocalToolHost({
@@ -531,7 +533,8 @@ describe('Kun built-in tools', () => {
     })
     expect(output.backend).toBe('fd')
     expect(output.matches).toHaveLength(1)
-  })
+    }
+  )
 
   it('writes, reads, edits, and searches workspace files', async () => {
     const writeOutput = await executeTool(host, workspace, 'write', {


### PR DESCRIPTION
## Summary

- mark the `/bin/echo` fd integration fixture as POSIX-only
- retain platform-neutral `resolveExecutable` coverage for Windows `where`, explicit backslash paths, and non-Windows `which`

## Root cause

The integration test supplied `/bin/echo` as a fake fd executable. On Windows that path cannot resolve, so the tool correctly fell back to filesystem scan and the Unix-specific assertion failed.

## Tests

- `npm.cmd --prefix kun test -- tests/builtin-tools.test.ts -t "POSIX executable candidate"`
- `npm.cmd --prefix kun test -- src/adapters/tool/builtin-tool-utils.test.ts -t "resolveExecutable"`
- focused ESLint
- `git diff --check`
