### PR TITLE
fix(write): protect unsaved drafts from assistant edits

### DIFF
--- a/src/renderer/src/components/workbench/useWorkbenchComposerSubmitController.ts
+++ b/src/renderer/src/components/workbench/useWorkbenchComposerSubmitController.ts
@@ -284,10 +284,16 @@ export function useWorkbenchComposerSubmitController({
       setAttachmentUploadError(t('composerAttachmentModelUnsupported'))
       return
     }
-    const writeState = useWriteWorkspaceStore.getState()
+    let writeState = useWriteWorkspaceStore.getState()
     const writeWorkspaceRoot = writeState.workspaceRoot || workspaceRoot
     setInput('')
     void (async () => {
+      if (!await writeState.prepareActiveFileForAssistant(writeWorkspaceRoot)) {
+        useWriteWorkspaceStore.getState().setFileError(t('writeAssistantSaveBeforeSendFailed'))
+        setInput(v)
+        return
+      }
+      writeState = useWriteWorkspaceStore.getState()
       const threadId = await ensureWriteThreadForWorkspace(writeWorkspaceRoot)
       if (!threadId) {
         setInput(v)

--- a/src/renderer/src/components/write/WriteWorkspaceView.tsx
+++ b/src/renderer/src/components/write/WriteWorkspaceView.tsx
@@ -844,11 +844,17 @@ export function WriteWorkspaceView({
       nextDoc: nextContent
     }) ?? false
     if (!started) {
-      // Rich mode / no source editor / identical content: apply directly.
+      const latest = useWriteWorkspaceStore.getState()
+      if (latest.saveStatus !== 'saved') {
+        setFileError(t('writeExternalChangeConflict'))
+        setReviewActive(false)
+        return
+      }
+      // Rich mode / no source editor / identical saved content: apply directly.
       setFileContent(nextContent)
       setReviewActive(false)
     }
-  }, [pendingAgentReview, clearPendingAgentReview, setFileContent, setReviewActive])
+  }, [pendingAgentReview, clearPendingAgentReview, setFileContent, setFileError, setReviewActive, t])
 
   useEffect(() => {
     if (saveTimerRef.current) {

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -2330,6 +2330,8 @@
   "writeAssistantChangeWorkspace": "Change AI working directory",
   "writeAssistantModel": "Model",
   "writeAssistantNewConversation": "New writing assistant conversation",
+  "writeAssistantSaveBeforeSendFailed": "Save the current document before sending it to the writing assistant.",
+  "writeExternalChangeConflict": "The file changed on disk while you had unsaved edits. Your draft was preserved; review or save it before continuing.",
   "writeAssistantEmptyTitle": "Writing assistant is ready",
   "writeAssistantEmptySub": "It stays out of the way. Select text to quote it, or start with one of these writing actions.",
   "writeAssistantSummarize": "Summarize document",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -2330,6 +2330,8 @@
   "writeAssistantChangeWorkspace": "更换 AI 工作目录",
   "writeAssistantModel": "模型",
   "writeAssistantNewConversation": "新建写作助手会话",
+  "writeAssistantSaveBeforeSendFailed": "请先成功保存当前文档，再发送给写作助手。",
+  "writeExternalChangeConflict": "文件在你有未保存修改时发生了外部变化。当前草稿已保留，请先审阅或保存后再继续。",
   "writeAssistantEmptyTitle": "写作助手待命中",
   "writeAssistantEmptySub": "它不会再抢占写作空间。选中文本后点引用，或直接从下面选一个写作动作开始。",
   "writeAssistantSummarize": "总结当前文档",

--- a/src/renderer/src/write/write-file-watch.test.ts
+++ b/src/renderer/src/write/write-file-watch.test.ts
@@ -66,7 +66,8 @@ describe('write file watch helper', () => {
       content: 'fresh content',
       size: 13,
       truncated: false,
-      animate: false
+      animate: false,
+      reviewAsDiff: false
     })
   })
 
@@ -147,12 +148,14 @@ describe('write file watch helper', () => {
       content: 'changed',
       size: 7,
       truncated: false,
-      animate: true
+      animate: true,
+      reviewAsDiff: true
     })
     expect(onTextSnapshot).toHaveBeenNthCalledWith(2, {
       path: '/tmp/app/draft.md',
       message: 'read failed',
-      animate: false
+      animate: false,
+      reviewAsDiff: false
     })
   })
 

