### PR TITLE
fix(shell): flush background output before summary

### DIFF
--- a/kun/src/services/background-shell-output.ts
+++ b/kun/src/services/background-shell-output.ts
@@ -128,6 +128,15 @@ export class BackgroundShellOutputWriter {
   async buildReturnFields(
     maxChars = DEFAULT_BACKGROUND_SHELL_OUTPUT_SUMMARY_MAX_CHARS
   ): Promise<BackgroundShellOutputSummary & { output_file: string }> {
+    const stream = this.stream
+    if (stream) {
+      await new Promise<void>((resolvePromise, reject) => {
+        stream.write('', (error) => {
+          if (error) reject(error)
+          else resolvePromise()
+        })
+      })
+    }
     const summary = await readBackgroundShellOutputSummary(this.paths.outputFilePath, maxChars)
     return {
       ...summary,


### PR DESCRIPTION
## Summary

- wait for queued background-shell stream writes before reading the output file
- prevent live summaries from observing stale or empty disk content
- preserve the existing close and persisted-output behavior

## Tests

- background-shell-output test file, repeated 5 times
- npm.cmd --prefix kun run typecheck
- git diff --check