### PR TITLE
refactor(model): extract compat capability resolver

### DIFF
--- a/kun/src/adapters/model/compat-capabilities.test.ts
+++ b/kun/src/adapters/model/compat-capabilities.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelCapabilityMetadata } from '../../contracts/capabilities.js'
+import { resolveCompatModelCapabilities } from './compat-capabilities.js'
+
+function metadata(overrides: Partial<ModelCapabilityMetadata> = {}): ModelCapabilityMetadata {
+  return {
+    id: 'vision-reasoning',
+    inputModalities: ['text', 'image'],
+    outputModalities: ['text'],
+    supportsToolCalling: false,
+    messageParts: ['text', 'image_url'],
+    maxOutputTokens: 12_000,
+    reasoning: {
+      supportedEfforts: ['auto', 'off', 'high'],
+      defaultEffort: 'auto',
+      requestProtocol: 'openai-responses'
+    },
+    ...overrides
+  }
+}
+
+describe('compat model capabilities', () => {
+  it('inherits provider endpoint format without model metadata', () => {
+    expect(resolveCompatModelCapabilities({
+      model: 'plain-model',
+      providerEndpointFormat: 'messages'
+    })).toMatchObject({
+      model: 'plain-model',
+      endpointFormat: 'messages',
+      inputModalities: ['text'],
+      messageParts: ['text'],
+      supportsStreaming: true,
+      supportsVision: false,
+      supportsReasoning: false,
+      supportsCacheUsage: true,
+      supportsToolCalling: true
+    })
+  })
+
+  it('lets per-model metadata override endpoint format and capabilities', () => {
+    const capabilities = resolveCompatModelCapabilities({
+      model: 'vision-reasoning',
+      providerEndpointFormat: 'chat_completions',
+      modelCapabilities: (model) => metadata({ id: model, endpointFormat: 'responses' })
+    })
+
+    expect(capabilities.endpointFormat).toBe('responses')
+    expect(capabilities.supportsVision).toBe(true)
+    expect(capabilities.supportsReasoning).toBe(true)
+    expect(capabilities.supportsToolCalling).toBe(false)
+    expect(capabilities.maxOutputTokens).toBe(12_000)
+    expect(capabilities.reasoning?.requestProtocol).toBe('openai-responses')
+  })
+})

--- a/kun/src/adapters/model/compat-capabilities.ts
+++ b/kun/src/adapters/model/compat-capabilities.ts
@@ -1,0 +1,46 @@
+import type { ModelCapabilityMetadata } from '../../contracts/capabilities.js'
+import {
+  DEFAULT_MODEL_ENDPOINT_FORMAT,
+  normalizeModelEndpointFormat,
+  type ModelEndpointFormat
+} from '../../contracts/model-endpoint-format.js'
+
+export type CompatModelCapabilities = {
+  model: string
+  endpointFormat: ModelEndpointFormat
+  inputModalities: ModelCapabilityMetadata['inputModalities']
+  messageParts: ModelCapabilityMetadata['messageParts']
+  supportsStreaming: boolean
+  supportsVision: boolean
+  supportsReasoning: boolean
+  supportsCacheUsage: boolean
+  supportsToolCalling: boolean
+  maxOutputTokens?: number
+  reasoning?: ModelCapabilityMetadata['reasoning']
+}
+
+export function resolveCompatModelCapabilities(input: {
+  model: string
+  providerEndpointFormat?: ModelEndpointFormat
+  modelCapabilities?: (model: string) => ModelCapabilityMetadata
+}): CompatModelCapabilities {
+  const metadata = input.modelCapabilities?.(input.model)
+  const endpointFormat = normalizeModelEndpointFormat(
+    metadata?.endpointFormat ?? input.providerEndpointFormat ?? DEFAULT_MODEL_ENDPOINT_FORMAT
+  )
+  const inputModalities = metadata?.inputModalities ?? ['text']
+  const messageParts = metadata?.messageParts ?? ['text']
+  return {
+    model: input.model,
+    endpointFormat,
+    inputModalities,
+    messageParts,
+    supportsStreaming: true,
+    supportsVision: inputModalities.includes('image'),
+    supportsReasoning: metadata?.reasoning !== undefined,
+    supportsCacheUsage: true,
+    supportsToolCalling: metadata?.supportsToolCalling ?? true,
+    ...(metadata?.maxOutputTokens ? { maxOutputTokens: metadata.maxOutputTokens } : {}),
+    ...(metadata?.reasoning ? { reasoning: metadata.reasoning } : {})
+  }
+}

