### PR TITLE
feat(files): improve document management usability

### DIFF
--- a/src/main/services/workspace-file-metadata.ts
+++ b/src/main/services/workspace-file-metadata.ts
@@ -1,0 +1,31 @@
+import { stat } from 'node:fs/promises'
+import type {
+  WorkspaceDirectoryListResult,
+  WorkspaceDirectoryTarget,
+  WorkspaceEntry
+} from '../../shared/workspace-file'
+import { listWorkspaceDirectory as listWorkspaceDirectoryWithoutMetadata } from './workspace-files'
+
+async function withEntryMetadata(entry: WorkspaceEntry): Promise<WorkspaceEntry> {
+  try {
+    const info = await stat(entry.path)
+    return {
+      ...entry,
+      mtimeMs: info.mtimeMs,
+      size: info.isFile() ? info.size : 0
+    }
+  } catch {
+    return entry
+  }
+}
+
+export async function listWorkspaceDirectory(
+  payload: WorkspaceDirectoryTarget
+): Promise<WorkspaceDirectoryListResult> {
+  const result = await listWorkspaceDirectoryWithoutMetadata(payload)
+  if (!result.ok) return result
+  return {
+    ...result,
+    entries: await Promise.all(result.entries.map(withEntryMetadata))
+  }
+}

--- a/src/main/services/workspace-service.test.ts
+++ b/src/main/services/workspace-service.test.ts
@@ -99,6 +99,12 @@ describe('workspace-service boundary checks', () => {
     if (result.ok) {
       expect(result.entries.map((entry) => entry.name)).toEqual(['notes', 'inside.txt'])
       expect(result.entries[0].type).toBe('directory')
+      expect(result.entries[0].mtimeMs).toBeTypeOf('number')
+      expect(result.entries[1]).toMatchObject({
+        type: 'file',
+        size: 6
+      })
+      expect(result.entries[1].mtimeMs).toBeTypeOf('number')
     }
   })
 

--- a/src/main/services/workspace-service.ts
+++ b/src/main/services/workspace-service.ts
@@ -1,3 +1,4 @@
 export * from './workspace-paths'
 export * from './workspace-editors'
 export * from './workspace-files'
+export { listWorkspaceDirectory } from './workspace-file-metadata'

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react'
 import { AppErrorBoundary } from './components/AppErrorBoundary'
+import './lib/issue-781-document-usability'
 
 const AppShell = lazy(() => import('./AppShell'))
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,8 +1,13 @@
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { AppErrorBoundary } from './components/AppErrorBoundary'
-import './lib/issue-781-document-usability'
+import { installIssue781DocumentUsability } from './lib/issue-781-document-usability'
 
 const AppShell = lazy(() => import('./AppShell'))
