### PR TITLE
fix(write): keep selection actions visible

### DIFF
--- a/src/renderer/src/components/write/WriteInlineAgent.tsx
+++ b/src/renderer/src/components/write/WriteInlineAgent.tsx
@@ -41,7 +41,11 @@ import { WRITE_BLOCK_TYPES, type WriteBlockType } from '../../write/block-type'
 import type { WriteInlineFormatKind } from '../../write/inline-format'
 import type { ResolvedWriteQuickAction } from '../../write/quick-actions'
 import type { ResolvedWriteAgentPreset } from '../../write/agent-presets'
-import { clamp, INLINE_AGENT_GAP, type WriteInlineAgentPosition } from './write-workspace-view-utils'
+import {
+  inlineAgentPlacement,
+  type WriteInlineAgentPlacement,
+  type WriteInlineAgentPosition
+} from './write-workspace-view-utils'
 
 type Props = {
   action: WriteInlineAgentPosition
@@ -196,7 +200,11 @@ export function WriteInlineAgent({
 }: Props): ReactElement {
   const { t } = useTranslation('common')
   const menuRef = useRef<HTMLDivElement | null>(null)
-  const [placement, setPlacement] = useState<{ top: number; origin: 'top-center' | 'bottom-center' } | null>(null)
+  const [placement, setPlacement] = useState<WriteInlineAgentPlacement | null>(null)
+  const [viewport, setViewport] = useState(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight
+  }))
   const [blockMenuOpen, setBlockMenuOpen] = useState(false)
 
   const showBlockSelector = !imageMode && formattingEnabled && Boolean(onSetBlockType)
