### PR TITLE
fix(write): render rich text list markers

### DIFF
--- a/src/renderer/src/styles/write-rich-editor.css
+++ b/src/renderer/src/styles/write-rich-editor.css
@@ -149,6 +149,30 @@
   padding-left: 1.4em;
 }
 
+.write-rich-editor ul:not([data-type='taskList']) {
+  list-style: disc;
+}
+
+.write-rich-editor ol {
+  list-style: decimal;
+}
+
+.write-rich-editor ul:not([data-type='taskList']) ul:not([data-type='taskList']) {
+  list-style: circle;
+}
+
+.write-rich-editor ul:not([data-type='taskList']) ul:not([data-type='taskList']) ul:not([data-type='taskList']) {
+  list-style: square;
+}
+
+.write-rich-editor ol ol {
+  list-style: lower-alpha;
+}
+
+.write-rich-editor ol ol ol {
+  list-style: lower-roman;
+}
+
 .write-rich-editor li > p {
   margin: 0;
 }

--- a/src/renderer/src/write/tiptap/markdown-manager.test.ts
+++ b/src/renderer/src/write/tiptap/markdown-manager.test.ts
@@ -46,6 +46,16 @@ describe('write markdown round-trip', () => {
     expect(firstPass).toContain('![架构图](images/arch.png)')
   })
 
+  it('parses dash and asterisk bullets as rich list nodes', () => {
+    const doc = parseWriteMarkdown('- Dash item\n- Second item\n\n* Star item\n')
+    const bulletLists = doc.content?.filter((node) => node.type === 'bulletList') ?? []
+
+    expect(bulletLists).toHaveLength(2)
+    expect(bulletLists.every((list) =>
+      list.content?.every((item) => item.type === 'listItem') === true
+    )).toBe(true)
+  })
+
   it('keeps pending infographic tokens intact across the round trip', () => {
     const token = '![信息图](kun-pending-infographic://0a1b2c3d-e4f5-6789-abcd-ef0123456789)'
     const doc = `第一段。\n\n${token}\n\n第二段。\n`


### PR DESCRIPTION
## Summary

- restore disc and decimal markers for ordinary Rich Text lists after the global CSS reset
- provide distinct nested bullet and ordered-list markers
- keep task-list checkboxes excluded from ordinary list markers
- verify dash and asterisk Markdown parse into rich `bulletList`/`listItem` nodes

## Root cause

The Markdown parser and TipTap schema already produced list nodes, but the Rich Text stylesheet only added indentation. The global reset removed the browser's list marker styles, so valid list nodes appeared markerless.

## Tests

- `npm.cmd test -- src/renderer/src/write/tiptap/markdown-manager.test.ts src/renderer/src/write/tiptap/markdown-projection.test.ts` (16 passed)
- `npm.cmd run typecheck`
- `npm.cmd run build`
- focused ESLint
- `git diff --check`

Fixes #836