### PR TITLE
fix(skills): refresh slash command catalog

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -41,6 +41,7 @@ import {
 } from '../lib/composer-file-references'
 import { useDesignWorkspaceStore } from '../design/design-workspace-store'
 import { designDocumentComposerFileReferences } from '../design/design-document-file-reference'
+import { getSlashQuery } from './chat/floating-composer-commands'
 
 const FILE_TREE_SIDEBAR_WIDTH = 320
 
@@ -142,7 +143,8 @@ export function Workbench(): ReactElement {
   })
   const { runtimeInfo, runtimeSkills } = useWorkbenchRuntimeMetadata({
     activeSkillWorkspace,
-    runtimeConnection
+    runtimeConnection,
+    skillMenuOpen: getSlashQuery(input) !== null
   })
   const {
     beginLeftResize, beginRightResize, beginTerminalResize, filePreviewTarget,

--- a/src/renderer/src/components/workbench/useWorkbenchRuntimeMetadata.test.ts
+++ b/src/renderer/src/components/workbench/useWorkbenchRuntimeMetadata.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hookHarness = vi.hoisted(() => {
+  type Cleanup = () => void
+  type Effect = () => void | Cleanup
+  const states: unknown[] = []
+  const refs: Array<{ current: unknown }> = []
+  const effects: Array<{ deps?: unknown[]; cleanup?: Cleanup }> = []
+  const pendingEffects: Array<() => void> = []
+  let stateIndex = 0
+  let refIndex = 0
+  let effectIndex = 0
+
+  const depsChanged = (previous: unknown[] | undefined, next: unknown[] | undefined): boolean =>
+    !previous || !next || previous.length !== next.length || previous.some((value, index) => !Object.is(value, next[index]))
+
+  return {
+    beginRender(): void {
+      stateIndex = 0
+      refIndex = 0
+      effectIndex = 0
+    },
+    flushEffects(): void {
+      for (const run of pendingEffects.splice(0)) run()
+    },
+    reset(): void {
+      for (const effect of effects) effect.cleanup?.()
+      states.length = 0
+      refs.length = 0
+      effects.length = 0
+      pendingEffects.length = 0
+      stateIndex = 0
+      refIndex = 0
+      effectIndex = 0
+    },
+    useEffect(effect: Effect, deps?: unknown[]): void {
+      const index = effectIndex++
+      const slot = effects[index] ?? {}
+      effects[index] = slot
+      if (!depsChanged(slot.deps, deps)) return
+      pendingEffects.push(() => {
+        slot.cleanup?.()
+        const cleanup = effect()
+        slot.cleanup = typeof cleanup === 'function' ? cleanup : undefined
+        slot.deps = deps
+      })
+    },
+    useRef<T>(initial: T): { current: T } {
+      const index = refIndex++
+      if (!refs[index]) refs[index] = { current: initial }
+      return refs[index] as { current: T }
+    },
+    useState<T>(initial: T): [T, (value: T | ((current: T) => T)) => void] {
+      const index = stateIndex++
+      if (!(index in states)) states[index] = initial
+      return [
+        states[index] as T,
+        (value) => {
+          states[index] = typeof value === 'function'
+            ? (value as (current: T) => T)(states[index] as T)
+            : value
+        }
+      ]
+    }
+  }
+})
+
+const runtime = vi.hoisted(() => ({
+  getRuntimeInfo: vi.fn(),
+  listSkills: vi.fn(),
+  listLocalSkills: vi.fn()
+}))
+
+vi.mock('react', () => ({
+  useEffect: hookHarness.useEffect,
+  useRef: hookHarness.useRef,
+  useState: hookHarness.useState
+}))
+
+vi.mock('../../agent/registry', () => ({
+  getProvider: () => ({
+    getRuntimeInfo: runtime.getRuntimeInfo,
+    listSkills: runtime.listSkills
+  })
+}))
+
+import { useWorkbenchRuntimeMetadata } from './useWorkbenchRuntimeMetadata'
+
+const baselineSkill = {
+  id: 'baseline',
+  name: 'Baseline',
+  root: '/workspace/.kun/skills/baseline',
+  scope: 'project' as const,
+  legacy: true
+}
+
+function RuntimeMetadataHookProbe(skillMenuOpen: boolean) {
+  hookHarness.beginRender()
+  const result = useWorkbenchRuntimeMetadata({
+    activeSkillWorkspace: '/workspace',
+    runtimeConnection: 'ready',
+    skillMenuOpen
+  })
+  hookHarness.flushEffects()
+  return result
+}
+
+async function mountClosedMenu(): Promise<void> {
+  RuntimeMetadataHookProbe(false)
+  await vi.waitFor(() => expect(runtime.listLocalSkills).toHaveBeenCalledTimes(1))
+  await Promise.resolve()
+  RuntimeMetadataHookProbe(false)
+  runtime.listSkills.mockClear()
+  runtime.listLocalSkills.mockClear()
+}
+
+describe('useWorkbenchRuntimeMetadata', () => {
+  beforeEach(() => {
+    hookHarness.reset()
+    runtime.getRuntimeInfo.mockReset().mockResolvedValue(null)
+    runtime.listSkills.mockReset().mockResolvedValue([])
+    runtime.listLocalSkills.mockReset().mockResolvedValue({
+      ok: true,
+      skills: [baselineSkill],
+      validationErrors: []
+    })
+    vi.stubGlobal('window', {
+      kunGui: { listSkills: runtime.listLocalSkills }
+    })
+  })
+
+  afterEach(() => {
+    hookHarness.reset()
+    vi.unstubAllGlobals()
+  })
+
+  it('reloads Skills once on closed-to-open and not while the menu remains open', async () => {
+    await mountClosedMenu()
+
+    RuntimeMetadataHookProbe(true)
+    await vi.waitFor(() => expect(runtime.listLocalSkills).toHaveBeenCalledTimes(1))
+    expect(runtime.listSkills).toHaveBeenCalledTimes(1)
+
+    RuntimeMetadataHookProbe(true)
+    expect(runtime.listLocalSkills).toHaveBeenCalledTimes(1)
+    expect(runtime.listSkills).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a stale Skill response when the menu closes before it resolves', async () => {
+    await mountClosedMenu()
+    let resolveLocalSkills!: (value: {
+      ok: true
+      skills: Array<typeof baselineSkill>
+      validationErrors: []
+    }) => void
+    runtime.listLocalSkills.mockReturnValueOnce(new Promise((resolve) => {
+      resolveLocalSkills = resolve
+    }))
+
+    RuntimeMetadataHookProbe(true)
+    RuntimeMetadataHookProbe(false)
+    resolveLocalSkills({
+      ok: true,
+      skills: [{ ...baselineSkill, id: 'stale', name: 'Stale' }],
+      validationErrors: []
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(RuntimeMetadataHookProbe(false).runtimeSkills).toEqual([baselineSkill])
+  })
+})

--- a/src/renderer/src/components/workbench/useWorkbenchRuntimeMetadata.ts
+++ b/src/renderer/src/components/workbench/useWorkbenchRuntimeMetadata.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { SkillListItem } from '@shared/kun-gui-api'
 import type { CoreRuntimeInfoJson, CoreRuntimeSkillJson } from '../../agent/kun-contract'
 import { getProvider } from '../../agent/registry'
@@ -30,38 +30,55 @@ function mergeSkillCommands(
   return [...merged.values()]
 }
 
+function skillMenuJustOpened(wasOpen: boolean, isOpen: boolean): boolean {
+  return !wasOpen && isOpen
+}
+
+async function loadSkillCommands(
+  runtimeReady: boolean,
+  activeSkillWorkspace: string
+): Promise<CoreRuntimeSkillJson[]> {
+  const provider = getProvider()
+  const localSkillsTask = typeof window !== 'undefined' && typeof window.kunGui?.listSkills === 'function'
+    ? window.kunGui.listSkills(activeSkillWorkspace || undefined)
+    : Promise.resolve({ ok: true as const, skills: [], validationErrors: [] })
+  const [runtimeResult, localSkillsResult] = await Promise.allSettled([
+    runtimeReady && provider.listSkills ? provider.listSkills() : Promise.resolve([]),
+    localSkillsTask
+  ])
+  const runtimeSkillList = runtimeResult.status === 'fulfilled' ? runtimeResult.value : []
+  const localSkillList =
+    localSkillsResult.status === 'fulfilled' && localSkillsResult.value.ok
+      ? localSkillsResult.value.skills
+      : []
+  return mergeSkillCommands(runtimeSkillList, localSkillList)
+}
+
 export function useWorkbenchRuntimeMetadata(input: {
   activeSkillWorkspace: string
   runtimeConnection: string
+  skillMenuOpen: boolean
 }): {
   runtimeInfo: CoreRuntimeInfoJson | null
   runtimeSkills: CoreRuntimeSkillJson[]
 } {
   const [runtimeInfo, setRuntimeInfo] = useState<CoreRuntimeInfoJson | null>(null)
   const [runtimeSkills, setRuntimeSkills] = useState<CoreRuntimeSkillJson[]>([])
+  const skillMenuOpenRef = useRef(input.skillMenuOpen)
 
   useEffect(() => {
     let cancelled = false
     const runtimeReady = input.runtimeConnection === 'ready'
     if (!runtimeReady) setRuntimeInfo(null)
     const provider = getProvider()
-    const localSkillsTask = typeof window !== 'undefined' && typeof window.kunGui?.listSkills === 'function'
-      ? window.kunGui.listSkills(input.activeSkillWorkspace || undefined)
-      : Promise.resolve({ ok: true as const, skills: [], validationErrors: [] })
     void Promise.allSettled([
       runtimeReady && provider.getRuntimeInfo ? provider.getRuntimeInfo() : Promise.resolve(null),
-      runtimeReady && provider.listSkills ? provider.listSkills() : Promise.resolve([]),
-      localSkillsTask
+      loadSkillCommands(runtimeReady, input.activeSkillWorkspace)
     ])
-      .then(([runtimeResult, skillsResult, localSkillsResult]) => {
+      .then(([runtimeResult, skillsResult]) => {
         if (cancelled) return
         setRuntimeInfo(runtimeResult.status === 'fulfilled' ? runtimeResult.value : null)
-        const runtimeSkillList = skillsResult.status === 'fulfilled' ? skillsResult.value : []
-        const localSkillList =
-          localSkillsResult.status === 'fulfilled' && localSkillsResult.value.ok
-            ? localSkillsResult.value.skills
-            : []
-        setRuntimeSkills(mergeSkillCommands(runtimeSkillList, localSkillList))
+        setRuntimeSkills(skillsResult.status === 'fulfilled' ? skillsResult.value : [])
       })
       .catch(() => {
         if (!cancelled) {
@@ -73,6 +90,22 @@ export function useWorkbenchRuntimeMetadata(input: {
       cancelled = true
     }
   }, [input.activeSkillWorkspace, input.runtimeConnection])
+
+  useEffect(() => {
+    const opened = skillMenuJustOpened(skillMenuOpenRef.current, input.skillMenuOpen)
+    skillMenuOpenRef.current = input.skillMenuOpen
+    if (!opened) return
+    let cancelled = false
+    void loadSkillCommands(
+      input.runtimeConnection === 'ready',
+      input.activeSkillWorkspace
+    ).then((skills) => {
+      if (!cancelled) setRuntimeSkills(skills)
+    }).catch(() => undefined)
+    return () => {
+      cancelled = true
+    }
+  }, [input.activeSkillWorkspace, input.runtimeConnection, input.skillMenuOpen])
 
   return { runtimeInfo, runtimeSkills }
 }


### PR DESCRIPTION
## Summary

- refresh the slash-command Skill catalog when the menu transitions from closed to open
- reuse the existing workspace-local `window.kunGui.listSkills(activeSkillWorkspace)` scan and merge it with runtime metadata
- ignore late Skill responses after the menu closes or the effect is superseded

## Root cause

Workbench loaded Skill metadata only when the active workspace or runtime connection changed. A project Skill added or updated under a supported root such as `.kun/skills` could therefore be usable by command while remaining absent from the `/` menu until the workspace or runtime reconnected.

## Changes

- derive the real slash-menu open state with `getSlashQuery(input)`
- refresh once on the closed-to-open edge, without polling while the menu remains open
- keep the existing initial workspace/runtime metadata load
- add hook-level coverage for one-shot refresh, no duplicate refresh while open, and stale-response cancellation

## Tests

- `npm exec -- vitest run src/renderer/src/components/workbench/useWorkbenchRuntimeMetadata.test.ts src/renderer/src/components/chat/FloatingComposer.test.ts -t 'reloads Skills once on closed-to-open|ignores a stale Skill response|shows discovered project Skills in the slash command menu'`
- `npm run typecheck`
- `npm --prefix kun run typecheck`
- `npm run build`
- focused ESLint on the changed Renderer files
- `git diff --check`

Fixes #842
