### PR TITLE
perf(renderer): lazy load message timeline

### DIFF
--- a/src/renderer/src/components/chat/LazyMessageTimeline.tsx
+++ b/src/renderer/src/components/chat/LazyMessageTimeline.tsx
@@ -1,0 +1,27 @@
+import {
+  lazy,
+  Suspense,
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode
+} from 'react'
+import type { MessageTimeline } from './MessageTimeline'
+
+const LazyLoadedMessageTimeline = lazy(() =>
+  import('./MessageTimeline').then((module) => ({ default: module.MessageTimeline }))
+)
+
+export type LazyMessageTimelineProps = ComponentProps<typeof MessageTimeline> & {
+  fallback?: ReactNode
+}
+
+export function LazyMessageTimeline({
+  fallback = null,
+  ...props
+}: LazyMessageTimelineProps): ReactElement {
+  return (
+    <Suspense fallback={fallback}>
+      <LazyLoadedMessageTimeline {...props} />
+    </Suspense>
+  )
+}

--- a/src/renderer/src/components/design/DesignAIRail.tsx
+++ b/src/renderer/src/components/design/DesignAIRail.tsx
@@ -24,7 +24,7 @@ import { DESIGN_ASSISTANT_THREAD_TITLE } from '../../design/design-thread-regist
 import { useDesignWorkspaceStore } from '../../design/design-workspace-store'
 import { defaultFrameSizeForDesignTarget } from '../../design/design-context'
 import { cancelDesignPagesRun } from '../../design/design-pages-run'
-import { MessageTimeline } from '../chat/MessageTimeline'
+import { LazyMessageTimeline } from '../chat/LazyMessageTimeline'
 import { FloatingComposer } from '../chat/FloatingComposer'
 import type { DesignComposerContext } from '../chat/FloatingComposer'
 import type { ComposerReasoningEffort } from '../chat/FloatingComposerModelPicker'
