### PR TITLE
fix(runtime): make approval lifecycle race-safe

### DIFF
--- a/kun/src/adapters/in-memory-approval-gate.ts
+++ b/kun/src/adapters/in-memory-approval-gate.ts
@@ -1,10 +1,15 @@
 import type { ApprovalGate } from '../ports/approval-gate.js'
 import type { ApprovalRequest } from '../domain/approval.js'
-import { resolveApprovalRequest } from '../domain/approval.js'
+import { expireApprovalRequest, resolveApprovalRequest } from '../domain/approval.js'
 
 type PendingResolver = {
   resolve: (decision: 'allow' | 'deny') => void
   reject: (error: Error) => void
+}
+
+type ReservedDecision = {
+  decision: 'allow' | 'deny'
+  reason?: string
 }
 
 /**
@@ -15,8 +20,13 @@ type PendingResolver = {
 export class InMemoryApprovalGate implements ApprovalGate {
   private readonly approvals = new Map<string, ApprovalRequest>()
   private readonly resolvers = new Map<string, PendingResolver>()
+  private readonly reservations = new Map<string, ReservedDecision>()
+  private readonly deferredExpirations = new Map<string, string | undefined>()
 
   request(approval: ApprovalRequest): Promise<'allow' | 'deny'> {
+    if (this.approvals.has(approval.id)) {
+      throw new Error(`duplicate approval id: ${approval.id}`)
+    }
     this.approvals.set(approval.id, approval)
     return new Promise<'allow' | 'deny'>((resolve, reject) => {
       this.resolvers.set(approval.id, { resolve, reject })
@@ -24,14 +34,60 @@ export class InMemoryApprovalGate implements ApprovalGate {
   }
 
   decide(approvalId: string, decision: 'allow' | 'deny', reason?: string): boolean {
+    if (!this.reserveDecision(approvalId, decision, reason)) return false
+    return this.commitDecision(approvalId)
+  }
+
+  reserveDecision(approvalId: string, decision: 'allow' | 'deny', reason?: string): boolean {
     const approval = this.approvals.get(approvalId)
-    if (!approval) return false
-    if (approval.status !== 'pending') return false
-    const resolved = resolveApprovalRequest(approval, decision, reason)
+    if (!approval || approval.status !== 'pending' || this.reservations.has(approvalId)) {
+      return false
+    }
+    this.reservations.set(approvalId, { decision, ...(reason ? { reason } : {}) })
+    return true
+  }
+
+  commitDecision(approvalId: string): boolean {
+    const approval = this.approvals.get(approvalId)
+    const reserved = this.reservations.get(approvalId)
+    if (!approval || approval.status !== 'pending' || !reserved) return false
+    const resolved = resolveApprovalRequest(approval, reserved.decision, reserved.reason)
     this.approvals.set(approvalId, resolved)
+    this.reservations.delete(approvalId)
+    this.deferredExpirations.delete(approvalId)
     const resolver = this.resolvers.get(approvalId)
     this.resolvers.delete(approvalId)
-    resolver?.resolve(decision)
+    resolver?.resolve(reserved.decision)
+    return true
+  }
+
+  rollbackDecision(approvalId: string): boolean {
+    if (!this.reservations.delete(approvalId)) return false
+    if (this.deferredExpirations.has(approvalId)) {
+      const reason = this.deferredExpirations.get(approvalId)
+      this.deferredExpirations.delete(approvalId)
+      this.expireNow(approvalId, reason)
+    }
+    return true
+  }
+
+  expire(approvalId: string, reason?: string): boolean {
+    const approval = this.approvals.get(approvalId)
+    if (!approval || approval.status !== 'pending') return false
+    if (this.reservations.has(approvalId)) {
+      this.deferredExpirations.set(approvalId, reason)
+      return true
+    }
+    return this.expireNow(approvalId, reason)
+  }
+
+  private expireNow(approvalId: string, reason?: string): boolean {
+    const approval = this.approvals.get(approvalId)
+    if (!approval || approval.status !== 'pending') return false
+    this.approvals.set(approvalId, expireApprovalRequest(approval, reason))
+    const resolver = this.resolvers.get(approvalId)
+    this.resolvers.delete(approvalId)
+    resolver?.resolve('deny')
     return true
   }
 

--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -28,6 +28,67 @@ describe('LocalToolHost approval policy', () => {
     expect(result.approved).toBe(false)
   })
 
+  it('returns an error tool result when the user denies approval', async () => {
+    const host = new LocalToolHost({ tools: [echoTool] })
+    const result = await host.execute(
+      { callId: 'call_denied', toolName: 'echo', arguments: { text: 'blocked' } },
+      {
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        workspace: '/tmp/workspace',
+        approvalPolicy: 'always',
+        sandboxMode: 'danger-full-access',
+        abortSignal: new AbortController().signal,
+        awaitApproval: vi.fn(async () => ({
+          decision: 'deny' as const,
+          reason: 'Command is not expected here'
+        }))
+      }
+    )
+
+    expect(result).toMatchObject({
+      approved: false,
+      item: {
+        kind: 'tool_result',
+        callId: 'call_denied',
+        isError: true,
+        output: {
+          code: 'approval_denied',
+          approvalId: expect.stringMatching(/^appr_[a-f0-9]{32}$/),
+          reason: 'Command is not expected here'
+        }
+      }
+    })
+  })
+
+  it('uses fresh approval ids when providers reuse call ids', async () => {
+    const host = new LocalToolHost({ tools: [echoTool] })
+    const approvalIds: string[] = []
+    const execute = (threadId: string, turnId: string) => host.execute(
+      { callId: 'shared_call_id', toolName: 'echo', arguments: { text: 'blocked' } },
+      {
+        threadId,
+        turnId,
+        workspace: '/tmp/workspace',
+        approvalPolicy: 'always',
+        sandboxMode: 'danger-full-access',
+        abortSignal: new AbortController().signal,
+        awaitApproval: async (approval) => {
+          approvalIds.push(approval.id)
+          return 'deny'
+        }
+      }
+    )
+
+    await Promise.all([
+      execute('thread_a', 'turn_a'),
+      execute('thread_b', 'turn_b'),
+      execute('thread_a', 'turn_a')
+    ])
+    expect(approvalIds).toHaveLength(3)
+    expect(new Set(approvalIds).size).toBe(3)
+  })
+
   it('offloads oversized successful tool output to the artifact store', async () => {
     const artifactStore = new InMemoryArtifactStore()
     const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({

--- a/kun/src/adapters/tool/local-tool-host.ts
+++ b/kun/src/adapters/tool/local-tool-host.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type {
   ToolHost,
   ToolHostContext,
@@ -9,7 +10,7 @@ import type { UserInputQuestion } from '../../ports/user-input-gate.js'
 import type { ApprovalRequest } from '../../domain/approval.js'
 import { createApprovalRequest } from '../../domain/approval.js'
 import type { TurnItem } from '../../contracts/items.js'
-import { makeToolResultItem, makeApprovalItem } from '../../domain/item.js'
+import { makeToolResultItem } from '../../domain/item.js'
 import { buildBuiltinLocalTools } from './builtin-tools.js'
 import type { BuiltinLocalToolsOptions } from './builtin-tool-types.js'
 import { CapabilityRegistry } from './capability-registry.js'
@@ -185,7 +186,7 @@ export class LocalToolHost implements ToolHost {
     }
     const needsApproval = !preHooks.autoApproved && this.requiresApproval(tool, activeCall, context)
     if (needsApproval) {
-      const approvalId = `appr_${activeCall.callId}`
+      const approvalId = `appr_${randomUUID().replaceAll('-', '')}`
       const approval: ApprovalRequest = createApprovalRequest({
         id: approvalId,
         threadId: context.threadId,
@@ -193,17 +194,30 @@ export class LocalToolHost implements ToolHost {
         toolName: activeCall.toolName,
         summary: this.buildApprovalSummary(activeCall)
       })
-      const decision = await context.awaitApproval(approval)
+      const resolution = await context.awaitApproval(approval)
+      const decision = typeof resolution === 'string' ? resolution : resolution.decision
       if (decision !== 'allow') {
-        const item = makeApprovalItem({
-          id: `item_${approvalId}`,
-          turnId: context.turnId,
-          threadId: context.threadId,
-          approvalId,
-          toolName: activeCall.toolName,
-          summary: approval.summary
-        })
-        return { item, approved: false }
+        const reason = typeof resolution === 'string' ? undefined : resolution.reason
+        return {
+          item: makeToolResultItem({
+            id: `item_${activeCall.callId}`,
+            turnId: context.turnId,
+            threadId: context.threadId,
+            callId: activeCall.callId,
+            toolName: activeCall.toolName,
+            toolKind: activeCall.toolKind ?? tool.toolKind,
+            output: {
+              code: 'approval_denied',
+              error: reason
+                ? `User denied approval for ${activeCall.toolName}: ${reason}`
+                : `User denied approval for ${activeCall.toolName}`,
+              approvalId,
+              ...(reason ? { reason } : {})
+            },
+            isError: true
+          }),
+          approved: false
+        }
       }
     }
     if (context.abortSignal.aborted) {

--- a/kun/src/contracts/approvals.ts
+++ b/kun/src/contracts/approvals.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 export const ApprovalDecisionRequest = z.object({
   decision: z.enum(['allow', 'deny']),
   /** Optional human-readable reason stored alongside the resolution. */
