### PR TITLE
fix(files): connect file tree drag references

### DIFF
--- a/src/renderer/src/components/chat/ChatFileTreePanel.tsx
+++ b/src/renderer/src/components/chat/ChatFileTreePanel.tsx
@@ -28,6 +28,7 @@ import {
 import type { TFunction } from 'i18next'
 import type { ComposerFileReference } from '../../lib/composer-file-references'
 import {
+  COMPOSER_FILE_REFERENCE_DRAG_MIME,
   formatComposerFileMentionToken,
   relativeWorkspacePath
 } from '../../lib/composer-file-references'
@@ -342,7 +343,7 @@ export function ChatFileTreePanel({
     const token = formatComposerFileMentionToken(reference.relativePath, reference.type === 'directory')
     event.dataTransfer.effectAllowed = 'copy'
     event.dataTransfer.setData('text/plain', `${token} `)
-    event.dataTransfer.setData('application/x-kun-file-reference', JSON.stringify(reference))
+    event.dataTransfer.setData(COMPOSER_FILE_REFERENCE_DRAG_MIME, JSON.stringify(reference))
   }
 
   const copyEntryPath = async (entry: WorkspaceEntry, mode: 'absolute' | 'relative'): Promise<void> => {

--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -49,6 +49,7 @@ import type { AttachmentReference, ChatBlock, ReviewTarget } from '../../agent/t
 import { useChatStore } from '../../store/chat-store'
 import { normalizeWorkspaceRoot } from '../../lib/workspace-path'
 import {
+  COMPOSER_FILE_REFERENCE_DRAG_MIME,
   composerFileReferenceKey,
   composerFileReferenceFromPath,
   filterWorkspaceFileMentionSuggestions,
@@ -56,6 +57,7 @@ import {
   getFileMentionAtCursor,
   hasComposerFileMentionToken,
   isComposerDirectoryReference,
+  parseComposerFileReferenceDragData,
   removeComposerFileMentionToken,
   replaceFileMentionInInput,
   type ComposerFileMention,
@@ -602,6 +604,7 @@ export function FloatingComposer({
   const canPickFileReference = canCompose && fileReferenceEnabled && Boolean(effectiveWorkspaceRoot) && Boolean(onOpenFileReferencePicker)
   const canPickDesignReference = canCompose && fileReferenceEnabled && Boolean(onOpenDesignReferencePicker)
   const canPickLocalFileReference = canCompose && fileReferenceEnabled && Boolean(onPickFileReferences)
+  const canAddFileReference = canCompose && fileReferenceEnabled && Boolean(effectiveWorkspaceRoot) && Boolean(onAddFileReference)
   const showIntentToolbar = !compact && route === 'chat'
   const showComposerMenuButton = showIntentToolbar
   const canTogglePlanMode = canCompose && Boolean(onPlanCommand)
@@ -1696,14 +1699,18 @@ export function FloatingComposer({
 
   const handleComposerDragOver = (event: ReactDragEvent<HTMLDivElement>): void => {
     const dataTransferTypes = Array.from(event.dataTransfer.types ?? [])
+    const canAcceptFileReference = canAddFileReference && dataTransferTypes.includes(COMPOSER_FILE_REFERENCE_DRAG_MIME)
     const canAcceptImages = canPickAttachment && imageTransferHasImages(event.dataTransfer)
     const canAcceptPdf = canPickAttachment && Array.from(event.dataTransfer.files ?? []).some(isPdfFile)
-    if (!dataTransferTypes.includes('Files') && !canAcceptImages && !canAcceptPdf) return
+    if (!dataTransferTypes.includes('Files') && !canAcceptImages && !canAcceptPdf && !canAcceptFileReference) return
     event.preventDefault()
     event.dataTransfer.dropEffect = 'copy'
   }
 
   const handleComposerDrop = (event: ReactDragEvent<HTMLDivElement>): void => {
+    const draggedReference = canAddFileReference
+      ? parseComposerFileReferenceDragData(event.dataTransfer.getData(COMPOSER_FILE_REFERENCE_DRAG_MIME))
+      : null
     const imageFiles = canPickAttachment ? imageFilesFromTransfer(event.dataTransfer) : []
     const rawFiles = Array.from(event.dataTransfer.files ?? [])
     const isImageLike = (file: File): boolean =>
@@ -1712,8 +1719,9 @@ export function FloatingComposer({
     const pathFiles = canPickLocalFileReference && onAddFileReference
       ? rawFiles.filter((file) => !isImageLike(file) && !isPdfFile(file))
       : []
-    if (imageFiles.length === 0 && pdfFiles.length === 0 && pathFiles.length === 0) return
+    if (!draggedReference && imageFiles.length === 0 && pdfFiles.length === 0 && pathFiles.length === 0) return
     event.preventDefault()
+    if (draggedReference) onAddFileReference?.(draggedReference)
     if ((imageFiles.length > 0 || pdfFiles.length > 0) && onPickAttachments) {
       onPickAttachments([...imageFiles, ...pdfFiles])
     }

--- a/src/renderer/src/lib/composer-file-references.ts
+++ b/src/renderer/src/lib/composer-file-references.ts
@@ -22,6 +22,9 @@ export type ComposerFileContextEntry = {
   truncated?: boolean
 }
 
+export const COMPOSER_FILE_REFERENCE_DRAG_MIME = 'application/x-kun-file-reference'
+const MAX_COMPOSER_FILE_REFERENCE_DRAG_BYTES = 16 * 1024
+
 const FILE_MENTION_BOUNDARY = /(^|[\s([{，。；：、])@([^\s@"']*)$/u
 const QUOTED_FILE_MENTION_BOUNDARY = /(^|[\s([{，。；：、])@"([^"\n\r]*)$/u
 const TOKEN_SPECIAL_CHARS = /[\s"']/u
@@ -36,6 +39,46 @@ function trimTrailingSlash(value: string): string {
 
 function normalizeForCompare(value: string): string {
   return trimTrailingSlash(value).toLowerCase()
+}
+
+function isComposerFileReferenceKind(value: unknown): value is ComposerFileReferenceKind {
+  return value === 'file' || value === 'directory'
+}
+
+export function parseComposerFileReferenceDragData(raw: string): ComposerFileReference | null {
+  if (!raw || raw.length > MAX_COMPOSER_FILE_REFERENCE_DRAG_BYTES) return null
+  try {
+    const value = JSON.parse(raw) as Record<string, unknown>
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+    if (
+      typeof value.path !== 'string' || !value.path.trim() ||
+      typeof value.relativePath !== 'string' || !value.relativePath.trim() ||
+      typeof value.name !== 'string' || !value.name.trim()
+    ) {
+      return null
+    }
+    if (value.type !== undefined && !isComposerFileReferenceKind(value.type)) return null
+    if (
+      value.workspaceRoot !== undefined &&
+      value.workspaceRoot !== null &&
+      typeof value.workspaceRoot !== 'string'
+    ) {
+      return null
+    }
+    return {
+      path: normalizeSlashes(value.path),
+      relativePath: normalizeSlashes(value.relativePath),
+      name: value.name.trim(),
+      ...(value.type ? { type: value.type } : {}),
+      ...(value.workspaceRoot === null
+        ? { workspaceRoot: null }
+        : typeof value.workspaceRoot === 'string'
+          ? { workspaceRoot: normalizeSlashes(value.workspaceRoot) }
+          : {})
+    }
+  } catch {
+    return null
+  }
 }
 
 export function relativeWorkspacePath(path: string, workspaceRoot: string): string {

--- a/src/renderer/src/lib/workspace-file-index.test.ts
+++ b/src/renderer/src/lib/workspace-file-index.test.ts
@@ -7,8 +7,10 @@ import {
   mergeMentionCandidates
 } from './workspace-file-index'
 import {
+  COMPOSER_FILE_REFERENCE_DRAG_MIME,
   composerFileReferenceFromPath,
   filterWorkspaceFileMentionSuggestions,
+  parseComposerFileReferenceDragData,
   type ComposerFileReference
 } from './composer-file-references'
 
@@ -50,6 +52,28 @@ describe('composerFileReferenceFromPath', () => {
       type: 'file',
       workspaceRoot: null
     })
+  })
+
+  it('parses bounded internal drag data and rejects malformed payloads', () => {
+    const reference = {
+      path: 'C:\\repo\\docs\\plan.md',
+      relativePath: 'docs\\plan.md',
+      name: 'plan.md',
+      type: 'file' as const,
+      workspaceRoot: 'C:\\repo'
+    }
+
+    expect(COMPOSER_FILE_REFERENCE_DRAG_MIME).toBe('application/x-kun-file-reference')
+    expect(parseComposerFileReferenceDragData(JSON.stringify(reference))).toEqual({
+      path: 'C:/repo/docs/plan.md',
+      relativePath: 'docs/plan.md',
+      name: 'plan.md',
+      type: 'file',
+      workspaceRoot: 'C:/repo'
+    })
+    expect(parseComposerFileReferenceDragData('{bad json')).toBeNull()
+    expect(parseComposerFileReferenceDragData(JSON.stringify({ ...reference, type: 'link' }))).toBeNull()
+    expect(parseComposerFileReferenceDragData('x'.repeat(16 * 1024 + 1))).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary
- connect file-tree drag data to the composer file-reference flow
- share one MIME contract between producer and consumer
- reject malformed or oversized internal drag payloads

## Why
#802 made workspace entries draggable, but the composer only handled OS file drops. The custom `application/x-kun-file-reference` payload was never consumed, so dragging a workspace file did not add a structured context reference.

## Tests
- `npm.cmd test -- src/renderer/src/lib/workspace-file-index.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts`
- `npm.cmd exec -- tsc --noEmit -p tsconfig.web.json`
- focused ESLint
- `git diff --check`

Addresses #781