### PR TITLE
fix(design): require explicit multi-page mode

### DIFF
--- a/src/renderer/src/design/design-image-intent.ts
+++ b/src/renderer/src/design/design-image-intent.ts
@@ -11,10 +11,9 @@ const HARD_SCREEN_DESIGN_RE =
   /\b(page|screen|landing page|dashboard|prototype|mockup)\b|页面|界面|原型|设计稿|看板/i
 
 /**
- * Empty design boards normally route a broad brief into the multi-page design
- * pipeline. Strong image-asset briefs (logo/icon/illustration/etc.) should stay
- * on the canvas lane so the agent calls generate_image and places a reusable
- * picture on the whiteboard instead of creating an HTML screen.
+ * Strong image-asset briefs (logo/icon/illustration/etc.) should stay on the
+ * canvas lane so the agent calls generate_image and places a reusable picture
+ * on the whiteboard instead of creating an HTML screen.
  */
 export function looksLikeStandaloneImageAssetPrompt(text: string): boolean {
   const prompt = text.trim()

--- a/src/renderer/src/design/design-pages-gate.test.ts
+++ b/src/renderer/src/design/design-pages-gate.test.ts
@@ -34,8 +34,8 @@ function gate(input: Partial<DesignMultiPageGateInput> = {}) {
 }
 
 describe('design pages gate', () => {
-  it('routes from-scratch generate briefs to the multi-page pipeline', () => {
-    expect(gate()).toEqual({ route: 'multi-page', reason: 'from-scratch' })
+  it('keeps from-scratch briefs in the single-turn lane by default', () => {
+    expect(gate()).toEqual({ route: 'single-turn', reason: 'multi-page-disabled' })
   })
 
   it('lets the explicit multi-page toggle force the pipeline when pages already exist', () => {
@@ -48,7 +48,7 @@ describe('design pages gate', () => {
   it('keeps incremental existing-page work in the single-turn lane', () => {
     expect(gate({
       artifacts: [artifact('board', 'canvas'), artifact('home', 'html')]
-    })).toEqual({ route: 'single-turn', reason: 'incremental-existing-pages' })
+    })).toEqual({ route: 'single-turn', reason: 'multi-page-disabled' })
   })
 
   it('does not fan out selected, attached, active-page, or running prompts', () => {

--- a/src/renderer/src/design/design-pages-gate.test.ts
+++ b/src/renderer/src/design/design-pages-gate.test.ts
@@ -45,6 +45,14 @@ describe('design pages gate', () => {
     })).toEqual({ route: 'multi-page', reason: 'explicit-toggle' })
   })
 
+  it('lets the explicit multi-page toggle force the pipeline from an active page', () => {
+    expect(gate({
+      artifacts: [artifact('board', 'canvas'), artifact('home', 'html')],
+      activeArtifactId: 'home',
+      multiPageMode: true
+    })).toEqual({ route: 'multi-page', reason: 'explicit-toggle' })
+  })
+
   it('keeps incremental existing-page work in the single-turn lane', () => {
     expect(gate({
       artifacts: [artifact('board', 'canvas'), artifact('home', 'html')]
@@ -59,6 +67,21 @@ describe('design pages gate', () => {
       activeArtifactId: 'home'
     })).toEqual({ route: 'single-turn', reason: 'active-html-artifact' })
     expect(gate({ pagesRunActive: true })).toEqual({ route: 'single-turn', reason: 'pages-run-active' })
+  })
+
+  it('keeps safety short-circuits ahead of the explicit multi-page toggle', () => {
+    expect(gate({ selectedCount: 1, multiPageMode: true })).toEqual({
+      route: 'single-turn',
+      reason: 'canvas-selection'
+    })
+    expect(gate({ attachmentCount: 1, multiPageMode: true })).toEqual({
+      route: 'single-turn',
+      reason: 'has-attachments'
+    })
+    expect(gate({ pagesRunActive: true, multiPageMode: true })).toEqual({
+      route: 'single-turn',
+      reason: 'pages-run-active'
+    })
   })
 
   it('keeps standalone image asset prompts out of the multi-page pipeline', () => {

--- a/src/renderer/src/design/design-pages-gate.ts
+++ b/src/renderer/src/design/design-pages-gate.ts
@@ -13,7 +13,7 @@ export type DesignMultiPageGateInput = {
 }
 
 export type DesignMultiPageGateDecision =
-  | { route: 'multi-page'; reason: 'from-scratch' | 'explicit-toggle' }
+  | { route: 'multi-page'; reason: 'explicit-toggle' }
   | { route: 'single-turn'; reason: string }
 
 export function shouldRouteDesignPromptToMultiPage(
@@ -30,8 +30,6 @@ export function shouldRouteDesignPromptToMultiPage(
   const activeArtifact = input.artifacts.find((artifact) => artifact.id === input.activeArtifactId) ?? null
   if (activeArtifact?.kind === 'html') return { route: 'single-turn', reason: 'active-html-artifact' }
 
-  const hasExistingPages = input.artifacts.some((artifact) => artifact.kind === 'html')
   if (input.multiPageMode) return { route: 'multi-page', reason: 'explicit-toggle' }
-  if (!hasExistingPages) return { route: 'multi-page', reason: 'from-scratch' }
-  return { route: 'single-turn', reason: 'incremental-existing-pages' }
+  return { route: 'single-turn', reason: 'multi-page-disabled' }
 }

--- a/src/renderer/src/design/design-pages-gate.ts
+++ b/src/renderer/src/design/design-pages-gate.ts
@@ -27,9 +27,10 @@ export function shouldRouteDesignPromptToMultiPage(
   if (input.selectedCount > 0) return { route: 'single-turn', reason: 'canvas-selection' }
   if (looksLikeStandaloneImageAssetPrompt(text)) return { route: 'single-turn', reason: 'standalone-image-asset' }
 
+  if (input.multiPageMode) return { route: 'multi-page', reason: 'explicit-toggle' }
+
   const activeArtifact = input.artifacts.find((artifact) => artifact.id === input.activeArtifactId) ?? null
   if (activeArtifact?.kind === 'html') return { route: 'single-turn', reason: 'active-html-artifact' }
 
-  if (input.multiPageMode) return { route: 'multi-page', reason: 'explicit-toggle' }
   return { route: 'single-turn', reason: 'multi-page-disabled' }
 }

--- a/src/renderer/src/design/design-prompt-router.test.ts
+++ b/src/renderer/src/design/design-prompt-router.test.ts
@@ -64,12 +64,28 @@ describe('design prompt router', () => {
     })).toEqual({ kind: 'attachment-unsupported' })
   })
 
-  it('routes from-scratch generate briefs to the multi-page lane', () => {
+  it('routes from-scratch generate briefs to a single turn by default', () => {
     expect(routeDesignPrompt({
       value: 'Design an operations app',
       attachments: [],
       attachmentUploadEnabled: true,
       designState: state(),
+      selectedCount: 0,
+      imageOnlyDisplay: 'image display',
+      imageOnlyPrompt: 'image prompt'
+    })).toMatchObject({
+      kind: 'single-turn',
+      promptText: 'Design an operations app',
+      workspaceRoot: '/workspace'
+    })
+  })
+
+  it('routes from-scratch briefs to the multi-page lane when explicitly enabled', () => {
+    expect(routeDesignPrompt({
+      value: 'Design an operations app',
+      attachments: [],
+      attachmentUploadEnabled: true,
+      designState: state({ multiPageMode: true }),
       selectedCount: 0,
       imageOnlyDisplay: 'image display',
       imageOnlyPrompt: 'image prompt'

--- a/src/renderer/src/design/design-prompt-router.test.ts
+++ b/src/renderer/src/design/design-prompt-router.test.ts
@@ -96,6 +96,26 @@ describe('design prompt router', () => {
     })
   })
 
+  it('routes active-page briefs to the multi-page lane when explicitly enabled', () => {
+    expect(routeDesignPrompt({
+      value: 'Design an operations app',
+      attachments: [],
+      attachmentUploadEnabled: true,
+      designState: state({
+        artifacts: [artifact('board', 'canvas'), artifact('home', 'html')],
+        activeArtifactId: 'home',
+        multiPageMode: true
+      }),
+      selectedCount: 0,
+      imageOnlyDisplay: 'image display',
+      imageOnlyPrompt: 'image prompt'
+    })).toEqual({
+      kind: 'multi-page',
+      brief: 'Design an operations app',
+      workspaceRoot: '/workspace'
+    })
+  })
+
   it('builds single-turn display and prompt text for image-only sends', () => {
     expect(routeDesignPrompt({
       value: ' ',


### PR DESCRIPTION
## Summary

- keep new single-page design prompts on the normal single-turn path
- enter the foundation-first pipeline only when multi-page mode is explicitly enabled
- update routing regression coverage and stale intent documentation

## Tests

- npm.cmd test -- --run src/renderer/src/design/design-pages-gate.test.ts src/renderer/src/design/design-prompt-router.test.ts
- npm.cmd run typecheck
- git diff --check

Fixes #756