@@ -212,24 +220,36 @@ export function WriteInlineAgent({
   const activeBlock = BLOCK_TYPE_META[blockType] ?? BLOCK_TYPE_META.paragraph
   const ActiveBlockIcon = activeBlock.icon
 
-  // Measure the rendered menu and place it below the selection, flipping above
-  // when there isn't enough room. Runs before paint so there is no flash.
+  useLayoutEffect(() => {
+    const updateViewport = (): void => {
+      setViewport({ width: window.innerWidth, height: window.innerHeight })
+    }
+    window.addEventListener('resize', updateViewport)
+    return () => window.removeEventListener('resize', updateViewport)
+  }, [])
+
+  // Measure before paint, then choose a non-overlapping side of the selection.
   useLayoutEffect(() => {
     const el = menuRef.current
     if (!el) return
-    const height = el.offsetHeight
-    const viewportHeight = window.innerHeight
-    const below = action.anchorBottom + INLINE_AGENT_GAP
-    const above = action.anchorTop - height - INLINE_AGENT_GAP
-    const canPlaceAbove = above >= 16
-    const placeAbove = preferAbove
-      ? canPlaceAbove
-      : below + height > viewportHeight - 16 && canPlaceAbove
-    const top = clamp(placeAbove ? above : below, 16, Math.max(16, viewportHeight - height - 16))
-    setPlacement({ top, origin: placeAbove ? 'bottom-center' : 'top-center' })
+    setPlacement(inlineAgentPlacement({
+      left: action.left,
+      width: action.width,
+      anchorLeft: action.anchorLeft,
+      anchorRight: action.anchorRight,
+      anchorTop: action.anchorTop,
+      anchorBottom: action.anchorBottom
+    }, {
+      menuHeight: el.scrollHeight,
+      viewportWidth: viewport.width,
+      viewportHeight: viewport.height,
+      preferAbove
+    }))
   }, [
     action.anchorTop,
     action.anchorBottom,
+    action.anchorLeft,
+    action.anchorRight,
     action.left,
     action.width,
     value,
@@ -243,7 +263,9 @@ export function WriteInlineAgent({
     showComposer,
     blockMenuOpen,
     quickActions.length,
-    preferAbove
+    preferAbove,
+    viewport.height,
+    viewport.width
   ])
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>): void => {
@@ -274,13 +296,22 @@ export function WriteInlineAgent({
       data-origin={placement?.origin ?? 'top-center'}
       data-selection-ignore="true"
       style={{
-        left: action.left,
-        top: placement?.top ?? action.anchorBottom + INLINE_AGENT_GAP,
+        left: placement?.left ?? action.left,
+        top: placement?.top ?? action.anchorBottom,
         width: action.width,
+        maxHeight: placement?.maxHeight,
+        transformOrigin: placement?.origin.replace('-', ' '),
         visibility: placement ? 'visible' : 'hidden'
       }}
     >
-      <div ref={menuRef} className="write-inline-agent-menu">
+      <div
+        ref={menuRef}
+        className="write-inline-agent-menu"
+        style={{
+          maxHeight: placement?.maxHeight,
+          overflowY: placement?.constrained ? 'auto' : 'visible'
+        }}
+      >
         {showBlockSelector ? (
           <div className="write-inline-agent-block">
             <button

--- a/src/renderer/src/components/write/write-workspace-view-utils.test.ts
+++ b/src/renderer/src/components/write/write-workspace-view-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { computeWriteDocumentStats } from './write-workspace-view-utils'
+import {
+  computeWriteDocumentStats,
+  inlineAgentPlacement,
+  type WriteInlineAgentPosition
+} from './write-workspace-view-utils'
 
 describe('computeWriteDocumentStats', () => {
   it('counts visible markdown text instead of syntax markers', () => {
@@ -12,5 +16,64 @@ describe('computeWriteDocumentStats', () => {
     const stats = computeWriteDocumentStats('Hello world\n  2026  ', false)
 
     expect(stats).toEqual({ characterCount: 14 })
+  })
+})
+
+const action: WriteInlineAgentPosition = {
+  left: 320,
+  width: 300,
+  anchorLeft: 400,
+  anchorRight: 600,
+  anchorTop: 300,
+  anchorBottom: 340
+}
+
+describe('inlineAgentPlacement', () => {
+  it('places the menu below a selection when it fits', () => {
+    expect(inlineAgentPlacement(action, {
+      menuHeight: 200,
+      viewportWidth: 1000,
+      viewportHeight: 800
+    })).toMatchObject({
+      left: 320,
+      top: 348,
+      maxHeight: 200,
+      origin: 'top-center'
+    })
+  })
+
+  it('flips above without overlapping the selection', () => {
+    expect(inlineAgentPlacement(
+      { ...action, anchorTop: 600, anchorBottom: 640 },
+      { menuHeight: 200, viewportWidth: 1000, viewportHeight: 800 }
+    )).toMatchObject({
+      top: 392,
+      origin: 'bottom-center'
+    })
+  })
+
+  it('moves beside a tall selection when neither vertical side fits', () => {
+    expect(inlineAgentPlacement(
+      { ...action, anchorLeft: 250, anchorRight: 450, anchorTop: 180, anchorBottom: 620 },
+      { menuHeight: 260, viewportWidth: 1000, viewportHeight: 800 }
+    )).toMatchObject({
+      left: 458,
+      top: 270,
+      origin: 'center-left'
+    })
+  })
+
+  it('constrains the menu to the larger vertical gap when no side fits', () => {
+    const placement = inlineAgentPlacement(
+      { ...action, anchorLeft: 180, anchorRight: 820, anchorTop: 260, anchorBottom: 500 },
+      { menuHeight: 420, viewportWidth: 1000, viewportHeight: 800 }
+    )
+
+    expect(placement).toMatchObject({
+      top: 508,
+      maxHeight: 276,
+      origin: 'top-center'
+    })
+    expect(placement.top).toBeGreaterThan(500)
   })
 })

--- a/src/renderer/src/components/write/write-workspace-view-utils.ts
+++ b/src/renderer/src/components/write/write-workspace-view-utils.ts
@@ -19,6 +19,7 @@ export function writePreviewDebounceMs(contentLength: number): number {
 export const INLINE_AGENT_MIN_WIDTH = 264
 export const INLINE_AGENT_MAX_WIDTH = 340
 export const INLINE_AGENT_GAP = 8
+export const INLINE_AGENT_VIEWPORT_MARGIN = 16
 export const WRITE_EXPORT_NOTICE_MS = 3_600
 export const INLINE_EDIT_RECENT_CONTEXT_CHARS = 180
 export const WRITE_EXPORT_FORMATS: WriteExportFormat[] = ['html', 'pdf', 'png', 'doc', 'docx']
@@ -44,10 +45,20 @@ export type WriteModeMenuItem = {
 export type WriteInlineAgentPosition = {
   left: number
   width: number
+  anchorLeft: number
+  anchorRight: number
   /** Top of the selection rect in viewport coords; the menu measures itself and places above/below. */
   anchorTop: number
   /** Bottom of the selection rect in viewport coords. */
   anchorBottom: number
+}
+
+export type WriteInlineAgentPlacement = {
+  left: number
+  top: number
+  maxHeight: number
+  constrained: boolean
+  origin: 'top-center' | 'bottom-center' | 'center-left' | 'center-right'
 }
 
 export function isMarkdownFile(filePath: string): boolean {
@@ -105,7 +116,7 @@ export function useDebouncedValue<T>(value: T, delayMs: number): T {
 }
 
 export function inlineAgentPosition(selection: {
-  anchorRect?: { left: number; top: number; bottom: number; width: number } | null
+  anchorRect?: { left: number; right?: number; top: number; bottom: number; width: number } | null
 }, options: { compact?: boolean } = {}): WriteInlineAgentPosition | null {
   const rect = selection.anchorRect
   if (!rect) return null
@@ -117,8 +128,99 @@ export function inlineAgentPosition(selection: {
   return {
     left,
     width,
+    anchorLeft: rect.left,
+    anchorRight: Number.isFinite(rect.right) ? Number(rect.right) : rect.left + rect.width,
     anchorTop: rect.top,
     anchorBottom: rect.bottom
+  }
+}
+
+export function inlineAgentPlacement(
+  action: WriteInlineAgentPosition,
+  options: {
+    menuHeight: number
+    viewportWidth: number
+    viewportHeight: number
+    preferAbove?: boolean
+  }
+): WriteInlineAgentPlacement {
+  const viewportWidth = Math.max(0, options.viewportWidth)
+  const viewportHeight = Math.max(0, options.viewportHeight)
+  const maxViewportHeight = Math.max(0, viewportHeight - INLINE_AGENT_VIEWPORT_MARGIN * 2)
+  const naturalMenuHeight = Math.max(0, options.menuHeight)
+  const menuHeight = Math.min(naturalMenuHeight, maxViewportHeight)
+  const left = clamp(
+    action.left,
+    INLINE_AGENT_VIEWPORT_MARGIN,
+    viewportWidth - action.width - INLINE_AGENT_VIEWPORT_MARGIN
+  )
+  const aboveSpace = Math.max(
+    0,
+    action.anchorTop - INLINE_AGENT_GAP - INLINE_AGENT_VIEWPORT_MARGIN
+  )
+  const belowSpace = Math.max(
+    0,
+    viewportHeight - INLINE_AGENT_VIEWPORT_MARGIN - action.anchorBottom - INLINE_AGENT_GAP
+  )
+  const aboveFits = menuHeight <= aboveSpace
+  const belowFits = menuHeight <= belowSpace
+
+  if (options.preferAbove && aboveFits || !belowFits && aboveFits) {
+    return {
+      left,
+      top: action.anchorTop - INLINE_AGENT_GAP - menuHeight,
+      maxHeight: menuHeight,
+      constrained: naturalMenuHeight > menuHeight,
+      origin: 'bottom-center'
+    }
+  }
+  if (belowFits) {
+    return {
+      left,
+      top: action.anchorBottom + INLINE_AGENT_GAP,
+      maxHeight: menuHeight,
+      constrained: naturalMenuHeight > menuHeight,
+      origin: 'top-center'
+    }
+  }
+
+  const rightSpace = Math.max(
+    0,
+    viewportWidth - INLINE_AGENT_VIEWPORT_MARGIN - action.anchorRight - INLINE_AGENT_GAP
+  )
+  const leftSpace = Math.max(
+    0,
+    action.anchorLeft - INLINE_AGENT_GAP - INLINE_AGENT_VIEWPORT_MARGIN
+  )
+  const rightFits = action.width <= rightSpace
+  const leftFits = action.width <= leftSpace
+  if (rightFits || leftFits) {
+    const placeRight = rightFits && (!leftFits || rightSpace >= leftSpace)
+    return {
+      left: placeRight
+        ? action.anchorRight + INLINE_AGENT_GAP
+        : action.anchorLeft - INLINE_AGENT_GAP - action.width,
+      top: clamp(
+        (action.anchorTop + action.anchorBottom - menuHeight) / 2,
+        INLINE_AGENT_VIEWPORT_MARGIN,
+        viewportHeight - menuHeight - INLINE_AGENT_VIEWPORT_MARGIN
+      ),
+      maxHeight: menuHeight,
+      constrained: naturalMenuHeight > menuHeight,
+      origin: placeRight ? 'center-left' : 'center-right'
+    }
+  }
+
+  const placeAbove = options.preferAbove ? aboveSpace > 0 : aboveSpace > belowSpace
+  const maxHeight = placeAbove ? aboveSpace : belowSpace
+  return {
+    left,
+    top: placeAbove
+      ? action.anchorTop - INLINE_AGENT_GAP - maxHeight
+      : action.anchorBottom + INLINE_AGENT_GAP,
+    maxHeight,
+    constrained: naturalMenuHeight > maxHeight,
+    origin: placeAbove ? 'bottom-center' : 'top-center'
   }
 }
 


### PR DESCRIPTION
## Summary

- replace the vertical-only selection popup clamp with measured collision-aware placement
- try below/above first, then move beside tall selections when either horizontal side fits
- constrain and scroll the menu in the remaining non-overlapping gap when no side can fit it at full height
- recompute placement after window resize or zoom-related viewport changes

## Root cause

The existing popup flipped above only when the complete menu fit there. When neither the top nor bottom had enough room, viewport clamping pushed the menu back over the selected text.

## Tests

- `npm.cmd test -- src/renderer/src/components/write/write-workspace-view-utils.test.ts src/renderer/src/write/write-selection.test.ts` (13 passed)
- `npm.cmd run typecheck`
- `npm.cmd run build`
- focused ESLint
- `git diff --check`

Fixes #840