### PR TITLE
refactor(settings): split agents section helpers

### DIFF
--- a/src/renderer/src/components/settings-section-agents-utils.test.ts
+++ b/src/renderer/src/components/settings-section-agents-utils.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import type { SkillRootListItem } from '@shared/kun-gui-api'
+import {
+  compactList,
+  modelContextProfileSummary,
+  skillRootShortLabel,
+  summarizeMcpPermissionSources,
+  summarizeSkillPermissionSources
+} from './settings-section-agents-utils'
+
+describe('settings-section-agents-utils', () => {
+  it('summarizes skill permission sources by enabled root scope and disabled ids', () => {
+    const roots: SkillRootListItem[] = [
+      root({ id: 'workspace', scope: 'project', enabled: true }),
+      root({ id: 'global', scope: 'global', enabled: true }),
+      root({ id: 'disabled', scope: 'project', enabled: false })
+    ]
+
+    expect(summarizeSkillPermissionSources(roots, ['a', 'b'])).toEqual({
+      enabledRoots: 2,
+      disabledRoots: 1,
+      workspaceRoots: 1,
+      globalRoots: 1,
+      disabledSkillIds: 2
+    })
+  })
+
+  it('summarizes MCP permission sources from the editable config text', () => {
+    const summary = summarizeMcpPermissionSources(JSON.stringify({
+      servers: {
+        local: {
+          transport: 'stdio',
+          command: 'node',
+          env: { TOKEN: 'secret' },
+          trustScope: 'workspace',
+          workspaceRoots: ['/repo']
+        },
+        remote: {
+          transport: 'streamable-http',
+          url: 'https://example.test/mcp',
+          headers: { Authorization: 'Bearer secret' },
+          trustScope: 'user'
+        },
+        off: { enabled: false, transport: 'stdio', command: 'node' }
+      }
+    }))
+
+    expect(summary).toMatchObject({
+      parseError: null,
+      enabledServers: 2,
+      disabledServers: 1,
+      userScopeServers: 1,
+      workspaceScopeServers: 1,
+      workspaceVisibleServers: 1,
+      localServers: 1,
+      remoteServers: 1,
+      envServers: 1,
+      headerServers: 1
+    })
+  })
+
+  it('returns parse errors without reporting stale MCP counts', () => {
+    expect(summarizeMcpPermissionSources('{broken')).toMatchObject({
+      parseError: expect.any(String),
+      enabledServers: 0,
+      remoteServers: 0
+    })
+  })
+
+  it('uses built-in DeepSeek context labels only for known model ids', () => {
+    expect(modelContextProfileSummary({
+      model: 'provider/deepseek-v4-pro',
+      fallbackSoftThreshold: 10,
+      fallbackHardThreshold: 20
+    })).toMatchObject({
+      modelLabel: 'deepseek-v4-pro',
+      contextWindowLabel: '1,000,000',
+      sourceLabelKey: 'kunModelContextSourceBuiltIn'
+    })
+
+    expect(modelContextProfileSummary({
+      model: 'custom-model',
+      fallbackSoftThreshold: 10,
+      fallbackHardThreshold: 20
+    })).toEqual({
+      modelLabel: 'custom-model',
+      contextWindowLabel: 'models.profiles',
+      softThresholdLabel: '10',
+      hardThresholdLabel: '20',
+      sourceLabelKey: 'kunModelContextSourceFallback'
+    })
+  })
+
+  it('formats compact labels without leaking long lists into settings cards', () => {
+    expect(skillRootShortLabel('C:\\Users\\me\\.kun\\skills')).toBe('.kun/skills')
+    expect(compactList(['one', 'two', 'three', 'four', 'five'], 'empty')).toBe('one, two, three, four')
+    expect(compactList([], 'empty')).toBe('empty')
+  })
+})
+
+function root(patch: Partial<SkillRootListItem>): SkillRootListItem {
+  return {
+    id: patch.id ?? 'root',
+    disableKey: `${patch.id ?? 'root'}:disable`,
+    path: patch.path ?? '/repo/.kun/skills',
+    scope: patch.scope ?? 'project',
+    source: patch.source ?? 'extra',
+    exists: patch.exists ?? true,
+    enabled: patch.enabled ?? true,
+    skillCount: patch.skillCount ?? 0
+  }
+}

