### PR TITLE
fix(shell): resolve Windows spawn EPERM for Kun commands

### DIFF
--- a/kun/src/adapters/tool/builtin-bash-tool.ts
+++ b/kun/src/adapters/tool/builtin-bash-tool.ts
@@ -1,6 +1,6 @@
 import { mkdir } from 'node:fs/promises'
 import { randomBytes } from 'node:crypto'
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { LocalToolHost, type LocalTool } from './local-tool-host.js'
 import { OutputAccumulator } from './output-accumulator.js'
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from './truncate.js'
@@ -12,9 +12,9 @@ import {
 import {
   describeKind,
   normalizePositiveInteger,
-  shellCommandArgs,
-  shellRuntimeInfo,
-  shellSpawnEnv,
+  createShellCommandRunner,
+  ShellSpawnError,
+  type ShellCommandRunner,
   terminateSpawnTree,
   waitForSpawnExit,
   withToolBoundary,
@@ -90,7 +90,8 @@ async function bashExecute(
     command: string,
     cwd: string,
     options: { signal: AbortSignal; timeoutSeconds: number; onData?: (data: Buffer) => void }
-  ) => Promise<{ exitCode: number | null; shell?: string }>
+  ) => Promise<{ exitCode: number | null; shell?: string }>,
+  shellRunner: ShellCommandRunner = createShellCommandRunner()
 ): Promise<{
   output: string
   exitCode: number | null
@@ -99,17 +100,17 @@ async function bashExecute(
   fullOutputPath?: string
 }> {
   await mkdir(cwd, { recursive: true })
-  const shellRuntime = shellRuntimeInfo()
-  let resultShell = shellRuntime.name
-  const child = execOperation
+  let resultShell = shellRunner.runtime.name
+  const started = execOperation
     ? null
-    : spawn(shellRuntime.shell, shellCommandArgs(shellRuntime, command), {
+    : await shellRunner.spawn(command, {
         cwd,
-        env: shellSpawnEnv(),
         detached: process.platform !== 'win32',
         stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true
       })
+  const child = started?.child ?? null
+  if (started) resultShell = started.runtime.name
   let timedOut = false
   let settled = false
   const output = new OutputAccumulator({
@@ -561,20 +562,21 @@ async function startBackgroundBashSession(
     outputLimits: { maxLines: number; maxBytes: number }
   },
   hooks: BashLocalToolOptions['backgroundShell'],
-  onUpdate?: (update: { output: unknown; isError?: boolean }) => Promise<void> | void
+  onUpdate?: (update: { output: unknown; isError?: boolean }) => Promise<void> | void,
+  shellRunner: ShellCommandRunner = createShellCommandRunner()
 ): Promise<{ payload: BashPayload; isError?: boolean }> {
   if (!input.dataDir?.trim()) {
     throw new Error('background shell sessions require runtime dataDir')
   }
   await mkdir(input.cwd, { recursive: true })
-  const shellRuntime = shellRuntimeInfo()
-  const child = spawn(shellRuntime.shell, shellCommandArgs(shellRuntime, input.command), {
+  const started = await shellRunner.spawn(input.command, {
     cwd: input.cwd,
-    env: shellSpawnEnv(),
     detached: process.platform !== 'win32',
     stdio: ['pipe', 'pipe', 'pipe'],
     windowsHide: true
   })
+  const shellRuntime = started.runtime
+  const child = started.child as ChildProcessWithoutNullStreams
   const sessionId = nextSessionId()
   const outputWriter = new BackgroundShellOutputWriter(input.dataDir, input.threadId, sessionId)
   await outputWriter.open()
@@ -692,7 +694,8 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
     maxLines: options.maxLines ?? DEFAULT_MAX_LINES,
     maxBytes: options.maxBytes ?? DEFAULT_MAX_BYTES
   }
-  const shellRuntime = shellRuntimeInfo()
+  const shellRunner = createShellCommandRunner()
+  const shellRuntime = shellRunner.runtime
   return LocalToolHost.defineTool({
     name: 'bash',
     description: `Execute a shell command in the workspace using the host platform shell. Current shell: ${shellRuntime.name}. Use ${shellRuntime.syntax} syntax. Return combined stdout and stderr. Runs synchronously by default (background defaults to false). Set background=true to start a detached session that keeps running after the turn ends; the tool assigns an 8-character session_id in the response. Use the background_shell tool to list, read, poll, write, or stop background sessions.`,
@@ -738,7 +741,8 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
               outputLimits
             },
             shellHooks,
-            onUpdate
+            onUpdate,
+            shellRunner
           )
           return {
             output: result.payload,
@@ -752,7 +756,8 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
           timeout,
           outputLimits,
           onUpdate,
-          bashOps?.exec
+          bashOps?.exec,
+          shellRunner
         )
         const payload = resultPayload({
           command,
@@ -774,11 +779,13 @@ export function createBashLocalTool(options: BashLocalToolOptions = {}): LocalTo
           output: payload
         }
       } catch (error) {
+        const spawnError = error instanceof ShellSpawnError ? error.toJSON() : undefined
         return {
           output: {
             command,
             cwd,
-            error: error instanceof Error ? error.message : String(error)
+            error: error instanceof Error ? error.message : String(error),
+            ...(spawnError ? { spawn_error: spawnError } : {})
           },
           isError: true
         }

--- a/kun/src/adapters/tool/builtin-tool-operations.ts
+++ b/kun/src/adapters/tool/builtin-tool-operations.ts
@@ -1,6 +1,5 @@
 import { existsSync } from 'node:fs'
 import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
-import { spawn } from 'node:child_process'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import type {
@@ -19,11 +18,9 @@ import {
   DEFAULT_IMAGE_MAX_DIMENSION
 } from './builtin-tool-types.js'
 import {
+  createShellCommandRunner,
   detectImageMimeType,
   resolveExecutable,
-  shellCommandArgs,
-  shellRuntimeInfo,
-  shellSpawnEnv,
   spawnCapture,
   terminateSpawnTree,
   waitForSpawnExit
@@ -132,16 +129,16 @@ export const defaultReadLocalToolOperations: ReadLocalToolOperations = {
 }
 
 export function createLocalBashOperations(): BashLocalToolOperations {
+  const shellRunner = createShellCommandRunner()
   return {
     exec: async (command, cwd, options) => {
-      const { shell, args, name } = shellRuntimeInfo()
-      const child = spawn(shell, shellCommandArgs({ shell, args }, command), {
+      const started = await shellRunner.spawn(command, {
         cwd,
-        env: shellSpawnEnv(),
         detached: process.platform !== 'win32',
         stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true
       })
+      const child = started.child
       let timedOut = false
       const kill = () => terminateSpawnTree(child)
       const timer = setTimeout(() => {
@@ -162,7 +159,7 @@ export function createLocalBashOperations(): BashLocalToolOperations {
       })
       if (options.signal.aborted) throw new Error('command aborted')
       if (timedOut) throw new Error(`command timed out after ${options.timeoutSeconds} seconds`)
-      return { exitCode, shell: name }
+      return { exitCode, shell: started.runtime.name }
     }
   }
 }

--- a/kun/src/adapters/tool/builtin-tool-utils.test.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.test.ts
@@ -1,14 +1,18 @@
 import { statSync } from 'node:fs'
+import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  createShellCommandRunner,
   makeListEntry,
   normalizeToolPath,
   resolveExecutable,
+  ShellSpawnError,
   shellConfig,
   shellCommandArgs,
   shellDisplayName,
   shellRuntimeInfo,
   shellRuntimeInstruction,
+  shellRuntimePlan,
   shellSpawnEnv,
   terminateSpawnTree
 } from './builtin-tool-utils.js'
@@ -24,30 +28,45 @@ function lookup(results: Record<string, string>) {
   }) as never
 }
 
+function powerShellRuntime(shell: string) {
+  return shellRuntimeInfo({
+    shell,
+    args: ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command']
+  })
+}
+
+function spawnFailure(code: string, errno: number): NodeJS.ErrnoException {
+  return Object.assign(new Error('spawn failed'), {
+    code,
+    errno,
+    syscall: 'spawn'
+  })
+}
+
 describe('shellConfig', () => {
   it('prefers PowerShell on Windows even when Git Bash is available', () => {
     expect(shellConfig('win32', lookup({
       'where pwsh.exe': 'C:\\Program Files\\PowerShell\\7\\pwsh.exe\r\n',
       'where bash.exe': 'C:\\Program Files\\Git\\bin\\bash.exe\r\n'
-    }))).toEqual({
+    }), () => false, {})).toEqual({
       shell: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
-      args: ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command']
+      args: ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command']
     })
   })
 
   it('falls back to Windows PowerShell when pwsh is unavailable', () => {
     expect(shellConfig('win32', lookup({
       'where powershell.exe': 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n'
-    }))).toEqual({
+    }), () => false, {})).toEqual({
       shell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
-      args: ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command']
+      args: ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command']
     })
   })
 
   it('falls back to Git Bash on Windows when PowerShell is unavailable', () => {
     expect(shellConfig('win32', lookup({
       'where bash.exe': 'C:\\Program Files\\Git\\bin\\bash.exe\r\n'
-    }))).toEqual({
+    }), () => false, {})).toEqual({
       shell: 'C:\\Program Files\\Git\\bin\\bash.exe',
       args: ['-lc']
     })
@@ -61,8 +80,31 @@ describe('shellConfig', () => {
       shellConfig('win32', lookup({}), (path) => path === winPwsh, { SystemRoot: 'C:\\Windows' })
     ).toEqual({
       shell: winPwsh,
-      args: ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command']
+      args: ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command']
     })
+  })
+
+  it('skips WindowsApps aliases and keeps PowerShell fallbacks in one syntax family', () => {
+    const winPowerShell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+    const plan = shellRuntimePlan({
+      platform: 'win32',
+      lookup: lookup({
+        'where pwsh.exe': [
+          'C:\\Users\\demo\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe',
+          'D:\\Tools\\PowerShell\\pwsh.exe'
+        ].join('\r\n'),
+        'where powershell.exe': winPowerShell
+      }),
+      fileExists: (path) => path === winPowerShell,
+      env: { SystemRoot: 'C:\\Windows' }
+    })
+
+    expect(plan.candidates.map((candidate) => candidate.shell)).toEqual([
+      'D:\\Tools\\PowerShell\\pwsh.exe',
+      winPowerShell
+    ])
+    expect(plan.candidates.every((candidate) => candidate.syntax === 'PowerShell')).toBe(true)
+    expect(plan.candidates.some((candidate) => /WindowsApps/i.test(candidate.shell))).toBe(false)
   })
 
   it('falls back to an absolute cmd.exe (never a bare name) when nothing else resolves', () => {
@@ -175,11 +217,11 @@ describe('shell runtime metadata', () => {
     expect(instruction).not.toMatch(/Do not assume|Write shell commands/)
   })
 
-  it('runs PowerShell commands through a UTF-8 output preamble', () => {
+  it('runs PowerShell commands through a plain UTF-8 command argument', () => {
     const args = shellCommandArgs(
       {
         shell: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
-        args: ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command']
+        args: ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command']
       },
       'Write-Output "测试"'
     )
@@ -187,17 +229,142 @@ describe('shell runtime metadata', () => {
     expect(args.slice(0, -1)).toEqual([
       '-NoLogo',
       '-NoProfile',
-      '-ExecutionPolicy',
-      'Bypass',
-      '-EncodedCommand'
+      '-NonInteractive',
+      '-Command'
     ])
-    const script = Buffer.from(args.at(-1) ?? '', 'base64').toString('utf16le')
+    expect(args).not.toContain('-ExecutionPolicy')
+    expect(args).not.toContain('Bypass')
+    expect(args).not.toContain('-EncodedCommand')
+    const script = args.at(-1) ?? ''
     expect(script).toContain('[Console]::OutputEncoding = $OutputEncoding')
     expect(script).toContain('Write-Output "测试"')
   })
 
   it('keeps non-PowerShell command arguments unchanged', () => {
     expect(shellCommandArgs({ shell: '/bin/bash', args: ['-lc'] }, 'echo hi')).toEqual(['-lc', 'echo hi'])
+  })
+})
+
+describe('shell command runner', () => {
+  it('retries a same-syntax candidate when error arrives before spawn', async () => {
+    const primary = powerShellRuntime('C:\\Blocked\\pwsh.exe')
+    const fallback = powerShellRuntime('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
+    const calls: Array<{ shell: string; args: string[]; options: Record<string, unknown> }> = []
+    const spawnImpl = vi.fn((shell: string, args: string[], options: Record<string, unknown>) => {
+      const child = new EventEmitter()
+      const callIndex = calls.length
+      calls.push({ shell, args, options })
+      queueMicrotask(() => {
+        if (callIndex === 0) child.emit('error', spawnFailure('EPERM', -4048))
+        else child.emit('spawn')
+      })
+      return child as never
+    })
+    const runner = createShellCommandRunner({
+      platform: 'win32',
+      env: { Path: 'C:\\Tools', SystemRoot: 'C:\\Windows' },
+      plan: { primary, candidates: [primary, fallback] },
+      spawnImpl: spawnImpl as never
+    })
+
+    const result = await runner.spawn('Write-Output "中文"', {
+      cwd: 'C:\\Workspace With Spaces',
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    expect(result.runtime.shell).toBe(fallback.shell)
+    expect(calls.map((call) => call.shell)).toEqual([primary.shell, fallback.shell])
+    expect(calls[0]?.args).toEqual(calls[1]?.args)
+    expect(calls[1]?.args.at(-1)).toContain('Write-Output "中文"')
+    expect(calls[1]?.options).toMatchObject({
+      cwd: 'C:\\Workspace With Spaces',
+      windowsHide: true,
+      shell: false
+    })
+    expect((calls[1]?.options.env as NodeJS.ProcessEnv).Path).toContain('C:\\Windows\\System32')
+  })
+
+  it('does not fall back after the child emits spawn', async () => {
+    const primary = powerShellRuntime('C:\\PowerShell\\pwsh.exe')
+    const fallback = powerShellRuntime('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
+    const child = new EventEmitter()
+    const spawnImpl = vi.fn(() => {
+      queueMicrotask(() => child.emit('spawn'))
+      return child as never
+    })
+    const runner = createShellCommandRunner({
+      platform: 'win32',
+      plan: { primary, candidates: [primary, fallback] },
+      spawnImpl: spawnImpl as never
+    })
+
+    const result = await runner.spawn('Write-Output ok', { cwd: 'C:\\Workspace' })
+    const observedError = vi.fn()
+    child.once('error', observedError)
+    child.emit('error', spawnFailure('EIO', -5))
+
+    expect(result.runtime.shell).toBe(primary.shell)
+    expect(spawnImpl).toHaveBeenCalledTimes(1)
+    expect(observedError).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a structured error without command arguments when every candidate fails', async () => {
+    const primary = powerShellRuntime('C:\\Blocked\\pwsh.exe')
+    const fallback = powerShellRuntime('C:\\Blocked\\powershell.exe')
+    const differentSyntax = shellRuntimeInfo({
+      shell: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c']
+    })
+    let callIndex = 0
+    const spawnImpl = vi.fn(() => {
+      const child = new EventEmitter()
+      const current = callIndex
+      callIndex += 1
+      queueMicrotask(() => {
+        child.emit('error', current === 0
+          ? spawnFailure('EPERM', -4048)
+          : spawnFailure('ENOENT', -4058))
+      })
+      return child as never
+    })
+    const runner = createShellCommandRunner({
+      platform: 'win32',
+      plan: { primary, candidates: [primary, fallback, differentSyntax] },
+      spawnImpl: spawnImpl as never
+    })
+    const command = 'Write-Output "do-not-leak-this-command"'
+
+    let caught: unknown
+    try {
+      await runner.spawn(command, { cwd: 'C:\\Workspace' })
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(ShellSpawnError)
+    const shellError = caught as ShellSpawnError
+    expect(shellError.attempts).toEqual([
+      {
+        shell: primary.shell,
+        name: 'pwsh',
+        code: 'EPERM',
+        errno: -4048,
+        syscall: 'spawn'
+      },
+      {
+        shell: fallback.shell,
+        name: 'powershell',
+        code: 'ENOENT',
+        errno: -4058,
+        syscall: 'spawn'
+      }
+    ])
+    expect(shellError.code).toBe('ENOENT')
+    expect(spawnImpl).toHaveBeenCalledTimes(2)
+    const serialized = JSON.stringify(shellError)
+    expect(serialized).not.toContain(command)
+    expect(serialized).not.toContain('do-not-leak-this-command')
+    expect(serialized).not.toContain('EncodedCommand')
   })
 })
 

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { lstat, readFile, readdir, readlink, realpath, stat } from 'node:fs/promises'
-import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path'
 import type { ToolHostContext } from '../../ports/tool-host.js'
 import { effectiveSandboxMode } from './sandbox-policy.js'
@@ -25,18 +25,29 @@ const POWERSHELL_UTF8_OUTPUT_PREAMBLE = [
   'try { [Console]::InputEncoding = $OutputEncoding } catch {}'
 ].join('; ')
 
+function lookupResults(
+  lookup: SpawnSyncLike,
+  command: string,
+  args: string[]
+): string[] {
+  try {
+    const result = lookup(command, args, { encoding: 'utf8' })
+    if (result.status !== 0) return []
+    return result.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
 function firstLookupResult(
   lookup: SpawnSyncLike,
   command: string,
   args: string[]
 ): string {
-  const result = lookup(command, args, { encoding: 'utf8' })
-  return result.status === 0
-    ? result.stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .find(Boolean) ?? ''
-    : ''
+  return lookupResults(lookup, command, args)[0] ?? ''
 }
 
 export async function withToolBoundary(
@@ -289,7 +300,7 @@ export function describeKind(mode: TruncateMode): string {
   return mode === 'head' ? 'first' : 'last'
 }
 
-const WINDOWS_POWERSHELL_ARGS = ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command']
+const WINDOWS_POWERSHELL_ARGS = ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command']
 
 // `%SystemRoot%` (a.k.a. `%windir%`) — the Windows install directory. Always
 // present in a sane environment; the literal fallback covers the rare case
@@ -304,38 +315,129 @@ function windowsComSpec(env: NodeJS.ProcessEnv = process.env): string {
   return env.ComSpec || env.COMSPEC || win32.join(windowsSystemRoot(env), 'System32', 'cmd.exe')
 }
 
+export type ShellRuntimeInfo = ShellConfig & {
+  name: string
+  syntax: string
+}
+
+export type ShellRuntimePlan = {
+  primary: ShellRuntimeInfo
+  candidates: readonly ShellRuntimeInfo[]
+}
+
+export type ShellRuntimePlanOptions = {
+  platform?: NodeJS.Platform
+  lookup?: SpawnSyncLike
+  fileExists?: (path: string) => boolean
+  env?: NodeJS.ProcessEnv
+}
+
+function isWindowsAppsAlias(candidate: string): boolean {
+  return /(?:^|[\\/])windowsapps(?:[\\/]|$)/i.test(candidate)
+}
+
+function pathExists(fileExists: (path: string) => boolean, candidate: string): boolean {
+  try {
+    return fileExists(candidate)
+  } catch {
+    return false
+  }
+}
+
+function uniqueShellConfigs(configs: ShellConfig[], platform: NodeJS.Platform): ShellConfig[] {
+  const seen = new Set<string>()
+  return configs.filter((config) => {
+    if (!config.shell.trim()) return false
+    const normalized = config.shell.replace(/[\\/]+$/, '')
+    const key = platform === 'win32' ? normalized.toLowerCase() : normalized
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function runtimePlan(configs: ShellConfig[], platform: NodeJS.Platform): ShellRuntimePlan {
+  const candidates = uniqueShellConfigs(configs, platform).map((config) => shellRuntimeInfo(config))
+  const primary = candidates[0]
+  if (!primary) throw new Error('shell runtime plan requires at least one candidate')
+  return { primary, candidates }
+}
+
+function windowsPowerShellConfigs(
+  lookup: SpawnSyncLike,
+  fileExists: (path: string) => boolean,
+  env: NodeJS.ProcessEnv
+): ShellConfig[] {
+  const configs: ShellConfig[] = []
+  const programFilesRoots = [env.ProgramW6432, env.ProgramFiles, env['ProgramFiles(x86)']]
+    .map((value) => value?.trim() ?? '')
+    .filter(Boolean)
+  for (const root of programFilesRoots) {
+    const pwsh = win32.join(root, 'PowerShell', '7', 'pwsh.exe')
+    if (pathExists(fileExists, pwsh)) configs.push({ shell: pwsh, args: WINDOWS_POWERSHELL_ARGS })
+  }
+
+  for (const pwsh of lookupResults(lookup, 'where', ['pwsh.exe'])) {
+    // WindowsApps 中的 App Execution Alias 不是可直接依赖的普通可执行文件。
+    if (!isWindowsAppsAlias(pwsh)) configs.push({ shell: pwsh, args: WINDOWS_POWERSHELL_ARGS })
+  }
+
+  const windowsPowerShell = win32.join(
+    windowsSystemRoot(env),
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe'
+  )
+  if (pathExists(fileExists, windowsPowerShell)) {
+    configs.push({ shell: windowsPowerShell, args: WINDOWS_POWERSHELL_ARGS })
+  }
+
+  for (const powershell of lookupResults(lookup, 'where', ['powershell.exe'])) {
+    if (!isWindowsAppsAlias(powershell)) {
+      configs.push({ shell: powershell, args: WINDOWS_POWERSHELL_ARGS })
+    }
+  }
+  return uniqueShellConfigs(configs, 'win32')
+}
+
+export function shellRuntimePlan(options: ShellRuntimePlanOptions = {}): ShellRuntimePlan {
+  const platform = options.platform ?? process.platform
+  const lookup = options.lookup ?? spawnSync
+  const fileExists = options.fileExists ?? existsSync
+  const env = options.env ?? process.env
+
+  if (platform === 'win32') {
+    const powershells = windowsPowerShellConfigs(lookup, fileExists, env)
+    if (powershells.length > 0) return runtimePlan(powershells, platform)
+
+    const bashes = lookupResults(lookup, 'where', ['bash.exe'])
+      .filter((candidate) => !isWindowsAppsAlias(candidate))
+      .map((shell) => ({ shell, args: ['-lc'] }))
+    if (bashes.length > 0) return runtimePlan(bashes, platform)
+
+    // cmd 候选保持同一语法族，并在损坏的 ComSpec 后保留系统路径兜底。
+    return runtimePlan([
+      { shell: windowsComSpec(env), args: ['/d', '/s', '/c'] },
+      { shell: win32.join(windowsSystemRoot(env), 'System32', 'cmd.exe'), args: ['/d', '/s', '/c'] }
+    ], platform)
+  }
+
+  const configs: ShellConfig[] = []
+  if (pathExists(fileExists, '/bin/bash')) configs.push({ shell: '/bin/bash', args: ['-lc'] })
+  for (const shell of lookupResults(lookup, 'which', ['bash'])) configs.push({ shell, args: ['-lc'] })
+  configs.push({ shell: 'sh', args: ['-lc'] })
+  return runtimePlan(configs, platform)
+}
+
 export function shellConfig(
   platform: NodeJS.Platform = process.platform,
   lookup: SpawnSyncLike = spawnSync,
   fileExists: (path: string) => boolean = existsSync,
   env: NodeJS.ProcessEnv = process.env
 ): ShellConfig {
-  if (platform === 'win32') {
-    const pwsh = firstLookupResult(lookup, 'where', ['pwsh.exe'])
-    if (pwsh) return { shell: pwsh, args: WINDOWS_POWERSHELL_ARGS }
-    const powershell = firstLookupResult(lookup, 'where', ['powershell.exe'])
-    if (powershell) return { shell: powershell, args: WINDOWS_POWERSHELL_ARGS }
-    const bash = firstLookupResult(lookup, 'where', ['bash.exe'])
-    if (bash) return { shell: bash, args: ['-lc'] }
-    // Every branch above resolves the shell through PATH (`where` itself lives
-    // in System32). A GUI-launched Windows app frequently inherits a PATH that
-    // has lost System32, so `where.exe`, `powershell.exe` and even a bare
-    // `cmd.exe` all fail to spawn with "ENOENT". Resolve a shell by absolute
-    // path from well-known environment variables so the shell always starts.
-    const winPowerShell = win32.join(
-      windowsSystemRoot(env),
-      'System32',
-      'WindowsPowerShell',
-      'v1.0',
-      'powershell.exe'
-    )
-    if (fileExists(winPowerShell)) return { shell: winPowerShell, args: WINDOWS_POWERSHELL_ARGS }
-    return { shell: windowsComSpec(env), args: ['/d', '/s', '/c'] }
-  }
-  if (fileExists('/bin/bash')) return { shell: '/bin/bash', args: ['-lc'] }
-  const candidate = firstLookupResult(lookup, 'which', ['bash'])
-  if (candidate) return { shell: candidate, args: ['-lc'] }
-  return { shell: 'sh', args: ['-lc'] }
+  const { shell, args } = shellRuntimePlan({ platform, lookup, fileExists, env }).primary
+  return { shell, args }
 }
 
 // Environment for spawned shells/commands. On Windows, guarantees the core
@@ -369,11 +471,6 @@ export function shellSpawnEnv(
   }
 }
 
-export type ShellRuntimeInfo = ShellConfig & {
-  name: string
-  syntax: string
-}
-
 export function shellDisplayName(shell: string): string {
   const name = shell.replace(/\\/g, '/').split('/').pop()?.toLowerCase() ?? shell.toLowerCase()
   if (name === 'cmd.exe') return 'cmd.exe'
@@ -392,12 +489,149 @@ export function shellRuntimeInfo(config: ShellConfig = shellConfig()): ShellRunt
 export function shellCommandArgs(config: ShellConfig, command: string): string[] {
   const name = shellDisplayName(config.shell)
   if (name === 'pwsh' || name === 'powershell') {
-    const baseArgs = config.args.filter((arg) => arg.toLowerCase() !== '-command')
-    const encodedCommand = Buffer.from(`${POWERSHELL_UTF8_OUTPUT_PREAMBLE}\n${command}`, 'utf16le')
-      .toString('base64')
-    return [...baseArgs, '-EncodedCommand', encodedCommand]
+    const script = `${POWERSHELL_UTF8_OUTPUT_PREAMBLE}\n${command}`
+    return [...WINDOWS_POWERSHELL_ARGS, script]
   }
   return [...config.args, command]
+}
+
+export type ShellSpawnAttempt = {
+  shell: string
+  name: string
+  code?: string
+  errno?: string | number
+  syscall?: string
+}
+
+export class ShellSpawnError extends Error {
+  readonly attempts: readonly ShellSpawnAttempt[]
+  readonly code?: string
+  readonly errno?: string | number
+  readonly syscall?: string
+
+  constructor(attempts: readonly ShellSpawnAttempt[]) {
+    const copiedAttempts = attempts.map((attempt) => ({ ...attempt }))
+    const summary = copiedAttempts
+      .map((attempt) => `${attempt.name}: ${attempt.code ?? 'UNKNOWN'}`)
+      .join(', ')
+    super(`Failed to start shell${summary ? ` (${summary})` : ''}`)
+    this.name = 'ShellSpawnError'
+    this.attempts = copiedAttempts
+    const last = copiedAttempts.at(-1)
+    this.code = last?.code
+    this.errno = last?.errno
+    this.syscall = last?.syscall
+  }
+
+  toJSON(): {
+    name: string
+    message: string
+    code?: string
+    errno?: string | number
+    syscall?: string
+    attempts: readonly ShellSpawnAttempt[]
+  } {
+    return {
+      name: this.name,
+      message: this.message,
+      ...(this.code ? { code: this.code } : {}),
+      ...(this.errno !== undefined ? { errno: this.errno } : {}),
+      ...(this.syscall ? { syscall: this.syscall } : {}),
+      attempts: this.attempts
+    }
+  }
+}
+
+export type ShellCommandSpawnOptions = Omit<SpawnOptions, 'cwd' | 'env' | 'shell'> & {
+  cwd: string
+  env?: NodeJS.ProcessEnv
+}
+
+export type ShellCommandRunnerOptions = ShellRuntimePlanOptions & {
+  plan?: ShellRuntimePlan
+  spawnImpl?: SpawnLike
+}
+
+export type SpawnedShellCommand = {
+  child: ChildProcess
+  runtime: ShellRuntimeInfo
+}
+
+export type ShellCommandRunner = {
+  runtime: ShellRuntimeInfo
+  candidates: readonly ShellRuntimeInfo[]
+  spawn: (command: string, options: ShellCommandSpawnOptions) => Promise<SpawnedShellCommand>
+}
+
+function spawnAttempt(runtime: ShellRuntimeInfo, error: unknown): ShellSpawnAttempt {
+  const nodeError = error && typeof error === 'object' ? error as NodeJS.ErrnoException : undefined
+  return {
+    shell: runtime.shell,
+    name: runtime.name,
+    ...(typeof nodeError?.code === 'string' ? { code: nodeError.code } : {}),
+    ...(typeof nodeError?.errno === 'number' || typeof nodeError?.errno === 'string'
+      ? { errno: nodeError.errno }
+      : {}),
+    ...(typeof nodeError?.syscall === 'string' ? { syscall: nodeError.syscall } : {})
+  }
+}
+
+function waitForSpawn(child: ChildProcess): Promise<ChildProcess> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const cleanup = () => {
+      child.off('spawn', onSpawn)
+      child.off('error', onError)
+    }
+    const onSpawn = () => {
+      cleanup()
+      resolvePromise(child)
+    }
+    const onError = (error: Error) => {
+      cleanup()
+      rejectPromise(error)
+    }
+    child.once('spawn', onSpawn)
+    child.once('error', onError)
+  })
+}
+
+export function createShellCommandRunner(options: ShellCommandRunnerOptions = {}): ShellCommandRunner {
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+  const resolvedPlan = options.plan ?? shellRuntimePlan(options)
+  // 防御性地限制为主候选的语法族，避免回退后用另一种 shell 重放同一命令。
+  const candidates = uniqueShellConfigs(
+    [resolvedPlan.primary, ...resolvedPlan.candidates]
+      .filter((runtime) => runtime.syntax === resolvedPlan.primary.syntax),
+    platform
+  ).map((config) => shellRuntimeInfo(config))
+  const primary = candidates[0] ?? resolvedPlan.primary
+  const spawnImpl = options.spawnImpl ?? spawn
+
+  return {
+    runtime: primary,
+    candidates,
+    async spawn(command, spawnOptions) {
+      const attempts: ShellSpawnAttempt[] = []
+      const childOptions: SpawnOptions = {
+        ...spawnOptions,
+        env: shellSpawnEnv(spawnOptions.env ?? env, platform),
+        windowsHide: spawnOptions.windowsHide ?? true,
+        shell: false
+      }
+      for (const runtime of candidates) {
+        try {
+          const child = spawnImpl(runtime.shell, shellCommandArgs(runtime, command), childOptions)
+          await waitForSpawn(child)
+          return { child, runtime }
+        } catch (error) {
+          // error 先于 spawn 事件时，系统尚未创建进程，可以安全尝试同语法族候选。
+          attempts.push(spawnAttempt(runtime, error))
+        }
+      }
+      throw new ShellSpawnError(attempts)
+    }
+  }
 }
 
 // Factual environment block, not an instruction. Modeled on Codex's


### PR DESCRIPTION
## Summary

- Fix Windows shell execution failures where packaged Kun returned `spawn EPERM`.
- Fix shell selection and preserve actionable spawn diagnostics.

## Root cause

Windows shell discovery trusted the first `where pwsh.exe` result, including WindowsApps execution aliases that may not be launchable from a packaged Electron runtime. Kun also started PowerShell with `-ExecutionPolicy Bypass -EncodedCommand`, which can be rejected by endpoint security policies even when ordinary `powershell -Command` works.

## Changes

- Filter WindowsApps aliases and keep same-syntax fallback candidates.
- Retry only when the child reports an error before the `spawn` event.
- Use a UTF-8 PowerShell `-Command` argument without `Bypass` or `EncodedCommand`.
- Apply the shared runner to foreground, background, and local shell operations.
- Return sanitized shell/path/code/errno/syscall diagnostics.

Fixes #801

## Tests

- `npm test` (404 files, 3390 tests)
- `npm --prefix kun test` (131 files, 1192 tests)
- `npm run typecheck`
- `npm run build`
- Changed-file ESLint