@@ -445,7 +445,7 @@ function DesignAIRailInner({
               {t('designRailChildLoading')}
             </div>
           ) : hasTimeline ? (
-            <MessageTimeline
+            <LazyMessageTimeline
               blocks={timelineBlocks}
               liveReasoning={timelineLiveReasoning}
               live={timelineLiveAssistant}

--- a/src/renderer/src/components/design/DesignImplementPanel.tsx
+++ b/src/renderer/src/components/design/DesignImplementPanel.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import type { AttachmentReference, RuntimeConnectionStatus, ChatBlock } from '../../agent/types'
 import type { QueuedUserMessage } from '../../store/chat-store-types'
 import type { ModelProviderModelGroup } from '@shared/kun-gui-api'
-import { MessageTimeline } from '../chat/MessageTimeline'
+import { LazyMessageTimeline } from '../chat/LazyMessageTimeline'
 import { FloatingComposer } from '../chat/FloatingComposer'
 import type { ComposerReasoningEffort } from '../chat/FloatingComposerModelPicker'
 
@@ -128,7 +128,7 @@ export function DesignImplementPanel({
 
       <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden bg-ds-main/45 dark:bg-transparent">
         {hasTimeline ? (
-          <MessageTimeline
+          <LazyMessageTimeline
             blocks={blocks}
             liveReasoning={liveReasoning}
             live={liveAssistant}

--- a/src/renderer/src/components/sdd/SddAssistantPanel.tsx
+++ b/src/renderer/src/components/sdd/SddAssistantPanel.tsx
@@ -30,7 +30,7 @@ import type { AttachmentReference, ChatBlock, RuntimeConnectionStatus } from '..
 import type { QueuedUserMessage } from '../../store/chat-store-types'
 import type { ModelProviderModelGroup } from '@shared/kun-gui-api'
 import type { SddDraft } from '../../sdd/sdd-draft-store'
-import { MessageTimeline } from '../chat/MessageTimeline'
+import { LazyMessageTimeline } from '../chat/LazyMessageTimeline'
 import { FloatingComposer } from '../chat/FloatingComposer'
 import type { ComposerReasoningEffort } from '../chat/FloatingComposerModelPicker'
 import { SidebarTitlebarToggleButton } from '../sidebar/SidebarPrimitives'
@@ -181,7 +181,7 @@ export function SddAssistantPanel({
       <div className="sdd-assistant-body min-h-0 flex-1 overflow-y-auto overflow-x-hidden bg-ds-main/45 dark:bg-transparent">
         {hasTimeline ? (
           <div className="sdd-assistant-timeline">
-            <MessageTimeline
+            <LazyMessageTimeline
               blocks={blocks}
               liveReasoning={liveReasoning}
               live={liveAssistant}

--- a/src/renderer/src/components/workbench/WorkbenchChatStage.tsx
+++ b/src/renderer/src/components/workbench/WorkbenchChatStage.tsx
@@ -8,6 +8,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import type { ChatBlock, RuntimeConnectionStatus } from '../../agent/types'
 import { FloatingComposer } from '../chat/FloatingComposer'
+import { LazyMessageTimeline } from '../chat/LazyMessageTimeline'
 import { SubagentReturnBar } from '../chat/message-timeline-empty'
 import { WorkbenchTopActions } from '../chat/WorkbenchTopBar'
 import { IkunCameoLayer, KunCelebrationLayer } from '../chat/AnimatedWorkLogo'
@@ -15,9 +16,6 @@ import { DevPreviewLaunchCard } from '../DevPreviewLaunchCard'
 import { SessionHeader } from '../SessionHeader'
 import { SidebarTitlebarToggleButton } from '../sidebar/SidebarPrimitives'
 
-const MessageTimeline = lazy(() =>
-  import('../chat/MessageTimeline').then((module) => ({ default: module.MessageTimeline }))
-)
 const TerminalPanel = lazy(() =>
   import('../terminal/TerminalPanel').then((module) => ({ default: module.TerminalPanel }))
 )
@@ -127,32 +125,31 @@ export function WorkbenchChatStage({
           </div>
         </header>
         <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
-          <Suspense fallback={<WorkbenchPaneFallback />}>
-            <MessageTimeline
-              blocks={blocks}
-              liveReasoning={liveReasoning}
-              live={liveAssistant}
-              activeThreadId={activeThreadId}
-              runtimeConnection={runtimeConnection}
-              runtimeError={runtimeError}
-              onRetryConnection={onRetryConnection}
-              onOpenSettings={onOpenSettings}
-              onSelectSuggestion={onSelectSuggestion}
-              focusModeEnabled={focusModeEnabled}
-              planActionsBusy={planActionsBusy}
-              onBuildPlan={onBuildPlan}
-              onOpenPlan={onOpenPlan}
-              devPreviewCard={
-                devPreviewVisible && devPreviewUrl ? (
-                  <DevPreviewLaunchCard
-                    url={devPreviewUrl}
-                    opened={devPreviewOpened}
-                    onOpen={onOpenDevPreview}
-                  />
-                ) : null
-              }
-            />
-          </Suspense>
+          <LazyMessageTimeline
+            fallback={<WorkbenchPaneFallback />}
+            blocks={blocks}
+            liveReasoning={liveReasoning}
+            live={liveAssistant}
+            activeThreadId={activeThreadId}
+            runtimeConnection={runtimeConnection}
+            runtimeError={runtimeError}
+            onRetryConnection={onRetryConnection}
+            onOpenSettings={onOpenSettings}
+            onSelectSuggestion={onSelectSuggestion}
+            focusModeEnabled={focusModeEnabled}
+            planActionsBusy={planActionsBusy}
+            onBuildPlan={onBuildPlan}
+            onOpenPlan={onOpenPlan}
+            devPreviewCard={
+              devPreviewVisible && devPreviewUrl ? (
+                <DevPreviewLaunchCard
+                  url={devPreviewUrl}
+                  opened={devPreviewOpened}
+                  onOpen={onOpenDevPreview}
+                />
+              ) : null
+            }
+          />
           {uiModeCameosEnabled && !focusModeEnabled ? <IkunCameoLayer /> : null}
           {!focusModeEnabled ? <KunCelebrationLayer active={busy} suppressed={Boolean(runtimeError)} /> : null}
         </div>

--- a/src/renderer/src/components/write/WriteAssistantPanel.tsx
+++ b/src/renderer/src/components/write/WriteAssistantPanel.tsx
@@ -19,7 +19,7 @@ import {
   useWriteWorkspaceStore,
   writeRelativeToWorkspace
 } from '../../write/write-workspace-store'
-import { MessageTimeline } from '../chat/MessageTimeline'
+import { LazyMessageTimeline } from '../chat/LazyMessageTimeline'
 import { FloatingComposer } from '../chat/FloatingComposer'
 import type { ComposerReasoningEffort } from '../chat/FloatingComposerModelPicker'
 
@@ -194,7 +194,7 @@ export function WriteAssistantPanel({
 
       <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden bg-ds-main/45 dark:bg-transparent">
         {hasTimeline ? (
-          <MessageTimeline
+          <LazyMessageTimeline
             blocks={blocks}
             liveReasoning={liveReasoning}
             live={liveAssistant}


### PR DESCRIPTION
﻿## Summary
- Add a shared LazyMessageTimeline wrapper around the heavy MessageTimeline component
- Replace the remaining static imports in Workbench, Write, SDD, and Design panels so MessageTimeline can stay in its own renderer chunk
- Preserves the existing Workbench fallback and uses the default null fallback in side panels where the timeline is already conditional

## Validation
- npm.cmd run typecheck
- npm.cmd test -- src/renderer/src/components/chat/MessageTimeline.tool-summary.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts
- npm.cmd run build
- git diff --check

## Notes
- The previous build warning about MessageTimeline being both dynamically and statically imported is gone. The remaining Vite warning is the existing main-process image-gen-tool-provider split warning and is unrelated to this PR.