--- a/src/renderer/src/components/settings-section-agents-utils.ts
+++ b/src/renderer/src/components/settings-section-agents-utils.ts
@@ -1,0 +1,180 @@
+import type { SkillRootListItem } from '@shared/kun-gui-api'
+import { parseUsageResponse } from '../hooks/usage-response'
+import { parseMcpConfigText, type McpFormServer } from './mcp/mcp-config-form'
+
+export function statusPill(status: string | undefined): string {
+  if (status === 'available') return 'border-emerald-400/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+  if (status === 'disabled') return 'border-ds-border-muted bg-ds-card text-ds-faint'
+  return 'border-red-300/50 bg-red-500/10 text-red-700 dark:text-red-200'
+}
+
+export function skillRootShortLabel(path: string): string {
+  const parts = path.split(/[\\/]+/).filter(Boolean)
+  return parts.slice(-2).join('/') || path
+}
+
+export function compactList(values: unknown, empty: string): string {
+  if (!Array.isArray(values) || values.length === 0) return empty
+  return values
+    .map((value) => typeof value === 'string' ? value : JSON.stringify(value))
+    .slice(0, 4)
+    .join(', ')
+}
+
+export type SkillPermissionSummary = {
+  enabledRoots: number
+  disabledRoots: number
+  workspaceRoots: number
+  globalRoots: number
+  disabledSkillIds: number
+}
+
+export function summarizeSkillPermissionSources(
+  roots: readonly SkillRootListItem[],
+  disabledSkillIds: unknown
+): SkillPermissionSummary {
+  return {
+    enabledRoots: roots.filter((root) => root.enabled).length,
+    disabledRoots: roots.filter((root) => !root.enabled).length,
+    workspaceRoots: roots.filter((root) => root.enabled && root.scope === 'project').length,
+    globalRoots: roots.filter((root) => root.enabled && root.scope === 'global').length,
+    disabledSkillIds: Array.isArray(disabledSkillIds) ? disabledSkillIds.length : 0
+  }
+}
+
+export type McpPermissionSummary = {
+  parseError: string | null
+  enabledServers: number
+  disabledServers: number
+  userScopeServers: number
+  workspaceScopeServers: number
+  workspaceVisibleServers: number
+  localServers: number
+  remoteServers: number
+  envServers: number
+  headerServers: number
+}
+
+function hasEntries(entries: McpFormServer['env'] | McpFormServer['headers']): boolean {
+  return entries.some((entry) => entry.key.trim() || entry.value.trim())
+}
+
+export function summarizeMcpPermissionSources(text: string): McpPermissionSummary {
+  const parsed = parseMcpConfigText(text)
+  if (!parsed.ok) {
+    return {
+      parseError: parsed.error,
+      enabledServers: 0,
+      disabledServers: 0,
+      userScopeServers: 0,
+      workspaceScopeServers: 0,
+      workspaceVisibleServers: 0,
+      localServers: 0,
+      remoteServers: 0,
+      envServers: 0,
+      headerServers: 0
+    }
+  }
+  const enabled = parsed.model.servers.filter((server) => server.enabled)
+  return {
+    parseError: null,
+    enabledServers: enabled.length,
+    disabledServers: parsed.model.servers.length - enabled.length,
+    userScopeServers: enabled.filter((server) => server.trustScope === 'user').length,
+    workspaceScopeServers: enabled.filter((server) => server.trustScope === 'workspace').length,
+    workspaceVisibleServers: enabled.filter((server) =>
+      server.workspaceRoots.some((root) => root.trim())
+    ).length,
+    localServers: enabled.filter((server) => server.transport === 'stdio').length,
+    remoteServers: enabled.filter((server) => server.transport !== 'stdio').length,
+    envServers: enabled.filter((server) => hasEntries(server.env)).length,
+    headerServers: enabled.filter((server) => hasEntries(server.headers)).length
+  }
+}
+
+export type TokenEconomySavingsSummary = {
+  tokens: number
+}
+
+export type TokenEconomySavingsState = {
+  loading: boolean
+  loaded: boolean
+  summary: TokenEconomySavingsSummary | null
+}
+
+export const EMPTY_TOKEN_ECONOMY_SAVINGS_STATE: TokenEconomySavingsState = {
+  loading: false,
+  loaded: false,
+  summary: null
+}
+
+export type ModelContextProfileSummary = {
+  modelLabel: string
+  contextWindowLabel: string
+  softThresholdLabel: string
+  hardThresholdLabel: string
+  sourceLabelKey: string
+}
+
+const DEEPSEEK_V4_CONTEXT_PROFILE = {
+  contextWindowTokens: 1_000_000,
+  softThreshold: 980_000,
+  hardThreshold: 990_000
+}
+
+function formatTokenNumber(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value)
+}
+
+function normalizeModelId(model: string | undefined): string {
+  const normalized = model?.trim().toLowerCase() ?? ''
+  return normalized === 'auto' ? '' : normalized
+}
+
+function knownModelContextProfile(input: string | undefined): { modelLabel: string } | null {
+  const normalized = normalizeModelId(input)
+  if (!normalized) return null
+  const match = ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-chat', 'deepseek-reasoner']
+    .find((modelId) => normalized === modelId || normalized.endsWith(`/${modelId}`))
+  return match ? { modelLabel: match } : null
+}
+
+export function modelContextProfileSummary(input: {
+  model: string | undefined
+  fallbackSoftThreshold: number
+  fallbackHardThreshold: number
+}): ModelContextProfileSummary {
+  const known = knownModelContextProfile(input.model)
+  if (known) {
+    return {
+      modelLabel: known.modelLabel,
+      contextWindowLabel: formatTokenNumber(DEEPSEEK_V4_CONTEXT_PROFILE.contextWindowTokens),
+      softThresholdLabel: formatTokenNumber(DEEPSEEK_V4_CONTEXT_PROFILE.softThreshold),
+      hardThresholdLabel: formatTokenNumber(DEEPSEEK_V4_CONTEXT_PROFILE.hardThreshold),
+      sourceLabelKey: 'kunModelContextSourceBuiltIn'
+    }
+  }
+  const model = input.model?.trim() || 'auto'
+  return {
+    modelLabel: model,
+    contextWindowLabel: 'models.profiles',
+    softThresholdLabel: formatTokenNumber(input.fallbackSoftThreshold),
+    hardThresholdLabel: formatTokenNumber(input.fallbackHardThreshold),
+    sourceLabelKey: 'kunModelContextSourceFallback'
+  }
+}
+
+function usageNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+export async function loadTokenEconomySavingsSummary(): Promise<TokenEconomySavingsSummary | null> {
+  if (typeof window === 'undefined' || typeof window.kunGui?.runtimeRequest !== 'function') return null
+  const response = await window.kunGui.runtimeRequest('/v1/usage?group_by=thread', 'GET')
+  if (!response.ok || !response.body.trim()) return null
+  const parsed = parseUsageResponse<{ totals?: Record<string, unknown> }>(response.body, 'token economy usage')
+  const totals = parsed.totals ?? {}
+  const tokens = usageNumber(totals.token_economy_savings_tokens)
+  if (tokens <= 0) return null
+  return { tokens }
+}

