### PR TITLE
test(windows): limit GUI Vitest contention

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts']
+    include: ['src/**/*.test.ts'],
+    ...(process.platform === 'win32' ? { maxWorkers: 2 } : {})
   }
 })


### PR DESCRIPTION
## Summary

- cap top-level Vitest workers at two on Windows
- prevent IPC and Git subprocess tests from starving under suite-wide contention
- preserve the default worker strategy on macOS and Linux

## Tests

- previously timing-out IPC/checkpoint cases: 4 passed
- npm.cmd run typecheck
- git diff --check