-  reason: z.string().optional()
+  reason: z.string().trim().max(4096).optional().transform((value) => value || undefined)
 })
 export type ApprovalDecisionRequest = z.infer<typeof ApprovalDecisionRequest>
 

--- a/kun/src/contracts/events.ts
+++ b/kun/src/contracts/events.ts
@@ -151,7 +151,8 @@ export const ApprovalEvent = RuntimeEventBase.extend({
   status: z.enum(['pending', 'allowed', 'denied', 'expired']),
   approvalPolicy: ApprovalPolicySchema.optional(),
   sandboxMode: SandboxModeSchema.optional(),
-  summary: z.string().optional()
+  summary: z.string().optional(),
+  reason: z.string().optional()
 })
 export type ApprovalEvent = z.infer<typeof ApprovalEvent>
 

--- a/kun/src/domain/approval.ts
+++ b/kun/src/domain/approval.ts
@@ -1,5 +1,10 @@
 export type ApprovalStatus = 'pending' | 'allowed' | 'denied' | 'expired'
 
+export type ApprovalResolution = {
+  decision: 'allow' | 'deny'
+  reason?: string
+}
+
 /**
  * A pending approval request surfaced by the loop. The runtime stores
  * approval records so that an SSE subscriber can replay the request to
@@ -53,11 +58,13 @@ export function resolveApprovalRequest(
 
 export function expireApprovalRequest(
   request: ApprovalRequest,
+  reason?: string,
   decidedAt?: string
 ): ApprovalRequest {
   return {
     ...request,
     status: 'expired',
+    ...(reason ? { reason } : {}),
     decidedAt: decidedAt ?? new Date().toISOString()
   }
 }

--- a/kun/src/loop/agent-loop.test.ts
+++ b/kun/src/loop/agent-loop.test.ts
@@ -35,6 +35,22 @@ class AllowApprovalGate {
     return false
   }
 
+  reserveDecision(): boolean {
+    return false
+  }
+
+  commitDecision(): boolean {
+    return false
+  }
+
+  rollbackDecision(): boolean {
+    return false
+  }
+
+  expire(): boolean {
+    return false
+  }
+
   pending(): ApprovalRequest[] {
     return []
   }

--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -16,6 +16,7 @@ import { DEFAULT_APPROVAL_POLICY, DEFAULT_SANDBOX_MODE } from '../contracts/poli
 import type { ThreadStore } from '../ports/thread-store.js'
 import type { SessionStore } from '../ports/session-store.js'
 import type { ApprovalGate } from '../ports/approval-gate.js'
+import type { ApprovalRequest, ApprovalResolution } from '../domain/approval.js'
 import type { UserInputGate, UserInputQuestion, UserInputResolution } from '../ports/user-input-gate.js'
 import type { UsageService } from '../services/usage-service.js'
 import type { TurnService } from '../services/turn-service.js'
@@ -515,6 +516,11 @@ export class AgentLoop {
       }
       return status
     } catch (error) {
+      if (signal.aborted) {
+        await this.opts.turns.finishTurn({ threadId, turnId, status: 'aborted' })
+        finalStatus = 'aborted'
+        return 'aborted'
+      }
       const raw = error instanceof Error ? error.message : String(error)
       // Best-effort enrichment so the renderer can show "what failed where"
       // instead of the bare "Kun turn failed" string. See issue #26.
@@ -1925,20 +1931,12 @@ export class AgentLoop {
       ...(this.opts.runtimeDataDir ? { runtimeDataDir: this.opts.runtimeDataDir } : {}),
       ...(this.opts.artifactStore ? { artifactStore: this.opts.artifactStore } : {}),
       abortSignal: input.signal,
-      awaitApproval: async (approval) => {
-        await this.opts.events.record({
-          kind: 'approval_requested',
-          threadId: approval.threadId,
-          turnId: approval.turnId,
-          approvalId: approval.id,
-          toolName: approval.toolName,
-          status: 'pending',
-          approvalPolicy: input.approvalPolicy,
-          sandboxMode: input.sandboxMode,
-          summary: approval.summary
-        })
-        return this.opts.approvalGate.request(approval)
-      },
+      awaitApproval: (approval) => this.awaitApproval(
+        approval,
+        input.signal,
+        input.approvalPolicy,
+        input.sandboxMode
+      ),
       ...(input.userInputDisabled
         ? {}
         : {
@@ -1946,6 +1944,95 @@ export class AgentLoop {
               this.awaitUserInput(input.threadId, input.turnId, inputRequest, input.signal)
           })
     }
+  }
+
+  private async awaitApproval(
+    approval: ApprovalRequest,
+    signal: AbortSignal,
+    approvalPolicy: ToolHostContext['approvalPolicy'],
+    sandboxMode: NonNullable<ToolHostContext['sandboxMode']>
+  ): Promise<ApprovalResolution> {
+    const pending = this.opts.approvalGate.request(approval)
+    return new Promise<ApprovalResolution>((resolve, reject) => {
+      let settled = false
+      const cleanup = (): void => signal.removeEventListener('abort', onAbort)
+      const recordExpiredAfterRequest = (requested: Promise<unknown>): void => {
+        void requested.then(async () => {
+          await pending
+          const current = this.opts.approvalGate.get(approval.id)
+          if (current?.status !== 'expired') return
+          await this.opts.events.record({
+            kind: 'approval_resolved',
+            threadId: approval.threadId,
+            turnId: approval.turnId,
+            approvalId: approval.id,
+            toolName: approval.toolName,
+            status: 'expired',
+            summary: approval.summary,
+            ...(current.reason ? { reason: current.reason } : {})
+          })
+        }).catch(() => {})
+      }
+      let requested!: Promise<unknown>
+      const onAbort = (): void => {
+        if (settled) return
+        settled = true
+        cleanup()
+        const reason = 'turn aborted while awaiting approval'
+        if (this.opts.approvalGate.expire(approval.id, reason)) {
+          recordExpiredAfterRequest(requested)
+        }
+        reject(new Error(reason))
+      }
+
+      signal.addEventListener('abort', onAbort, { once: true })
+      requested = this.opts.events.record({
+        kind: 'approval_requested',
+        threadId: approval.threadId,
+        turnId: approval.turnId,
+        approvalId: approval.id,
+        toolName: approval.toolName,
+        status: 'pending',
+        approvalPolicy,
+        sandboxMode,
+        summary: approval.summary
+      })
+
+      if (signal.aborted) {
+        onAbort()
+        return
+      }
+      requested.then(
+        () => {
+          if (settled) return
+          pending.then(
+            (decision) => {
+              if (settled) return
+              settled = true
+              cleanup()
+              const resolved = this.opts.approvalGate.get(approval.id)
+              resolve({
+                decision,
+                ...(resolved?.reason ? { reason: resolved.reason } : {})
+              })
+            },
+            (error) => {
+              if (settled) return
+              settled = true
+              cleanup()
+              reject(error)
+            }
+          )
+        },
+        (error) => {
+          if (settled) return
+          settled = true
+          cleanup()
+          this.opts.approvalGate.expire(approval.id, 'failed to publish approval request')
+          reject(error)
+        }
+      )
+    })
   }
 
   private async executeToolCall(input: {

--- a/kun/src/ports/approval-gate.ts
+++ b/kun/src/ports/approval-gate.ts
@@ -9,6 +9,10 @@ import type { ApprovalRequest } from '../domain/approval.js'
 export interface ApprovalGate {
   request(approval: ApprovalRequest): Promise<'allow' | 'deny'>
   decide(approvalId: string, decision: 'allow' | 'deny', reason?: string): boolean
+  reserveDecision(approvalId: string, decision: 'allow' | 'deny', reason?: string): boolean
+  commitDecision(approvalId: string): boolean
+  rollbackDecision(approvalId: string): boolean
+  expire(approvalId: string, reason?: string): boolean
   pending(threadId?: string): ApprovalRequest[]
   get(approvalId: string): ApprovalRequest | undefined
 }

--- a/kun/src/ports/tool-host.ts
+++ b/kun/src/ports/tool-host.ts
@@ -1,5 +1,5 @@
 import type { ApprovalPolicy, SandboxMode } from '../contracts/policy.js'
-import type { ApprovalRequest } from '../domain/approval.js'
+import type { ApprovalRequest, ApprovalResolution } from '../domain/approval.js'
 import type { TurnItem } from '../contracts/items.js'
 import type { ModelCapabilityMetadata } from '../contracts/capabilities.js'
 import type { ArtifactStore } from '../artifacts/artifact-store.js'
@@ -104,7 +104,9 @@ export type ToolHostContext = {
   artifactStore?: ArtifactStore
   abortSignal: AbortSignal
   /** Resolves a pending approval with the user's decision. */
