### PR TITLE
fix(ci): restore Kun typecheck

### DIFF
--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -125,7 +125,7 @@ describe('LocalToolHost approval policy', () => {
 
   it('normalizes structured multi-select user input questions', async () => {
     const host = new LocalToolHost({ tools: [userInputTool] })
-    let captured: Parameters<NonNullable<ToolHostContext['awaitUserInput']>>[0] | null = null
+    const captured: Parameters<NonNullable<ToolHostContext['awaitUserInput']>>[0][] = []
     const context = {
       threadId: 'thread_1',
       turnId: 'turn_1',
@@ -135,7 +135,7 @@ describe('LocalToolHost approval policy', () => {
       abortSignal: new AbortController().signal,
       awaitApproval: vi.fn(async () => 'allow' as const),
       awaitUserInput: vi.fn(async (input) => {
-        captured = input
+        captured.push(input)
         return { status: 'submitted' as const, answers: [] }
       })
     } satisfies ToolHostContext
@@ -160,7 +160,7 @@ describe('LocalToolHost approval policy', () => {
       context
     )
 
-    expect(captured?.questions).toEqual([
+    expect(captured[0]?.questions).toEqual([
       {
         header: 'Question 1',
         id: 'requirements',

--- a/kun/src/adapters/tool/output-accumulator.ts
+++ b/kun/src/adapters/tool/output-accumulator.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto'
 import { createWriteStream, type WriteStream } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { TextDecoder } from 'node:util'
 import {
   type TruncationResult as OutputAccumulatorTruncation,
   truncateTail


### PR DESCRIPTION
## Summary

- keep the multi-select user-input test capture visible to TypeScript control-flow analysis
- import Node's `TextDecoder` explicitly so the accumulator can use it as both a runtime value and a type

## Why

The current `develop` branch fails `npm --prefix kun run typecheck` before PR-specific tests run. TypeScript narrows the callback-assigned test variable to `never`, then reports the implicit global `TextDecoder` as value-only after that first error is fixed.

## Tests

- `npm.cmd --prefix kun run typecheck`
- `npm.cmd --prefix kun test -- src/adapters/tool/local-tool-host.test.ts tests/output-accumulator.test.ts`
- `npm.cmd run build:kun`
- focused ESLint
- `git diff --check`