### PR TITLE
fix(write): preserve completion word boundaries

### DIFF
--- a/src/renderer/src/write/inline-completion/feedback.test.ts
+++ b/src/renderer/src/write/inline-completion/feedback.test.ts
@@ -110,4 +110,44 @@ describe('evaluateInlineCompletionCandidate', () => {
     })
     expect(decision.feedback.reason).toBe('model-selected-edit')
   })
+
+  it('adds a missing space between adjacent Latin words', () => {
+    const decision = evaluateInlineCompletionCandidate(
+      context({
+        currentLinePrefix: 'hello',
+        prefixWindow: 'hello',
+        endsWithWordChar: true
+      }),
+      { text: 'world', action: { kind: 'short', text: 'world' } },
+      { minAcceptScore: 0.52, mode: 'short' }
+    )
+
+    expect(decision.accepted).toBe(true)
+    expect(decision.text).toBe(' world')
+    expect(decision.action).toEqual({ kind: 'short', text: ' world' })
+  })
+
+  it.each([
+    ['existing whitespace', 'hello', ' world', false, false, ' world'],
+    ['punctuation continuation', 'hello', ', world', false, false, ', world'],
+    ['cursor inside a word', 'hello', 'world', true, false, 'world'],
+    ['URL continuation', 'https://example.com', 'path', false, true, 'path'],
+    ['CJK continuation', '你好', '世界', false, false, '世界']
+  ])('keeps %s unchanged', (_label, prefix, suggestion, nextCharIsWord, looksLikeUrlTail, expected) => {
+    const decision = evaluateInlineCompletionCandidate(
+      context({
+        currentLinePrefix: prefix,
+        prefixWindow: prefix,
+        endsWithWordChar: true,
+        nextCharIsWord,
+        looksLikeUrlTail
+      }),
+      { text: suggestion, action: { kind: 'short', text: suggestion } },
+      { minAcceptScore: 0, mode: 'short' }
+    )
+
+    expect(decision.accepted).toBe(true)
+    expect(decision.text).toBe(expected)
+    expect(decision.action).toEqual({ kind: 'short', text: expected })
+  })
 })

--- a/src/renderer/src/write/inline-completion/feedback.ts
+++ b/src/renderer/src/write/inline-completion/feedback.ts
@@ -33,6 +33,29 @@ function compactText(text = ''): string {
   return sanitizeText(text).replace(/\s+/g, ' ').trim()
 }
 
+const SPACE_SEPARATED_WORD_CHAR = /[\p{Script=Latin}\p{Number}_]/u
+
+function normalizeCompletionBoundary(
+  context: InlineCompletionRequestContext,
+  text: string
+): string {
+  if (
+    !context.endsWithWordChar ||
+    context.nextCharIsWord ||
+    context.looksLikeUrlTail ||
+    !text ||
+    /^\s/u.test(text)
+  ) {
+    return text
+  }
+
+  const previous = context.currentLinePrefix.at(-1) ?? ''
+  const next = text.at(0) ?? ''
+  return SPACE_SEPARATED_WORD_CHAR.test(previous) && SPACE_SEPARATED_WORD_CHAR.test(next)
+    ? ` ${text}`
+    : text
+}
+
 function clipPreview(text = '', maxChars = 100): string {
   const normalized = compactText(text)
   if (normalized.length <= maxChars) return normalized
@@ -193,7 +216,10 @@ export function evaluateInlineCompletionCandidate(
   const rawAction = actionFromSuggestion(suggestion, requestedMode)
   const isEditAction = rawAction?.kind === 'edit'
   const structuredModelAction = hasStructuredModelAction(suggestion)
-  const text = sanitizeText(rawAction ? actionText(rawAction) : '')
+  const sanitizedText = sanitizeText(rawAction ? actionText(rawAction) : '')
+  const text = isEditAction
+    ? sanitizedText
+    : normalizeCompletionBoundary(context, sanitizedText)
   const mode = rawAction?.kind ?? requestedMode
   const minAcceptScore = Number.isFinite(options.minAcceptScore)
     ? Number(options.minAcceptScore)


### PR DESCRIPTION
## Summary

- normalize inline completion text at the shared candidate boundary used by both CodeMirror and TipTap
- insert a missing space only when adjacent Latin/number word characters would otherwise be concatenated
- preserve existing whitespace, punctuation, in-word completions, URL continuations, and CJK text

## Tests

- `npm.cmd test -- src/renderer/src/write/inline-completion/feedback.test.ts src/renderer/src/write/inline-completion/codemirror.test.ts src/renderer/src/write/tiptap/extensions/inline-completion.test.ts` (22 passed)
- `npm.cmd run typecheck`
- `npm.cmd run build`
- focused ESLint
- `git diff --check`

Fixes #834