### PR TITLE
feat(composer): improve file mention completion

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposer.test.ts
+++ b/src/renderer/src/components/chat/FloatingComposer.test.ts
@@ -13,6 +13,7 @@ import {
   parseNewCommand,
   parseResearchCommand,
   parseReviewCommand,
+  shouldCaptureFileMentionCommitKey,
   shouldShowGoalFloater
 } from './FloatingComposer'
 import {
@@ -39,6 +40,7 @@ import {
   filterWorkspaceFileMentionSuggestions,
   formatComposerFileMentionToken,
   getFileMentionAtCursor,
+  hasComposerFileMentionToken,
   isFileWithinDirectory,
   removeComposerFileMentionToken,
   replaceFileMentionInInput,
@@ -175,6 +177,33 @@ describe('FloatingComposer goal helpers', () => {
 })
 
 describe('FloatingComposer file references', () => {
+  it('captures file mention commit keys while the menu is active before candidates load', () => {
+    expect(shouldCaptureFileMentionCommitKey({
+      key: 'Enter',
+      shiftKey: false,
+      metaKey: false,
+      ctrlKey: false
+    })).toBe(true)
+    expect(shouldCaptureFileMentionCommitKey({
+      key: 'Tab',
+      shiftKey: false,
+      metaKey: false,
+      ctrlKey: false
+    })).toBe(true)
+    expect(shouldCaptureFileMentionCommitKey({
+      key: 'Enter',
+      shiftKey: true,
+      metaKey: false,
+      ctrlKey: false
+    })).toBe(false)
+    expect(shouldCaptureFileMentionCommitKey({
+      key: 'Enter',
+      shiftKey: false,
+      metaKey: true,
+      ctrlKey: false
+    })).toBe(false)
+  })
+
   it('parses @ file mention queries at the current cursor', () => {
     expect(getFileMentionAtCursor('please inspect @src/ren', 'please inspect @src/ren'.length)).toEqual({
       start: 15,
@@ -230,6 +259,14 @@ describe('FloatingComposer file references', () => {
     expect(removeComposerFileMentionToken(reordered, 'src', true)).toBe('review @src/App.tsx and now')
   })
 
+  it('detects exact inserted mention tokens without matching path prefixes', () => {
+    expect(hasComposerFileMentionToken('review @src/renderer/src/App.tsx now', 'src/renderer/src/App.tsx')).toBe(true)
+    expect(hasComposerFileMentionToken('review @"docs/product plan.md" now', 'docs/product plan.md')).toBe(true)
+    expect(hasComposerFileMentionToken('review @src/ now', 'src', true)).toBe(true)
+    expect(hasComposerFileMentionToken('review @src/App.tsx now', 'src', true)).toBe(false)
+    expect(hasComposerFileMentionToken('email test@src/App.tsx now', 'src/App.tsx')).toBe(false)
+  })
+
   it('ranks directories alongside files and favors them for trailing-slash queries', () => {
     const entries: ComposerFileReference[] = [
       { path: '/repo/src', relativePath: 'src', name: 'src', type: 'directory' },
@@ -239,6 +276,18 @@ describe('FloatingComposer file references', () => {
     const suggestions = filterWorkspaceFileMentionSuggestions(entries, 'src/')
     expect(suggestions[0]).toEqual(entries[0])
     expect(suggestions.map((entry) => entry.relativePath)).toContain('src/App.tsx')
+  })
+
+  it('filters path-like @ queries and excludes already selected duplicate paths', () => {
+    const entries: ComposerFileReference[] = [
+      { path: '/repo/src/renderer', relativePath: 'src/renderer', name: 'renderer', type: 'directory' },
+      { path: '/repo/src/renderer/src/FloatingComposer.tsx', relativePath: 'src/renderer/src/FloatingComposer.tsx', name: 'FloatingComposer.tsx', type: 'file' },
+      { path: '/repo/packages/ui/src/FloatingComposer.tsx', relativePath: 'packages/ui/src/FloatingComposer.tsx', name: 'FloatingComposer.tsx', type: 'file' }
+    ]
+
+    const suggestions = filterWorkspaceFileMentionSuggestions(entries, 'src/ren', [entries[1]!])
+
+    expect(suggestions.map((entry) => entry.relativePath)).toEqual(['src/renderer'])
   })
 
   it('lists every indexed file beneath a referenced directory', () => {

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -47,10 +47,12 @@ import type { AttachmentReference, ChatBlock, ReviewTarget } from '../../agent/t
 import { useChatStore } from '../../store/chat-store'
 import { normalizeWorkspaceRoot } from '../../lib/workspace-path'
 import {
+  composerFileReferenceKey,
   composerFileReferenceFromPath,
   filterWorkspaceFileMentionSuggestions,
   formatComposerFileMentionToken,
   getFileMentionAtCursor,
+  hasComposerFileMentionToken,
   isComposerDirectoryReference,
   removeComposerFileMentionToken,
   replaceFileMentionInInput,
@@ -227,6 +229,13 @@ type Props = {
 }
 
 type SkillCommand = NonNullable<Props['skillCommands']>[number]
+
+export function shouldCaptureFileMentionCommitKey(
+  event: Pick<ReactKeyboardEvent<HTMLTextAreaElement>, 'key' | 'shiftKey' | 'metaKey' | 'ctrlKey'>
+): boolean {
+  if (event.key === 'Tab') return true
+  return event.key === 'Enter' && !event.shiftKey && !event.metaKey && !event.ctrlKey
+}
 
 const EMPTY_CONTEXT_BLOCKS: ChatBlock[] = []
 const EMPTY_MODEL_GROUPS: ModelProviderModelGroup[] = []
@@ -680,6 +689,7 @@ export function FloatingComposer({
   const composerMenuPanelRef = useRef<HTMLDivElement | null>(null)
   const goalPanelRef = useRef<HTMLDivElement | null>(null)
   const contextCapacityRef = useRef<HTMLDivElement | null>(null)
+  const fileMentionPresenceRef = useRef<Map<string, boolean>>(new Map())
   const messageTokenCacheRef = useRef<WeakMap<object, number>>(new WeakMap())
   // Cache the last-known runtime capacity inputs. `runtimeInfo` (and thus these
   // props) goes null whenever the runtime drops/reconnects; without caching, the
@@ -1111,6 +1121,29 @@ export function FloatingComposer({
   ])
 
   useEffect(() => {
+    const previous = fileMentionPresenceRef.current
+    const next = new Map<string, boolean>()
+    const removedRelativePaths: string[] = []
+
+    for (const reference of fileReferences) {
+      const isDirectory = isComposerDirectoryReference(reference)
+      const key = composerFileReferenceKey(reference)
+      const present = hasComposerFileMentionToken(input, reference.relativePath, isDirectory)
+      if (previous.get(key) === true && !present) {
+        removedRelativePaths.push(reference.relativePath)
+      }
+      next.set(key, present)
+    }
+
+    fileMentionPresenceRef.current = next
+
+    if (!onRemoveFileReference || removedRelativePaths.length === 0) return
+    for (const relativePath of removedRelativePaths) {
+      onRemoveFileReference(relativePath)
+    }
+  }, [fileReferences, input, onRemoveFileReference])
+
+  useEffect(() => {
     if (!composerMenuOpen && !goalPanelOpen) return
 
     const onPointerDown = (event: PointerEvent): void => {
@@ -1375,6 +1408,7 @@ export function FloatingComposer({
 
   const removeFileReference = (reference: ComposerFileReference): void => {
     onRemoveFileReference?.(reference.relativePath)
+    fileMentionPresenceRef.current.set(composerFileReferenceKey(reference), false)
     const nextInput = removeComposerFileMentionToken(
       input,
       reference.relativePath,
@@ -1491,9 +1525,11 @@ export function FloatingComposer({
         )
         return
       }
-      if ((event.key === 'Enter' || event.key === 'Tab') && highlightedFileMention) {
+      if (shouldCaptureFileMentionCommitKey(event)) {
         event.preventDefault()
-        applyFileMention(highlightedFileMention)
+        if (highlightedFileMention) {
+          applyFileMention(highlightedFileMention)
+        }
         return
       }
       if (event.key === 'Escape') {

--- a/src/renderer/src/components/workbench/workbench-composer-prompts.test.ts
+++ b/src/renderer/src/components/workbench/workbench-composer-prompts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { composerReferencesToUserFileReferences } from './workbench-composer-prompts'
+
+describe('workbench composer prompt helpers', () => {
+  it('maps composer file references to the Kun request contract', () => {
+    expect(composerReferencesToUserFileReferences([
+      {
+        path: '/repo/src/renderer/App.tsx',
+        relativePath: 'src/renderer/App.tsx',
+        name: 'App.tsx',
+        type: 'file'
+      },
+      {
+        path: '/repo/src/renderer',
+        relativePath: 'src/renderer',
+        name: 'renderer',
+        type: 'directory'
+      }
+    ])).toEqual([
+      {
+        path: '/repo/src/renderer/App.tsx',
+        relativePath: 'src/renderer/App.tsx',
+        name: 'App.tsx',
+        kind: 'file'
+      },
+      {
+        path: '/repo/src/renderer',
+        relativePath: 'src/renderer',
+        name: 'renderer',
+        kind: 'directory'
+      }
+    ])
+  })
+})

--- a/src/renderer/src/lib/composer-file-references.ts
+++ b/src/renderer/src/lib/composer-file-references.ts
@@ -134,6 +134,44 @@ function isMentionTokenBoundary(char: string | undefined): boolean {
   return !MENTION_TOKEN_CONTINUATION.test(char)
 }
 
+function isMentionTokenStartBoundary(char: string | undefined): boolean {
+  if (char === undefined) return true
+  return /[\s([{，。；：、]/u.test(char)
+}
+
+function composerFileMentionTokenCandidates(relativePath: string, isDirectory: boolean): string[] {
+  const normalized = trimTrailingSlash(relativePath)
+  return isDirectory
+    ? [
+        formatComposerFileMentionToken(normalized, true),
+        formatComposerFileMentionToken(normalized, false)
+      ]
+    : [formatComposerFileMentionToken(normalized, false)]
+}
+
+export function hasComposerFileMentionToken(
+  input: string,
+  relativePath: string,
+  isDirectory = false
+): boolean {
+  const candidates = composerFileMentionTokenCandidates(relativePath, isDirectory)
+  return candidates.some((token) => {
+    let from = 0
+    while (from <= input.length) {
+      const index = input.indexOf(token, from)
+      if (index < 0) return false
+      if (
+        isMentionTokenStartBoundary(input[index - 1]) &&
+        isMentionTokenBoundary(input[index + token.length])
+      ) {
+        return true
+      }
+      from = index + token.length
+    }
+    return false
+  })
+}
+
 export function removeComposerFileMentionToken(
   input: string,
   relativePath: string,


### PR DESCRIPTION
## Summary
- Improve the existing textarea Composer @ file mention flow without replacing the input editor.
- Keep inserted mentions synchronized with Composer file reference state so Kun requests carry real fileReferences.

## Changes
- Add exact mention token detection for inserted file and directory references.
- Capture Enter/Tab while the file mention menu is active to insert highlighted candidates or prevent accidental sends while candidates are pending.
- Sync chip state when inserted mention text is manually removed, while preserving picker-added references that were never in the textarea.
- Add regression coverage for filtering, de-duping, token detection, key handling, and Kun fileReferences mapping.

## Tests
- npm run test -- src/renderer/src/components/chat/FloatingComposer.test.ts src/renderer/src/lib/workspace-file-index.test.ts src/renderer/src/components/workbench/workbench-composer-prompts.test.ts
- npm run typecheck
- npm run dev