### PR TITLE
test(lsp): use native diagnostic file URIs

### DIFF
--- a/kun/src/adapters/tool/lsp-client.test.ts
+++ b/kun/src/adapters/tool/lsp-client.test.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from 'node:events'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const { accessMock, spawnMock } = vi.hoisted(() => ({
@@ -241,24 +243,27 @@ describe('LSP notifications', () => {
       throw new Error(`Unexpected spawn: ${command}`)
     })
 
-    const session = await acquireLspSession('/workspace/diagnostics', 'typescript')
+    const workspaceRoot = resolve('/workspace/diagnostics')
+    const filePath = join(workspaceRoot, 'app.ts')
+    const fileUri = pathToFileURL(filePath).href
+    const session = await acquireLspSession(workspaceRoot, 'typescript')
     emitJsonRpc(serverProcess as MockProcess, {
       jsonrpc: '2.0',
       method: 'textDocument/publishDiagnostics',
       params: {
-        uri: 'file:///workspace/diagnostics/app.ts',
+        uri: fileUri,
         diagnostics: [{ message: 'boom', severity: 1 }]
       }
     })
 
-    expect(session.diagnostics.get('file:///workspace/diagnostics/app.ts')).toEqual([
+    expect(session.diagnostics.get(fileUri)).toEqual([
       { message: 'boom', severity: 1 }
     ])
-    await expect(lspGetDiagnostics(session, '/workspace/diagnostics/app.ts')).resolves.toEqual({
+    await expect(lspGetDiagnostics(session, filePath)).resolves.toEqual({
       diagnostics: [{ message: 'boom', severity: 1 }],
       source: 'publishDiagnostics-cache'
     })
-    releaseLspSession('/workspace/diagnostics', 'typescript')
+    releaseLspSession(workspaceRoot, 'typescript')
   })
 
   it('logs server messages from window/logMessage notifications', async () => {


### PR DESCRIPTION
## Summary

- construct the diagnostics fixture path with the host path implementation
- derive the publishDiagnostics URI with pathToFileURL
- keep the pushed diagnostics cache assertion portable on Windows

## Tests

- npm.cmd --prefix kun test -- src/adapters/tool/lsp-client.test.ts --reporter=verbose
- npm.cmd --prefix kun run typecheck
- git diff --check