--- a/src/renderer/src/write/write-file-watch.ts
+++ b/src/renderer/src/write/write-file-watch.ts
@@ -17,6 +17,7 @@ type TextSnapshot = {
   truncated?: boolean
   message?: string
   animate: boolean
+  reviewAsDiff: boolean
 }
 
 type StartWriteFileWatchOptions = {
@@ -37,10 +38,14 @@ export function startWriteWorkspaceFileWatch(options: StartWriteFileWatchOptions
     void options.api.unwatchWorkspaceFile(id).catch(() => undefined)
   }
 
-  const handleTextSnapshot = (snapshot: Omit<TextSnapshot, 'animate'> & { animate?: boolean }): void => {
+  const handleTextSnapshot = (
+    snapshot: Omit<TextSnapshot, 'animate' | 'reviewAsDiff'> & { animate?: boolean }
+  ): void => {
+    const animate = snapshot.animate ?? true
     options.onTextSnapshot({
       ...snapshot,
-      animate: snapshot.animate ?? true
+      animate,
+      reviewAsDiff: animate
     })
   }
 

--- a/src/renderer/src/write/write-workspace-file-actions.test.ts
+++ b/src/renderer/src/write/write-workspace-file-actions.test.ts
@@ -37,6 +37,7 @@ function makeBaseState(): WriteWorkspaceState {
     syncActiveFileFromDisk: async () => false,
     syncActiveImageFromDisk: async () => false,
     flushSave: async () => true,
+    prepareActiveFileForAssistant: async () => true,
     createFile: async () => null,
     createDirectory: async () => null,
     renameEntry: async () => null,

--- a/src/renderer/src/write/write-workspace-store-types.ts
+++ b/src/renderer/src/write/write-workspace-store-types.ts
@@ -83,6 +83,7 @@ export type WriteWorkspaceState = {
   ) => Promise<boolean>
   syncActiveImageFromDisk: (workspaceRoot: string, path?: string) => Promise<boolean>
   flushSave: (workspaceRoot: string) => Promise<boolean>
+  prepareActiveFileForAssistant: (workspaceRoot: string) => Promise<boolean>
   createFile: (workspaceRoot: string, path: string, content?: string) => Promise<string | null>
   createDirectory: (workspaceRoot: string, path: string) => Promise<string | null>
   renameEntry: (workspaceRoot: string, path: string, newName: string) => Promise<string | null>

--- a/src/renderer/src/write/write-workspace-store.test.ts
+++ b/src/renderer/src/write/write-workspace-store.test.ts
@@ -59,4 +59,227 @@ describe('write workspace store', () => {
       saveStatus: 'saved'
     })
   })
+
+  it('saves the current draft before the writing assistant reads the file', async () => {
+    const writeWorkspaceFile = vi.fn(async () => ({
+      ok: true as const,
+      path: '/tmp/write/draft.md',
+      savedAt: '2026-07-11T00:00:00.000Z'
+    }))
+    installDsGui({ writeWorkspaceFile })
+    activateTextFile()
+    useWriteWorkspaceStore.setState({
+      fileContent: 'unsaved current draft',
+      saveStatus: 'dirty'
+    })
+
+    await expect(
+      useWriteWorkspaceStore.getState().prepareActiveFileForAssistant('/tmp/write')
+    ).resolves.toBe(true)
+
+    expect(writeWorkspaceFile).toHaveBeenCalledWith({
+      path: '/tmp/write/draft.md',
+      workspaceRoot: '/tmp/write',
+      content: 'unsaved current draft'
+    })
+    expect(useWriteWorkspaceStore.getState().saveStatus).toBe('saved')
+  })
+
+  it('blocks assistant context when the current draft cannot be saved', async () => {
+    installDsGui({
+      writeWorkspaceFile: vi.fn(async () => ({ ok: false as const, message: 'disk is read-only' }))
+    })
+    activateTextFile()
+    useWriteWorkspaceStore.setState({ fileContent: 'unsaved draft', saveStatus: 'dirty' })
+
+    await expect(
+      useWriteWorkspaceStore.getState().prepareActiveFileForAssistant('/tmp/write')
+    ).resolves.toBe(false)
+    expect(useWriteWorkspaceStore.getState()).toMatchObject({
+      fileContent: 'unsaved draft',
+      saveStatus: 'error',
+      fileError: 'disk is read-only'
+    })
+  })
+
+  it('does not mark edits typed during a save as saved and flushes the newer draft', async () => {
+    let finishFirst!: (value: {
+      ok: true
+      path: string
+      savedAt: string
+    }) => void
+    const firstWrite = new Promise<{
+      ok: true
+      path: string
+      savedAt: string
+    }>((resolve) => { finishFirst = resolve })
+    const writeWorkspaceFile = vi.fn()
+      .mockImplementationOnce(async () => firstWrite)
+      .mockResolvedValue({
+        ok: true as const,
+        path: '/tmp/write/draft.md',
+        savedAt: '2026-07-11T00:00:01.000Z'
+      })
+    installDsGui({ writeWorkspaceFile })
+    activateTextFile()
+    useWriteWorkspaceStore.setState({ fileContent: 'first draft', saveStatus: 'dirty' })
+
+    const preparing = useWriteWorkspaceStore.getState().prepareActiveFileForAssistant('/tmp/write')
+    await vi.waitFor(() => expect(writeWorkspaceFile).toHaveBeenCalledTimes(1))
+    useWriteWorkspaceStore.getState().setFileContent('newer draft')
+    finishFirst({
+      ok: true,
+      path: '/tmp/write/draft.md',
+      savedAt: '2026-07-11T00:00:00.000Z'
+    })
+
+    await expect(preparing).resolves.toBe(true)
+    expect(writeWorkspaceFile).toHaveBeenCalledTimes(2)
+    expect(writeWorkspaceFile.mock.calls.map(([payload]) => payload.content)).toEqual([
+      'first draft',
+      'newer draft'
+    ])
+    expect(useWriteWorkspaceStore.getState()).toMatchObject({
+      fileContent: 'newer draft',
+      saveStatus: 'saved'
+    })
+  })
+
+  it('coalesces concurrent saves and then persists the newest draft', async () => {
+    let finishFirst!: (value: {
+      ok: true
+      path: string
+      savedAt: string
+    }) => void
+    const firstWrite = new Promise<{
+      ok: true
+      path: string
+      savedAt: string
+    }>((resolve) => { finishFirst = resolve })
+    const writeWorkspaceFile = vi.fn()
+      .mockImplementationOnce(async () => firstWrite)
+      .mockResolvedValue({
+        ok: true as const,
+        path: '/tmp/write/draft.md',
+        savedAt: '2026-07-11T00:00:01.000Z'
+      })
+    installDsGui({ writeWorkspaceFile })
+    activateTextFile()
+    useWriteWorkspaceStore.setState({ fileContent: 'first draft', saveStatus: 'dirty' })
+
+    const firstSave = useWriteWorkspaceStore.getState().flushSave('/tmp/write')
+    useWriteWorkspaceStore.getState().setFileContent('newer draft')
+    const coalescedSave = useWriteWorkspaceStore.getState().flushSave('/tmp/write')
+    finishFirst({
+      ok: true,
+      path: '/tmp/write/draft.md',
+      savedAt: '2026-07-11T00:00:00.000Z'
+    })
+
+    await expect(Promise.all([firstSave, coalescedSave])).resolves.toEqual([true, true])
+    expect(writeWorkspaceFile.mock.calls.map(([payload]) => payload.content)).toEqual([
+      'first draft',
+      'newer draft'
+    ])
+    expect(useWriteWorkspaceStore.getState()).toMatchObject({
+      fileContent: 'newer draft',
+      saveStatus: 'saved'
+    })
+  })
+
+  it('preserves a dirty draft and queues external content for diff review', async () => {
+    installDsGui({})
+    activateTextFile()
+    useWriteWorkspaceStore.setState({
+      fileContent: 'local unsaved draft',
+      saveStatus: 'dirty'
+    })
+
+    await expect(useWriteWorkspaceStore.getState().syncActiveFileFromDisk('/tmp/write', {
+      path: '/tmp/write/draft.md',
+      content: 'agent version on disk',
+      size: 21,
+      truncated: false,
+      animate: true,
+      reviewAsDiff: true
+    })).resolves.toBe(true)
+
+    expect(useWriteWorkspaceStore.getState()).toMatchObject({
+      fileContent: 'local unsaved draft',
+      saveStatus: 'dirty',
+      reviewActive: true,
+      pendingAgentReview: { nextContent: 'agent version on disk' }
+    })
+  })
+
+  it('preserves a draft after a save error when external content arrives', async () => {
+    installDsGui({})
+    activateTextFile()
+    useWriteWorkspaceStore.setState({
+      fileContent: 'local draft after failed save',
+      fileError: 'disk is read-only',
+      saveStatus: 'error'
+    })
+
+    await expect(useWriteWorkspaceStore.getState().syncActiveFileFromDisk('/tmp/write', {
+      path: '/tmp/write/draft.md',
+      content: 'agent version on disk',
+      size: 21,
+      truncated: false,
+      animate: true,
+      reviewAsDiff: true
+    })).resolves.toBe(true)
+
+    expect(useWriteWorkspaceStore.getState()).toMatchObject({
+      fileContent: 'local draft after failed save',
+      saveStatus: 'error',
+      reviewActive: true,
+      pendingAgentReview: { nextContent: 'agent version on disk' }
+    })
+  })
+
+  it('ignores the file watcher echo from an in-flight save without losing newer edits', async () => {
+    let finishWrite!: (value: {
+      ok: true
+      path: string
+      savedAt: string
+    }) => void
+    const write = new Promise<{
+      ok: true
+      path: string
+      savedAt: string
+    }>((resolve) => { finishWrite = resolve })
+    installDsGui({ writeWorkspaceFile: vi.fn(async () => write) })
+    activateTextFile()
+    useWriteWorkspaceStore.setState({ fileContent: 'saving draft', saveStatus: 'dirty' })
+
+    const saving = useWriteWorkspaceStore.getState().flushSave('/tmp/write')
+    useWriteWorkspaceStore.getState().setFileContent('newer unsaved draft')
+
+    await expect(useWriteWorkspaceStore.getState().syncActiveFileFromDisk('/tmp/write', {
+      path: '/tmp/write/draft.md',
+      content: 'saving draft',
+      size: 12,
+      truncated: false,
+      animate: true,
+      reviewAsDiff: true
+    })).resolves.toBe(true)
+    expect(useWriteWorkspaceStore.getState()).toMatchObject({
+      fileContent: 'newer unsaved draft',
+      saveStatus: 'dirty',
+      pendingAgentReview: null
+    })
+
+    finishWrite({
+      ok: true,
+      path: '/tmp/write/draft.md',
+      savedAt: '2026-07-11T00:00:00.000Z'
+    })
+    await expect(saving).resolves.toBe(true)
+    expect(useWriteWorkspaceStore.getState()).toMatchObject({
+      fileContent: 'newer unsaved draft',
+      saveStatus: 'dirty',
+      pendingAgentReview: null
+    })
+  })
 })

