### PR TITLE
fix(deps): add root diff dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.11.0",
         "better-sqlite3": "^12.10.0",
+        "diff": "^8.0.4",
         "electron-store": "^10.1.0",
         "electron-updater": "^6.8.3",
         "html-to-docx": "^1.8.0",
@@ -8097,6 +8098,15 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmmirror.com/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.11.0",
     "better-sqlite3": "^12.10.0",
+    "diff": "^8.0.4",
     "electron-store": "^10.1.0",
     "electron-updater": "^6.8.3",
     "html-to-docx": "^1.8.0",


### PR DESCRIPTION
﻿Summary
- Adds `diff` to the root GUI dependency graph so top-level `npm run typecheck` can resolve `kun/src/adapters/tool/edit-diff.ts` when `src/main` references bundled Kun runtime sources.
- Keeps the change to dependency metadata only. `@streamdown/math` is already declared on current develop; the remaining typecheck break was the missing root `diff` package.

Tests
- npm.cmd run typecheck
- git diff --check
