### PR TITLE
fix(tools): scope operation journal by turn

### DIFF
--- a/kun/src/adapters/tool/local-tool-host.operation-journal.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.operation-journal.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { ToolHostContext } from '../../ports/tool-host.js'
+import { ToolOperationJournal } from '../../reliability/operation-journal.js'
+import { LocalToolHost } from './local-tool-host.js'
+
+function context(turnId: string): ToolHostContext {
+  return {
+    threadId: 'thread-1',
+    turnId,
+    workspace: '/tmp/workspace',
+    approvalPolicy: 'auto',
+    abortSignal: new AbortController().signal,
+    awaitApproval: async () => 'allow'
+  }
+}
+
+describe('LocalToolHost operation journal', () => {
+  it('reuses completed results for the exact same turn-scoped identity', async () => {
+    let executions = 0
+    const host = new LocalToolHost({
+      operationJournal: new ToolOperationJournal({ nowIso: () => '2026-01-01T00:00:00.000Z' }),
+      tools: [LocalToolHost.defineTool({
+        name: 'counted',
+        description: 'count executions',
+        policy: 'auto',
+        inputSchema: { type: 'object' },
+        execute: async () => {
+          executions += 1
+          return { output: { executions } }
+        }
+      })]
+    })
+
+    const call = { callId: 'call_1', toolName: 'counted', arguments: { value: 1 } }
+    const first = await host.execute(call, context('turn-1'))
+    const second = await host.execute(call, context('turn-1'))
+
+    expect(executions).toBe(1)
+    expect(first.item).toMatchObject({ output: { executions: 1 } })
+    expect(second.item).toMatchObject({ output: { executions: 1 } })
+  })
+
+  it('does not reuse fallback call ids across turns in the same thread', async () => {
+    let executions = 0
+    const host = new LocalToolHost({
+      operationJournal: new ToolOperationJournal({ nowIso: () => '2026-01-01T00:00:00.000Z' }),
+      tools: [LocalToolHost.defineTool({
+        name: 'counted',
+        description: 'count executions',
+        policy: 'auto',
+        inputSchema: { type: 'object' },
+        execute: async () => {
+          executions += 1
+          return { output: { executions } }
+        }
+      })]
+    })
+
+    const call = { callId: 'call_1', toolName: 'counted', arguments: { value: 1 } }
+    const first = await host.execute(call, context('turn-1'))
+    const second = await host.execute(call, context('turn-2'))
+
+    expect(executions).toBe(2)
+    expect(first.item).toMatchObject({ output: { executions: 1 } })
+    expect(second.item).toMatchObject({ output: { executions: 2 } })
+  })
+
+  it('does not reuse the same call id when arguments change', async () => {
+    let executions = 0
+    const host = new LocalToolHost({
+      operationJournal: new ToolOperationJournal({ nowIso: () => '2026-01-01T00:00:00.000Z' }),
+      tools: [LocalToolHost.defineTool({
+        name: 'counted',
+        description: 'count executions',
+        policy: 'auto',
+        inputSchema: { type: 'object' },
+        execute: async () => {
+          executions += 1
+          return { output: { executions } }
+        }
+      })]
+    })
+
+    await host.execute({ callId: 'call_1', toolName: 'counted', arguments: { value: 1 } }, context('turn-1'))
+    await host.execute({ callId: 'call_1', toolName: 'counted', arguments: { value: 2 } }, context('turn-1'))
+
+    expect(executions).toBe(2)
+  })
+})

--- a/kun/src/adapters/tool/local-tool-host.ts
+++ b/kun/src/adapters/tool/local-tool-host.ts
@@ -28,6 +28,10 @@ import {
   type ReadTrackerOptions
 } from './read-tracker.js'
 import { sandboxBlockForTool, type SandboxBlock } from './sandbox-policy.js'
+import {
+  createToolOperationIdentity,
+  ToolOperationJournal
+} from '../../reliability/operation-journal.js'
 
 /**
  * A single registered tool. Tools are pure functions that observe the
@@ -67,6 +71,11 @@ export type LocalToolHostOptions = {
   hooks?: readonly ResolvedHook[]
   /** Runtime read-before-edit guard. Disabled by default for direct unit use. */
   readTracker?: boolean | ReadTrackerOptions