--- a/src/renderer/src/write/write-workspace-store.ts
+++ b/src/renderer/src/write/write-workspace-store.ts
@@ -28,6 +28,7 @@ import {
   initialState,
   isMissingImageIpc,
   normalizeWriteAssistantModel,
+  normalizePath,
   pathsEqual,
   readStoredAssistantModel,
   readStoredAssistantOpen,
@@ -45,6 +46,8 @@ const MAX_ANIMATED_EXTERNAL_SYNC_CHARS = 120_000
 let lastSavedContent = ''
 let externalSyncTimer: number | null = null
 let externalSyncAnimationToken = 0
+const saveFlights = new Map<string, Promise<boolean>>()
+const pendingSaveContents = new Map<string, string>()
 
 function cancelExternalSyncAnimation(): void {
   externalSyncAnimationToken += 1
@@ -118,7 +121,11 @@ export const useWriteWorkspaceStore = create<WriteWorkspaceState>((set, get) => 
     const force = options.force === true
     if (!snapshot.activeFilePath) return false
     if (snapshot.activeFileKind !== 'text') return false
-    if (!force && (snapshot.saveStatus === 'dirty' || snapshot.saveStatus === 'saving')) return false
+    if (
+      !force &&
+      snapshot.saveStatus !== 'saved' &&
+      typeof options.content !== 'string'
+    ) return false
     if (options.path && !pathsEqual(options.path, snapshot.activeFilePath)) return false
 
     if (options.message) {
@@ -165,7 +172,47 @@ export const useWriteWorkspaceStore = create<WriteWorkspaceState>((set, get) => 
 
     const latest = get()
     if (!latest.activeFilePath || !pathsEqual(latest.activeFilePath, resolvedPath)) return false
-    if (!force && (latest.saveStatus === 'dirty' || latest.saveStatus === 'saving')) return false
+    const hasLocalEdits = latest.saveStatus !== 'saved'
+    if (!force && hasLocalEdits) {
+      const pendingSaveContent = pendingSaveContents.get(normalizePath(resolvedPath))
+      if (latest.fileContent === content) {
+        lastSavedContent = content
+        set({
+          saveStatus: 'saved',
+          fileError: null,
+          fileLoading: false,
+          fileSize: nextSize,
+          fileTruncated: nextTruncated
+        })
+        return true
+      }
+      if (content === lastSavedContent || content === pendingSaveContent) {
+        set({
+          fileError: null,
+          fileLoading: false,
+          fileSize: nextSize,
+          fileTruncated: nextTruncated
+        })
+        return true
+      }
+      if (
+        options.reviewAsDiff === true &&
+        !nextTruncated &&
+        content.length <= MAX_ANIMATED_EXTERNAL_SYNC_CHARS
+      ) {
+        lastSavedContent = content
+        set({
+          pendingAgentReview: { nextContent: content },
+          reviewActive: true,
+          fileSize: nextSize,
+          fileTruncated: nextTruncated,
+          fileError: null,
+          fileLoading: false
+        })
+        return true
+      }
+      return false
+    }
     if (
       latest.fileContent === content &&
       lastSavedContent === content &&
@@ -314,27 +361,79 @@ export const useWriteWorkspaceStore = create<WriteWorkspaceState>((set, get) => 
       set({ saveStatus: 'saved' })
       return true
     }
-    set({ saveStatus: 'saving' })
-    try {
-      const result = await window.kunGui.writeWorkspaceFile({
-        path: state.activeFilePath,
-        workspaceRoot,
-        content: state.fileContent
-      })
-      if (!result.ok) {
-        set({ saveStatus: 'error', fileError: result.message })
-        return false
+    const filePath = state.activeFilePath
+    const pathKey = normalizePath(filePath)
+    const existing = saveFlights.get(pathKey)
+    if (existing) {
+      if (!await existing) return false
+      const latest = get()
+      if (
+        !latest.activeFilePath ||
+        !pathsEqual(latest.activeFilePath, filePath) ||
+        latest.activeFileKind !== 'text' ||
+        latest.fileContent === lastSavedContent
+      ) {
+        return true
       }
-      lastSavedContent = state.fileContent
-      set({ saveStatus: 'saved', fileError: null })
-      return true
-    } catch (error) {
-      set({
-        saveStatus: 'error',
-        fileError: error instanceof Error ? error.message : String(error)
-      })
-      return false
+      return get().flushSave(workspaceRoot)
     }
+
+    const content = state.fileContent
+    const operation = (async (): Promise<boolean> => {
+      pendingSaveContents.set(pathKey, content)
+      set({ saveStatus: 'saving' })
+      try {
+        const result = await window.kunGui.writeWorkspaceFile({
+          path: filePath,
+          workspaceRoot,
+          content
+        })
+        const latest = get()
+        if (!result.ok) {
+          if (latest.activeFilePath && pathsEqual(latest.activeFilePath, filePath)) {
+            set({ saveStatus: 'error', fileError: result.message })
+          }
+          return false
+        }
+        if (latest.activeFilePath && pathsEqual(latest.activeFilePath, filePath)) {
+          lastSavedContent = content
+          set({
+            saveStatus: latest.fileContent === content ? 'saved' : 'dirty',
+            fileError: null
+          })
+        }
+        return true
+      } catch (error) {
+        const latest = get()
+        if (latest.activeFilePath && pathsEqual(latest.activeFilePath, filePath)) {
+          set({
+            saveStatus: 'error',
+            fileError: error instanceof Error ? error.message : String(error)
+          })
+        }
+        return false
+      } finally {
+        if (pendingSaveContents.get(pathKey) === content) pendingSaveContents.delete(pathKey)
+      }
+    })()
+    saveFlights.set(pathKey, operation)
+    try {
+      return await operation
+    } finally {
+      if (saveFlights.get(pathKey) === operation) saveFlights.delete(pathKey)
+    }
+  },
+
+  prepareActiveFileForAssistant: async (workspaceRoot) => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const state = get()
+      if (!state.activeFilePath || state.activeFileKind !== 'text' || state.fileTruncated) {
+        return true
+      }
+      if (state.saveStatus === 'saved') return true
+      if (!await state.flushSave(workspaceRoot)) return false
+    }
+    return get().saveStatus === 'saved'
   },
 
   setFileError: (message) => {


### PR DESCRIPTION
## Summary

- save the active Write draft before the writing assistant builds file context
- keep newer typing dirty when an older save completes and coalesce overlapping saves onto the latest draft
- distinguish local save watcher echoes from external/agent writes
- present external agent changes as a diff without replacing unsaved local text

## Root cause

The writing assistant read the active file from disk while the editor could still hold a newer in-memory draft. At the same time, save completion and file watcher events did not carry enough lifecycle state to distinguish an app save from an external agent write, so a late event could replace or misclassify newer editor content.

## Tests

- `npm.cmd test -- src/renderer/src/write/write-workspace-store.test.ts src/renderer/src/write/write-file-watch.test.ts src/renderer/src/write/write-workspace-file-actions.test.ts src/renderer/src/write/quoted-selection.test.ts` (36 passed)
- `npm.cmd run typecheck`
- `npm.cmd run build`
- focused ESLint: 0 errors; one pre-existing exhaustive-deps warning in `useWorkbenchComposerSubmitController.ts`
- `git diff --check`

Fixes #838