### PR TITLE
fix(chat): retire expired approval cards

### DIFF
--- a/src/renderer/src/agent/kun-contract.ts
+++ b/src/renderer/src/agent/kun-contract.ts
@@ -651,6 +651,7 @@ export type CoreRuntimeEventJson = {
   label?: string
   details?: unknown
   summary?: string
+  reason?: string
   prompt?: string
   inputId?: string
   questions?: Array<{

--- a/src/renderer/src/agent/kun-mapper.test.ts
+++ b/src/renderer/src/agent/kun-mapper.test.ts
@@ -868,6 +868,46 @@ describe('approval mapping', () => {
     )
     expect(called).toBe(false)
   })
+
+  it('rehydrates expired approval items as non-actionable blocks', () => {
+    expect(chatBlockFromItem({
+      id: 'item_approval_expired',
+      turnId: 'turn_1',
+      threadId: 'thr_1',
+      role: 'tool',
+      status: 'expired',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      kind: 'approval',
+      approvalId: 'appr_expired',
+      toolName: 'shell',
+      summary: 'Approval required'
+    })).toMatchObject({
+      kind: 'approval',
+      approvalId: 'appr_expired',
+      status: 'expired'
+    })
+  })
+
+  it('maps live approval resolution events to status updates', async () => {
+    const onApprovalStatus = vi.fn()
+    await dispatchKunRuntimeEvent(
+      {
+        kind: 'approval_resolved',
+        seq: 10,
+        approvalId: 'appr_expired',
+        status: 'expired',
+        reason: 'turn aborted while awaiting approval'
+      },
+      { ...makeSink(), onApprovalStatus },
+      async () => undefined
+    )
+
+    expect(onApprovalStatus).toHaveBeenCalledWith({
+      approvalId: 'appr_expired',
+      status: 'expired',
+      errorMessage: 'turn aborted while awaiting approval'
+    })
+  })
 })
 
 describe('tool block merging', () => {

--- a/src/renderer/src/agent/kun-mapper.ts
+++ b/src/renderer/src/agent/kun-mapper.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovalStatusPayload,
   ChatBlock,
   CompactionEventPayload,
   GeneratedFileReference,
@@ -838,12 +839,27 @@ function approvalBlockFromItem(item: CoreTurnItemJson, child?: CoreChildRuntimeM
     summary: item.summary?.trim() || 'Approval required',
     toolName: item.toolName,
     status:
-      item.status === 'allowed' || item.status === 'denied'
+      item.status === 'allowed' || item.status === 'denied' || item.status === 'expired'
         ? item.status
         : item.status === 'failed'
           ? 'error'
           : 'pending',
     ...(Object.keys(meta).length > 0 ? { meta } : {})
+  }
+}
+
+function approvalStatusFromEvent(event: CoreRuntimeEventJson): ApprovalStatusPayload | null {
+  const approvalId = event.approvalId ?? event.itemId ?? ''
+  if (!approvalId) return null
+  if (event.status !== 'allowed' && event.status !== 'denied' && event.status !== 'expired') {
+    return null
+  }
+  return {
+    approvalId,
+    status: event.status,
+    ...(event.status === 'expired' && event.reason?.trim()
+      ? { errorMessage: redactSecretText(event.reason.trim()) }
+      : {})
   }
 }
 
@@ -1359,6 +1375,11 @@ export async function dispatchKunRuntimeEvent(
     case 'approval_requested':
       await handleApprovalRequest(event, sink)
       return
+    case 'approval_resolved': {
+      const status = approvalStatusFromEvent(event)
+      if (status) sink.onApprovalStatus?.(status)
+      return
+    }
     case 'user_input_requested':
       sink.onUserInput(
         userInputRequestFromCore({

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -307,7 +307,7 @@ export type ChatBlock =
       approvalId: string
       summary: string
       toolName?: string
-      status: 'pending' | 'submitting' | 'allowed' | 'denied' | 'error'
+      status: 'pending' | 'submitting' | 'allowed' | 'denied' | 'expired' | 'error'
       errorMessage?: string
       meta?: RuntimeDisclosureMetadata
     }
@@ -334,6 +334,12 @@ export type ApprovalRequestPayload = {
   summary: string
   toolName?: string
   meta?: RuntimeDisclosureMetadata
+}
+
+export type ApprovalStatusPayload = {
+  approvalId: string
+  status: 'allowed' | 'denied' | 'expired' | 'error'
+  errorMessage?: string
 }
 
 export type ToolEventPayload = {
@@ -455,6 +461,7 @@ export type ThreadEventSink = {
   onCompaction(ev: CompactionEventPayload): void
   onReview?(ev: ReviewEventPayload): void
   onApproval(req: ApprovalRequestPayload): void
+  onApprovalStatus?(ev: ApprovalStatusPayload): void
   onUserInput(req: UserInputRequestPayload): void
   onUserInputStatus(ev: UserInputStatusPayload): void
   onRuntimeStatus?(ev: RuntimeStatusEventPayload): void

--- a/src/renderer/src/components/chat/message-timeline-bubbles.tsx
+++ b/src/renderer/src/components/chat/message-timeline-bubbles.tsx
@@ -1643,6 +1643,8 @@ function MessageBubbleImpl({
         ? t('approvalAllowed')
         : block.status === 'denied'
           ? t('approvalDenied')
+          : block.status === 'expired'
+            ? t('approvalExpired')
           : block.status === 'error'
             ? t('approvalFailed')
             : submitting
@@ -1653,6 +1655,8 @@ function MessageBubbleImpl({
         className={`rounded-[22px] border px-4 py-4 text-[13px] leading-6 shadow-[0_12px_30px_rgba(86,103,136,0.04)] ${
           block.status === 'error'
             ? 'border-red-300/80 bg-red-500/10 dark:border-red-800/60 dark:bg-red-950/35'
+            : block.status === 'expired'
+              ? 'border-amber-300/80 bg-amber-500/10 dark:border-amber-800/60 dark:bg-amber-950/30'
             : 'border-accent/35 bg-[linear-gradient(180deg,rgba(79,124,255,0.08),rgba(79,124,255,0.12))] text-ds-ink'
         }`}
       >

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1824,6 +1824,7 @@
   "approvalDeny": "Deny",
   "approvalAllowed": "Allowed",
   "approvalDenied": "Denied",
+  "approvalExpired": "Expired because the turn ended",
   "approvalSubmitting": "Submitting decision…",
   "approvalFailed": "Request failed",
   "userInputTitle": "Input required",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1824,6 +1824,7 @@
   "approvalDeny": "拒绝",
   "approvalAllowed": "已允许",
   "approvalDenied": "已拒绝",
+  "approvalExpired": "当前任务已结束，此审批已过期",
   "approvalSubmitting": "正在提交选择…",
   "approvalFailed": "请求失败",
   "userInputTitle": "需要你的输入",

--- a/src/renderer/src/store/chat-store-runtime.test.ts
+++ b/src/renderer/src/store/chat-store-runtime.test.ts
@@ -136,6 +136,31 @@ describe('code thread classification', () => {
 })
 
 describe('thread event sink binding', () => {
+  it('marks a resolved approval as expired so it cannot be submitted again', () => {
+    const approval: ChatBlock = {
+      kind: 'approval',
+      id: 'approval-appr_1',
+      approvalId: 'appr_1',
+      summary: 'Run shell command',
+      status: 'pending'
+    }
+    const { getState, set, get } = makeSinkHarness({ blocks: [approval] })
+    const sink = buildThreadEventSink(set, get, { threadId: 'thread-current' })
+
+    sink.onApprovalStatus?.({
+      approvalId: 'appr_1',
+      status: 'expired',
+      errorMessage: 'turn aborted while awaiting approval'
+    })
+
+    expect(getState().blocks[0]).toMatchObject({
+      kind: 'approval',
+      approvalId: 'appr_1',
+      status: 'expired',
+      errorMessage: 'turn aborted while awaiting approval'
+    })
+  })
+
   it('ignores reasoning deltas from a stream bound to a different active thread', () => {
     const { getState, set, get } = makeSinkHarness({ activeThreadId: 'thread-new' })
     const controller = new AbortController()

--- a/src/renderer/src/store/chat-store-runtime.ts
+++ b/src/renderer/src/store/chat-store-runtime.ts
@@ -1160,6 +1160,21 @@ export function buildThreadEventSink(
           error: clearRuntimeStreamRecoveringError(s.error)
         }
       }),
+    onApprovalStatus: (ev) => {
+      if (!isCurrentStream()) return
+      resetBusyRecoveryAttempts()
+      set((s) => ({
+        blocks: s.blocks.map((block) =>
+          block.kind === 'approval' && block.approvalId === ev.approvalId
+            ? {
+                ...block,
+                status: ev.status,
+                errorMessage: ev.errorMessage ?? block.errorMessage
+              }
+            : block
+        )
+      }))
+    },
     onUserInput: (req) => {
       if (!isCurrentStream()) return
       resetBusyRecoveryAttempts()

--- a/src/renderer/src/store/chat-store-side-actions.test.ts
+++ b/src/renderer/src/store/chat-store-side-actions.test.ts
@@ -349,6 +349,24 @@ describe('chat-store-side-actions', () => {
     expect(state.busy).toBe(true)
   })
 
+  it('updates approval resolution inside the matching side conversation', async () => {
+    const { actions, state, provider } = buildHarness()
+    const id = (await actions.spawnSideConversation())!
+    const lastCall = provider.subscribeMock.mock.calls.at(-1) as
+      | [string, number, ThreadEventSink, AbortSignal]
+      | undefined
+    const sink = lastCall?.[2]
+    sink?.onApproval({ approvalId: 'appr_side', summary: 'Run remote command' })
+    sink?.onApprovalStatus?.({ approvalId: 'appr_side', status: 'expired' })
+
+    expect(state.sideConversations[id].blocks).toContainEqual(expect.objectContaining({
+      kind: 'approval',
+      approvalId: 'appr_side',
+      status: 'expired'
+    }))
+    expect(state.blocks).toEqual([])
+  })
+
   it('promoteSideConversation clears the relation by PATCH /v1/threads/{id} and refreshes the thread list', async () => {
     const { actions, state } = buildHarness()
     const id = (await actions.spawnSideConversation())!

--- a/src/renderer/src/store/chat-store-side-actions.ts
+++ b/src/renderer/src/store/chat-store-side-actions.ts
@@ -222,6 +222,22 @@ function buildSideSink(sideId: string, ctx: SideContext, sinceSeq = 0): ThreadEv
         }))
       )
     },
+    onApprovalStatus: (ev) => {
+      ctx.set((s) =>
+        patchSide(s, sideId, (side) => ({
+          ...side,
+          blocks: side.blocks.map((block) =>
+            block.kind === 'approval' && block.approvalId === ev.approvalId
+              ? {
+                  ...block,
+                  status: ev.status,
+                  errorMessage: ev.errorMessage ?? block.errorMessage
+                }
+              : block
+          )
+        }))
+      )
+    },
     onUserInput: (req) => {
       ctx.set((s) =>
         patchSide(s, sideId, (side) => ({


### PR DESCRIPTION
## Summary
- consume live `approval_resolved` events in the renderer
- rehydrate expired approvals as non-actionable history
- keep main and side conversation approval state consistent

## Changes
- add an explicit `expired` approval UI state and localized status copy
- update approval blocks by `approvalId` when allowed, denied, or expired
- redact the optional expiration reason before display
- render expired cards as read-only amber status cards without decision buttons

## Tests
- `npm.cmd test -- src/renderer/src/agent/kun-mapper.test.ts src/renderer/src/store/chat-store-runtime.test.ts src/renderer/src/store/chat-store-side-actions.test.ts` (85 passed)
- `npm.cmd run typecheck`
- `npm.cmd run build`
- focused ESLint and `git diff --check`

Complements the backend lifecycle hardening in #844, but the renderer change remains safe on its own because `expired` is already part of the runtime approval event contract.