### PR TITLE
refactor(loop): extract tool call dispatcher

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -93,6 +93,7 @@ import {
   type AutoModelRouteSelection
 } from './auto-model-router.js'
 import { ToolStormBreaker, type ToolStormBreakerOptions } from './tool-storm-breaker.js'
+import { dispatchToolCalls as dispatchToolCallBatch } from './tool-call-dispatcher.js'
 import { healLoadedHistoryItems } from './history-healing.js'
 import { repairDispatchToolArguments } from './tool-call-repair.js'
 import { CREATE_PLAN_TOOL_NAME } from '../adapters/tool/create-plan-tool.js'
@@ -148,9 +149,6 @@ export {
   todoContinuationInstruction
 } from './continuation-instructions.js'
 
-const PARALLEL_READ_ONLY_TOOL_NAMES = new Set(['read', 'grep', 'find', 'ls'])
-const DELEGATE_TASK_TOOL_NAME = 'delegate_task'
-const MAX_PARALLEL_TOOL_CALLS = 3
 // Number of most-recent tool-result screenshots/images kept inline in a
 // request. Older ones collapse to a text note (Anthropic-style "keep last
 // N images"), bounding context growth for long computer-use sessions.
@@ -1761,129 +1759,29 @@ export class AgentLoop {
     signal: AbortSignal
   }): Promise<'continue' | 'aborted' | 'all_suppressed'> {
     const context = this.createToolContext(input)
-    let index = 0
-    let executedAny = false
-    const markProgress = (toolName: string): void => {
-      if (!GOAL_NON_PROGRESS_TOOL_NAMES.has(toolName)) {
-        this.turnMadeProgress.add(input.turnId)
-      }
-    }
-
-    while (index < input.calls.length) {
-      if (input.signal.aborted) return 'aborted'
-
-      const call = input.calls[index]
-      if (!call) break
-
-      const storm = this.toolStormBreakers.get(input.turnId)?.inspect(call)
-      if (storm?.suppress) {
-        await this.persistSuppressedToolCall({
+    return dispatchToolCallBatch(input, {
+      inspectStorm: (call) => this.toolStormBreakers.get(input.turnId)?.inspect(call),
+      execute: (call) => this.executeToolCallSafely({
+        threadId: input.threadId,
+        turnId: input.turnId,
+        call,
+        context
+      }),
+      persistResult: (call, result) =>
+        this.persistToolCallResult(input.threadId, input.turnId, call, result),
+      persistSuppressed: (call, reason) =>
+        this.persistSuppressedToolCall({
           threadId: input.threadId,
           turnId: input.turnId,
           call,
-          reason: storm.reason
-        })
-        index += 1
-        continue
-      }
-
-      if (!this.isParallelSafeToolCall(call, input.approvalPolicy, input.toolProviderKinds)) {
-        const result = await this.executeToolCallSafely({
-          threadId: input.threadId,
-          turnId: input.turnId,
-          call,
-          context
-        })
-        executedAny = true
-        markProgress(call.toolName)
-        await this.persistToolCallResult(input.threadId, input.turnId, call, result)
-        index += 1
-        continue
-      }
-
-      // Keep batches homogeneous: delegation children fan out together (the
-      // runtime semaphore bounds real concurrency), while built-in read-only
-      // tools stay capped at MAX_PARALLEL_TOOL_CALLS.
-      const headIsDelegation = this.isParallelDelegationCall(call, input.toolProviderKinds)
-      const batchCap = headIsDelegation ? input.calls.length : MAX_PARALLEL_TOOL_CALLS
-      const batch: ToolCallLike[] = [call]
-      index += 1
-      let suppressedAfterBatch: { call: ToolCallLike; reason?: string } | undefined
-
-      while (batch.length < batchCap && index < input.calls.length) {
-        const next = input.calls[index]
-        if (!next) break
-        if (!this.isParallelSafeToolCall(next, input.approvalPolicy, input.toolProviderKinds)) break
-        if (this.isParallelDelegationCall(next, input.toolProviderKinds) !== headIsDelegation) break
-
-        const nextStorm = this.toolStormBreakers.get(input.turnId)?.inspect(next)
-        if (nextStorm?.suppress) {
-          suppressedAfterBatch = { call: next, reason: nextStorm.reason }
-          index += 1
-          break
+          reason
+        }),
+      markProgress: (toolName) => {
+        if (!GOAL_NON_PROGRESS_TOOL_NAMES.has(toolName)) {
+          this.turnMadeProgress.add(input.turnId)
         }
-
-        batch.push(next)
-        index += 1
       }
-
-      const settled = await Promise.allSettled(
-        batch.map((entry) =>
-          this.executeToolCallSafely({
-            threadId: input.threadId,
-            turnId: input.turnId,
-            call: entry,
-            context
-          })
-        )
-      )
-      executedAny = true
-      for (let batchIndex = 0; batchIndex < batch.length; batchIndex += 1) {
-        const result = settled[batchIndex]
-        const batchCall = batch[batchIndex]
-        if (!result || !batchCall) continue
-        if (result.status === 'rejected') throw result.reason
-        markProgress(batchCall.toolName)
-        await this.persistToolCallResult(input.threadId, input.turnId, batchCall, result.value)
-      }
-
-      if (suppressedAfterBatch) {
-        await this.persistSuppressedToolCall({
-          threadId: input.threadId,
-          turnId: input.turnId,
-          call: suppressedAfterBatch.call,
-          reason: suppressedAfterBatch.reason
-        })
-      }
-    }
-
-    return executedAny ? 'continue' : 'all_suppressed'
-  }
-
-  private isParallelSafeToolCall(
-    call: ToolCallLike,
-    approvalPolicy: ToolHostContext['approvalPolicy'],
-    toolProviderKinds: ReadonlyMap<string, ToolProviderKind | undefined>
-  ): boolean {
-    // always / untrusted / never 会触发审批或阻断工具调用，不能并发扇出。
-    if (approvalPolicy === 'always' || approvalPolicy === 'untrusted' || approvalPolicy === 'never') return false
-    // Delegated children are isolated runs; multiple in one assistant message
-    // are independent and safe to fan out. The delegation runtime caps real
-    // concurrency at maxParallel and queues the overflow.
-    if (this.isParallelDelegationCall(call, toolProviderKinds)) return true
-    if (!PARALLEL_READ_ONLY_TOOL_NAMES.has(call.toolName)) return false
-    if (call.toolKind && call.toolKind !== 'tool_call') return false
-    return toolProviderKinds.get(call.toolName) === 'built-in'
-  }
-
-  private isParallelDelegationCall(
-    call: ToolCallLike,
-    toolProviderKinds: ReadonlyMap<string, ToolProviderKind | undefined>
-  ): boolean {
-    return (
-      call.toolName === DELEGATE_TASK_TOOL_NAME &&
-      toolProviderKinds.get(call.toolName) === 'delegation'
-    )
+    })
   }
 
   private createToolContext(input: {

--- a/kun/src/loop/tool-call-dispatcher.test.ts
+++ b/kun/src/loop/tool-call-dispatcher.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from 'vitest'
+import { makeToolResultItem } from '../domain/item.js'
+import type { ToolCallLike, ToolHostResult, ToolProviderKind } from '../ports/tool-host.js'
+import { dispatchToolCalls, type ToolCallDispatchDependencies } from './tool-call-dispatcher.js'
+
+function call(toolName: string, index: number): ToolCallLike {
+  return {
+    callId: `call_${index}`,
+    toolName,
+    toolKind: 'tool_call',
+    arguments: { index }
+  }
+}
+
+function toolResult(toolCall: ToolCallLike): ToolHostResult {
+  return {
+    item: makeToolResultItem({
+      id: `result_${toolCall.callId}`,
+      threadId: 'thread_1',
+      turnId: 'turn_1',
+      callId: toolCall.callId,
+      toolName: toolCall.toolName,
+      toolKind: toolCall.toolKind ?? 'tool_call',
+      output: { ok: true }
+    }),
+    approved: false
+  }
+}
+
+function providers(entries: Array<[string, ToolProviderKind]>): Map<string, ToolProviderKind> {
+  return new Map(entries)
+}
+
+function dependencies(options: {
+  suppressed?: ReadonlySet<string>
+  delayMs?: number
+} = {}): ToolCallDispatchDependencies & {
+  persisted: string[]
+  suppressed: string[]
+  progress: string[]
+  maxActive: () => number
+} {
+  const persisted: string[] = []
+  const suppressed: string[] = []
+  const progress: string[] = []
+  let active = 0
+  let maxActive = 0
+  return {
+    persisted,
+    suppressed,
+    progress,
+    maxActive: () => maxActive,
+    inspectStorm: (toolCall) => options.suppressed?.has(toolCall.callId)
+      ? { suppress: true, reason: 'repeat' }
+      : { suppress: false },
+    execute: async (toolCall) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, options.delayMs ?? 1))
+      active -= 1
+      return toolResult(toolCall)
+    },
+    persistResult: async (toolCall) => {
+      persisted.push(toolCall.callId)
+    },
+    persistSuppressed: async (toolCall) => {
+      suppressed.push(toolCall.callId)
+    },
+    markProgress: (toolName) => {
+      progress.push(toolName)
+    }
+  }
+}
+
+describe('dispatchToolCalls', () => {
+  it('caps built-in read-only batches at three and persists in model order', async () => {
+    const calls = Array.from({ length: 7 }, (_, index) => call('read', index))
+    const deps = dependencies()
+
+    await expect(dispatchToolCalls({
+      calls,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'built-in']]),
+      signal: new AbortController().signal
+    }, deps)).resolves.toBe('continue')
+
+    expect(deps.maxActive()).toBe(3)
+    expect(deps.persisted).toEqual(calls.map((entry) => entry.callId))
+    expect(deps.progress).toHaveLength(calls.length)
+  })
+
+  it('fans out isolated delegation calls through the runtime concurrency gate', async () => {
+    const calls = Array.from({ length: 5 }, (_, index) => call('delegate_task', index))
+    const deps = dependencies()
+
+    await dispatchToolCalls({
+      calls,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['delegate_task', 'delegation']]),
+      signal: new AbortController().signal
+    }, deps)
+
+    expect(deps.maxActive()).toBe(5)
+    expect(deps.persisted).toEqual(calls.map((entry) => entry.callId))
+  })
+
+  it('keeps approval-gated and mutating calls sequential', async () => {
+    const calls = [call('read', 0), call('write', 1), call('read', 2)]
+    const deps = dependencies()
+
+    await dispatchToolCalls({
+      calls,
+      approvalPolicy: 'always',
+      toolProviderKinds: providers([['read', 'built-in'], ['write', 'built-in']]),
+      signal: new AbortController().signal
+    }, deps)
+
+    expect(deps.maxActive()).toBe(1)
+    expect(deps.persisted).toEqual(calls.map((entry) => entry.callId))
+  })
+
+  it('persists storm-suppressed calls without treating them as progress', async () => {
+    const calls = [call('read', 0), call('read', 1)]
+    const deps = dependencies({ suppressed: new Set(calls.map((entry) => entry.callId)) })
+
+    await expect(dispatchToolCalls({
+      calls,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'built-in']]),
+      signal: new AbortController().signal
+    }, deps)).resolves.toBe('all_suppressed')
+
+    expect(deps.persisted).toEqual([])
+    expect(deps.suppressed).toEqual(calls.map((entry) => entry.callId))
+    expect(deps.progress).toEqual([])
+  })
+
+  it('does not execute after the turn is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const deps = dependencies()
+    deps.execute = vi.fn(deps.execute)
+
+    await expect(dispatchToolCalls({
+      calls: [call('read', 0)],
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'built-in']]),
+      signal: controller.signal
+    }, deps)).resolves.toBe('aborted')
+    expect(deps.execute).not.toHaveBeenCalled()
+  })
+
+  it('splits read and delegation calls into homogeneous batches', async () => {
+    const calls = [
+      call('read', 0),
+      call('delegate_task', 1),
+      call('delegate_task', 2),
+      call('read', 3)
+    ]
+    const deps = dependencies()
+
+    await dispatchToolCalls({
+      calls,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'built-in'], ['delegate_task', 'delegation']]),
+      signal: new AbortController().signal
+    }, deps)
+
+    expect(deps.maxActive()).toBe(2)
+    expect(deps.persisted).toEqual(calls.map((entry) => entry.callId))
+  })
+
+  it('continues after a storm-suppressed call at a batch boundary', async () => {
+    const calls = [call('read', 0), call('read', 1), call('write', 2)]
+    const deps = dependencies({ suppressed: new Set(['call_1']) })
+
+    await dispatchToolCalls({
+      calls,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'built-in'], ['write', 'built-in']]),
+      signal: new AbortController().signal
+    }, deps)
+
+    expect(deps.persisted).toEqual(['call_0', 'call_2'])
+    expect(deps.suppressed).toEqual(['call_1'])
+  })
+
+  it('persists parallel results in model order regardless of completion order', async () => {
+    const calls = [call('read', 0), call('read', 1), call('read', 2)]
+    const deps = dependencies()
+    deps.execute = async (toolCall) => {
+      const index = Number(toolCall.arguments.index)
+      await new Promise((resolve) => setTimeout(resolve, (3 - index) * 2))
+      return toolResult(toolCall)
+    }
+
+    await dispatchToolCalls({
+      calls,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'built-in']]),
+      signal: new AbortController().signal
+    }, deps)
+
+    expect(deps.persisted).toEqual(calls.map((entry) => entry.callId))
+  })
+
+  it('does not start a second batch after the turn aborts', async () => {
+    const controller = new AbortController()
+    const calls = Array.from({ length: 4 }, (_, index) => call('read', index))
+    const deps = dependencies()
+    const started: string[] = []
+    deps.execute = async (toolCall) => {
+      started.push(toolCall.callId)
+      if (started.length === 3) controller.abort()
+      return toolResult(toolCall)
+    }
+
+    await expect(dispatchToolCalls({
+      calls,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'built-in']]),
+      signal: controller.signal
+    }, deps)).resolves.toBe('aborted')
+
+    expect(started).toEqual(['call_0', 'call_1', 'call_2'])
+    expect(deps.persisted).toEqual(['call_0', 'call_1', 'call_2'])
+  })
+
+  it('does not parallelize provider tools or file-changing calls by name alone', async () => {
+    const providerRead = [call('read', 0), call('read', 1)]
+    const providerDeps = dependencies()
+    await dispatchToolCalls({
+      calls: providerRead,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'mcp']]),
+      signal: new AbortController().signal
+    }, providerDeps)
+    expect(providerDeps.maxActive()).toBe(1)
+
+    const changingRead = providerRead.map((entry) => ({ ...entry, toolKind: 'file_change' as const }))
+    const changingDeps = dependencies()
+    await dispatchToolCalls({
+      calls: changingRead,
+      approvalPolicy: 'on-request',
+      toolProviderKinds: providers([['read', 'built-in']]),
+      signal: new AbortController().signal
+    }, changingDeps)
+    expect(changingDeps.maxActive()).toBe(1)
+  })
+})

