### PR TITLE
fix(test): fix develop baseline typecheck failure in local-tool-host.test.ts

### DIFF
--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -125,7 +125,7 @@ describe('LocalToolHost approval policy', () => {
 
   it('normalizes structured multi-select user input questions', async () => {
     const host = new LocalToolHost({ tools: [userInputTool] })
-    let captured: Parameters<NonNullable<ToolHostContext['awaitUserInput']>>[0] | null = null
+    const captured: { value: Parameters<NonNullable<ToolHostContext['awaitUserInput']>>[0] | null } = { value: null }
     const context = {
       threadId: 'thread_1',
       turnId: 'turn_1',
@@ -135,7 +135,7 @@ describe('LocalToolHost approval policy', () => {
       abortSignal: new AbortController().signal,
       awaitApproval: vi.fn(async () => 'allow' as const),
       awaitUserInput: vi.fn(async (input) => {
-        captured = input
+        captured.value = input
         return { status: 'submitted' as const, answers: [] }
       })
     } satisfies ToolHostContext
@@ -160,7 +160,7 @@ describe('LocalToolHost approval policy', () => {
       context
     )
 
-    expect(captured?.questions).toEqual([
+    expect(captured.value?.questions).toEqual([
       {
         header: 'Question 1',
         id: 'requirements',


### PR DESCRIPTION
## Summary

Fix a baseline `tsc --noEmit` failure on `develop` that blocks every open PR's `Typecheck and test` CI check.

## Root cause

Commit `e7954fa6` added a test in `kun/src/adapters/tool/local-tool-host.test.ts` that captures a value inside a `vi.fn` closure:

```ts
let captured: Parameters<...>[0] | null = null
// ...
awaitUserInput: vi.fn(async (input) => {
  captured = input
  // ...
})
// ...
expect(captured?.questions).toEqual([...])
```

TypeScript control-flow analysis does not track assignments inside closures. After the closure, `captured` is still narrowed to `null`, so `captured?.questions` resolves on `never`, producing:

```
error TS2339: Property 'questions' does not exist on type 'never'.
```

This is a `develop` baseline bug — it is **not** introduced by any of the currently open PRs, but all of them inherit it.

## Changes

Replace the closure-captured `let` variable with a wrapper object. TypeScript does not narrow object properties across closures, so the type stays correct:

```ts
const captured: { value: Parameters<...>[0] | null } = { value: null }
// ...
awaitUserInput: vi.fn(async (input) => {
  captured.value = input
  // ...
})
// ...
expect(captured.value?.questions).toEqual([...])
```

## Tests

- `npm --prefix kun run typecheck` — passes
- `npm --prefix kun run test` — 132 files / 1190 tests pass

## Impact

Unblocks **12 open PRs** currently failing `Typecheck and test` CI:
#830 #831 #833 #844 #845 #846 #847 #848 #849 #850 #851 #852

This PR should merge **before** the others so they can rebase clean.