### PR TITLE
feat(write): show document word counts

### DIFF
--- a/src/renderer/src/components/write/WriteWorkspaceView.tsx
+++ b/src/renderer/src/components/write/WriteWorkspaceView.tsx
@@ -231,7 +231,12 @@ export function WriteWorkspaceView({
     () => (activeFileIsText ? computeWriteDocumentStats(fileContent, isMarkdown) : null),
     [activeFileIsText, fileContent, isMarkdown],
   )
-  const documentStatsLabel = documentStats ? t('writeCharacterCount', { count: documentStats.characterCount }) : null
+  const documentStatsLabel = documentStats
+    ? t('writeDocumentStats', {
+        words: documentStats.wordCount,
+        characters: documentStats.characterCount
+      })
+    : null
   const workspacePathLabel = rootDirectory || workspaceRoot
   const workspaceName = workspacePathLabel ? writeBasenameFromPath(workspacePathLabel) : t('writeWorkspace')
   const exportInFlight = exportingFormat !== null

--- a/src/renderer/src/components/write/write-workspace-view-utils.test.ts
+++ b/src/renderer/src/components/write/write-workspace-view-utils.test.ts
@@ -5,12 +5,18 @@ describe('computeWriteDocumentStats', () => {
   it('counts visible markdown text instead of syntax markers', () => {
     const stats = computeWriteDocumentStats('# 标题\n\n- 第一项\n- 第二项 **加粗**\n', true)
 
-    expect(stats).toEqual({ characterCount: 10 })
+    expect(stats).toEqual({ characterCount: 10, wordCount: 6 })
   })
 
   it('counts non-whitespace characters for plain text files', () => {
     const stats = computeWriteDocumentStats('Hello world\n  2026  ', false)
 
-    expect(stats).toEqual({ characterCount: 14 })
+    expect(stats).toEqual({ characterCount: 14, wordCount: 3 })
+  })
+
+  it('does not merge words across Markdown node boundaries', () => {
+    const stats = computeWriteDocumentStats('first paragraph\n\nsecond paragraph', true)
+
+    expect(stats.wordCount).toBe(4)
   })
 })

--- a/src/renderer/src/components/write/write-workspace-view-utils.ts
+++ b/src/renderer/src/components/write/write-workspace-view-utils.ts
@@ -31,6 +31,7 @@ export type WriteNotice = {
 
 export type WriteDocumentStats = {
   characterCount: number
+  wordCount: number
 }
 
 export type WriteModeMenuItem = {
@@ -76,16 +77,26 @@ function collectVisibleText(node: { type?: string; text?: string; content?: unkn
 
 function visibleTextFromMarkdown(markdown: string): string {
   try {
-    return collectVisibleText(parseWriteMarkdown(markdown), []).join('')
+    // Preserve block boundaries so adjacent Markdown nodes cannot become one
+    // word when document statistics are calculated.
+    return collectVisibleText(parseWriteMarkdown(markdown), []).join(' ')
   } catch {
     return markdown
   }
 }
 
+function countWords(text: string): number {
+  if (typeof Intl.Segmenter === 'function') {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: 'word' })
+    return [...segmenter.segment(text)].filter((segment) => segment.isWordLike).length
+  }
+  return text.match(/[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)*/gu)?.length ?? 0
+}
+
 export function computeWriteDocumentStats(content: string, isMarkdown: boolean): WriteDocumentStats {
   const visibleText = isMarkdown ? visibleTextFromMarkdown(content) : content
   const characterCount = Array.from(visibleText.replace(/\s+/g, '')).length
-  return { characterCount }
+  return { characterCount, wordCount: countWords(visibleText) }
 }
 
 export function clamp(value: number, min: number, max: number): number {

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -2248,6 +2248,7 @@
   "writeModeSplit": "Split preview",
   "writeModePreview": "Preview only",
   "writeCharacterCount": "{{count}} chars",
+  "writeDocumentStats": "{{words}} words · {{characters}} chars",
   "writePreviewErrorFallback": "Markdown preview failed, showing source text instead.",
   "writeUnsupportedFileType": "Write currently opens only Markdown, TXT, PDF, and common image files.",
   "writeImagePreview": "Image preview",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -2248,6 +2248,7 @@
   "writeModeSplit": "分栏预览",
   "writeModePreview": "仅预览",
   "writeCharacterCount": "字数 {{count}}",
+  "writeDocumentStats": "{{words}} 词 · {{characters}} 字",
   "writePreviewErrorFallback": "Markdown 预览渲染失败，已临时显示源码文本。",
   "writeUnsupportedFileType": "Write 模式目前只打开 Markdown、TXT、PDF 和常见图片文件。",
   "writeImagePreview": "图片预览",


### PR DESCRIPTION
## Summary
Add word counts to Write document statistics.

## Changes
- calculate words from rendered visible text, using `Intl.Segmenter` with a Unicode fallback
- preserve Markdown node boundaries so separate blocks are not merged into one word
- show localized word and character counts in the Write toolbar

## Tests
- `npm.cmd test -- src/renderer/src/components/write/write-workspace-view-utils.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd exec eslint -- src/renderer/src/components/write/write-workspace-view-utils.ts src/renderer/src/components/write/write-workspace-view-utils.test.ts src/renderer/src/components/write/WriteWorkspaceView.tsx`
- `npm.cmd run build`

Part of #841