### PR TITLE
fix(write): support long code fences in rich text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@tencent-weixin/openclaw-weixin": "2.4.3",
         "@tesseract.js-data/eng": "^1.0.0",
         "@tiptap/core": "^3.26.0",
+        "@tiptap/extension-code-block": "^3.26.0",
         "@tiptap/extension-image": "^3.26.0",
         "@tiptap/extension-list": "^3.26.0",
         "@tiptap/extension-table": "^3.26.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@tencent-weixin/openclaw-weixin": "2.4.3",
     "@tesseract.js-data/eng": "^1.0.0",
     "@tiptap/core": "^3.26.0",
+    "@tiptap/extension-code-block": "^3.26.0",
     "@tiptap/extension-image": "^3.26.0",
     "@tiptap/extension-list": "^3.26.0",
     "@tiptap/extension-table": "^3.26.0",

--- a/src/renderer/src/write/tiptap/WriteRichEditor.tsx
+++ b/src/renderer/src/write/tiptap/WriteRichEditor.tsx
@@ -25,6 +25,7 @@ import type { WriteBlockType } from '../block-type'
 import type { WriteInlineFormatKind } from '../inline-format'
 import { createWriteRecentEdit, type WriteRecentEdit } from '../recent-edits'
 import {
+  WriteCodeBlock,
   auditWriteMarkdownFidelity,
   getWriteMarkdownManager,
   parseWriteMarkdown,
@@ -363,11 +364,13 @@ export function WriteRichEditor({
     const extensions: AnyExtension[] = [
       StarterKit.configure({
         link: { openOnClick: false },
+        codeBlock: false,
         undoRedo: { depth: 200 }
       }),
       TableKit.configure({ table: { resizable: false } }),
       TaskList,
       TaskItem.configure({ nested: true }),
+      WriteCodeBlock,
       WriteLocalImage.configure({
         getFilePath: () => filePathRef.current,
         getWorkspaceRoot: () => workspaceRootRef.current

--- a/src/renderer/src/write/tiptap/markdown-manager.test.ts
+++ b/src/renderer/src/write/tiptap/markdown-manager.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
+import { getSchema } from '@tiptap/core'
+import { EditorState, TextSelection } from '@tiptap/pm/state'
 import {
+  WRITE_BACKTICK_FENCE_INPUT_REGEX,
   WRITE_RICH_MAX_CHARS,
   auditWriteMarkdownFidelity,
+  buildWriteRichExtensions,
+  closeWriteRichCodeFence,
   parseWriteMarkdown,
   serializeWriteMarkdown
 } from './markdown-manager'
@@ -51,6 +56,49 @@ describe('write markdown round-trip', () => {
     const doc = `第一段。\n\n${token}\n\n第二段。\n`
     const firstPass = serializeWriteMarkdown(parseWriteMarkdown(doc))
     expect(firstPass).toContain(token)
+  })
+
+  it('parses four-backtick fenced Markdown as a code block', () => {
+    const doc = parseWriteMarkdown('````ts\nconst value = 1\n````\n')
+    expect(doc.content?.[0]).toMatchObject({
+      type: 'codeBlock',
+      attrs: { language: 'ts' },
+      content: [{ type: 'text', text: 'const value = 1' }]
+    })
+  })
+
+  it('matches typed three-or-longer backtick fences and preserves their length', () => {
+    expect('````ts '.match(WRITE_BACKTICK_FENCE_INPUT_REGEX)?.slice(1)).toEqual(['````', 'ts'])
+    expect('`````\n'.match(WRITE_BACKTICK_FENCE_INPUT_REGEX)?.[1]).toBe('`````')
+    expect('``` '.match(WRITE_BACKTICK_FENCE_INPUT_REGEX)?.[1]).toBe('```')
+  })
+
+  it('serializes a safe longer fence when code contains triple backticks', () => {
+    const source = '````\nconst marker = "```"\n````\n'
+    expect(serializeWriteMarkdown(parseWriteMarkdown(source))).toContain('````\nconst marker = "```"\n````')
+  })
+
+  it('closes a typed four-backtick code block into a following paragraph', () => {
+    const schema = getSchema(buildWriteRichExtensions())
+    const codeBlock = schema.nodes.codeBlock.create(
+      { language: 'ts', writeFenceLength: 4 },
+      schema.text('const value = 1\n```')
+    )
+    const doc = schema.nodes.doc.create(null, [codeBlock])
+    const cursor = codeBlock.nodeSize - 1
+    const state = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, cursor)
+    })
+
+    const tr = closeWriteRichCodeFence(state, cursor, cursor, '`')
+    expect(tr).not.toBeNull()
+    const next = state.apply(tr!)
+    expect(next.doc.childCount).toBe(2)
+    expect(next.doc.child(0).type.name).toBe('codeBlock')
+    expect(next.doc.child(0).textContent).toBe('const value = 1')
+    expect(next.doc.child(1).type.name).toBe('paragraph')
+    expect(next.selection.$from.parent.type.name).toBe('paragraph')
   })
 })
 

--- a/src/renderer/src/write/tiptap/markdown-manager.ts
+++ b/src/renderer/src/write/tiptap/markdown-manager.ts
@@ -1,8 +1,14 @@
-import type { AnyExtension, JSONContent } from '@tiptap/core'
+import {
+  textblockTypeInputRule,
+  type AnyExtension,
+  type JSONContent
+} from '@tiptap/core'
 import { MarkdownManager } from '@tiptap/markdown'
 import { StarterKit } from '@tiptap/starter-kit'
 import { TableKit } from '@tiptap/extension-table'
 import { TaskItem, TaskList } from '@tiptap/extension-list'
+import { CodeBlock } from '@tiptap/extension-code-block'
+import { Plugin, TextSelection, type EditorState, type Transaction } from '@tiptap/pm/state'
 import { WriteLocalImage } from './local-image'
 
 export type WriteRichFidelity =
@@ -12,11 +18,91 @@ export type WriteRichFidelity =
 // Rich mode refuses documents above this size; CodeMirror handles them better
 // and the open-time fidelity audit below would get expensive.
 export const WRITE_RICH_MAX_CHARS = 300_000
+export const WRITE_BACKTICK_FENCE_INPUT_REGEX = /^(`{3,})([A-Za-z0-9_+#.-]+)?[\s\n]$/
+
+export function closeWriteRichCodeFence(
+  state: EditorState,
+  from: number,
+  to: number,
+  text: string
+): Transaction | null {
+  if (text !== '`' || from !== to) return null
+  const $from = state.doc.resolve(from)
+  if ($from.parent.type.name !== 'codeBlock') return null
+  const fenceLength = Math.max(3, Math.floor(Number($from.parent.attrs.writeFenceLength) || 3))
+  const before = $from.parent.textBetween(0, $from.parentOffset, '\n', '\n')
+  const lineStartOffset = before.lastIndexOf('\n') + 1
+  const linePrefix = before.slice(lineStartOffset)
+  if (linePrefix !== '`'.repeat(fenceLength - 1)) return null
+
+  let deleteFrom = from - linePrefix.length
+  if (lineStartOffset > 0) deleteFrom -= 1
+  const paragraph = state.schema.nodes.paragraph
+  if (!paragraph) return null
+  const afterCodeBlock = $from.after($from.depth)
+  const tr = state.tr.delete(deleteFrom, to)
+  const insertAt = tr.mapping.map(afterCodeBlock)
+  tr.insert(insertAt, paragraph.create())
+  tr.setSelection(TextSelection.create(tr.doc, insertAt + 1))
+  return tr.scrollIntoView()
+}
+
+function safeBacktickFence(text: string, requestedLength: unknown): string {
+  const longestRun = Math.max(0, ...(text.match(/`+/g) ?? []).map((run) => run.length))
+  const requested = Math.max(3, Math.floor(Number(requestedLength) || 3))
+  return '`'.repeat(Math.max(requested, longestRun + 1))
+}
+
+export const WriteCodeBlock = CodeBlock.extend({
+  name: 'codeBlock',
+
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      writeFenceLength: {
+        default: 3,
+        rendered: false
+      }
+    }
+  },
+
+  addInputRules() {
+    return [textblockTypeInputRule({
+      find: WRITE_BACKTICK_FENCE_INPUT_REGEX,
+      type: this.type,
+      getAttributes: (match) => ({
+        language: match[2] || null,
+        writeFenceLength: match[1]?.length ?? 3
+      })
+    })]
+  },
+
+  renderMarkdown(node, h) {
+    const language = typeof node.attrs?.language === 'string' ? node.attrs.language : ''
+    const code = node.content ? h.renderChildren(node.content) : ''
+    const fence = safeBacktickFence(code, node.attrs?.writeFenceLength)
+    return [fence + language, code, fence].join('\n')
+  },
+
+  addProseMirrorPlugins() {
+    return [...(this.parent?.() ?? []), new Plugin({
+      props: {
+        handleTextInput: (view, from, to, text) => {
+          const tr = closeWriteRichCodeFence(view.state, from, to, text)
+          if (!tr) return false
+          view.dispatch(tr)
+          return true
+        }
+      }
+    })]
+  }
+})
 
 export function buildWriteRichExtensions(): AnyExtension[] {
   return [
     StarterKit.configure({
       link: { openOnClick: false },
+      codeBlock: false,
       // The rich editor manages undo depth like the CodeMirror history()
       undoRedo: { depth: 200 }
     }),
@@ -25,6 +111,7 @@ export function buildWriteRichExtensions(): AnyExtension[] {
     }),
     TaskList,
     TaskItem.configure({ nested: true }),
+    WriteCodeBlock,
     WriteLocalImage
   ]
 }


### PR DESCRIPTION
## Summary
Fixes Rich Text code fences with four or more backticks.

## Changes
- replace Write's default code block with a compatible extension that records the typed fence length
- support typed fences of three or more backticks and exit on the matching closing fence
- serialize a fence longer than any backtick run in code content, preventing invalid Markdown after save

## Tests
- `npm.cmd test -- src/renderer/src/write/tiptap/markdown-manager.test.ts src/renderer/src/write/tiptap/markdown-projection.test.ts src/renderer/src/write/tiptap/markdown-sync.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd exec eslint -- src/renderer/src/write/tiptap/WriteRichEditor.tsx src/renderer/src/write/tiptap/markdown-manager.ts src/renderer/src/write/tiptap/markdown-manager.test.ts`
- `npm.cmd run build`

Fixes #837