--- a/src/renderer/src/components/settings-section-agents.tsx
+++ b/src/renderer/src/components/settings-section-agents.tsx
@@ -46,7 +46,6 @@ import {
 } from 'lucide-react'
 import { GuiUpdateControl } from './settings-gui-update'
 import { McpServersEditor } from './mcp/McpServersEditor'
-import { parseMcpConfigText, type McpFormServer } from './mcp/mcp-config-form'
 import {
   AdvancedSettingsDisclosure,
   InlineNoticeView,
@@ -58,7 +57,17 @@ import {
   Toggle
 } from './settings-controls'
 import { formatCompactNumber } from '../hooks/use-thread-usage'
-import { parseUsageResponse } from '../hooks/usage-response'
+import {
+  compactList,
+  EMPTY_TOKEN_ECONOMY_SAVINGS_STATE,
+  loadTokenEconomySavingsSummary,
+  modelContextProfileSummary,
+  skillRootShortLabel,
+  statusPill,
+  summarizeMcpPermissionSources,
+  summarizeSkillPermissionSources,
+  type TokenEconomySavingsState
+} from './settings-section-agents-utils'
 
 export { modelProvidersSettingsPatch } from './settings-section-providers'
 
@@ -112,183 +121,6 @@ const TOOL_PERMISSION_OPTIONS: Array<{
     iconClass: 'border-orange-400/35 bg-orange-500/10 text-orange-700 dark:text-orange-200'
   }
 ]
