### PR TITLE
test(checkpoint): use Windows junction fixture

### DIFF
--- a/src/main/services/git-checkpoint-service.test.ts
+++ b/src/main/services/git-checkpoint-service.test.ts
@@ -241,7 +241,7 @@ describe('git checkpoint service', () => {
     // traversal that a lexical-only check misses.
     const outsideDir = join(sandbox, 'outside')
     await mkdir(outsideDir, { recursive: true })
-    await symlink(outsideDir, join(repoRoot, 'link'), 'dir')
+    await symlink(outsideDir, join(repoRoot, 'link'), process.platform === 'win32' ? 'junction' : 'dir')
 
     await expect(
       testResolvePathWithinRepository(repoRoot, 'link/payload.txt')


### PR DESCRIPTION
## Summary

- use a directory junction for the checkpoint escape fixture on Windows
- retain directory symlinks on macOS and Linux
- exercise the same repository-boundary rejection without requiring Windows Developer Mode

## Tests

- 22/22 git checkpoint service tests
- npm.cmd run typecheck
- git diff --check