+  /**
+   * Turn-scoped operation journal. Defaults to an in-memory journal so fallback
+   * call ids such as `call_1` are isolated by turnId/toolName/argsHash.
+   */
+  operationJournal?: ToolOperationJournal
 }
 
 /**
@@ -89,12 +98,14 @@ export class LocalToolHost implements ToolHost {
   private readonly allowList: Set<string>
   private hooks: readonly ResolvedHook[]
   private readonly readTracker: ReadTracker
+  private readonly operationJournal: ToolOperationJournal
 
   constructor(options: LocalToolHostOptions) {
     this.registry = options.registry ?? CapabilityRegistry.fromLocalTools(options.tools ?? [])
     this.allowList = new Set(options.allowList ?? [])
     this.hooks = options.hooks ?? []
     this.readTracker = new ReadTracker(normalizeReadTrackerOptions(options.readTracker))
+    this.operationJournal = options.operationJournal ?? new ToolOperationJournal()
   }
 
   replaceRuntimeComponents(input: {
@@ -197,6 +208,21 @@ export class LocalToolHost implements ToolHost {
     if (context.abortSignal.aborted) {
       throw new Error('tool call aborted while waiting for approval')
     }
+    const operationIdentity = createToolOperationIdentity({
+      threadId: context.threadId,
+      turnId: context.turnId,
+      callId: activeCall.callId,
+      toolName: activeCall.toolName,
+      args: activeCall.arguments
+    })
+    const replayed = this.operationJournal.getCompleted(operationIdentity)
+    if (replayed) {
+      return {
+        item: this.completedToolResult(context, activeCall, tool, replayed.output, replayed.isError),
+        approved: !needsApproval
+      }
+    }
+    this.operationJournal.begin(operationIdentity)
     let result: Awaited<ReturnType<LocalTool['execute']>>
     try {
       result = await tool.execute(activeCall.arguments, context, async (update) => {
@@ -218,7 +244,11 @@ export class LocalToolHost implements ToolHost {
       // A tool blowing up (an MCP server returning a protocol error, a
       // provider bug) is feedback for the model, not a reason to kill the
       // whole turn. Only abort keeps propagating.
-      if (context.abortSignal.aborted) throw error
+      if (context.abortSignal.aborted) {
+        this.operationJournal.unknown(operationIdentity, 'tool call aborted during execution')
+        throw error
+      }
+      this.operationJournal.fail(operationIdentity, error)
       const message = error instanceof Error ? error.message : String(error)
       return {
         item: this.errorToolResult(context, activeCall, tool, message, 'tool_execution_failed'),
@@ -233,6 +263,7 @@ export class LocalToolHost implements ToolHost {
         result
       })
     } catch (error) {
+      this.operationJournal.fail(operationIdentity, error)
       return {
         item: this.errorToolResult(context, activeCall, tool, hookErrorMessage(error), 'hook_failed'),
         approved: true
@@ -248,16 +279,8 @@ export class LocalToolHost implements ToolHost {
       isError
     })
     if (!isError) output = await offloadLargeToolOutput(output, activeCall.toolName, context)
-    const item = makeToolResultItem({
-      id: `item_${activeCall.callId}`,
-      turnId: context.turnId,
-      threadId: context.threadId,
-      callId: activeCall.callId,
-      toolName: activeCall.toolName,
-      toolKind: activeCall.toolKind ?? tool.toolKind,
-      output,
-      isError
-    })
+    this.operationJournal.complete(operationIdentity, { output, isError })
+    const item = this.completedToolResult(context, activeCall, tool, output, isError)
     return { item, approved: !needsApproval }
   }
 
@@ -310,6 +333,25 @@ export class LocalToolHost implements ToolHost {
       .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
       .join(', ')
     return `Run ${call.toolName}(${args})`
+  }
+
+  private completedToolResult(
+    context: ToolHostContext,
+    call: ToolCallLike,
+    tool: LocalTool,
+    output: unknown,
+    isError?: boolean
+  ): TurnItem {
+    return makeToolResultItem({
+      id: `item_${call.callId}`,
+      turnId: context.turnId,
+      threadId: context.threadId,
+      callId: call.callId,
+      toolName: call.toolName,
+      toolKind: call.toolKind ?? tool.toolKind,
+      output,
+      isError
+    })
   }
 
   private errorToolResult(

--- a/kun/src/reliability/operation-journal.test.ts
+++ b/kun/src/reliability/operation-journal.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createToolOperationIdentity,
+  ToolOperationJournal
+} from './operation-journal.js'
+
+describe('ToolOperationJournal', () => {
+  it('includes turnId in the operation key so fallback call ids do not collide across turns', () => {
+    const first = createToolOperationIdentity({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      callId: 'call_1',
+      toolName: 'write_file',
+      args: { path: 'a.md' }
+    })
+    const second = createToolOperationIdentity({
+      threadId: 'thread-1',
+      turnId: 'turn-2',
+      callId: 'call_1',
+      toolName: 'write_file',
+      args: { path: 'a.md' }
+    })
+
+    expect(ToolOperationJournal.key(first)).not.toBe(ToolOperationJournal.key(second))
+  })
+
+  it('hashes arguments with stable object key ordering', () => {
+    const left = createToolOperationIdentity({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      callId: 'call_1',
+      toolName: 'tool',
+      args: { b: 2, a: { y: true, x: 1 } }
+    })
+    const right = createToolOperationIdentity({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      callId: 'call_1',
+      toolName: 'tool',
+      args: { a: { x: 1, y: true }, b: 2 }
+    })
+
+    expect(left.argsHash).toBe(right.argsHash)
+  })
+
+  it('only replays completed records for the exact identity', () => {
+    const journal = new ToolOperationJournal({ nowIso: () => '2026-01-01T00:00:00.000Z' })
+    const identity = createToolOperationIdentity({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      callId: 'call_1',
+      toolName: 'tool',
+      args: { value: 1 }
+    })
+    const differentArgs = createToolOperationIdentity({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      callId: 'call_1',
+      toolName: 'tool',
+      args: { value: 2 }
+    })
+
+    journal.begin(identity)
+    expect(journal.getCompleted(identity)).toBeNull()
+    journal.complete(identity, { output: { ok: true } })
+
+    expect(journal.getCompleted(identity)).toEqual({ output: { ok: true } })
+    expect(journal.getCompleted(differentArgs)).toBeNull()
+  })
+})

--- a/kun/src/reliability/operation-journal.ts
+++ b/kun/src/reliability/operation-journal.ts
@@ -1,0 +1,163 @@
+import { createHash } from 'node:crypto'
+
+export type ToolOperationIdentity = {
+  threadId: string
+  turnId: string
+  callId: string
+  toolName: string
+  argsHash: string
+}
+
+export type ToolOperationResult = {
+  output: unknown
+  isError?: boolean
+}
+
+export type ToolOperationRecord =
+  | {
+      status: 'started'
+      identity: ToolOperationIdentity
+      startedAt: string
+    }
+  | {
+      status: 'completed'
+      identity: ToolOperationIdentity
+      startedAt: string
+      completedAt: string
+      result: ToolOperationResult
+    }
+  | {
+      status: 'failed'
+      identity: ToolOperationIdentity
+      startedAt: string
+      failedAt: string
+      error: string
+    }
+  | {
+      status: 'unknown'
+      identity: ToolOperationIdentity
+      startedAt: string
+      updatedAt: string
+      reason: string
+    }
+
+export type ToolOperationJournalOptions = {
+  nowIso?: () => string
+}
+
+export class ToolOperationJournal {
+  private readonly records = new Map<string, ToolOperationRecord>()
+  private readonly nowIso: () => string
+
+  constructor(options: ToolOperationJournalOptions = {}) {
+    this.nowIso = options.nowIso ?? (() => new Date().toISOString())
+  }
+
+  static argsHash(args: Record<string, unknown>): string {
+    return createHash('sha256').update(stableStringify(args)).digest('hex')
+  }
+
+  static key(identity: ToolOperationIdentity): string {
+    return [
+      identity.threadId,
+      identity.turnId,
+      identity.callId,
+      identity.toolName,
+      identity.argsHash
+    ].join('\u0000')
+  }
+
+  get(identity: ToolOperationIdentity): ToolOperationRecord | undefined {
+    return this.records.get(ToolOperationJournal.key(identity))
+  }
+
+  getCompleted(identity: ToolOperationIdentity): ToolOperationResult | null {
+    const record = this.get(identity)
+    return record?.status === 'completed' ? record.result : null
+  }
+
+  begin(identity: ToolOperationIdentity): void {
+    const key = ToolOperationJournal.key(identity)
+    const existing = this.records.get(key)
+    if (existing?.status === 'completed') return
+    this.records.set(key, {
+      status: 'started',
+      identity,
+      startedAt: this.nowIso()
+    })
+  }
+
+  complete(identity: ToolOperationIdentity, result: ToolOperationResult): void {
+    const key = ToolOperationJournal.key(identity)
+    const existing = this.records.get(key)
+    this.records.set(key, {
+      status: 'completed',
+      identity,
+      startedAt: existing?.startedAt ?? this.nowIso(),
+      completedAt: this.nowIso(),
+      result
+    })
+  }
+
+  fail(identity: ToolOperationIdentity, error: unknown): void {
+    const key = ToolOperationJournal.key(identity)
+    const existing = this.records.get(key)
+    this.records.set(key, {
+      status: 'failed',
+      identity,
+      startedAt: existing?.startedAt ?? this.nowIso(),
+      failedAt: this.nowIso(),
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  unknown(identity: ToolOperationIdentity, reason: string): void {
+    const key = ToolOperationJournal.key(identity)
+    const existing = this.records.get(key)
+    this.records.set(key, {
+      status: 'unknown',
+      identity,
+      startedAt: existing?.startedAt ?? this.nowIso(),
+      updatedAt: this.nowIso(),
+      reason
+    })
+  }
+
+  clear(): void {
+    this.records.clear()
+  }
+}
+
+export function createToolOperationIdentity(input: {
+  threadId: string
+  turnId: string
+  callId: string
+  toolName: string
+  args: Record<string, unknown>
+}): ToolOperationIdentity {
+  return {
+    threadId: input.threadId,
+    turnId: input.turnId,
+    callId: input.callId,
+    toolName: input.toolName,
+    argsHash: ToolOperationJournal.argsHash(input.args)
+  }
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null) return 'null'
+  const type = typeof value
+  if (type === 'string') return JSON.stringify(value)
+  if (type === 'number' || type === 'boolean') return JSON.stringify(value)
+  if (type === 'bigint') return JSON.stringify(String(value))
+  if (type === 'undefined') return '"[undefined]"'
+  if (type === 'function') return '"[function]"'
+  if (type === 'symbol') return JSON.stringify(String(value))
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  if (value instanceof Date) return JSON.stringify(value.toISOString())
+  if (value && type === 'object') {
+    const object = value as Record<string, unknown>
+    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(object[key])}`).join(',')}}`
+  }
+  return JSON.stringify(String(value))
+}


### PR DESCRIPTION
## Summary
- add a turn-scoped tool operation journal for replaying completed local tool results
- prevent fallback call ids like call_1 from colliding across turns
- keep the latest develop user-input and create-plan behavior intact while wiring the journal

## Changes
- add a small in-memory operation journal keyed by thread, turn, call id, tool name, and argument hash
- reuse completed local tool results only for the exact same operation identity
- record failed and aborted executions in the journal for diagnostics
- add focused journal and local-tool-host tests

## Tests
- npm.cmd --prefix kun test -- local-tool-host.operation-journal.test.ts operation-journal.test.ts
- npm.cmd --prefix kun run typecheck
- npm.cmd --prefix kun run build

Supersedes #692