--- a/kun/src/adapters/model/compat-model-client.ts
+++ b/kun/src/adapters/model/compat-model-client.ts
@@ -24,6 +24,7 @@ import {
 } from '../../contracts/model-endpoint-format.js'
 import { createProxyFetch } from './proxy-fetch.js'
 import { wrapUntrustedContent } from '../../security/untrusted-content.js'
+import { resolveCompatModelCapabilities } from './compat-capabilities.js'
 
 /**
  * Configuration for the compatible HTTP model client. Chat
@@ -378,17 +379,24 @@ export class CompatModelClient implements ModelClient {
    * Anthropic Messages models (e.g. OpenCode Go's minimax/qwen entries).
    */
   private endpointFormatForModel(model: string): ModelEndpointFormat {
-    const perModel = this.config.modelCapabilities?.(model).endpointFormat
-    return normalizeModelEndpointFormat(perModel ?? this.config.endpointFormat ?? DEFAULT_MODEL_ENDPOINT_FORMAT)
+    return this.capabilitiesForModel(model).endpointFormat
   }
 
   private modelReasoningFor(model: string): ModelCapabilityMetadata['reasoning'] | undefined {
-    return this.config.modelCapabilities?.(model).reasoning
+    return this.capabilitiesForModel(model).reasoning
   }
 
   /** Per-model output-token cap from capability metadata, if declared. */
   private maxOutputTokensFor(model: string): number | undefined {
-    return this.config.modelCapabilities?.(model).maxOutputTokens
+    return this.capabilitiesForModel(model).maxOutputTokens
+  }
+
+  private capabilitiesForModel(model: string) {
+    return resolveCompatModelCapabilities({
+      model,
+      providerEndpointFormat: this.config.endpointFormat,
+      modelCapabilities: this.config.modelCapabilities
+    })
   }
 
   /**
@@ -899,9 +907,8 @@ export class CompatModelClient implements ModelClient {
    * resolver is configured (the runtime always sets one).
    */
   private modelSupportsImageInput(model: string): boolean {
-    const capabilities = this.config.modelCapabilities?.(model)
-    if (!capabilities) return true
-    return capabilities.inputModalities.includes('image')
+    if (!this.config.modelCapabilities) return true
+    return this.capabilitiesForModel(model).supportsVision
   }
 
   private itemToMessage(item: TurnItem, thinkingMode: boolean, supportsImages: boolean): ChatMessage | null {


### PR DESCRIPTION
﻿## Summary
- Extracts per-model compatibility capability resolution from the large HTTP model client.
- Keeps existing request body and stream parser behavior unchanged.
- Adds focused tests for provider defaults and per-model endpoint/capability overrides.

## Changes
- Adds `compat-capabilities.ts` as the compatibility capability registry boundary for endpoint format, vision, reasoning, cache usage, tool calling, and max output tokens.
- Routes `CompatModelClient` endpoint format, reasoning, max-token, and vision checks through the resolver.
- Preserves the legacy default that image forwarding is allowed when no capability resolver is configured.

## Tests
- `npm.cmd --prefix kun test -- src/adapters/model/compat-capabilities.test.ts src/adapters/model/compat-model-client.endpoint-format.test.ts src/adapters/model/compat-model-client.tool-images.test.ts src/adapters/model/compat-model-client.streaming-tool-calls.test.ts src/adapters/model/compat-model-client.retry.test.ts`
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd --prefix kun run build`
- `git diff --check kunagent/develop...HEAD`