--- a/kun/src/loop/tool-call-dispatcher.ts
+++ b/kun/src/loop/tool-call-dispatcher.ts
@@ -1,0 +1,120 @@
+import type {
+  ToolCallLike,
+  ToolHostContext,
+  ToolHostResult,
+  ToolProviderKind
+} from '../ports/tool-host.js'
+
+const PARALLEL_READ_ONLY_TOOL_NAMES = new Set(['read', 'grep', 'find', 'ls'])
+const DELEGATE_TASK_TOOL_NAME = 'delegate_task'
+const MAX_PARALLEL_TOOL_CALLS = 3
+
+export type ToolCallDispatchInput = {
+  calls: readonly ToolCallLike[]
+  approvalPolicy: ToolHostContext['approvalPolicy']
+  toolProviderKinds: ReadonlyMap<string, ToolProviderKind | undefined>
+  signal: AbortSignal
+}
+
+export type ToolCallDispatchDependencies = {
+  inspectStorm: (call: ToolCallLike) => { suppress: boolean; reason?: string } | undefined
+  execute: (call: ToolCallLike) => Promise<ToolHostResult>
+  persistResult: (call: ToolCallLike, result: ToolHostResult) => Promise<void>
+  persistSuppressed: (call: ToolCallLike, reason?: string) => Promise<void>
+  markProgress: (toolName: string) => void
+}
+
+function isParallelDelegationCall(
+  call: ToolCallLike,
+  toolProviderKinds: ReadonlyMap<string, ToolProviderKind | undefined>
+): boolean {
+  return (
+    call.toolName === DELEGATE_TASK_TOOL_NAME &&
+    toolProviderKinds.get(call.toolName) === 'delegation'
+  )
+}
+
+function isParallelSafeToolCall(input: ToolCallDispatchInput, call: ToolCallLike): boolean {
+  if (
+    input.approvalPolicy === 'always' ||
+    input.approvalPolicy === 'untrusted' ||
+    input.approvalPolicy === 'never'
+  ) {
+    return false
+  }
+  if (isParallelDelegationCall(call, input.toolProviderKinds)) return true
+  if (!PARALLEL_READ_ONLY_TOOL_NAMES.has(call.toolName)) return false
+  if (call.toolKind && call.toolKind !== 'tool_call') return false
+  return input.toolProviderKinds.get(call.toolName) === 'built-in'
+}
+
+export async function dispatchToolCalls(
+  input: ToolCallDispatchInput,
+  dependencies: ToolCallDispatchDependencies
+): Promise<'continue' | 'aborted' | 'all_suppressed'> {
+  let index = 0
+  let executedAny = false
+
+  while (index < input.calls.length) {
+    if (input.signal.aborted) return 'aborted'
+    const call = input.calls[index]
+    if (!call) break
+
+    const storm = dependencies.inspectStorm(call)
+    if (storm?.suppress) {
+      await dependencies.persistSuppressed(call, storm.reason)
+      index += 1
+      continue
+    }
+
+    if (!isParallelSafeToolCall(input, call)) {
+      const result = await dependencies.execute(call)
+      executedAny = true
+      dependencies.markProgress(call.toolName)
+      await dependencies.persistResult(call, result)
+      index += 1
+      continue
+    }
+
+    const headIsDelegation = isParallelDelegationCall(call, input.toolProviderKinds)
+    const batchCap = headIsDelegation ? input.calls.length : MAX_PARALLEL_TOOL_CALLS
+    const batch: ToolCallLike[] = [call]
+    index += 1
+    let suppressedAfterBatch: { call: ToolCallLike; reason?: string } | undefined
+
+    while (batch.length < batchCap && index < input.calls.length) {
+      const next = input.calls[index]
+      if (!next || !isParallelSafeToolCall(input, next)) break
+      if (isParallelDelegationCall(next, input.toolProviderKinds) !== headIsDelegation) break
+
+      const nextStorm = dependencies.inspectStorm(next)
+      if (nextStorm?.suppress) {
+        suppressedAfterBatch = { call: next, reason: nextStorm.reason }
+        index += 1
+        break
+      }
+      batch.push(next)
+      index += 1
+    }
+
+    const settled = await Promise.allSettled(batch.map((entry) => dependencies.execute(entry)))
+    executedAny = true
+    for (let batchIndex = 0; batchIndex < batch.length; batchIndex += 1) {
+      const result = settled[batchIndex]
+      const batchCall = batch[batchIndex]
+      if (!result || !batchCall) continue
+      if (result.status === 'rejected') throw result.reason
+      dependencies.markProgress(batchCall.toolName)
+      await dependencies.persistResult(batchCall, result.value)
+    }
+
+    if (suppressedAfterBatch) {
+      await dependencies.persistSuppressed(
+        suppressedAfterBatch.call,
+        suppressedAfterBatch.reason
+      )
+    }
+  }
+
+  return executedAny ? 'continue' : 'all_suppressed'
+}


### PR DESCRIPTION
## Summary
- extract tool batching, parallel-safety classification and storm suppression flow from `AgentLoop`
- keep approval context, actual execution, inflight tracking and Turn/event persistence injected by the existing composition root
- preserve deterministic result persistence order and the three-call cap for built-in reads

`agent-loop.ts` drops from 3030 to 2928 lines without adding another runtime or moving product side effects out of the loop.

## Tests
- `npm.cmd --prefix kun test -- src/loop/tool-call-dispatcher.test.ts tests/loop.test.ts tests/delegation-runtime.test.ts` (111 passed)
- `npm.cmd run build:kun`
- focused ESLint
- `git diff --check`

The full Kun typecheck currently reaches the pre-existing `local-tool-host.test.ts` inference failure on `develop`; #829 fixes that baseline and is green in CI.