### PR TITLE
fix(mcp): keep facade tools available after late connections

### DIFF
--- a/kun/src/adapters/tool/mcp-facade-provider.ts
+++ b/kun/src/adapters/tool/mcp-facade-provider.ts
@@ -1,0 +1,228 @@
+import type { McpServerConfig } from '../../contracts/capabilities.js'
+import type { ToolHostContext } from '../../ports/tool-host.js'
+import type { CapabilityToolProvider } from './capability-registry.js'
+import { LocalToolHost, type LocalTool } from './local-tool-host.js'
+import {
+  canUseMcpServer,
+  isMcpServerTrusted,
+  isMcpServerVisible
+} from './mcp-naming.js'
+import type { McpClientLike } from './mcp-types.js'
+
+export type McpFacadeConnectionState = {
+  serverId: string
+  server: McpServerConfig
+  client: McpClientLike
+  status: 'connected' | 'reconnecting' | 'error'
+}
+
+type FacadeCapability =
+  | 'listResources'
+  | 'readResource'
+  | 'listResourceTemplates'
+  | 'listPrompts'
+  | 'getPrompt'
+
+const MCP_FACADE_PROVIDER_ID = 'mcp:facade'
+
+export function createMcpFacadeProvider(connected: McpFacadeConnectionState[]): CapabilityToolProvider {
+  return {
+    id: MCP_FACADE_PROVIDER_ID,
+    kind: 'mcp',
+    enabled: true,
+    available: true,
+    tools: [
+      createListResourcesTool(connected),
+      createReadResourceTool(connected),
+      createListResourceTemplatesTool(connected),
+      createListPromptsTool(connected),
+      createGetPromptTool(connected)
+    ]
+  }
+}
+
+function createListResourcesTool(connected: McpFacadeConnectionState[]): LocalTool {
+  return LocalToolHost.defineTool({
+    name: 'mcp_list_resources',
+    description: 'List MCP resources exposed by currently connected MCP servers.',
+    policy: 'auto',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: { type: 'string' }
+      }
+    },
+    shouldAdvertise: (context) => hasUsableServer(connected, context, 'listResources'),
+    execute: async (args, context) => {
+      const states = selectUsableServers(connected, context, 'listResources', stringArg(args.serverId))
+      if (!states.length) return unavailableOutput('listResources')
+      const results = []
+      for (const state of states) {
+        const listed = await state.client.listResources?.({ signal: context.abortSignal, timeout: state.server.timeoutMs })
+        results.push({ serverId: state.serverId, resources: listed?.resources ?? [], nextCursor: listed?.nextCursor })
+      }
+      return { output: { servers: results } }
+    }
+  })
+}
+
+function createReadResourceTool(connected: McpFacadeConnectionState[]): LocalTool {
+  return LocalToolHost.defineTool({
+    name: 'mcp_read_resource',
+    description: 'Read one MCP resource from a connected MCP server.',
+    policy: 'auto',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: { type: 'string' },
+        uri: { type: 'string' }
+      },
+      required: ['uri']
+    },
+    shouldAdvertise: (context) => hasUsableServer(connected, context, 'readResource'),
+    execute: async (args, context) => {
+      const uri = stringArg(args.uri)
+      if (!uri) return { output: { error: 'uri is required' }, isError: true }
+      const state = selectSingleUsableServer(connected, context, 'readResource', stringArg(args.serverId))
+      if (!state) return unavailableOutput('readResource')
+      const result = await state.client.readResource?.({ uri }, { signal: context.abortSignal, timeout: state.server.timeoutMs })
+      return { output: { serverId: state.serverId, uri, result } }
+    }
+  })
+}
+
+function createListResourceTemplatesTool(connected: McpFacadeConnectionState[]): LocalTool {
+  return LocalToolHost.defineTool({
+    name: 'mcp_list_resource_templates',
+    description: 'List MCP resource templates exposed by currently connected MCP servers.',
+    policy: 'auto',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: { type: 'string' }
+      }
+    },
+    shouldAdvertise: (context) => hasUsableServer(connected, context, 'listResourceTemplates'),
+    execute: async (args, context) => {
+      const states = selectUsableServers(connected, context, 'listResourceTemplates', stringArg(args.serverId))
+      if (!states.length) return unavailableOutput('listResourceTemplates')
+      const results = []
+      for (const state of states) {
+        const listed = await state.client.listResourceTemplates?.({ signal: context.abortSignal, timeout: state.server.timeoutMs })
+        results.push({ serverId: state.serverId, resourceTemplates: listed?.resourceTemplates ?? [], nextCursor: listed?.nextCursor })
+      }
+      return { output: { servers: results } }
+    }
+  })
+}
+
+function createListPromptsTool(connected: McpFacadeConnectionState[]): LocalTool {
+  return LocalToolHost.defineTool({
+    name: 'mcp_list_prompts',
+    description: 'List MCP prompts exposed by currently connected MCP servers.',
+    policy: 'auto',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: { type: 'string' }
+      }
+    },
+    shouldAdvertise: (context) => hasUsableServer(connected, context, 'listPrompts'),
+    execute: async (args, context) => {
+      const states = selectUsableServers(connected, context, 'listPrompts', stringArg(args.serverId))
+      if (!states.length) return unavailableOutput('listPrompts')
+      const results = []
+      for (const state of states) {
+        const listed = await state.client.listPrompts?.({ signal: context.abortSignal, timeout: state.server.timeoutMs })
+        results.push({ serverId: state.serverId, prompts: listed?.prompts ?? [], nextCursor: listed?.nextCursor })
+      }
+      return { output: { servers: results } }
+    }
+  })
+}
+
+function createGetPromptTool(connected: McpFacadeConnectionState[]): LocalTool {
+  return LocalToolHost.defineTool({
+    name: 'mcp_get_prompt',
+    description: 'Get one MCP prompt from a connected MCP server.',
+    policy: 'auto',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: { type: 'string' },
+        name: { type: 'string' },
+        arguments: { type: 'object', additionalProperties: true }
+      },
+      required: ['name']
+    },
+    shouldAdvertise: (context) => hasUsableServer(connected, context, 'getPrompt'),
+    execute: async (args, context) => {
+      const name = stringArg(args.name)
+      if (!name) return { output: { error: 'name is required' }, isError: true }
+      const state = selectSingleUsableServer(connected, context, 'getPrompt', stringArg(args.serverId))
+      if (!state) return unavailableOutput('getPrompt')
+      const result = await state.client.getPrompt?.(
+        { name, arguments: objectArg(args.arguments) },
+        { signal: context.abortSignal, timeout: state.server.timeoutMs }
+      )
+      return { output: { serverId: state.serverId, name, result } }
+    }
+  })
+}
+
+function hasUsableServer(
+  connected: McpFacadeConnectionState[],
+  context: ToolHostContext,
+  capability: FacadeCapability
+): boolean {
+  return connected.some((state) => isUsableServer(state, context, capability))
+}
+
+function selectUsableServers(
+  connected: McpFacadeConnectionState[],
+  context: ToolHostContext,
+  capability: FacadeCapability,
+  serverId?: string
+): McpFacadeConnectionState[] {
+  return connected.filter((state) => {
+    if (serverId && state.serverId !== serverId) return false
+    return isUsableServer(state, context, capability)
+  })
+}
+
+function selectSingleUsableServer(
+  connected: McpFacadeConnectionState[],
+  context: ToolHostContext,
+  capability: FacadeCapability,
+  serverId?: string
+): McpFacadeConnectionState | null {
+  const states = selectUsableServers(connected, context, capability, serverId)
+  return states[0] ?? null
+}
+
+function isUsableServer(
+  state: McpFacadeConnectionState,
+  context: ToolHostContext,
+  capability: FacadeCapability
+): boolean {
+  return state.status === 'connected' &&
+    typeof state.client[capability] === 'function' &&
+    canUseMcpServer(state.server, context.workspace) &&
+    isMcpServerVisible(state.server, context.workspace) &&
+    isMcpServerTrusted(state.server, context.workspace)
+}
+
+function unavailableOutput(capability: FacadeCapability): { output: { error: string }; isError: true } {
+  return {
+    output: { error: `No connected MCP server can use ${capability} in this workspace.` },
+    isError: true
+  }
+}
+
+function stringArg(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function objectArg(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+}

--- a/kun/src/adapters/tool/mcp-tool-provider.test.ts
+++ b/kun/src/adapters/tool/mcp-tool-provider.test.ts
@@ -3,6 +3,7 @@ import { McpCapabilityConfig, type McpServerConfig } from '../../contracts/capab
 import type { ToolHostContext } from '../../ports/tool-host.js'
 import {
   buildMcpToolProviders,
+  McpAuthorizationRequiredError,
   type McpClientLifecycleHandlers,
   type McpClientLike,
   type McpToolDescriptor
@@ -11,11 +12,19 @@ import {
 class MockMcpClient implements McpClientLike {
   lifecycle: McpClientLifecycleHandlers = {}
   close = vi.fn(async () => undefined)
+  listResources?: McpClientLike['listResources']
+  readResource?: McpClientLike['readResource']
+  listResourceTemplates?: McpClientLike['listResourceTemplates']
+  listPrompts?: McpClientLike['listPrompts']
+  getPrompt?: McpClientLike['getPrompt']
 
   constructor(
     private readonly tools: McpToolDescriptor[],
-    readonly callTool: McpClientLike['callTool']
-  ) {}
+    readonly callTool: McpClientLike['callTool'],
+    extras: Partial<Pick<McpClientLike, 'listResources' | 'readResource' | 'listResourceTemplates' | 'listPrompts' | 'getPrompt'>> = {}
+  ) {
+    Object.assign(this, extras)
+  }
 
   async listTools(): Promise<{ tools: McpToolDescriptor[] }> {
     return { tools: this.tools }
@@ -43,6 +52,12 @@ const config = McpCapabilityConfig.parse({
   enabled: true,
   servers: { docs: server },
   search: { enabled: false }
+})
+
+const searchConfig = McpCapabilityConfig.parse({
+  enabled: true,
+  servers: { docs: server },
+  search: { enabled: true, mode: 'search', topKDefault: 5, topKMax: 10, minScore: 0.15 }
 })
 
 const context: ToolHostContext = {
@@ -138,6 +153,124 @@ describe('mcp tool provider reliability', () => {
       status: 'connected',
       available: true,
       lastError: 'Invalid arguments: query is required'
+    })
+  })
+
+  it('always registers the facade provider and hides facade tools without capable servers', async () => {
+    const client = new MockMcpClient([descriptor], vi.fn(async () => ({ ok: true })))
+    const built = await buildMcpToolProviders(config, {
+      clientFactory: vi.fn(async () => client)
+    })
+
+    expect(built.providers.map((provider) => provider.id)).toContain('mcp:facade')
+    const facade = built.providers.find((provider) => provider.id === 'mcp:facade')
+    expect(facade?.tools.map((tool) => tool.name)).toEqual([
+      'mcp_list_resources',
+      'mcp_read_resource',
+      'mcp_list_resource_templates',
+      'mcp_list_prompts',
+      'mcp_get_prompt'
+    ])
+    expect(facade?.tools.every((tool) => tool.shouldAdvertise?.(context) === false)).toBe(true)
+  })
+
+  it('uses search plus facade providers without direct per-server MCP providers in search mode', async () => {
+    const client = new MockMcpClient(
+      [descriptor],
+      vi.fn(async () => ({ ok: true })),
+      {
+        listResources: vi.fn(async () => ({ resources: [{ uri: 'file:///docs/readme.md' }] }))
+      }
+    )
+    const built = await buildMcpToolProviders(searchConfig, {
+      clientFactory: vi.fn(async () => client)
+    })
+
+    expect(built.providers.map((provider) => provider.id)).toEqual(['mcp:search', 'mcp:facade'])
+    const facade = built.providers.find((provider) => provider.id === 'mcp:facade')
+    expect(facade?.tools.find((tool) => tool.name === 'mcp_list_resources')?.shouldAdvertise?.(context)).toBe(true)
+  })
+
+  it('updates facade availability after OAuth authorization without a runtime restart', async () => {
+    const authorizedClient = new MockMcpClient(
+      [descriptor],
+      vi.fn(async () => ({ ok: true })),
+      {
+        listResources: vi.fn(async () => ({ resources: [{ uri: 'file:///docs/spec.md' }] }))
+      }
+    )
+    const clientFactory = vi.fn()
+      .mockRejectedValueOnce(new McpAuthorizationRequiredError('docs'))
+      .mockResolvedValueOnce(authorizedClient)
+    const authorize = vi.fn(async () => ({
+      serverId: 'docs',
+      status: 'authorized' as const,
+      authorized: true
+    }))
+
+    const built = await buildMcpToolProviders(searchConfig, {
+      clientFactory,
+      authorize,
+      oauthStorageDir: 'C:/tmp/oauth'
+    })
+    const facade = built.providers.find((provider) => provider.id === 'mcp:facade')
+    const listResourcesTool = facade?.tools.find((tool) => tool.name === 'mcp_list_resources')
+
+    expect(listResourcesTool?.shouldAdvertise?.(context)).toBe(false)
+    await expect(built.authorizeOAuth('docs')).resolves.toMatchObject({ authorized: true })
+    expect(listResourcesTool?.shouldAdvertise?.(context)).toBe(true)
+  })
+
+  it('updates facade availability after background reconnect succeeds', async () => {
+    const reconnectedClient = new MockMcpClient(
+      [descriptor],
+      vi.fn(async () => ({ ok: true })),
+      {
+        listPrompts: vi.fn(async () => ({ prompts: [{ name: 'summarize' }] }))
+      }
+    )
+    const clientFactory = vi.fn()
+      .mockRejectedValueOnce(new Error('startup timeout'))
+      .mockResolvedValueOnce(reconnectedClient)
+
+    const built = await buildMcpToolProviders(searchConfig, {
+      clientFactory,
+      delay: async () => undefined
+    })
+    const facade = built.providers.find((provider) => provider.id === 'mcp:facade')
+    const listPromptsTool = facade?.tools.find((tool) => tool.name === 'mcp_list_prompts')
+
+    expect(listPromptsTool?.shouldAdvertise?.(context)).toBe(false)
+    await built.startBackgroundReconnect(() => undefined)
+    expect(listPromptsTool?.shouldAdvertise?.(context)).toBe(true)
+  })
+
+  it('fails facade execution closed when the workspace cannot use the server', async () => {
+    const restrictedServer = {
+      ...server,
+      workspaceRoots: ['/allowed']
+    } satisfies McpServerConfig
+    const client = new MockMcpClient(
+      [descriptor],
+      vi.fn(async () => ({ ok: true })),
+      {
+        listResources: vi.fn(async () => ({ resources: [{ uri: 'file:///docs/spec.md' }] }))
+      }
+    )
+    const built = await buildMcpToolProviders(McpCapabilityConfig.parse({
+      enabled: true,
+      servers: { docs: restrictedServer },
+      search: { enabled: false }
+    }), {
+      clientFactory: vi.fn(async () => client)
+    })
+    const facade = built.providers.find((provider) => provider.id === 'mcp:facade')
+    const tool = facade?.tools.find((item) => item.name === 'mcp_list_resources')
+
+    expect(tool?.shouldAdvertise?.(context)).toBe(false)
+    await expect(tool?.execute({}, context)).resolves.toMatchObject({
+      output: { error: 'No connected MCP server can use listResources in this workspace.' },
+      isError: true
     })
   })
 })

--- a/kun/src/adapters/tool/mcp-tool-provider.ts
+++ b/kun/src/adapters/tool/mcp-tool-provider.ts
@@ -20,6 +20,7 @@ import {
   isMcpAuthorizationRequiredError
 } from './mcp-transport.js'
 import { errorMessage, formatMcpConnectionError } from './mcp-stdio-environment.js'
+import { createMcpFacadeProvider } from './mcp-facade-provider.js'
 import type {
   McpClientLike,
   McpOAuthAuthorizeResult,
@@ -328,6 +329,7 @@ export async function buildMcpToolProviders(
   } else {
     providers.push(...directProviders)
   }
+  providers.push(createMcpFacadeProvider(connected))
   const advertisedToolCount = providers.reduce((total, provider) => total + provider.tools.length, 0)
 
   // Servers that need OAuth authorization are NOT retried by the background

--- a/kun/src/adapters/tool/mcp-transport.ts
+++ b/kun/src/adapters/tool/mcp-transport.ts
@@ -24,6 +24,14 @@ type OAuthTransport = Transport & {
   finishAuth?: (authorizationCode: string) => Promise<void>
 }
 
+type SdkClientFacade = Client & {
+  listResources?: (params?: { cursor?: string }, options?: { signal?: AbortSignal; timeout?: number }) => Promise<unknown>
+  readResource?: (input: { uri: string }, options?: { signal?: AbortSignal; timeout?: number }) => Promise<unknown>
+  listResourceTemplates?: (params?: { cursor?: string }, options?: { signal?: AbortSignal; timeout?: number }) => Promise<unknown>
+  listPrompts?: (params?: { cursor?: string }, options?: { signal?: AbortSignal; timeout?: number }) => Promise<unknown>
+  getPrompt?: (input: { name: string; arguments?: Record<string, unknown> }, options?: { signal?: AbortSignal; timeout?: number }) => Promise<unknown>
+}
+
 export type SdkMcpClientOptions = {
   storageDir?: string
   openExternal?: (url: URL) => void | Promise<void>
@@ -48,6 +56,7 @@ export async function createSdkMcpClient(
   options: SdkMcpClientOptions = {}
 ): Promise<McpClientLike> {
   const client = new Client({ name: `kun-${serverId}`, version: '0.1.0' })
+  const sdk = client as SdkClientFacade
   // Observe transport-level failures explicitly (#639). The SDK routes a
   // dropped SSE stream / exhausted reconnect to `onerror`; with no handler it
   // is silently swallowed and can escape as an unhandled rejection that
@@ -106,6 +115,39 @@ export async function createSdkMcpClient(
       })
     },
     callTool: (input, callOptions) => client.callTool(input, undefined, callOptions),
+    ...(sdk.listResources ? {
+      listResources: async (listOptions) => {
+        const params = listOptions?.cursor ? { cursor: listOptions.cursor } : undefined
+        return await sdk.listResources?.(params, {
+          signal: listOptions?.signal,
+          timeout: listOptions?.timeout
+        }) as Awaited<ReturnType<NonNullable<McpClientLike['listResources']>>>
+      }
+    } : {}),
+    ...(sdk.readResource ? {
+      readResource: async (input, callOptions) => await sdk.readResource?.(input, callOptions) as unknown
+    } : {}),
+    ...(sdk.listResourceTemplates ? {
+      listResourceTemplates: async (listOptions) => {
+        const params = listOptions?.cursor ? { cursor: listOptions.cursor } : undefined
+        return await sdk.listResourceTemplates?.(params, {
+          signal: listOptions?.signal,
+          timeout: listOptions?.timeout
+        }) as Awaited<ReturnType<NonNullable<McpClientLike['listResourceTemplates']>>>
+      }
+    } : {}),
+    ...(sdk.listPrompts ? {
+      listPrompts: async (listOptions) => {
+        const params = listOptions?.cursor ? { cursor: listOptions.cursor } : undefined
+        return await sdk.listPrompts?.(params, {
+          signal: listOptions?.signal,
+          timeout: listOptions?.timeout
+        }) as Awaited<ReturnType<NonNullable<McpClientLike['listPrompts']>>>
+      }
+    } : {}),
+    ...(sdk.getPrompt ? {
+      getPrompt: async (input, callOptions) => await sdk.getPrompt?.(input, callOptions) as unknown
+    } : {}),
     close: () => client.close(),
     setLifecycleHandlers: (handlers) => {
       ;(client as { onerror?: (error: Error) => void }).onerror = handlers.onError

--- a/kun/src/adapters/tool/mcp-types.ts
+++ b/kun/src/adapters/tool/mcp-types.ts
@@ -18,6 +18,40 @@ export type McpToolDescriptor = {
   _meta?: Record<string, unknown>
 }
 
+export type McpResourceDescriptor = {
+  uri: string
+  name?: string
+  title?: string
+  description?: string
+  mimeType?: string
+  size?: number
+  annotations?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+export type McpResourceTemplateDescriptor = {
+  uriTemplate: string
+  name?: string
+  title?: string
+  description?: string
+  mimeType?: string
+  annotations?: Record<string, unknown>
+  _meta?: Record<string, unknown>
+}
+
+export type McpPromptDescriptor = {
+  name: string
+  title?: string
+  description?: string
+  arguments?: Array<{
+    name: string
+    title?: string
+    description?: string
+    required?: boolean
+  }>
+  _meta?: Record<string, unknown>
+}
+
 export type McpClientLifecycleHandlers = {
   onError?: (error: Error) => void
   onClose?: () => void
@@ -31,6 +65,29 @@ export type McpClientLike = {
   }): Promise<{ tools: McpToolDescriptor[]; nextCursor?: string }>
   callTool(
     input: { name: string; arguments: Record<string, unknown> },
+    options?: { signal?: AbortSignal; timeout?: number }
+  ): Promise<unknown>
+  listResources?(options?: {
+    cursor?: string
+    signal?: AbortSignal
+    timeout?: number
+  }): Promise<{ resources: McpResourceDescriptor[]; nextCursor?: string }>
+  readResource?(
+    input: { uri: string },
+    options?: { signal?: AbortSignal; timeout?: number }
+  ): Promise<unknown>
+  listResourceTemplates?(options?: {
+    cursor?: string
+    signal?: AbortSignal
+    timeout?: number
+  }): Promise<{ resourceTemplates: McpResourceTemplateDescriptor[]; nextCursor?: string }>
+  listPrompts?(options?: {
+    cursor?: string
+    signal?: AbortSignal
+    timeout?: number
+  }): Promise<{ prompts: McpPromptDescriptor[]; nextCursor?: string }>
+  getPrompt?(
+    input: { name: string; arguments?: Record<string, unknown> },
     options?: { signal?: AbortSignal; timeout?: number }
   ): Promise<unknown>
   close(): Promise<void>

--- a/kun/tests/mcp-tool-provider.test.ts
+++ b/kun/tests/mcp-tool-provider.test.ts
@@ -339,7 +339,7 @@ describe('MCP tool provider', () => {
       mode: 'search',
       active: true,
       indexedToolCount: 2,
-      advertisedToolCount: 4
+      advertisedToolCount: 9
     })
     expect((await host.listTools(context)).map((tool) => tool.name)).toEqual([
       'mcp_search',
@@ -461,7 +461,7 @@ describe('MCP tool provider', () => {
       }
     })
 
-    expect(built.providers).toEqual([])
+    expect(built.providers.map((provider) => provider.id)).toEqual(['mcp:facade'])
     expect(built.connectedServers).toBe(0)
     expect(built.diagnostics[0]).toMatchObject({
       id: 'broken',
@@ -492,7 +492,7 @@ describe('MCP tool provider', () => {
       }
     })
 
-    expect(built.providers).toEqual([])
+    expect(built.providers.map((provider) => provider.id)).toEqual(['mcp:facade'])
     expect(built.diagnostics[0]).toMatchObject({
       id: 'filesystem',
       status: 'error'
@@ -708,7 +708,7 @@ describe('MCP tool provider', () => {
 
     // Startup pass: the server failed and advertised no tools.
     expect(built.diagnostics).toEqual([expect.objectContaining({ id: 'github', status: 'error' })])
-    expect(built.providers).toHaveLength(0)
+    expect(built.providers.map((provider) => provider.id)).toEqual(['mcp:facade'])
 
     const registry = new CapabilityRegistry(built.providers)
     await built.startBackgroundReconnect((provider) => registry.registerProvider(provider))


### PR DESCRIPTION
## Summary
- keep MCP facade tools registered even when per-server tools are deferred or unavailable
- let facade capabilities become visible after OAuth authorization and background reconnects
- cover the late-registration path with focused MCP provider tests

## Changes
- add an MCP facade provider that exposes resources, prompts, and templates from connected servers
- wire the facade provider into MCP provider construction alongside search/direct modes
- extend the SDK transport facade and MCP client types for resources/prompts APIs
- update MCP provider tests to reflect the always-present facade and verify late connection recovery

## Tests
- npm.cmd --prefix kun test -- mcp-tool-provider.test.ts
- npm.cmd --prefix kun run typecheck
- npm.cmd --prefix kun run build

Supersedes #697