### PR TITLE
test(windows): limit Vitest worker contention

### DIFF
--- a/kun/vitest.config.ts
+++ b/kun/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
-    globals: false
+    globals: false,
+    ...(process.platform === 'win32' ? { maxWorkers: 2 } : {})
   }
 })


### PR DESCRIPTION
## Summary

- cap Kun Vitest workers at two on Windows
- avoid scheduler starvation across process-heavy, filesystem-heavy, and multi-step loop tests
- preserve the default Vitest worker strategy on macOS and Linux

## Tests

- 89 goal/loop tests passed on the standalone branch
- integration stack full Kun suite: 345/345 suites, 1149 passed, 3 skipped, 0 failed
- npm.cmd --prefix kun run typecheck
- git diff --check