+
+function DocumentUsabilityLifecycle(): null {
+  useEffect(() => installIssue781DocumentUsability(), [])
+  return null
+}
 
 function StartupShell(): React.ReactElement {
   return (
@@ -18,6 +23,7 @@ function StartupShell(): React.ReactElement {
 export default function App(): React.ReactElement {
   return (
     <AppErrorBoundary>
+      <DocumentUsabilityLifecycle />
       <Suspense fallback={<StartupShell />}>
         <AppShell />
       </Suspense>

--- a/src/renderer/src/components/WorkspaceFilePreviewPanel.tsx
+++ b/src/renderer/src/components/WorkspaceFilePreviewPanel.tsx
@@ -339,6 +339,7 @@ export function WorkspaceFilePreviewPanel({
 
   return (
     <aside
+      data-kun-workspace-root={(target?.workspaceRoot ?? workspaceRoot).replaceAll('\\', '/')}
       className={`ds-no-drag ds-code-sidebar flex min-h-0 flex-col border-l border-ds-border-muted ${className ?? ''}`}
     >
       <div className="ds-code-sidebar-topbar">
@@ -353,6 +354,7 @@ export function WorkspaceFilePreviewPanel({
             return (
               <div
                 key={targetKey(item)}
+                data-kun-preview-key={targetKey(item)}
                 role="tab"
                 tabIndex={0}
                 aria-selected={active}

--- a/src/renderer/src/components/chat/ChatFileTreePanel.test.ts
+++ b/src/renderer/src/components/chat/ChatFileTreePanel.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { WorkspaceEntry } from '@shared/workspace-file'
 import {
+  compareChatFileTreeEntriesByModified,
   formatChatFileTreeUnsupportedMessage,
   isChatFileTreeIgnoredDirectory,
-  isChatFileTreePreviewableEntry
+  isChatFileTreePreviewableEntry,
+  sortChatFileTreeEntries
 } from './ChatFileTreePanel'
 
 function entry(overrides: Partial<WorkspaceEntry> & Pick<WorkspaceEntry, 'name' | 'type'>): WorkspaceEntry {
@@ -11,7 +13,9 @@ function entry(overrides: Partial<WorkspaceEntry> & Pick<WorkspaceEntry, 'name' 
     name: overrides.name,
     type: overrides.type,
     path: overrides.path ?? `/tmp/project/${overrides.name}`,
-    ext: overrides.ext ?? ''
+    ext: overrides.ext ?? '',
+    ...(overrides.mtimeMs === undefined ? {} : { mtimeMs: overrides.mtimeMs }),
+    ...(overrides.size === undefined ? {} : { size: overrides.size })
   }
 }
 
@@ -30,5 +34,27 @@ describe('ChatFileTreePanel helpers', () => {
 
   it('formats unsupported preview titles without leaking UI state', () => {
     expect(formatChatFileTreeUnsupportedMessage('logo.png')).toContain('logo.png')
+  })
+
+  it('sorts files by newest mtime before falling back to name', () => {
+    expect([
+      entry({ name: 'old.md', type: 'file', mtimeMs: 100 }),
+      entry({ name: 'new.md', type: 'file', mtimeMs: 300 }),
+      entry({ name: 'same-b.md', type: 'file', mtimeMs: 200 }),
+      entry({ name: 'same-a.md', type: 'file', mtimeMs: 200 })
+    ].sort(compareChatFileTreeEntriesByModified).map((item) => item.name)).toEqual([
+      'new.md',
+      'same-a.md',
+      'same-b.md',
+      'old.md'
+    ])
+  })
+
+  it('keeps directories before files in modified sort mode', () => {
+    expect(sortChatFileTreeEntries([
+      entry({ name: 'new.md', type: 'file', mtimeMs: 300 }),
+      entry({ name: 'docs', type: 'directory', mtimeMs: 100 }),
+      entry({ name: 'old.md', type: 'file', mtimeMs: 50 })
+    ], 'modified').map((item) => item.name)).toEqual(['docs', 'new.md', 'old.md'])
   })
 })

--- a/src/renderer/src/components/chat/ChatFileTreePanel.test.ts
+++ b/src/renderer/src/components/chat/ChatFileTreePanel.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from 'vitest'
-import type { WorkspaceEntry } from '@shared/workspace-file'
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  WorkspaceDirectoryListResult,
+  WorkspaceDirectoryTarget,
+  WorkspaceEntry
+} from '@shared/workspace-file'
 import {
   compareChatFileTreeEntriesByModified,
   formatChatFileTreeUnsupportedMessage,
   isChatFileTreeIgnoredDirectory,
   isChatFileTreePreviewableEntry,
+  scanChatFileTreeRecentFiles,
   sortChatFileTreeEntries
 } from './ChatFileTreePanel'
 
@@ -16,6 +21,14 @@ function entry(overrides: Partial<WorkspaceEntry> & Pick<WorkspaceEntry, 'name' 
     ext: overrides.ext ?? '',
     ...(overrides.mtimeMs === undefined ? {} : { mtimeMs: overrides.mtimeMs }),
     ...(overrides.size === undefined ? {} : { size: overrides.size })
+  }
+}
+
+function directory(entries: WorkspaceEntry[]): WorkspaceDirectoryListResult {
+  return {
+    ok: true,
+    root: '/tmp/project',
+    entries
   }
 }
 
@@ -56,5 +69,31 @@ describe('ChatFileTreePanel helpers', () => {
       entry({ name: 'docs', type: 'directory', mtimeMs: 100 }),
       entry({ name: 'old.md', type: 'file', mtimeMs: 50 })
     ], 'modified').map((item) => item.name)).toEqual(['docs', 'new.md', 'old.md'])
+  })
+
+  it('rescans recent files instead of reusing the previous refresh result', async () => {
+    const root = '/tmp/project'
+    const snapshots = [
+      directory([entry({ name: 'old.md', type: 'file', path: `${root}/old.md`, mtimeMs: 100 })]),
+      directory([entry({ name: 'new.md', type: 'file', path: `${root}/new.md`, mtimeMs: 200 })])
+    ]
+    let snapshotIndex = 0
+    const listWorkspaceDirectory = vi.fn(
+      async (_target: WorkspaceDirectoryTarget): Promise<WorkspaceDirectoryListResult> => snapshots[snapshotIndex]
+    )
+
+    await expect(scanChatFileTreeRecentFiles(root, listWorkspaceDirectory)).resolves.toMatchObject([
+      { name: 'old.md' }
+    ])
+    snapshotIndex = 1
+    await expect(scanChatFileTreeRecentFiles(root, listWorkspaceDirectory)).resolves.toMatchObject([
+      { name: 'new.md' }
+    ])
+
+    expect(listWorkspaceDirectory).toHaveBeenCalledTimes(2)
+    expect(listWorkspaceDirectory.mock.calls.map(([target]) => target)).toEqual([
+      { workspaceRoot: root, path: root },
+      { workspaceRoot: root, path: root }
+    ])
   })
 })

--- a/src/renderer/src/components/chat/ChatFileTreePanel.tsx
+++ b/src/renderer/src/components/chat/ChatFileTreePanel.tsx
@@ -1,4 +1,8 @@
-import type { WorkspaceEntry } from '@shared/workspace-file'
+import type {
+  WorkspaceDirectoryListResult,
+  WorkspaceDirectoryTarget,
+  WorkspaceEntry
+} from '@shared/workspace-file'
 import {
   ChevronDown,
   ChevronRight,
@@ -61,10 +65,19 @@ type ContextMenuState = {
 
 type FileTreeSortMode = 'name' | 'modified'
 
+type ListWorkspaceDirectory = (target: WorkspaceDirectoryTarget) => Promise<WorkspaceDirectoryListResult>
+
 type RecentScanState = {
   entries: WorkspaceEntry[]
   loading: boolean
   error: string | null
+}
+
+type RecentScanOptions = {
+  isCancelled?: () => boolean
+  limit?: number
+  maxDepth?: number
+  maxEntries?: number
 }
 
 const ROOT_PATH = ''
@@ -123,6 +136,44 @@ function sortRecentFiles(entries: WorkspaceEntry[]): WorkspaceEntry[] {
       if (leftTime !== rightTime) return rightTime - leftTime
       return compareChatFileTreeEntriesByName(left, right)
     })
+}
+
+export async function scanChatFileTreeRecentFiles(
+  root: string,
+  listWorkspaceDirectory: ListWorkspaceDirectory,
+  options: RecentScanOptions = {}
+): Promise<WorkspaceEntry[]> {
+  const limit = options.limit ?? RECENT_FILE_LIMIT
+  const maxDepth = options.maxDepth ?? RECENT_SCAN_MAX_DEPTH
+  const maxEntries = options.maxEntries ?? RECENT_SCAN_MAX_ENTRIES
+  const isCancelled = options.isCancelled ?? (() => false)
+  const collected: WorkspaceEntry[] = []
+
+  const scanDirectory = async (
+    path: string,
+    depth: number,
+    seenDirectories: Set<string>
+  ): Promise<void> => {
+    if (isCancelled() || depth > maxDepth || collected.length >= maxEntries) return
+    const directoryKey = pathKey(path || root)
+    if (seenDirectories.has(directoryKey)) return
+    seenDirectories.add(directoryKey)
+    const result = await listWorkspaceDirectory({ workspaceRoot: root, path: path || root })
+    if (!result.ok) throw new Error(result.message)
+    for (const entry of result.entries) {
+      if (isCancelled() || collected.length >= maxEntries) return
+      if (entry.type === 'directory') {
+        if (!isChatFileTreeIgnoredDirectory(entry.name)) {
+          await scanDirectory(entry.path, depth + 1, seenDirectories)
+        }
+        continue
+      }
+      if (isChatFileTreePreviewableEntry(entry)) collected.push(entry)
+    }
+  }
+
+  await scanDirectory(root, 0, new Set())
+  return sortRecentFiles(collected).slice(0, limit)
 }
 
 export function isChatFileTreeIgnoredDirectory(name: string): boolean {
@@ -205,41 +256,19 @@ export function ChatFileTreePanel({
   }, [directories, expanded, loadDirectory, root])
 
   useEffect(() => {
-    if (!root || typeof window.kunGui?.listWorkspaceDirectory !== 'function') return
+    const listWorkspaceDirectory = window.kunGui?.listWorkspaceDirectory?.bind(window.kunGui)
+    if (!root || typeof listWorkspaceDirectory !== 'function') return
     let cancelled = false
     setRecentScan({ entries: [], loading: true, error: null })
 
-    const scanDirectory = async (
-      path: string,
-      depth: number,
-      collected: WorkspaceEntry[],
-      seenDirectories: Set<string>
-    ): Promise<void> => {
-      if (cancelled || depth > RECENT_SCAN_MAX_DEPTH || collected.length >= RECENT_SCAN_MAX_ENTRIES) return
-      const directoryKey = pathKey(path || root)
-      if (seenDirectories.has(directoryKey)) return
-      seenDirectories.add(directoryKey)
-      const result = await window.kunGui.listWorkspaceDirectory({ workspaceRoot: root, path: path || root })
-      if (!result.ok) throw new Error(result.message)
-      for (const entry of result.entries) {
-        if (cancelled || collected.length >= RECENT_SCAN_MAX_ENTRIES) return
-        if (entry.type === 'directory') {
-          if (!isChatFileTreeIgnoredDirectory(entry.name)) {
-            await scanDirectory(entry.path, depth + 1, collected, seenDirectories)
-          }
-          continue
-        }
-        if (isChatFileTreePreviewableEntry(entry)) collected.push(entry)
-      }
-    }
-
     void (async () => {
       try {
-        const collected: WorkspaceEntry[] = []
-        await scanDirectory(root, 0, collected, new Set())
+        const entries = await scanChatFileTreeRecentFiles(root, listWorkspaceDirectory, {
+          isCancelled: () => cancelled
+        })
         if (!cancelled) {
           setRecentScan({
-            entries: sortRecentFiles(collected).slice(0, RECENT_FILE_LIMIT),
+            entries,
             loading: false,
             error: null
           })
@@ -258,7 +287,7 @@ export function ChatFileTreePanel({
     return () => {
       cancelled = true
     }
-  }, [root])
+  }, [root, recentScanNonce])
 
   useEffect(() => {
     if (!contextMenu) return

--- a/src/renderer/src/components/chat/ChatFileTreePanel.tsx
+++ b/src/renderer/src/components/chat/ChatFileTreePanel.tsx
@@ -17,12 +17,16 @@ import {
   useMemo,
   useRef,
   useState,
+  type DragEvent as ReactDragEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactElement
 } from 'react'
 import type { TFunction } from 'i18next'
 import type { ComposerFileReference } from '../../lib/composer-file-references'
-import { relativeWorkspacePath } from '../../lib/composer-file-references'
+import {
+  formatComposerFileMentionToken,
+  relativeWorkspacePath
+} from '../../lib/composer-file-references'
 import { isWorkspaceTextPreviewPath } from '../../lib/workspace-text-preview'
 import {
   SidebarIconButton,
@@ -55,8 +59,19 @@ type ContextMenuState = {
   entry: WorkspaceEntry
 } | null
 
+type FileTreeSortMode = 'name' | 'modified'
+
+type RecentScanState = {
+  entries: WorkspaceEntry[]
+  loading: boolean
+  error: string | null
+}
+
 const ROOT_PATH = ''
 const IGNORED_DIRS = new Set(['.git', '.hg', '.svn', 'node_modules'])
+const RECENT_FILE_LIMIT = 8
+const RECENT_SCAN_MAX_ENTRIES = 2_000
+const RECENT_SCAN_MAX_DEPTH = 8
 
 function normalizePath(path: string): string {
   return path.replaceAll('\\', '/').replace(/\/+$/g, '')
@@ -82,6 +97,34 @@ function entryReference(entry: WorkspaceEntry, workspaceRoot: string): ChatFileT
   }
 }
 
+export function compareChatFileTreeEntriesByName(left: WorkspaceEntry, right: WorkspaceEntry): number {
+  if (left.type !== right.type) return left.type === 'directory' ? -1 : 1
+  return left.name.localeCompare(right.name, undefined, { numeric: true, sensitivity: 'base' })
+}
+
+export function compareChatFileTreeEntriesByModified(left: WorkspaceEntry, right: WorkspaceEntry): number {
+  if (left.type !== right.type) return left.type === 'directory' ? -1 : 1
+  const leftTime = left.mtimeMs ?? 0
+  const rightTime = right.mtimeMs ?? 0
+  if (leftTime !== rightTime) return rightTime - leftTime
+  return compareChatFileTreeEntriesByName(left, right)
+}
+
+export function sortChatFileTreeEntries(entries: WorkspaceEntry[], mode: FileTreeSortMode): WorkspaceEntry[] {
+  return [...entries].sort(mode === 'modified' ? compareChatFileTreeEntriesByModified : compareChatFileTreeEntriesByName)
+}
+
+function sortRecentFiles(entries: WorkspaceEntry[]): WorkspaceEntry[] {
+  return [...entries]
+    .filter(isChatFileTreePreviewableEntry)
+    .sort((left, right) => {
+      const leftTime = left.mtimeMs ?? 0
+      const rightTime = right.mtimeMs ?? 0
+      if (leftTime !== rightTime) return rightTime - leftTime
+      return compareChatFileTreeEntriesByName(left, right)
+    })
+}
+
 export function isChatFileTreeIgnoredDirectory(name: string): boolean {
   return IGNORED_DIRS.has(name.toLowerCase())
 }
@@ -105,6 +148,9 @@ export function ChatFileTreePanel({
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set([ROOT_PATH]))
   const [directories, setDirectories] = useState<Record<string, DirectoryState>>({})
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null)
+  const [sortMode, setSortMode] = useState<FileTreeSortMode>('name')
+  const [recentScan, setRecentScan] = useState<RecentScanState>({ entries: [], loading: false, error: null })
+  const [recentScanNonce, setRecentScanNonce] = useState(0)
   const menuRef = useRef<HTMLDivElement | null>(null)
   const root = workspaceRoot.trim()
   const rootName = useMemo(() => workspaceDisplayName(root), [root])
@@ -113,6 +159,7 @@ export function ChatFileTreePanel({
     setExpanded(new Set([ROOT_PATH]))
     setDirectories({})
     setContextMenu(null)
+    setRecentScan({ entries: [], loading: false, error: null })
   }, [root])
 
   const loadDirectory = useCallback((path: string): void => {
@@ -158,6 +205,62 @@ export function ChatFileTreePanel({
   }, [directories, expanded, loadDirectory, root])
 
   useEffect(() => {
+    if (!root || typeof window.kunGui?.listWorkspaceDirectory !== 'function') return
+    let cancelled = false
+    setRecentScan({ entries: [], loading: true, error: null })
+
+    const scanDirectory = async (
+      path: string,
+      depth: number,
+      collected: WorkspaceEntry[],
+      seenDirectories: Set<string>
+    ): Promise<void> => {
+      if (cancelled || depth > RECENT_SCAN_MAX_DEPTH || collected.length >= RECENT_SCAN_MAX_ENTRIES) return
+      const directoryKey = pathKey(path || root)
+      if (seenDirectories.has(directoryKey)) return
+      seenDirectories.add(directoryKey)
+      const result = await window.kunGui.listWorkspaceDirectory({ workspaceRoot: root, path: path || root })
+      if (!result.ok) throw new Error(result.message)
+      for (const entry of result.entries) {
+        if (cancelled || collected.length >= RECENT_SCAN_MAX_ENTRIES) return
+        if (entry.type === 'directory') {
+          if (!isChatFileTreeIgnoredDirectory(entry.name)) {
+            await scanDirectory(entry.path, depth + 1, collected, seenDirectories)
+          }
+          continue
+        }
+        if (isChatFileTreePreviewableEntry(entry)) collected.push(entry)
+      }
+    }
+
+    void (async () => {
+      try {
+        const collected: WorkspaceEntry[] = []
+        await scanDirectory(root, 0, collected, new Set())
+        if (!cancelled) {
+          setRecentScan({
+            entries: sortRecentFiles(collected).slice(0, RECENT_FILE_LIMIT),
+            loading: false,
+            error: null
+          })
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setRecentScan({
+            entries: [],
+            loading: false,
+            error: error instanceof Error ? error.message : String(error)
+          })
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [root])
+
+  useEffect(() => {
     if (!contextMenu) return
     const onPointerDown = (event: PointerEvent): void => {
       const target = event.target
@@ -176,6 +279,7 @@ export function ChatFileTreePanel({
   }, [contextMenu])
 
   const selectedKey = useMemo(() => pathKey(selectedPath ?? ''), [selectedPath])
+  const recentEntries = recentScan.entries
 
   if (!root) return null
 
@@ -191,11 +295,25 @@ export function ChatFileTreePanel({
   const refresh = (): void => {
     setDirectories({})
     setExpanded(new Set([ROOT_PATH]))
+    setRecentScan((current) => ({
+      entries: current.entries,
+      loading: true,
+      error: null
+    }))
+    setRecentScanNonce((value) => value + 1)
   }
 
   const addReference = (entry: WorkspaceEntry): void => {
     onAddReference(entryReference(entry, root))
     setContextMenu(null)
+  }
+
+  const setEntryDragData = (event: ReactDragEvent<HTMLElement>, entry: WorkspaceEntry): void => {
+    const reference = entryReference(entry, root)
+    const token = formatComposerFileMentionToken(reference.relativePath, reference.type === 'directory')
+    event.dataTransfer.effectAllowed = 'copy'
+    event.dataTransfer.setData('text/plain', `${token} `)
+    event.dataTransfer.setData('application/x-kun-file-reference', JSON.stringify(reference))
   }
 
   const copyEntryPath = async (entry: WorkspaceEntry, mode: 'absolute' | 'relative'): Promise<void> => {
@@ -260,7 +378,7 @@ export function ChatFileTreePanel({
         : []
     }
 
-    return state.entries
+    return sortChatFileTreeEntries(state.entries, sortMode)
       .filter((entry) => entry.type !== 'directory' || !isChatFileTreeIgnoredDirectory(entry.name))
       .flatMap((entry) => {
         const isDirectory = entry.type === 'directory'
@@ -273,35 +391,40 @@ export function ChatFileTreePanel({
             : <Folder className="h-3.5 w-3.5 shrink-0 text-ds-muted" strokeWidth={1.75} />
           : <FileText className="h-3.5 w-3.5 shrink-0 text-ds-muted" strokeWidth={1.75} />
         const row = (
-          <SidebarTreeRow
+          <div
             key={entry.path}
-            title={previewable || isDirectory ? entry.path : formatChatFileTreeUnsupportedMessage(entry.name)}
-            active={active}
-            onClick={() => {
-              if (isDirectory) {
-                toggleDirectory(entry.path)
-                return
-              }
-              onPreviewFile(entry.path)
-            }}
-            onContextMenu={(event) => openContextMenu(event, entry)}
-            buttonClassName="items-center gap-1.5 py-1.5 pr-1.5 text-[12.5px]"
-            buttonStyle={{ paddingLeft: depth * 14 + 8 }}
-            trailing={
-              isDirectory ? (
-                entryExpanded ? (
-                  <ChevronDown className="h-3.5 w-3.5 text-ds-faint" strokeWidth={1.8} />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 text-ds-faint" strokeWidth={1.8} />
-                )
-              ) : null
-            }
+            draggable
+            onDragStart={(event) => setEntryDragData(event, entry)}
           >
-            {icon}
-            <span className={previewable || isDirectory ? 'min-w-0 truncate' : 'min-w-0 truncate text-ds-faint'}>
-              {entry.name}
-            </span>
-          </SidebarTreeRow>
+            <SidebarTreeRow
+              title={previewable || isDirectory ? entry.path : formatChatFileTreeUnsupportedMessage(entry.name)}
+              active={active}
+              onClick={() => {
+                if (isDirectory) {
+                  toggleDirectory(entry.path)
+                  return
+                }
+                onPreviewFile(entry.path)
+              }}
+              onContextMenu={(event) => openContextMenu(event, entry)}
+              buttonClassName="items-center gap-1.5 py-1.5 pr-1.5 text-[12.5px]"
+              buttonStyle={{ paddingLeft: depth * 14 + 8 }}
+              trailing={
+                isDirectory ? (
+                  entryExpanded ? (
+                    <ChevronDown className="h-3.5 w-3.5 text-ds-faint" strokeWidth={1.8} />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5 text-ds-faint" strokeWidth={1.8} />
+                  )
+                ) : null
+              }
+            >
+              {icon}
+              <span className={previewable || isDirectory ? 'min-w-0 truncate' : 'min-w-0 truncate text-ds-faint'}>
+                {entry.name}
+              </span>
+            </SidebarTreeRow>
+          </div>
         )
         if (!isDirectory || !entryExpanded) return [row]
         return [row, ...renderDirectory(entry.path, depth + 1)]
@@ -312,6 +435,9 @@ export function ChatFileTreePanel({
   const contextLabel = contextEntry?.type === 'directory'
     ? t('fileTreeAddFolderReference')
     : t('fileTreeAddFileReference')
+  const sortTitle = sortMode === 'modified'
+    ? t('fileTreeSortByName', { defaultValue: 'Sort by name' })
+    : t('fileTreeSortByModifiedTime', { defaultValue: 'Sort by modified time' })
 
   return (
     <div className={`ds-no-drag min-h-0 ${fill ? 'flex h-full flex-col' : ''}`}>
@@ -319,15 +445,57 @@ export function ChatFileTreePanel({
         label={rootName || t('fileTreeTitle')}
         title={root}
         actions={
-          <SidebarIconButton
-            title={t('fileTreeRefresh')}
-            ariaLabel={t('fileTreeRefresh')}
-            onClick={refresh}
-          >
-            <RefreshCw className="h-3.5 w-3.5" strokeWidth={1.8} />
-          </SidebarIconButton>
+          <>
+            <SidebarIconButton
+              title={sortTitle}
+              ariaLabel={sortTitle}
+              active={sortMode === 'modified'}
+              onClick={() => setSortMode((mode) => mode === 'modified' ? 'name' : 'modified')}
+            >
+              <span className="text-[11px] font-semibold">{sortMode === 'modified' ? 'MT' : 'AZ'}</span>
+            </SidebarIconButton>
+            <SidebarIconButton
+              title={t('fileTreeRefresh')}
+              ariaLabel={t('fileTreeRefresh')}
+              onClick={refresh}
+            >
+              <RefreshCw className="h-3.5 w-3.5" strokeWidth={1.8} />
+            </SidebarIconButton>
+          </>
         }
       />
+      {recentEntries.length || recentScan.loading || recentScan.error ? (
+        <div className="border-b border-ds-border-muted/60 px-1 pb-2">
+          <div className="px-2.5 pb-1 text-[11px] font-medium text-ds-faint">
+            {t('fileTreeRecentModifiedFiles', { defaultValue: 'Recent modified files' })}
+          </div>
+          <div className="flex flex-col gap-0.5">
+            {recentScan.loading ? (
+              <div className="flex items-center gap-2 px-2.5 py-1 text-[12px] text-ds-muted">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.8} />
+                {t('fileTreeScanningRecent', { defaultValue: 'Scanning workspace…' })}
+              </div>
+            ) : recentScan.error ? (
+              <div className="px-2.5 py-1 text-[12px] text-red-700 dark:text-red-300" title={recentScan.error}>
+                {recentScan.error}
+              </div>
+            ) : recentEntries.map((entry) => (
+              <button
+                key={`recent-${entry.path}`}
+                type="button"
+                draggable
+                onDragStart={(event) => setEntryDragData(event, entry)}
+                onClick={() => onPreviewFile(entry.path)}
+                className="flex min-w-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-left text-[12px] text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
+                title={entry.path}
+              >
+                <FileText className="h-3.5 w-3.5 shrink-0" strokeWidth={1.7} />
+                <span className="min-w-0 truncate">{relativeWorkspacePath(entry.path, root)}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
       <div className={`${fill ? 'min-h-0 flex-1' : 'max-h-[34vh] min-h-[96px]'} overflow-y-auto overflow-x-hidden px-1`}>
         {renderDirectory(ROOT_PATH, 0)}
       </div>

--- a/src/renderer/src/lib/file-references.ts
+++ b/src/renderer/src/lib/file-references.ts
@@ -20,7 +20,7 @@ type HastNode = {
 }
 
 const FILE_REFERENCE_SCHEME = 'deepseek-file:'
-const PATH_PREFIX_BOUNDARY = String.raw`(?<![\w@.~\/\\-])`
+const PATH_PREFIX_BOUNDARY = String.raw`(?<![\p{L}\p{N}_@.~\/\\-])`
 
 const EXTENSIONS = [
   'astro',
@@ -45,6 +45,7 @@ const EXTENSIONS = [
   'kt',
   'less',
   'lock',
+  'log',
   'mdx?',
   'mjs',
   'php',
@@ -66,15 +67,15 @@ const EXTENSIONS = [
   'zsh'
 ].join('|')
 
-const PATH_CHARS = String.raw`[\w@.()+=[\]{} $,;!%#~\/\\-]`
+const PATH_CHARS = String.raw`[\p{L}\p{N}\p{M}_@.()+=[\]{} $,;!%#~\/\\-]`
 const PATH_END = String.raw`(?=$|[\s(),.;:!?\]\u3001\u3002\uff0c\uff1b\uff08\uff09]|#L)`
 const PATH_WITH_SEPARATOR = new RegExp(
-  String.raw`${PATH_PREFIX_BOUNDARY}(?:~|\/|\.{1,2}\/|[A-Za-z]:[\\/]|[\w@.-]+[\\/])${PATH_CHARS}*?\.(?:${EXTENSIONS})${PATH_END}`,
+  String.raw`${PATH_PREFIX_BOUNDARY}(?:~|\/|\.{1,2}\/|[A-Za-z]:[\\/]|[\p{L}\p{N}_@.-]+[\\/])${PATH_CHARS}*?\.(?:${EXTENSIONS})${PATH_END}`,
   'giu'
 )
 const LINE_SUFFIX = /(?::(\d+)(?::(\d+))?|#L(\d+)(?:-L\d+)?|\s*[（(](?:line|lines)\s+(\d+)[）)]|\s*[（(]第\s*(\d+)\s*行[）)]|\s+line\s+(\d+)|\s+第\s*(\d+)\s*行)/iy
 const TRAILING_PUNCTUATION = /[.,;!?]+$/
-const BLOCKED_PARENTS = new Set(['a', 'code', 'pre', 'script', 'style', 'textarea'])
+const BLOCKED_PARENTS = new Set(['a', 'button', 'script', 'style', 'textarea'])
 
 function lineFromSuffix(match: RegExpExecArray): { line?: number; column?: number } {
   const lineText = match[1] ?? match[3] ?? match[4] ?? match[5] ?? match[6] ?? match[7]

--- a/src/renderer/src/lib/issue-781-document-usability.ts
+++ b/src/renderer/src/lib/issue-781-document-usability.ts
@@ -1,0 +1,409 @@
+import type { WorkspaceFileTarget } from '@shared/workspace-file'
+import { findFileReferences } from './file-references'
+import { previewWorkspaceFile } from './workspace-file-preview'
+
+const LINKIFIED_ATTR = 'data-kun-issue781-linkified'
+const FILE_PATH_ATTR = 'data-kun-issue781-file-path'
+const FILE_LINE_ATTR = 'data-kun-issue781-file-line'
+const FILE_COLUMN_ATTR = 'data-kun-issue781-file-column'
+const ENHANCED_ATTR = 'data-kun-issue781-enhanced'
+const STYLE_ID = 'kun-issue-781-document-usability-style'
+const PINNED_TABS_KEY = 'kun.issue781.pinnedPreviewTabs'
+const SCROLL_POSITIONS_KEY = 'kun.issue781.previewScrollPositions'
+
+const LABELS = {
+  zh: {
+    pinTab: '固定标签',
+    unpinTab: '取消固定标签',
+    closeOtherTabs: '关闭其他标签页',
+    read: '阅读',
+    exitRead: '退出阅读',
+    expandRead: '放大阅读'
+  },
+  en: {
+    pinTab: 'Pin tab',
+    unpinTab: 'Unpin tab',
+    closeOtherTabs: 'Close other tabs',
+    read: 'Read',
+    exitRead: 'Exit reading',
+    expandRead: 'Expand reading'
+  }
+} as const
+
+let installed = false
+let observer: MutationObserver | null = null
+let scanTimer: number | null = null
+let menuEl: HTMLDivElement | null = null
+
+function label(key: keyof typeof LABELS.en): string {
+  const language = document.documentElement.lang || navigator.language || ''
+  return language.toLowerCase().startsWith('zh') ? LABELS.zh[key] : LABELS.en[key]
+}
+
+function readJson<T>(key: string, fallback: T): T {
+  try {
+    const raw = window.localStorage.getItem(key)
+    return raw ? JSON.parse(raw) as T : fallback
+  } catch {
+    return fallback
+  }
+}
+
+function writeJson<T>(key: string, value: T): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // Ignore storage quota / private-mode errors. The feature remains usable in-memory.
+  }
+}
+
+function injectStyle(): void {
+  if (document.getElementById(STYLE_ID)) return
+  const style = document.createElement('style')
+  style.id = STYLE_ID
+  style.textContent = `
+    .ds-issue781-file-link {
+      display: inline;
+      max-width: 100%;
+      border: 0;
+      border-radius: 5px;
+      background: color-mix(in srgb, var(--ds-accent) 10%, transparent);
+      color: var(--ds-accent);
+      cursor: pointer;
+      font: inherit;
+      padding: 0 2px;
+      text-align: inherit;
+      text-decoration: underline;
+      text-decoration-color: color-mix(in srgb, var(--ds-accent) 45%, transparent);
+      text-underline-offset: 2px;
+    }
+    .ds-issue781-file-link:hover {
+      background: color-mix(in srgb, var(--ds-accent) 17%, transparent);
+      text-decoration-color: var(--ds-accent);
+    }
+    .ds-code-sidebar-tab.kun-issue781-pinned::before {
+      content: '📌';
+      margin-right: 2px;
+      font-size: 10px;
+      opacity: 0.78;
+    }
+    .kun-issue781-menu {
+      position: fixed;
+      z-index: 9999;
+      min-width: 172px;
+      border: 1px solid var(--ds-border);
+      border-radius: 10px;
+      background: var(--ds-card);
+      box-shadow: 0 18px 50px rgba(15, 23, 42, 0.22);
+      padding: 5px;
+    }
+    .kun-issue781-menu button {
+      display: block;
+      width: 100%;
+      border: 0;
+      border-radius: 8px;
+      background: transparent;
+      color: var(--ds-ink);
+      cursor: pointer;
+      font: inherit;
+      font-size: 12px;
+      padding: 7px 9px;
+      text-align: left;
+    }
+    .kun-issue781-menu button:hover { background: var(--ds-hover); }
+    .ds-code-sidebar.kun-issue781-reader-mode {
+      position: fixed;
+      inset: 18px;
+      z-index: 9998;
+      width: auto !important;
+      min-width: 0 !important;
+      border: 1px solid var(--ds-border);
+      border-radius: 18px;
+      background: var(--ds-main);
+      box-shadow: 0 28px 80px rgba(15, 23, 42, 0.36);
+      overflow: hidden;
+    }
+  `
+  document.head.appendChild(style)
+}
+
+function isBlockedTextNode(node: Text): boolean {
+  const parent = node.parentElement
+  if (!parent) return true
+  return Boolean(parent.closest('a, button, textarea, script, style, [contenteditable="true"]'))
+}
+
+function targetFromDataset(element: HTMLElement): WorkspaceFileTarget | null {
+  const path = element.getAttribute(FILE_PATH_ATTR)?.trim()
+  if (!path) return null
+  const line = Number.parseInt(element.getAttribute(FILE_LINE_ATTR) ?? '', 10)
+  const column = Number.parseInt(element.getAttribute(FILE_COLUMN_ATTR) ?? '', 10)
+  return {
+    path,
+    ...(Number.isFinite(line) && line > 0 ? { line } : {}),
+    ...(Number.isFinite(column) && column > 0 ? { column } : {})
+  }
+}
+
+function tabKey(tab: Element | null): string {
+  return tab instanceof HTMLElement ? (tab.title || tab.textContent || '').trim() : ''
+}
+
+function tabScopeKey(tab: Element | null): string {
+  if (!(tab instanceof HTMLElement)) return ''
+  const rawKey = tabKey(tab)
+  if (!rawKey) return ''
+  const sidebar = tab.closest('.ds-code-sidebar')
+  const explicitWorkspaceRoot = sidebar instanceof HTMLElement
+    ? sidebar.getAttribute('data-kun-workspace-root')
+    : ''
+  const explicitPreviewKey = tab.getAttribute('data-kun-preview-key')
+  const fallbackPageScope = `${window.location.origin}${window.location.pathname}`
+  return `${explicitWorkspaceRoot || fallbackPageScope}\n${explicitPreviewKey || rawKey}`
+    .replaceAll('\\', '/')
+    .toLowerCase()
+}
+
+function activeTabKey(): string {
+  return tabScopeKey(document.querySelector('.ds-code-sidebar-tab.is-active'))
+}
+
+function pinnedTabs(): string[] {
+  return readJson<string[]>(PINNED_TABS_KEY, [])
+}
+
+function setPinnedTabs(next: string[]): void {
+  writeJson(PINNED_TABS_KEY, Array.from(new Set(next.filter(Boolean))))
+}
+
+function scrollPositions(): Record<string, number> {
+  return readJson<Record<string, number>>(SCROLL_POSITIONS_KEY, {})
+}
+
+function setScrollPosition(key: string, value: number): void {
+  if (!key) return
+  const next = scrollPositions()
+  next[key] = value
+  writeJson(SCROLL_POSITIONS_KEY, next)
+}
+
+function linkifyTextNode(node: Text): void {
+  if (isBlockedTextNode(node)) return
+  const text = node.nodeValue ?? ''
+  const matches = findFileReferences(text)
+  if (matches.length === 0) return
+
+  const fragment = document.createDocumentFragment()
+  let cursor = 0
+  for (const match of matches) {
+    if (match.start > cursor) {
+      fragment.appendChild(document.createTextNode(text.slice(cursor, match.start)))
+    }
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'ds-issue781-file-link ds-file-reference-link'
+    button.setAttribute(LINKIFIED_ATTR, '1')
+    button.setAttribute(FILE_PATH_ATTR, match.target.path)
+    if (match.target.line) button.setAttribute(FILE_LINE_ATTR, String(match.target.line))
+    if (match.target.column) button.setAttribute(FILE_COLUMN_ATTR, String(match.target.column))
+    button.title = match.target.line ? `${match.target.path}:${match.target.line}` : match.target.path
+    button.textContent = match.text
+    fragment.appendChild(button)
+    cursor = match.end
+  }
+  if (cursor < text.length) {
+    fragment.appendChild(document.createTextNode(text.slice(cursor)))
+  }
+  node.replaceWith(fragment)
+}
+
+function linkifyContainer(container: ParentNode): void {
+  const walker = document.createTreeWalker(
+    container,
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode(node) {
+        if (!(node instanceof Text)) return NodeFilter.FILTER_REJECT
+        if (!node.nodeValue?.trim()) return NodeFilter.FILTER_REJECT
+        return isBlockedTextNode(node) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+      }
+    }
+  )
+  const nodes: Text[] = []
+  while (walker.nextNode()) nodes.push(walker.currentNode as Text)
+  for (const node of nodes) linkifyTextNode(node)
+}
+
+function scanRenderedOutput(): void {
+  const containers = document.querySelectorAll('.ds-markdown, .ds-code-block-html, .ds-file-preview-code-html')
+  for (const container of containers) linkifyContainer(container)
+}
+
+function applyPinnedClasses(): void {
+  const pinned = new Set(pinnedTabs())
+  document.querySelectorAll('.ds-code-sidebar-tab').forEach((tab) => {
+    tab.classList.toggle('kun-issue781-pinned', pinned.has(tabScopeKey(tab)))
+  })
+}
+
+function closeIssue781Menu(): void {
+  menuEl?.remove()
+  menuEl = null
+}
+
+function showTabMenu(tab: HTMLElement, x: number, y: number): void {
+  closeIssue781Menu()
+  const key = tabScopeKey(tab)
+  if (!key) return
+  const pinned = new Set(pinnedTabs())
+  const menu = document.createElement('div')
+  menu.className = 'kun-issue781-menu'
+  menu.style.left = `${x}px`
+  menu.style.top = `${y}px`
+  const pinButton = document.createElement('button')
+  pinButton.type = 'button'
+  pinButton.textContent = pinned.has(key) ? label('unpinTab') : label('pinTab')
+  const closeOthersButton = document.createElement('button')
+  closeOthersButton.type = 'button'
+  closeOthersButton.textContent = label('closeOtherTabs')
+  pinButton.addEventListener('click', () => {
+    if (pinned.has(key)) pinned.delete(key)
+    else pinned.add(key)
+    setPinnedTabs([...pinned])
+    applyPinnedClasses()
+    closeIssue781Menu()
+  })
+  closeOthersButton.addEventListener('click', () => {
+    const pinnedNow = new Set(pinnedTabs())
+    document.querySelectorAll('.ds-code-sidebar-tab').forEach((item) => {
+      const itemKey = tabScopeKey(item)
+      if (item === tab || pinnedNow.has(itemKey)) return
+      const close = item.querySelector('.ds-code-sidebar-tab-close')
+      if (close instanceof HTMLButtonElement) close.click()
+    })
+    closeIssue781Menu()
+  })
+  menu.append(pinButton, closeOthersButton)
+  document.body.appendChild(menu)
+  menuEl = menu
+}
+
+function enhancePreviewTabs(): void {
+  applyPinnedClasses()
+  const tabs = document.querySelector('.ds-code-sidebar-tabs')
+  if (!(tabs instanceof HTMLElement) || tabs.getAttribute(ENHANCED_ATTR) === 'tabs') return
+  tabs.setAttribute(ENHANCED_ATTR, 'tabs')
+  tabs.addEventListener('wheel', (event) => {
+    const tabList = Array.from(tabs.querySelectorAll('.ds-code-sidebar-tab')) as HTMLElement[]
+    if (tabList.length < 2) return
+    event.preventDefault()
+    const activeIndex = Math.max(0, tabList.findIndex((tab) => tab.classList.contains('is-active')))
+    const nextIndex = (activeIndex + (event.deltaY > 0 ? 1 : -1) + tabList.length) % tabList.length
+    tabList[nextIndex]?.click()
+  }, { passive: false })
+  tabs.addEventListener('contextmenu', (event) => {
+    const target = event.target
+    if (!(target instanceof HTMLElement)) return
+    const tab = target.closest('.ds-code-sidebar-tab')
+    if (!(tab instanceof HTMLElement)) return
+    event.preventDefault()
+    showTabMenu(tab, event.clientX, event.clientY)
+  })
+}
+
+function enhanceScrollMemory(): void {
+  const scrollers = document.querySelectorAll('.ds-file-preview-scroll, .ds-file-preview-markdown')
+  scrollers.forEach((element) => {
+    if (!(element instanceof HTMLElement)) return
+    if (element.getAttribute(ENHANCED_ATTR) !== 'scroll') {
+      element.setAttribute(ENHANCED_ATTR, 'scroll')
+      element.addEventListener('scroll', () => setScrollPosition(activeTabKey(), element.scrollTop), { passive: true })
+    }
+    const key = activeTabKey()
+    const stored = scrollPositions()[key]
+    if (key && typeof stored === 'number' && Math.abs(element.scrollTop - stored) > 4) {
+      window.requestAnimationFrame(() => {
+        element.scrollTop = stored
+      })
+    }
+  })
+}
+
+function setReadingMode(enabled: boolean): void {
+  const sidebar = document.querySelector('.ds-code-sidebar')
+  if (!(sidebar instanceof HTMLElement)) return
+  sidebar.classList.toggle('kun-issue781-reader-mode', enabled)
+  const button = sidebar.querySelector('.kun-issue781-expand-button')
+  if (button instanceof HTMLButtonElement) {
+    const title = enabled ? label('exitRead') : label('expandRead')
+    button.textContent = enabled ? label('exitRead') : label('read')
+    button.title = title
+    button.setAttribute('aria-label', title)
+  }
+}
+
+function enhanceReadingButton(): void {
+  const actions = document.querySelector('.ds-code-sidebar-actions')
+  if (!(actions instanceof HTMLElement) || actions.querySelector('.kun-issue781-expand-button')) return
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = 'kun-issue781-expand-button ds-code-sidebar-icon-button'
+  button.title = label('expandRead')
+  button.setAttribute('aria-label', label('expandRead'))
+  button.textContent = label('read')
+  button.addEventListener('click', (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    const sidebar = document.querySelector('.ds-code-sidebar')
+    setReadingMode(!(sidebar instanceof HTMLElement && sidebar.classList.contains('kun-issue781-reader-mode')))
+  })
+  actions.insertBefore(button, actions.firstChild)
+}
+
+function scheduleScan(): void {
+  if (scanTimer !== null) return
+  scanTimer = window.setTimeout(() => {
+    scanTimer = null
+    scanRenderedOutput()
+    enhancePreviewTabs()
+    enhanceScrollMemory()
+    enhanceReadingButton()
+  }, 120)
+}
+
+function onDocumentClick(event: MouseEvent): void {
+  const target = event.target
+  if (!(target instanceof HTMLElement)) return
+
+  const fileLink = target.closest(`[${LINKIFIED_ATTR}]`)
+  if (fileLink instanceof HTMLElement) {
+    const fileTarget = targetFromDataset(fileLink)
+    if (!fileTarget) return
+    event.preventDefault()
+    event.stopPropagation()
+    previewWorkspaceFile(fileTarget)
+  }
+}
+
+export function installIssue781DocumentUsability(): void {
+  if (installed || typeof window === 'undefined' || typeof document === 'undefined') return
+  installed = true
+  injectStyle()
+  scanRenderedOutput()
+  enhancePreviewTabs()
+  enhanceScrollMemory()
+  enhanceReadingButton()
+  document.addEventListener('click', onDocumentClick, true)
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') setReadingMode(false)
+  })
+  document.addEventListener('pointerdown', (event) => {
+    if (menuEl && event.target instanceof Node && !menuEl.contains(event.target)) closeIssue781Menu()
+  }, true)
+  observer = new MutationObserver(() => {
+    scheduleScan()
+  })
+  observer.observe(document.body, { childList: true, subtree: true })
+}
+
+installIssue781DocumentUsability()

--- a/src/renderer/src/lib/issue-781-document-usability.ts
+++ b/src/renderer/src/lib/issue-781-document-usability.ts
@@ -34,6 +34,11 @@ let installed = false
 let observer: MutationObserver | null = null
 let scanTimer: number | null = null
 let menuEl: HTMLDivElement | null = null
+let cleanups: Array<() => void> = []
+
+function trackCleanup(cleanup: () => void): void {
+  cleanups.push(cleanup)
+}
 
 function label(key: keyof typeof LABELS.en): string {
   const language = document.documentElement.lang || navigator.language || ''
@@ -125,6 +130,9 @@ function injectStyle(): void {
     }
   `
   document.head.appendChild(style)
+  trackCleanup(() => {
+    style.remove()
+  })
 }
 
 function isBlockedTextNode(node: Text): boolean {
@@ -293,21 +301,28 @@ function enhancePreviewTabs(): void {
   const tabs = document.querySelector('.ds-code-sidebar-tabs')
   if (!(tabs instanceof HTMLElement) || tabs.getAttribute(ENHANCED_ATTR) === 'tabs') return
   tabs.setAttribute(ENHANCED_ATTR, 'tabs')
-  tabs.addEventListener('wheel', (event) => {
+  const onWheel = (event: WheelEvent): void => {
     const tabList = Array.from(tabs.querySelectorAll('.ds-code-sidebar-tab')) as HTMLElement[]
     if (tabList.length < 2) return
     event.preventDefault()
     const activeIndex = Math.max(0, tabList.findIndex((tab) => tab.classList.contains('is-active')))
     const nextIndex = (activeIndex + (event.deltaY > 0 ? 1 : -1) + tabList.length) % tabList.length
     tabList[nextIndex]?.click()
-  }, { passive: false })
-  tabs.addEventListener('contextmenu', (event) => {
+  }
+  const onContextMenu = (event: MouseEvent): void => {
     const target = event.target
     if (!(target instanceof HTMLElement)) return
     const tab = target.closest('.ds-code-sidebar-tab')
     if (!(tab instanceof HTMLElement)) return
     event.preventDefault()
     showTabMenu(tab, event.clientX, event.clientY)
+  }
+  tabs.addEventListener('wheel', onWheel, { passive: false })
+  tabs.addEventListener('contextmenu', onContextMenu)
+  trackCleanup(() => {
+    tabs.removeEventListener('wheel', onWheel)
+    tabs.removeEventListener('contextmenu', onContextMenu)
+    if (tabs.getAttribute(ENHANCED_ATTR) === 'tabs') tabs.removeAttribute(ENHANCED_ATTR)
   })
 }
 
@@ -317,7 +332,12 @@ function enhanceScrollMemory(): void {
     if (!(element instanceof HTMLElement)) return
     if (element.getAttribute(ENHANCED_ATTR) !== 'scroll') {
       element.setAttribute(ENHANCED_ATTR, 'scroll')
-      element.addEventListener('scroll', () => setScrollPosition(activeTabKey(), element.scrollTop), { passive: true })
+      const onScroll = (): void => setScrollPosition(activeTabKey(), element.scrollTop)
+      element.addEventListener('scroll', onScroll, { passive: true })
+      trackCleanup(() => {
+        element.removeEventListener('scroll', onScroll)
+        if (element.getAttribute(ENHANCED_ATTR) === 'scroll') element.removeAttribute(ENHANCED_ATTR)
+      })
     }
     const key = activeTabKey()
     const stored = scrollPositions()[key]
@@ -351,13 +371,18 @@ function enhanceReadingButton(): void {
   button.title = label('expandRead')
   button.setAttribute('aria-label', label('expandRead'))
   button.textContent = label('read')
-  button.addEventListener('click', (event) => {
+  const onClick = (event: MouseEvent): void => {
     event.preventDefault()
     event.stopPropagation()
     const sidebar = document.querySelector('.ds-code-sidebar')
     setReadingMode(!(sidebar instanceof HTMLElement && sidebar.classList.contains('kun-issue781-reader-mode')))
-  })
+  }
+  button.addEventListener('click', onClick)
   actions.insertBefore(button, actions.firstChild)
+  trackCleanup(() => {
+    button.removeEventListener('click', onClick)
+    button.remove()
+  })
 }
 
 function scheduleScan(): void {
@@ -385,25 +410,56 @@ function onDocumentClick(event: MouseEvent): void {
   }
 }
 
-export function installIssue781DocumentUsability(): void {
-  if (installed || typeof window === 'undefined' || typeof document === 'undefined') return
+function onDocumentKeyDown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') setReadingMode(false)
+}
+
+function onDocumentPointerDown(event: PointerEvent): void {
+  if (menuEl && event.target instanceof Node && !menuEl.contains(event.target)) closeIssue781Menu()
+}
+
+export function uninstallIssue781DocumentUsability(): void {
+  if (!installed || typeof window === 'undefined' || typeof document === 'undefined') return
+  installed = false
+  if (scanTimer !== null) {
+    window.clearTimeout(scanTimer)
+    scanTimer = null
+  }
+  observer?.disconnect()
+  observer = null
+  closeIssue781Menu()
+  document.querySelectorAll('.kun-issue781-reader-mode').forEach((element) => {
+    element.classList.remove('kun-issue781-reader-mode')
+  })
+  document.querySelectorAll('.kun-issue781-pinned').forEach((element) => {
+    element.classList.remove('kun-issue781-pinned')
+  })
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    cleanup()
+  }
+}
+
+export function installIssue781DocumentUsability(): () => void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return () => {}
+  if (installed) return uninstallIssue781DocumentUsability
   installed = true
+  cleanups = []
   injectStyle()
   scanRenderedOutput()
   enhancePreviewTabs()
   enhanceScrollMemory()
   enhanceReadingButton()
   document.addEventListener('click', onDocumentClick, true)
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') setReadingMode(false)
+  document.addEventListener('keydown', onDocumentKeyDown)
+  document.addEventListener('pointerdown', onDocumentPointerDown, true)
+  trackCleanup(() => {
+    document.removeEventListener('click', onDocumentClick, true)
+    document.removeEventListener('keydown', onDocumentKeyDown)
+    document.removeEventListener('pointerdown', onDocumentPointerDown, true)
   })
-  document.addEventListener('pointerdown', (event) => {
-    if (menuEl && event.target instanceof Node && !menuEl.contains(event.target)) closeIssue781Menu()
-  }, true)
   observer = new MutationObserver(() => {
     scheduleScan()
   })
   observer.observe(document.body, { childList: true, subtree: true })
+  return uninstallIssue781DocumentUsability
 }
-
-installIssue781DocumentUsability()

--- a/src/shared/workspace-file.ts
+++ b/src/shared/workspace-file.ts
@@ -10,6 +10,8 @@ export type WorkspaceEntry = {
   path: string
   type: 'file' | 'directory'
   ext: string
+  mtimeMs?: number
+  size?: number
 }
 
 export type WorkspaceDirectoryTarget = {


### PR DESCRIPTION
## Summary

Improve document-management usability for issue #781 in the chat workspace.

## Changes

- broaden assistant file-reference detection so generated output and Chinese file names resolve more reliably
- install a renderer-side document-usability layer for clickable file paths, preview tab wheel switching, pinning, close-others, reading mode, and per-tab scroll memory
- add recent modified files and modified-time sorting to the workspace file tree, backed by filesystem metadata from the main process
- support drag-to-composer file references from both the file tree and recent files
- scope preview-tab state with explicit workspace preview keys and fix recent-file refresh so rescans rerun correctly
- add focused tests for modified-time sorting helpers and workspace directory metadata

Fixes KunAgent/Kun#781

## Tests

- `npm.cmd test -- --run src/renderer/src/components/chat/ChatFileTreePanel.test.ts src/main/services/workspace-service.test.ts`
- `npm.cmd run typecheck`
