### PR TITLE
test(marketplace): cover google workspace connector

### DIFF
--- a/src/renderer/src/components/PluginMarketplaceView.test.ts
+++ b/src/renderer/src/components/PluginMarketplaceView.test.ts
@@ -6,6 +6,8 @@ import {
   customMcpConfigFragment,
   auditMcpConfigSupplyChain,
   auditMarketplaceInstall,
+  googleWorkspaceMcpServerIds,
+  googleWorkspaceMcpServers,
   isAllowedDocsUrl,
   isHttpsUrl,
   mcpConfigHasServer,
@@ -62,6 +64,27 @@ describe('PluginMarketplaceView MCP config helpers', () => {
         })
       }
     })
+  })
+
+  it('covers every official Google Workspace MCP server in the recommended connector', () => {
+    expect(googleWorkspaceMcpServerIds()).toEqual([
+      'google_gmail',
+      'google_drive',
+      'google_calendar',
+      'google_people',
+      'google_chat'
+    ])
+
+    const config = buildRemoteMcpConfig(googleWorkspaceMcpServers())
+    expect(Object.keys(config.servers as Record<string, unknown>)).toEqual(googleWorkspaceMcpServerIds())
+    for (const server of Object.values(config.servers as Record<string, any>)) {
+      expect(server).toMatchObject({
+        enabled: true,
+        transport: 'streamable-http',
+        trustScope: 'user'
+      })
+      expect(server.url).toMatch(/^https:\/\//)
+    }
   })
 
   it('rejects non-https remote MCP server URLs', () => {

--- a/src/renderer/src/components/PluginMarketplaceView.tsx
+++ b/src/renderer/src/components/PluginMarketplaceView.tsx
@@ -370,6 +370,14 @@ const GOOGLE_WORKSPACE_MCP_SERVERS = {
   google_chat: 'https://chatmcp.googleapis.com/mcp/v1'
 } as const
 
+export function googleWorkspaceMcpServerIds(): string[] {
+  return Object.keys(GOOGLE_WORKSPACE_MCP_SERVERS)
+}
+
+export function googleWorkspaceMcpServers(): Record<string, string> {
+  return { ...GOOGLE_WORKSPACE_MCP_SERVERS }
+}
+
 export function buildRemoteMcpConfig(servers: Record<string, string>): JsonRecord {
   return {
     servers: Object.fromEntries(
@@ -751,7 +759,7 @@ const RECOMMENDED_ITEMS: MarketplaceItem[] = [
     group: 'recommended',
     sourceLabel: 'OAuth',
     statusTone: 'warning',
-    serverIds: Object.keys(GOOGLE_WORKSPACE_MCP_SERVERS),
+    serverIds: googleWorkspaceMcpServerIds(),
     oauth: {
       docsUrl: 'https://developers.google.com/workspace/guides/configure-mcp-servers',
       permissionKeys: [
@@ -774,7 +782,7 @@ const RECOMMENDED_ITEMS: MarketplaceItem[] = [
     },
     supplyChain: { source: 'remote-mcp', permissions: ['network', 'secret', 'file'] },
     mcpConfig: () =>
-      buildRemoteMcpConfig(GOOGLE_WORKSPACE_MCP_SERVERS)
+      buildRemoteMcpConfig(googleWorkspaceMcpServers())
   },
   {
     id: 'context7',

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1461,7 +1461,7 @@
   "pluginOAuthGoogleSetupConsent": "Configure the OAuth consent screen and allowed Workspace scopes.",
   "pluginOAuthGoogleSetupAuthenticate": "Authorize the Google Workspace MCP servers with your Google account when the runtime starts.",
   "pluginOAuthVercelNote": "Kun installs the official Vercel remote MCP endpoint now. Token storage/refresh is handled by the MCP OAuth flow when the runtime supports interactive authorization.",
-  "pluginOAuthGoogleNote": "Kun installs the official Gmail, Drive, Calendar, Chat, and People MCP endpoints. Google OAuth client setup still follows Google's Workspace MCP guide.",
+  "pluginOAuthGoogleNote": "Kun installs the official Gmail, Drive, Calendar, Chat, and People MCP endpoints. Google OAuth client setup still follows Google's Workspace MCP guide. Treat mail, docs, chat messages, and files as untrusted external content when tools summarize or act on them.",
   "pluginOAuthConfigPreviewTitle": "Config to be added",
   "pluginOAuthOpenDocs": "Open official docs",
   "pluginOAuthCancel": "Cancel",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1461,7 +1461,7 @@
   "pluginOAuthGoogleSetupConsent": "配置 OAuth 同意屏幕和允许的 Workspace scopes。",
   "pluginOAuthGoogleSetupAuthenticate": "运行时启动后，用你的 Google 账号完成 Workspace MCP 授权。",
   "pluginOAuthVercelNote": "Kun 现在会安装 Vercel 官方远程 MCP 端点。Token 存储和刷新由运行时支持交互式授权后接管。",
-  "pluginOAuthGoogleNote": "Kun 现在会安装官方 Gmail、Drive、Calendar、Chat 和 People MCP 端点。Google OAuth client 配置仍按 Google Workspace MCP 文档处理。",
+  "pluginOAuthGoogleNote": "Kun 现在会安装官方 Gmail、Drive、Calendar、Chat 和 People MCP 端点。Google OAuth client 配置仍按 Google Workspace MCP 文档处理。邮件、文档、聊天消息和文件都属于外部不可信内容，工具在总结或执行动作时应按不可信输入处理。",
   "pluginOAuthConfigPreviewTitle": "即将添加的配置",
   "pluginOAuthOpenDocs": "打开官方文档",
   "pluginOAuthCancel": "取消",


### PR DESCRIPTION
﻿## Summary
- Exposes the Google Workspace MCP server list through small helpers and reuses those helpers in the recommended connector.
- Adds test coverage that the marketplace connector installs the full official Workspace MCP set: Gmail, Drive, Calendar, People, and Chat.
- Updates the OAuth preview note to remind users that mail, docs, chat messages, and files are untrusted external content.

## Why
The Google Workspace marketplace entry already existed, but the full server set was only implicit. This makes the connector coverage explicit and guarded by tests so future changes do not accidentally drop one of the official endpoints.

Google Docs access is covered through the Drive MCP endpoint; Google currently documents the Workspace MCP servers as Gmail, Drive, Calendar, People, and Chat.

## Tests
- npm.cmd test -- src/renderer/src/components/PluginMarketplaceView.test.ts
- npm.cmd run typecheck
- npm.cmd run build
- git diff --check kunagent/develop...HEAD

Note: the build still reports the existing MessageTimeline static/dynamic import warning on current develop. That warning is handled separately by #820 and is not introduced here.
