### PR TITLE
feat(benchmark): add replay CI budget gate

### DIFF
--- a/.github/workflows/replay-benchmark.yml
+++ b/.github/workflows/replay-benchmark.yml
@@ -1,0 +1,124 @@
+name: Replay Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Path to the replay suite JSON file
+        required: true
+        type: string
+      runtime_url:
+        description: Kun runtime URL reachable from the runner
+        required: false
+        default: http://127.0.0.1:18899
+        type: string
+      tag:
+        description: Optional suite tag filter
+        required: false
+        type: string
+      repeat:
+        description: Repetitions per selected task
+        required: false
+        default: "1"
+        type: string
+      concurrency:
+        description: Parallel replay tasks
+        required: false
+        default: "1"
+        type: string
+      baseline:
+        description: Optional baseline report JSON path
+        required: false
+        type: string
+      budget:
+        description: Optional replay budget JSON path
+        required: false
+        type: string
+      fail_on_regression:
+        description: Fail when baseline comparison detects regressions
+        required: false
+        default: true
+        type: boolean
+      fail_on_budget:
+        description: Fail when explicit budget thresholds are exceeded
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: replay-benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  replay:
+    name: Run replay benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      KUN_RUNTIME_TOKEN: ${{ secrets.KUN_RUNTIME_TOKEN }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run replay benchmark
+        shell: bash
+        env:
+          SUITE_PATH: ${{ inputs.suite }}
+          RUNTIME_URL: ${{ inputs.runtime_url }}
+          TAG_FILTER: ${{ inputs.tag }}
+          REPEAT_COUNT: ${{ inputs.repeat }}
+          CONCURRENCY: ${{ inputs.concurrency }}
+          BASELINE_PATH: ${{ inputs.baseline }}
+          BUDGET_PATH: ${{ inputs.budget }}
+          FAIL_ON_REGRESSION: ${{ inputs.fail_on_regression }}
+          FAIL_ON_BUDGET: ${{ inputs.fail_on_budget }}
+        run: |
+          set -euo pipefail
+          mkdir -p replay-artifacts
+          args=(
+            --suite "${SUITE_PATH}"
+            --base-url "${RUNTIME_URL}"
+            --workspace "${{ github.workspace }}"
+            --repeat "${REPEAT_COUNT}"
+            --concurrency "${CONCURRENCY}"
+            --output replay-artifacts/replay-report.json
+            --summary-output replay-artifacts/replay-summary.md
+          )
+          if [[ -n "${TAG_FILTER}" ]]; then
+            args+=(--tag "${TAG_FILTER}")
+          fi
+          if [[ -n "${BASELINE_PATH}" ]]; then
+            args+=(--baseline "${BASELINE_PATH}")
+            if [[ "${FAIL_ON_REGRESSION}" == "true" ]]; then
+              args+=(--fail-on-regression)
+            fi
+          fi
+          if [[ -n "${BUDGET_PATH}" ]]; then
+            args+=(--budget "${BUDGET_PATH}")
+            if [[ "${FAIL_ON_BUDGET}" == "true" ]]; then
+              args+=(--fail-on-budget)
+            fi
+          fi
+          npm --prefix kun run benchmark:replay -- "${args[@]}"
+
+      - name: Upload replay report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kun-replay-report
+          path: |
+            replay-artifacts/replay-report.json
+            replay-artifacts/replay-summary.md
+          if-no-files-found: warn

--- a/kun/src/benchmark/replay-benchmark.test.ts
+++ b/kun/src/benchmark/replay-benchmark.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import type { RuntimeEvent } from '../contracts/events.js'
 import {
   compareReplayReports,
+  evaluateReplayBudget,
   evaluateReplayQuality,
+  formatReplayReportMarkdown,
   ReplaySuiteSchema,
   runReplaySuite,
   SseMessageDecoder,
@@ -169,6 +171,53 @@ describe('replay benchmark', () => {
       expect.stringContaining('total latency'),
       expect.stringContaining('cache hit rate')
     ]))
+  })
+
+  it('evaluates explicit replay budget gates', () => {
+    const passing = report([
+      replayRun('passed', 100, 1_000, 0.8),
+      replayRun('passed', 120, 1_100, 0.7)
+    ], '2026-06-29T00:00:00.000Z')
+
+    expect(evaluateReplayBudget(passing, {
+      minSuccessRate: 1,
+      maxTtftP95Ms: 150,
+      maxTotalP95Ms: 1_200,
+      maxPromptTokens: 250,
+      maxTotalTokens: 300,
+      minCacheHitRate: 0.7,
+      maxCostUsd: 0.01,
+      maxPeakRssBytes: 200
+    })).toEqual({ passed: true, violations: [] })
+
+    const failing = report([
+      replayRun('passed', 200, 2_000, 0.2),
+      replayRun('failed', 250, 2_500, 0.1)
+    ], '2026-06-29T00:00:00.000Z')
+    const result = evaluateReplayBudget(failing, {
+      minSuccessRate: 1,
+      maxTotalP95Ms: 2_000,
+      minCacheHitRate: 0.5
+    })
+
+    expect(result.passed).toBe(false)
+    expect(result.violations.map((violation) => violation.metric)).toEqual([
+      'successRate',
+      'totalP95Ms',
+      'cacheHitRate'
+    ])
+  })
+
+  it('renders a Markdown report with budget violations', () => {
+    const current = report([replayRun('failed', 250, 2_500, 0.2)], '2026-06-29T00:00:00.000Z')
+    current.budget = evaluateReplayBudget(current, {
+      minSuccessRate: 1,
+      maxTotalP95Ms: 2_000
+    })
+
+    expect(formatReplayReportMarkdown(current)).toContain('## Budget Gate')
+    expect(formatReplayReportMarkdown(current)).toContain('- Result: failed')
+    expect(formatReplayReportMarkdown(current)).toContain('totalP95Ms')
   })
 
   it('rejects duplicate task ids before spending model tokens', () => {

--- a/kun/src/benchmark/replay-benchmark.ts
+++ b/kun/src/benchmark/replay-benchmark.ts
@@ -148,6 +148,35 @@ export type ReplayComparison = {
   regressions: string[]
 }
 
+const ReplayBudgetSchema = z.object({
+  minSuccessRate: z.number().min(0).max(1).optional(),
+  maxTtftP95Ms: z.number().nonnegative().optional(),
+  maxTotalP95Ms: z.number().nonnegative().optional(),
+  maxToolDurationP95Ms: z.number().nonnegative().optional(),
+  maxSseDelayP95Ms: z.number().nonnegative().optional(),
+  maxPromptTokens: z.number().int().nonnegative().optional(),
+  maxTotalTokens: z.number().int().nonnegative().optional(),
+  minCacheHitRate: z.number().min(0).max(1).optional(),
+  minCacheableTokenHitRate: z.number().min(0).max(1).optional(),
+  minTotalInputTokenHitRate: z.number().min(0).max(1).optional(),
+  maxCostUsd: z.number().nonnegative().optional(),
+  maxPeakRssBytes: z.number().int().nonnegative().optional()
+}).strict()
+
+export type ReplayBudget = z.infer<typeof ReplayBudgetSchema>
+
+export type ReplayBudgetViolation = {
+  metric: string
+  actual: number | null
+  limit: number
+  message: string
+}
+
+export type ReplayBudgetEvaluation = {
+  passed: boolean
+  violations: ReplayBudgetViolation[]
+}
+
 export type ReplayReport = {
   version: 1
   generatedAt: string
@@ -161,6 +190,7 @@ export type ReplayReport = {
   summary: ReplayReportSummary
   runs: ReplayRunResult[]
   comparison?: ReplayComparison
+  budget?: ReplayBudgetEvaluation
 }
 
 export type RunReplaySuiteOptions = {
@@ -535,6 +565,81 @@ export function compareReplayReports(current: ReplayReport, baseline: ReplayRepo
   }
 }
 
+export function parseReplayBudget(input: unknown): ReplayBudget {
+  return ReplayBudgetSchema.parse(input)
+}
+
+export function evaluateReplayBudget(report: ReplayReport, budgetInput: unknown): ReplayBudgetEvaluation {
+  const budget = parseReplayBudget(budgetInput)
+  const { summary } = report
+  const violations: ReplayBudgetViolation[] = []
+
+  addMinimumViolation(violations, 'successRate', summary.successRate, budget.minSuccessRate)
+  addMaximumViolation(violations, 'ttftP95Ms', summary.ttftP95Ms, budget.maxTtftP95Ms)
+  addMaximumViolation(violations, 'totalP95Ms', summary.totalP95Ms, budget.maxTotalP95Ms)
+  addMaximumViolation(violations, 'toolDurationP95Ms', summary.toolDurationP95Ms, budget.maxToolDurationP95Ms)
+  addMaximumViolation(violations, 'sseDelayP95Ms', summary.sseDelayP95Ms, budget.maxSseDelayP95Ms)
+  addMaximumViolation(violations, 'promptTokens', summary.promptTokens, budget.maxPromptTokens)
+  addMaximumViolation(violations, 'totalTokens', summary.totalTokens, budget.maxTotalTokens)
+  addMinimumViolation(violations, 'cacheHitRate', summary.cacheHitRate, budget.minCacheHitRate)
+  addMinimumViolation(violations, 'cacheableTokenHitRate', summary.cacheableTokenHitRate, budget.minCacheableTokenHitRate)
+  addMinimumViolation(violations, 'totalInputTokenHitRate', summary.totalInputTokenHitRate, budget.minTotalInputTokenHitRate)
+  addMaximumViolation(violations, 'costUsd', summary.costUsd, budget.maxCostUsd)
+  addMaximumViolation(violations, 'peakRssBytes', summary.peakRssBytes, budget.maxPeakRssBytes)
+
+  return { passed: violations.length === 0, violations }
+}
+
+export function formatReplayReportMarkdown(report: ReplayReport): string {
+  const lines = [
+    `# Replay Benchmark Report`,
+    '',
+    `- Suite: ${report.suite.name}`,
+    `- Generated: ${report.generatedAt}`,
+    `- Runtime: ${report.runtime.baseUrl}`,
+    `- Model: ${report.runtime.model ?? 'n/a'}`,
+    `- Runs: ${report.summary.passed}/${report.summary.runCount} passed (${formatPercent(report.summary.successRate)})`,
+    `- TTFT p50/p95: ${formatOptionalMs(report.summary.ttftP50Ms)} / ${formatOptionalMs(report.summary.ttftP95Ms)}`,
+    `- Total p50/p95: ${formatOptionalMs(report.summary.totalP50Ms)} / ${formatOptionalMs(report.summary.totalP95Ms)}`,
+    `- Tool p95: ${formatOptionalMs(report.summary.toolDurationP95Ms)}`,
+    `- SSE delay p95: ${formatOptionalMs(report.summary.sseDelayP95Ms)}`,
+    `- Tokens: ${report.summary.promptTokens} input + ${report.summary.completionTokens} output`,
+    `- Cache hit: ${formatOptionalPercent(report.summary.cacheHitRate)}`,
+    `- Cost: $${report.summary.costUsd.toFixed(6)}`,
+    `- Peak RSS: ${report.summary.peakRssBytes === null ? 'n/a' : formatBytes(report.summary.peakRssBytes)}`,
+    ''
+  ]
+  if (report.comparison) {
+    lines.push('## Baseline Comparison', '')
+    lines.push(`- Baseline: ${report.comparison.baselineGeneratedAt}`)
+    lines.push(`- Success rate delta: ${formatSignedPercent(report.comparison.successRateDelta)}`)
+    lines.push(`- TTFT p95 delta: ${formatSignedOptionalMs(report.comparison.ttftP95MsDelta)}`)
+    lines.push(`- Total p95 delta: ${formatSignedOptionalMs(report.comparison.totalP95MsDelta)}`)
+    lines.push(`- Prompt token delta: ${formatSignedNumber(report.comparison.promptTokensDelta)}`)
+    lines.push(`- Cache hit delta: ${formatSignedOptionalPercent(report.comparison.cacheHitRateDelta)}`)
+    lines.push(`- Cost delta: $${formatSignedFixed(report.comparison.costUsdDelta, 6)}`)
+    lines.push('')
+    appendList(lines, 'Regressions', report.comparison.regressions)
+  }
+  if (report.budget) {
+    lines.push('## Budget Gate', '')
+    lines.push(`- Result: ${report.budget.passed ? 'passed' : 'failed'}`)
+    lines.push('')
+    appendList(lines, 'Violations', report.budget.violations.map((violation) => violation.message))
+  }
+  lines.push('## Failed Runs', '')
+  const failedRuns = report.runs.filter((run) => run.status !== 'passed')
+  if (failedRuns.length === 0) {
+    lines.push('- None')
+  } else {
+    for (const run of failedRuns) {
+      lines.push(`- ${run.id}: ${run.status}${run.failureReasons.length ? ` - ${run.failureReasons.join('; ')}` : ''}`)
+    }
+  }
+  lines.push('')
+  return `${lines.join('\n').trimEnd()}\n`
+}
+
 export type SseMessage = { event?: string; id?: string; data: string }
 
 export class SseMessageDecoder {
@@ -902,6 +1007,108 @@ function sum(left: number, right: number): number {
 
 function formatPercent(value: number): string {
   return `${(value * 100).toFixed(2)}%`
+}
+
+function addMinimumViolation(
+  violations: ReplayBudgetViolation[],
+  metric: string,
+  actual: number | null,
+  limit: number | undefined
+): void {
+  if (limit === undefined) return
+  if (actual === null) {
+    violations.push({
+      metric,
+      actual,
+      limit,
+      message: `${metric} is unavailable; required at least ${formatBudgetValue(metric, limit)}`
+    })
+    return
+  }
+  if (actual < limit) {
+    violations.push({
+      metric,
+      actual,
+      limit,
+      message: `${metric} ${formatBudgetValue(metric, actual)} is below ${formatBudgetValue(metric, limit)}`
+    })
+  }
+}
+
+function addMaximumViolation(
+  violations: ReplayBudgetViolation[],
+  metric: string,
+  actual: number | null,
+  limit: number | undefined
+): void {
+  if (limit === undefined) return
+  if (actual === null) {
+    violations.push({
+      metric,
+      actual,
+      limit,
+      message: `${metric} is unavailable; required at most ${formatBudgetValue(metric, limit)}`
+    })
+    return
+  }
+  if (actual > limit) {
+    violations.push({
+      metric,
+      actual,
+      limit,
+      message: `${metric} ${formatBudgetValue(metric, actual)} exceeds ${formatBudgetValue(metric, limit)}`
+    })
+  }
+}
+
+function appendList(lines: string[], title: string, values: string[]): void {
+  lines.push(`### ${title}`, '')
+  if (values.length === 0) {
+    lines.push('- None', '')
+    return
+  }
+  for (const value of values) lines.push(`- ${value}`)
+  lines.push('')
+}
+
+function formatBudgetValue(metric: string, value: number): string {
+  if (metric.endsWith('Rate')) return formatPercent(value)
+  if (metric.endsWith('Ms')) return `${Math.round(value)}ms`
+  if (metric === 'costUsd') return `$${value.toFixed(6)}`
+  if (metric.endsWith('Bytes')) return formatBytes(value)
+  return String(value)
+}
+
+function formatOptionalMs(value: number | null): string {
+  return value === null ? 'n/a' : `${Math.round(value)}ms`
+}
+
+function formatSignedOptionalMs(value: number | null): string {
+  return value === null ? 'n/a' : `${formatSignedNumber(Math.round(value))}ms`
+}
+
+function formatOptionalPercent(value: number | null): string {
+  return value === null ? 'n/a' : formatPercent(value)
+}
+
+function formatSignedOptionalPercent(value: number | null): string {
+  return value === null ? 'n/a' : formatSignedPercent(value)
+}
+
+function formatSignedPercent(value: number): string {
+  return `${value >= 0 ? '+' : ''}${formatPercent(value)}`
+}
+
+function formatSignedFixed(value: number, digits: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(digits)}`
+}
+
+function formatSignedNumber(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value}`
+}
+
+function formatBytes(value: number): string {
+  return `${(value / 1024 / 1024).toFixed(1)} MiB`
 }
 
 function errorMessage(error: unknown): string {

--- a/kun/src/cli/replay-entry.ts
+++ b/kun/src/cli/replay-entry.ts
@@ -3,6 +3,8 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import {
   compareReplayReports,
+  evaluateReplayBudget,
+  formatReplayReportMarkdown,
   runReplaySuite,
   type ReplayReport
 } from '../benchmark/replay-benchmark.js'
@@ -15,12 +17,15 @@ type CliOptions = {
   baseUrl: string
   workspace: string
   outputPath?: string
+  summaryPath?: string
   baselinePath?: string
+  budgetPath?: string
   repeat: number
   concurrency: number
   tag?: string
   keepThreads: boolean
   failOnRegression: boolean
+  failOnBudget: boolean
   help: boolean
 }
 
@@ -57,6 +62,10 @@ if (options.baselinePath) {
   const baseline = JSON.parse(await readFile(resolve(options.baselinePath), 'utf8')) as ReplayReport
   report.comparison = compareReplayReports(report, baseline)
 }
+if (options.budgetPath) {
+  const budget = JSON.parse(await readFile(resolve(options.budgetPath), 'utf8')) as unknown
+  report.budget = evaluateReplayBudget(report, budget)
+}
 
 printSummary(report)
 if (options.outputPath) {
@@ -67,8 +76,17 @@ if (options.outputPath) {
 } else {
   console.log(JSON.stringify(report, null, 2))
 }
+if (options.summaryPath) {
+  const summaryPath = resolve(options.summaryPath)
+  await mkdir(dirname(summaryPath), { recursive: true })
+  await writeFile(summaryPath, formatReplayReportMarkdown(report), 'utf8')
+  console.error(`Replay summary written to ${summaryPath}`)
+}
 
 if (options.failOnRegression && report.comparison?.regressions.length) {
+  process.exitCode = 1
+}
+if (options.failOnBudget && report.budget && !report.budget.passed) {
   process.exitCode = 1
 }
 
@@ -80,6 +98,7 @@ function parseArgs(args: string[]): CliOptions {
     concurrency: 1,
     keepThreads: false,
     failOnRegression: false,
+    failOnBudget: false,
     help: false
   }
   for (let index = 0; index < args.length; index += 1) {
@@ -97,8 +116,14 @@ function parseArgs(args: string[]): CliOptions {
       case '--output':
         options.outputPath = requiredValue(args, ++index, arg)
         break
+      case '--summary-output':
+        options.summaryPath = requiredValue(args, ++index, arg)
+        break
       case '--baseline':
         options.baselinePath = requiredValue(args, ++index, arg)
+        break
+      case '--budget':
+        options.budgetPath = requiredValue(args, ++index, arg)
         break
       case '--tag':
         options.tag = requiredValue(args, ++index, arg)
@@ -114,6 +139,9 @@ function parseArgs(args: string[]): CliOptions {
         break
       case '--fail-on-regression':
         options.failOnRegression = true
+        break
+      case '--fail-on-budget':
+        options.failOnBudget = true
         break
       case '--help':
       case '-h':
@@ -149,9 +177,12 @@ function printUsage(): void {
   console.log('  --repeat <n>              Repeat each selected task (default 1)')
   console.log('  --concurrency <n>         Parallel tasks, capped at 8 (default 1)')
   console.log('  --baseline <report.json>  Compare against an earlier report')
+  console.log('  --budget <budget.json>    Evaluate explicit CI budget thresholds')
   console.log('  --output <report.json>    Write the full machine-readable report')
+  console.log('  --summary-output <file>   Write a Markdown summary report')
   console.log('  --keep-threads            Keep generated replay threads')
   console.log('  --fail-on-regression      Exit 1 when comparison thresholds regress')
+  console.log('  --fail-on-budget          Exit 1 when explicit budget thresholds fail')
   console.log('')
   console.log('Authentication: set KUN_RUNTIME_TOKEN; it is intentionally not accepted as a CLI flag.')
 }
@@ -171,6 +202,10 @@ function printSummary(report: ReplayReport): void {
   if (report.comparison) {
     console.error(`Regressions: ${report.comparison.regressions.length}`)
     for (const regression of report.comparison.regressions) console.error(`  - ${regression}`)
+  }
+  if (report.budget) {
+    console.error(`Budget gate: ${report.budget.passed ? 'passed' : 'failed'}`)
+    for (const violation of report.budget.violations) console.error(`  - ${violation.message}`)
   }
 }
 


### PR DESCRIPTION
﻿## Summary
- Adds an explicit budget gate for the existing Kun replay benchmark report.
- Extends the replay CLI with budget evaluation and Markdown summary output.
- Adds a manual GitHub Actions workflow that runs replay suites and uploads JSON/Markdown artifacts.

## Changes
- `evaluateReplayBudget()` checks success rate, p95 latency, tool/SSE delay, token, cache, cost, and peak RSS budgets.
- `benchmark:replay` now accepts `--budget`, `--fail-on-budget`, and `--summary-output` while preserving existing baseline comparison behavior.
- The workflow is `workflow_dispatch` only, so it does not break normal PRs when no runtime/model credentials are available.

## Tests
- `npm.cmd --prefix kun test -- src/benchmark/replay-benchmark.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd --prefix kun run build`
- `git diff --check kunagent/develop...HEAD`