-  awaitApproval: (approval: ApprovalRequest) => Promise<'allow' | 'deny'>
+  awaitApproval: (
+    approval: ApprovalRequest
+  ) => Promise<'allow' | 'deny' | ApprovalResolution>
   /** Resolves structured GUI input requested by a tool call. */
   awaitUserInput?: (
     input: Omit<UserInputRequest, 'threadId' | 'turnId'>

--- a/kun/src/server/routes/approvals.ts
+++ b/kun/src/server/routes/approvals.ts
@@ -8,6 +8,73 @@ import { ERRORS } from './runtime-error.js'
 import type { ApprovalGate } from '../../ports/approval-gate.js'
 import type { RuntimeEventRecorder } from '../../services/runtime-event-recorder.js'
 
+const approvalDecisionFlights = new WeakMap<ApprovalGate, Map<string, Promise<boolean>>>()
+
+function resolvedDecision(status: string): 'allow' | 'deny' | null {
+  return status === 'allowed' ? 'allow' : status === 'denied' ? 'deny' : null
+}
+
+function decisionFlightsFor(gate: ApprovalGate): Map<string, Promise<boolean>> {
+  let flights = approvalDecisionFlights.get(gate)
+  if (!flights) {
+    flights = new Map()
+    approvalDecisionFlights.set(gate, flights)
+  }
+  return flights
+}
+
+async function recordApprovalResolution(input: {
+  approvalId: string
+  decision: 'allow' | 'deny'
+  reason?: string
+  gate: ApprovalGate
+  events: RuntimeEventRecorder
+}): Promise<{ joined: boolean }> {
+  const flights = decisionFlightsFor(input.gate)
+  const active = flights.get(input.approvalId)
+  if (active) {
+    await active
+    return { joined: true }
+  }
+
+  const approval = input.gate.get(input.approvalId)
+  if (!approval || approval.status !== 'pending') return { joined: true }
+  const status = input.decision === 'allow' ? 'allowed' : 'denied'
+  const flight = (async (): Promise<boolean> => {
+    if (!input.gate.reserveDecision(input.approvalId, input.decision, input.reason)) {
+      return false
+    }
+    try {
+      // Persist the audit event before releasing the loop to execute an allowed tool.
+      await input.events.record({
+        kind: 'approval_resolved',
+        threadId: approval.threadId,
+        turnId: approval.turnId,
+        itemId: undefined,
+        approvalId: input.approvalId,
+        toolName: approval.toolName,
+        status,
+        summary: approval.summary,
+        ...(input.reason ? { reason: input.reason } : {})
+      })
+    } catch (error) {
+      input.gate.rollbackDecision(input.approvalId)
+      throw error
+    }
+    if (!input.gate.commitDecision(input.approvalId)) {
+      throw new Error(`approval reservation lost before commit: ${input.approvalId}`)
+    }
+    return true
+  })()
+  flights.set(input.approvalId, flight)
+  try {
+    await flight
+    return { joined: false }
+  } finally {
+    if (flights.get(input.approvalId) === flight) flights.delete(input.approvalId)
+  }
+}
+
 /**
  * POST /v1/approvals/{approvalId}. Resolves a pending approval
  * request and emits a runtime event for the renderer to consume.
@@ -29,13 +96,8 @@ export async function decideApproval(input: {
     return ERRORS.notFound(`approval not found: ${input.approvalId}`)
   }
   if (approval.status !== 'pending') {
-    const resolvedDecision =
-      approval.status === 'allowed'
-        ? 'allow'
-        : approval.status === 'denied'
-          ? 'deny'
-          : null
-    if (resolvedDecision && resolvedDecision === parsed.data.decision) {
+    const existingDecision = resolvedDecision(approval.status)
+    if (existingDecision && existingDecision === parsed.data.decision) {
       const response: ApprovalDecisionResponse = {
         approvalId: input.approvalId,
         decision: parsed.data.decision,
@@ -46,24 +108,23 @@ export async function decideApproval(input: {
     }
     return ERRORS.conflict(`approval already decided: ${input.approvalId}`)
   }
-  const ok = input.gate.decide(input.approvalId, parsed.data.decision, parsed.data.reason)
-  if (!ok) {
+  const result = await recordApprovalResolution({
+    approvalId: input.approvalId,
+    decision: parsed.data.decision,
+    reason: parsed.data.reason,
+    gate: input.gate,
+    events: input.events
+  })
+  const resolved = input.gate.get(input.approvalId)
+  const finalDecision = resolved ? resolvedDecision(resolved.status) : null
+  if (finalDecision !== parsed.data.decision) {
     return ERRORS.conflict(`approval already decided: ${input.approvalId}`)
   }
   const response: ApprovalDecisionResponse = {
     approvalId: input.approvalId,
     decision: parsed.data.decision,
-    status: parsed.data.decision === 'allow' ? 'allowed' : 'denied'
+    status: parsed.data.decision === 'allow' ? 'allowed' : 'denied',
+    ...(result.joined ? { alreadyResolved: true } : {})
   }
-  await input.events.record({
-    kind: 'approval_resolved' as const,
-    threadId: approval.threadId,
-    turnId: approval.turnId,
-    itemId: undefined,
-    approvalId: input.approvalId,
-    toolName: approval.toolName,
-    status: response.status,
-    summary: approval.summary
-  })
   return jsonResponse(response)
 }

--- a/kun/tests/http-server.test.ts
+++ b/kun/tests/http-server.test.ts
@@ -1041,6 +1041,174 @@ describe('HTTP server', () => {
     expect(conflict.status).toBe(409)
   })
 
+  it('persists approval audit data before releasing an allowed tool waiter', async () => {
+    const h = buildHarness()
+    const approval = createApprovalRequest({
+      id: 'appr_audited',
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      toolName: 'echo',
+      summary: 'run echo'
+    })
+    const pending = h.approvalGate.request(approval)
+    const originalAppend = h.sessionStore.appendEvent.bind(h.sessionStore)
+    let releaseAudit!: () => void
+    const auditBlocked = new Promise<void>((resolve) => { releaseAudit = resolve })
+    let auditStarted = false
+    vi.spyOn(h.sessionStore, 'appendEvent').mockImplementation(async (threadId, event) => {
+      if (event.kind === 'approval_resolved') {
+        auditStarted = true
+        await auditBlocked
+      }
+      await originalAppend(threadId, event)
+    })
+
+    let waiterReleased = false
+    void pending.then(() => { waiterReleased = true })
+    const request = dispatchRequest(
+      h.router,
+      new Request('http://localhost/v1/approvals/appr_audited', {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok-1', 'content-type': 'application/json' },
+        body: JSON.stringify({ decision: 'allow' })
+      })
+    )
+    await vi.waitFor(() => expect(auditStarted).toBe(true))
+    expect(waiterReleased).toBe(false)
+    expect(h.approvalGate.get('appr_audited')?.status).toBe('pending')
+
+    releaseAudit()
+    expect((await request).status).toBe(200)
+    await expect(pending).resolves.toBe('allow')
+  })
+
+  it('rolls back a reserved decision when audit persistence fails', async () => {
+    const h = buildHarness()
+    const pending = h.approvalGate.request(createApprovalRequest({
+      id: 'appr_audit_failure',
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      toolName: 'echo',
+      summary: 'run echo'
+    }))
+    vi.spyOn(h.sessionStore, 'appendEvent').mockImplementation(async (_threadId, event) => {
+      if (event.kind === 'approval_resolved') throw new Error('audit write failed')
+    })
+
+    await expect(dispatchRequest(
+      h.router,
+      new Request('http://localhost/v1/approvals/appr_audit_failure', {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok-1', 'content-type': 'application/json' },
+        body: JSON.stringify({ decision: 'allow' })
+      })
+    )).rejects.toThrow('audit write failed')
+    expect(h.approvalGate.get('appr_audit_failure')?.status).toBe('pending')
+    expect(h.approvalGate.decide('appr_audit_failure', 'deny')).toBe(true)
+    await expect(pending).resolves.toBe('deny')
+  })
+
+  it('coalesces concurrent identical approval decisions into one audit event', async () => {
+    const h = buildHarness()
+    void h.approvalGate.request(createApprovalRequest({
+      id: 'appr_same_decision',
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      toolName: 'echo',
+      summary: 'run echo'
+    }))
+    const originalAppend = h.sessionStore.appendEvent.bind(h.sessionStore)
+    let releaseAudit!: () => void
+    const auditBlocked = new Promise<void>((resolve) => { releaseAudit = resolve })
+    let auditStarted = false
+    vi.spyOn(h.sessionStore, 'appendEvent').mockImplementation(async (threadId, event) => {
+      if (event.kind === 'approval_resolved') {
+        auditStarted = true
+        await auditBlocked
+      }
+      await originalAppend(threadId, event)
+    })
+    const makeRequest = () => dispatchRequest(
+      h.router,
+      new Request('http://localhost/v1/approvals/appr_same_decision', {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok-1', 'content-type': 'application/json' },
+        body: JSON.stringify({ decision: 'allow' })
+      })
+    )
+
+    const first = makeRequest()
+    await vi.waitFor(() => expect(auditStarted).toBe(true))
+    const second = makeRequest()
+    releaseAudit()
+    const responses = await Promise.all([first, second])
+    expect(responses.map((response) => response.status)).toEqual([200, 200])
+    const events = await h.sessionStore.loadEventsSince('thr_1', 0)
+    expect(events.filter((event) => event.kind === 'approval_resolved')).toHaveLength(1)
+  })
+
+  it('returns conflict for the losing concurrent opposite decision', async () => {
+    const h = buildHarness()
+    void h.approvalGate.request(createApprovalRequest({
+      id: 'appr_opposite_decision',
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      toolName: 'echo',
+      summary: 'run echo'
+    }))
+    const originalAppend = h.sessionStore.appendEvent.bind(h.sessionStore)
+    let releaseAudit!: () => void
+    const auditBlocked = new Promise<void>((resolve) => { releaseAudit = resolve })
+    let auditStarted = false
+    vi.spyOn(h.sessionStore, 'appendEvent').mockImplementation(async (threadId, event) => {
+      if (event.kind === 'approval_resolved') {
+        auditStarted = true
+        await auditBlocked
+      }
+      await originalAppend(threadId, event)
+    })
+    const request = (decision: 'allow' | 'deny') => dispatchRequest(
+      h.router,
+      new Request('http://localhost/v1/approvals/appr_opposite_decision', {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok-1', 'content-type': 'application/json' },
+        body: JSON.stringify({ decision })
+      })
+    )
+
+    const allow = request('allow')
+    await vi.waitFor(() => expect(auditStarted).toBe(true))
+    const deny = request('deny')
+    releaseAudit()
+    const [allowResponse, denyResponse] = await Promise.all([allow, deny])
+    expect(allowResponse.status).toBe(200)
+    expect(denyResponse.status).toBe(409)
+    expect(h.approvalGate.get('appr_opposite_decision')?.status).toBe('allowed')
+  })
+
+  it('rejects oversized approval reasons without resolving the request', async () => {
+    const h = buildHarness()
+    void h.approvalGate.request(createApprovalRequest({
+      id: 'appr_reason_limit',
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      toolName: 'echo',
+      summary: 'run echo'
+    }))
+
+    const response = await dispatchRequest(
+      h.router,
+      new Request('http://localhost/v1/approvals/appr_reason_limit', {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok-1', 'content-type': 'application/json' },
+        body: JSON.stringify({ decision: 'deny', reason: 'x'.repeat(4097) })
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(h.approvalGate.get('appr_reason_limit')?.status).toBe('pending')
+  })
+
   it('resolves GUI user input through both HTTP compatibility endpoints', async () => {
     const h = buildHarness()
     const pending = h.userInputGate.request({

--- a/kun/tests/loop.test.ts
+++ b/kun/tests/loop.test.ts
@@ -1397,6 +1397,209 @@ describe('AgentLoop', () => {
     expect(approvalDecisions).toEqual(['dangerous_auto'])
   })
 
+  it('expires a pending approval and releases tool inflight work when interrupted', async () => {
+    const guardedTool = LocalToolHost.defineTool({
+      name: 'guarded_action',
+      description: 'Waits for explicit approval.',
+      inputSchema: { type: 'object' },
+      policy: 'on-request',
+      execute: async () => ({ output: { ok: true } })
+    })
+    const h = makeHarness(makeFakeModel([
+      {
+        kind: 'tool_call_complete',
+        callId: 'call_guarded',
+        toolName: 'guarded_action',
+        arguments: {}
+      },
+      { kind: 'completed', stopReason: 'tool_calls' }
+    ]), { tools: [guardedTool] })
+    await bootstrapThread(h)
+    const thread = await h.threadStore.get(h.threadId)
+    if (!thread) throw new Error('expected thread')
+    await h.threadStore.upsert({ ...thread, approvalPolicy: 'on-request' })
+
+    const running = h.loop.runTurn(h.threadId, h.turnId)
+    let pendingApprovalId = ''
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      pendingApprovalId = h.approvalGate.pending(h.threadId)[0]?.id ?? ''
+      if (pendingApprovalId) break
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+    expect(pendingApprovalId).toMatch(/^appr_[a-f0-9]{32}$/)
+
+    await h.turns.interruptTurn({ threadId: h.threadId, turnId: h.turnId })
+    await expect(running).resolves.toBe('aborted')
+
+    expect(h.approvalGate.get(pendingApprovalId)).toMatchObject({ status: 'expired' })
+    expect(h.approvalGate.pending(h.threadId)).toEqual([])
+    expect(h.inflight.size()).toBe(0)
+    const events = await h.sessionStore.loadEventsSince(h.threadId, 0)
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'approval_resolved',
+        approvalId: pendingApprovalId,
+        status: 'expired',
+        reason: 'turn aborted while awaiting approval'
+      })
+    ]))
+  })
+
+  it('interrupts immediately while approval request persistence is blocked', async () => {
+    const guardedTool = LocalToolHost.defineTool({
+      name: 'guarded_action',
+      description: 'Waits for explicit approval.',
+      inputSchema: { type: 'object' },
+      policy: 'on-request',
+      execute: async () => ({ output: { ok: true } })
+    })
+    const h = makeHarness(makeFakeModel([
+      {
+        kind: 'tool_call_complete',
+        callId: 'call_blocked_event',
+        toolName: 'guarded_action',
+        arguments: {}
+      },
+      { kind: 'completed', stopReason: 'tool_calls' }
+    ]), { tools: [guardedTool] })
+    await bootstrapThread(h)
+    const thread = await h.threadStore.get(h.threadId)
+    if (!thread) throw new Error('expected thread')
+    await h.threadStore.upsert({ ...thread, approvalPolicy: 'on-request' })
+    const originalAppend = h.sessionStore.appendEvent.bind(h.sessionStore)
+    let releaseRequest!: () => void
+    const requestBlocked = new Promise<void>((resolve) => { releaseRequest = resolve })
+    let requestWriteStarted = false
+    vi.spyOn(h.sessionStore, 'appendEvent').mockImplementation(async (threadId, event) => {
+      if (event.kind === 'approval_requested') {
+        requestWriteStarted = true
+        await requestBlocked
+      }
+      await originalAppend(threadId, event)
+    })
+
+    const running = h.loop.runTurn(h.threadId, h.turnId)
+    await vi.waitFor(() => expect(requestWriteStarted).toBe(true))
+    await h.turns.interruptTurn({ threadId: h.threadId, turnId: h.turnId })
+    const status = await Promise.race([
+      running,
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 500))
+    ])
+    releaseRequest()
+
+    expect(status).toBe('aborted')
+    await expect(running).resolves.toBe('aborted')
+    await vi.waitFor(async () => {
+      const events = await h.sessionStore.loadEventsSince(h.threadId, 0)
+      expect(events).toEqual(expect.arrayContaining([
+        expect.objectContaining({ kind: 'approval_resolved', status: 'expired' })
+      ]))
+    })
+  })
+
+  it('persists a denied approval as a failed tool call with model-visible feedback', async () => {
+    const guardedTool = LocalToolHost.defineTool({
+      name: 'guarded_action',
+      description: 'Waits for explicit approval.',
+      inputSchema: { type: 'object' },
+      policy: 'on-request',
+      execute: async () => ({ output: { ok: true } })
+    })
+    let modelStep = 0
+    const modelRequests: ModelRequest[] = []
+    const h = makeHarness({
+      provider: 'approval-denied',
+      model: 'approval-denied',
+      async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
+        modelRequests.push(request)
+        modelStep += 1
+        if (modelStep === 1) {
+          yield {
+            kind: 'tool_call_complete',
+            callId: 'call_denied',
+            toolName: 'guarded_action',
+            arguments: {}
+          }
+          yield { kind: 'completed', stopReason: 'tool_calls' }
+          return
+        }
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    }, { tools: [guardedTool] })
+    await bootstrapThread(h)
+    const thread = await h.threadStore.get(h.threadId)
+    if (!thread) throw new Error('expected thread')
+    await h.threadStore.upsert({ ...thread, approvalPolicy: 'on-request' })
+
+    const running = h.loop.runTurn(h.threadId, h.turnId)
+    let approvalId = ''
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      approvalId = h.approvalGate.pending(h.threadId)[0]?.id ?? ''
+      if (approvalId) break
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+    expect(h.approvalGate.decide(approvalId, 'deny', 'not approved for this task')).toBe(true)
+    await expect(running).resolves.toBe('completed')
+
+    const items = await h.sessionStore.loadItems(h.threadId)
+    expect(items.find((item) => item.kind === 'tool_call' && item.callId === 'call_denied'))
+      .toMatchObject({ status: 'failed' })
+    expect(items.find((item) => item.kind === 'tool_result' && item.callId === 'call_denied'))
+      .toMatchObject({
+        isError: true,
+        output: {
+          code: 'approval_denied',
+          approvalId,
+          reason: 'not approved for this task'
+        }
+      })
+    expect(modelRequests).toHaveLength(2)
+    expect(JSON.stringify(modelRequests[1]?.history)).toContain('not approved for this task')
+  })
+
+  it('registers an approval before publishing it to live event subscribers', async () => {
+    const guardedTool = LocalToolHost.defineTool({
+      name: 'guarded_action',
+      description: 'Waits for explicit approval.',
+      inputSchema: { type: 'object' },
+      policy: 'on-request',
+      execute: async () => ({ output: { ok: true } })
+    })
+    let modelStep = 0
+    const h = makeHarness({
+      provider: 'approval-immediate',
+      model: 'approval-immediate',
+      async *stream(): AsyncIterable<ModelStreamChunk> {
+        modelStep += 1
+        if (modelStep === 1) {
+          yield {
+            kind: 'tool_call_complete',
+            callId: 'call_immediate',
+            toolName: 'guarded_action',
+            arguments: {}
+          }
+          yield { kind: 'completed', stopReason: 'tool_calls' }
+          return
+        }
+        yield { kind: 'completed', stopReason: 'stop' }
+      }
+    }, { tools: [guardedTool] })
+    await bootstrapThread(h)
+    const thread = await h.threadStore.get(h.threadId)
+    if (!thread) throw new Error('expected thread')
+    await h.threadStore.upsert({ ...thread, approvalPolicy: 'on-request' })
+    let registeredBeforePublish = false
+    const unsubscribe = h.bus.subscribe(h.threadId, (event) => {
+      if (event.kind !== 'approval_requested') return
+      registeredBeforePublish = h.approvalGate.get(event.approvalId)?.status === 'pending'
+      h.approvalGate.decide(event.approvalId, 'deny', 'decided immediately')
+    })
+
+    await expect(h.loop.runTurn(h.threadId, h.turnId)).resolves.toBe('completed')
+    unsubscribe()
+    expect(registeredBeforePublish).toBe(true)
+  })
+
   it('persists toolKind from the advertised tool metadata', async () => {
     const tool = LocalToolHost.defineTool({
       name: 'write_file',

--- a/kun/tests/ports.test.ts
+++ b/kun/tests/ports.test.ts
@@ -65,6 +65,25 @@ describe('InMemoryApprovalGate', () => {
     expect(gate.decide('missing', 'deny')).toBe(false)
   })
 
+  it('expires a pending approval and releases its waiter', async () => {
+    const gate = new InMemoryApprovalGate()
+    const pending = gate.request(createApprovalRequest({
+      id: 'expiring',
+      threadId: 't',
+      turnId: 'tu',
+      toolName: 'echo',
+      summary: 's'
+    }))
+
+    expect(gate.expire('expiring', 'turn aborted')).toBe(true)
+    await expect(pending).resolves.toBe('deny')
+    expect(gate.get('expiring')).toMatchObject({
+      status: 'expired',
+      reason: 'turn aborted'
+    })
+    expect(gate.expire('expiring')).toBe(false)
+  })
+
   it('filters pending by thread', () => {
     const gate = new InMemoryApprovalGate()
     gate.request(
@@ -74,6 +93,60 @@ describe('InMemoryApprovalGate', () => {
       createApprovalRequest({ id: 'b', threadId: 'th2', turnId: 't', toolName: 'x', summary: 's' })
     )
     expect(gate.pending('th1')).toHaveLength(1)
+  })
+
+  it('rejects duplicate ids instead of overwriting a pending waiter', async () => {
+    const gate = new InMemoryApprovalGate()
+    const approval = createApprovalRequest({
+      id: 'duplicate',
+      threadId: 't',
+      turnId: 'tu',
+      toolName: 'echo',
+      summary: 's'
+    })
+    const first = gate.request(approval)
+
+    expect(() => gate.request(approval)).toThrow('duplicate approval id: duplicate')
+    expect(gate.decide('duplicate', 'allow')).toBe(true)
+    await expect(first).resolves.toBe('allow')
+  })
+
+  it('commits a reserved decision after a concurrent expiration request', async () => {
+    const gate = new InMemoryApprovalGate()
+    const pending = gate.request(createApprovalRequest({
+      id: 'reserved',
+      threadId: 't',
+      turnId: 'tu',
+      toolName: 'echo',
+      summary: 's'
+    }))
+
+    expect(gate.reserveDecision('reserved', 'allow')).toBe(true)
+    expect(gate.expire('reserved', 'turn aborted')).toBe(true)
+    expect(gate.get('reserved')?.status).toBe('pending')
+    expect(gate.commitDecision('reserved')).toBe(true)
+    await expect(pending).resolves.toBe('allow')
+    expect(gate.get('reserved')?.status).toBe('allowed')
+  })
+
+  it('applies deferred expiration when an audited decision rolls back', async () => {
+    const gate = new InMemoryApprovalGate()
+    const pending = gate.request(createApprovalRequest({
+      id: 'rolled_back',
+      threadId: 't',
+      turnId: 'tu',
+      toolName: 'echo',
+      summary: 's'
+    }))
+
+    expect(gate.reserveDecision('rolled_back', 'allow')).toBe(true)
+    expect(gate.expire('rolled_back', 'turn aborted')).toBe(true)
+    expect(gate.rollbackDecision('rolled_back')).toBe(true)
+    await expect(pending).resolves.toBe('deny')
+    expect(gate.get('rolled_back')).toMatchObject({
+      status: 'expired',
+      reason: 'turn aborted'
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
- make approval waits abort-safe even when event persistence is blocked
- prevent approval ID collisions and duplicate resolver replacement
- persist approval decisions before releasing allowed tools
- return model-visible denial results with bounded reasons

## Changes
- add two-phase approval decision reservation/commit/rollback and per-approval single-flight
- make repeated decisions idempotent and conflicting concurrent decisions return 409
- expire interrupted approvals without leaving inflight tool work behind
- use fresh UUID-backed approval IDs and reject duplicate gate registrations
- carry denial reasons into audit events and tool results, capped at 4 KiB

## Tests
- `npm.cmd --prefix kun test -- src/adapters/tool/local-tool-host.test.ts src/loop/agent-loop.test.ts tests/ports.test.ts tests/loop.test.ts tests/http-server.test.ts tests/contracts.test.ts` (219 passed)
- `npm.cmd run build:kun`
- focused ESLint and `git diff --check`

## CI note
Full Kun typecheck on the current develop baseline still hits the pre-existing test typing error fixed by #829; this branch does not include that unrelated fix.