-
-function statusPill(status: string | undefined): string {
-  if (status === 'available') return 'border-emerald-400/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
-  if (status === 'disabled') return 'border-ds-border-muted bg-ds-card text-ds-faint'
-  return 'border-red-300/50 bg-red-500/10 text-red-700 dark:text-red-200'
-}
-
-function skillRootShortLabel(path: string): string {
-  const parts = path.split(/[\\/]+/).filter(Boolean)
-  return parts.slice(-2).join('/') || path
-}
-
-function compactList(values: unknown, empty: string): string {
-  if (!Array.isArray(values) || values.length === 0) return empty
-  return values
-    .map((value) => typeof value === 'string' ? value : JSON.stringify(value))
-    .slice(0, 4)
-    .join(', ')
-}
-
-type SkillPermissionSummary = {
-  enabledRoots: number
-  disabledRoots: number
-  workspaceRoots: number
-  globalRoots: number
-  disabledSkillIds: number
-}
-
-function summarizeSkillPermissionSources(
-  roots: readonly SkillRootListItem[],
-  disabledSkillIds: unknown
-): SkillPermissionSummary {
-  return {
-    enabledRoots: roots.filter((root) => root.enabled).length,
-    disabledRoots: roots.filter((root) => !root.enabled).length,
-    workspaceRoots: roots.filter((root) => root.enabled && root.scope === 'project').length,
-    globalRoots: roots.filter((root) => root.enabled && root.scope === 'global').length,
-    disabledSkillIds: Array.isArray(disabledSkillIds) ? disabledSkillIds.length : 0
-  }
-}
-
-type McpPermissionSummary = {
-  parseError: string | null
-  enabledServers: number
-  disabledServers: number
-  userScopeServers: number
-  workspaceScopeServers: number
-  workspaceVisibleServers: number
-  localServers: number
-  remoteServers: number
-  envServers: number
-  headerServers: number
-}
-
-function hasEntries(entries: McpFormServer['env'] | McpFormServer['headers']): boolean {
-  return entries.some((entry) => entry.key.trim() || entry.value.trim())
-}
-
-function summarizeMcpPermissionSources(text: string): McpPermissionSummary {
-  const parsed = parseMcpConfigText(text)
-  if (!parsed.ok) {
-    return {
-      parseError: parsed.error,
-      enabledServers: 0,
-      disabledServers: 0,
-      userScopeServers: 0,
-      workspaceScopeServers: 0,
-      workspaceVisibleServers: 0,
-      localServers: 0,
-      remoteServers: 0,
-      envServers: 0,
-      headerServers: 0
-    }
-  }
-  const enabled = parsed.model.servers.filter((server) => server.enabled)
-  return {
-    parseError: null,
-    enabledServers: enabled.length,
-    disabledServers: parsed.model.servers.length - enabled.length,
-    userScopeServers: enabled.filter((server) => server.trustScope === 'user').length,
-    workspaceScopeServers: enabled.filter((server) => server.trustScope === 'workspace').length,
-    workspaceVisibleServers: enabled.filter((server) =>
-      server.workspaceRoots.some((root) => root.trim())
-    ).length,
-    localServers: enabled.filter((server) => server.transport === 'stdio').length,
-    remoteServers: enabled.filter((server) => server.transport !== 'stdio').length,
-    envServers: enabled.filter((server) => hasEntries(server.env)).length,
-    headerServers: enabled.filter((server) => hasEntries(server.headers)).length
-  }
-}
-
-type TokenEconomySavingsSummary = {
-  tokens: number
-}
-
-type TokenEconomySavingsState = {
-  loading: boolean
-  loaded: boolean
-  summary: TokenEconomySavingsSummary | null
-}
-
-const EMPTY_TOKEN_ECONOMY_SAVINGS_STATE: TokenEconomySavingsState = {
-  loading: false,
-  loaded: false,
-  summary: null
-}
-
-type ModelContextProfileSummary = {
-  modelLabel: string
-  contextWindowLabel: string
-  softThresholdLabel: string
-  hardThresholdLabel: string
-  sourceLabelKey: string
-}
-
-const DEEPSEEK_V4_CONTEXT_PROFILE = {
-  contextWindowTokens: 1_000_000,
-  softThreshold: 980_000,
-  hardThreshold: 990_000
-}
-
-function formatTokenNumber(value: number): string {
-  return new Intl.NumberFormat('en-US').format(value)
-}
-
-function normalizeModelId(model: string | undefined): string {
-  const normalized = model?.trim().toLowerCase() ?? ''
-  return normalized === 'auto' ? '' : normalized
-}
-
-function knownModelContextProfile(input: string | undefined): { modelLabel: string } | null {
-  const normalized = normalizeModelId(input)
-  if (!normalized) return null
-  const match = ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-chat', 'deepseek-reasoner']
-    .find((modelId) => normalized === modelId || normalized.endsWith(`/${modelId}`))
-  return match ? { modelLabel: match } : null
-}
-
-function modelContextProfileSummary(input: {
-  model: string | undefined
-  fallbackSoftThreshold: number
-  fallbackHardThreshold: number
-}): ModelContextProfileSummary {
-  const known = knownModelContextProfile(input.model)
-  if (known) {
-    return {
-      modelLabel: known.modelLabel,
-      contextWindowLabel: formatTokenNumber(DEEPSEEK_V4_CONTEXT_PROFILE.contextWindowTokens),
-      softThresholdLabel: formatTokenNumber(DEEPSEEK_V4_CONTEXT_PROFILE.softThreshold),
-      hardThresholdLabel: formatTokenNumber(DEEPSEEK_V4_CONTEXT_PROFILE.hardThreshold),
-      sourceLabelKey: 'kunModelContextSourceBuiltIn'
-    }
-  }
-  const model = input.model?.trim() || 'auto'
-  return {
-    modelLabel: model,
-    contextWindowLabel: 'models.profiles',
-    softThresholdLabel: formatTokenNumber(input.fallbackSoftThreshold),
-    hardThresholdLabel: formatTokenNumber(input.fallbackHardThreshold),
-    sourceLabelKey: 'kunModelContextSourceFallback'
-  }
-}
-
-function usageNumber(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : 0
-}
-
-async function loadTokenEconomySavingsSummary(): Promise<TokenEconomySavingsSummary | null> {
-  if (typeof window === 'undefined' || typeof window.kunGui?.runtimeRequest !== 'function') return null
-  const response = await window.kunGui.runtimeRequest('/v1/usage?group_by=thread', 'GET')
-  if (!response.ok || !response.body.trim()) return null
-  const parsed = parseUsageResponse<{ totals?: Record<string, unknown> }>(response.body, 'token economy usage')
-  const totals = parsed.totals ?? {}
-  const tokens = usageNumber(totals.token_economy_savings_tokens)
-  if (tokens <= 0) return null
-  return { tokens }
-}
 
 export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): ReactElement {
   const {


### PR DESCRIPTION
﻿## Summary
- Splits pure helper logic out of the large Agents settings section into `settings-section-agents-utils`.
- Covers MCP permission summaries, Skill permission summaries, model context labels, compact list labels, and token economy savings loading from the new helper module.
- Keeps the settings UI and state update paths unchanged.

## Why
This is a small frontend performance/maintainability split. `settings-section-agents.tsx` was carrying pure parsing and summary logic inline, which made the lazy-loaded settings chunk harder to review and evolve. This PR moves that logic behind targeted tests without introducing a new runtime path.

## Tests
- npm.cmd test -- src/renderer/src/components/settings-section-agents-utils.test.ts src/renderer/src/components/settings-section-agents.test.ts
- npm.cmd run typecheck
- npm.cmd run build
- git diff --check kunagent/develop...HEAD

Note: the build still reports the existing MessageTimeline static/dynamic import warning on current develop. That warning is addressed separately by #820 and is not introduced by this PR.
