### PR TITLE
feat(write): add distraction-free focus mode

### DIFF
--- a/src/renderer/src/components/write/WriteWorkspaceDocumentPane.tsx
+++ b/src/renderer/src/components/write/WriteWorkspaceDocumentPane.tsx
@@ -1,4 +1,5 @@
-import { type MutableRefObject, type ReactElement, type RefObject } from 'react'
+import { useEffect, useState, type MutableRefObject, type ReactElement, type RefObject } from 'react'
+import { Maximize2, Minimize2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { WriteInlineCompletionSettingsV1 } from '@shared/app-settings'
 import type { WriteRenderSafety } from '../../write/write-render-safety'
@@ -13,6 +14,7 @@ import { WriteMarkdownPreview } from './WriteMarkdownPreview'
 import { WriteWorkspaceStart } from './WriteWorkspaceStart'
 import { WriteImagePreview } from './WriteImagePreview'
 import { WritePdfViewer } from './WritePdfViewer'
+import { isWriteFocusModeShortcut } from '../../write/write-focus-mode'
 
 type Props = {
   activeFilePath: string | null
@@ -108,6 +110,26 @@ export function WriteWorkspaceDocumentPane({
   onMarkdownReviewStateChange
 }: Props): ReactElement {
   const { t } = useTranslation('common')
+  const [focusMode, setFocusMode] = useState(false)
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (activeFileIsText && isWriteFocusModeShortcut(event)) {
+        event.preventDefault()
+        setFocusMode((active) => !active)
+        return
+      }
+      if (focusMode && event.key === 'Escape' && !event.defaultPrevented) {
+        setFocusMode(false)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [activeFileIsText, focusMode])
+
+  useEffect(() => {
+    if (!activeFileIsText && focusMode) setFocusMode(false)
+  }, [activeFileIsText, focusMode])
 
   if (!activeFilePath) {
     return (
@@ -165,7 +187,19 @@ export function WriteWorkspaceDocumentPane({
   }
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col">
+    <div className={`flex h-full min-h-0 min-w-0 flex-col ${focusMode ? 'fixed inset-0 z-[80] bg-white p-3 dark:bg-ds-canvas sm:p-6' : 'relative'}`}>
+      <button
+        type="button"
+        onClick={() => setFocusMode((active) => !active)}
+        className={`${focusMode ? 'fixed bottom-5 right-5 z-[90]' : 'absolute right-3 top-3 z-30 opacity-45 hover:opacity-100'} inline-flex h-9 w-9 items-center justify-center rounded-xl border border-ds-border bg-ds-card/95 text-ds-muted shadow-[0_12px_28px_rgba(20,47,95,0.12)] backdrop-blur-xl transition hover:bg-ds-hover hover:text-ds-ink`}
+        title={`${t(focusMode ? 'writeFocusModeExit' : 'writeFocusModeEnter')} · ${focusMode ? 'Esc' : t('writeFocusModeShortcut')}`}
+        aria-label={t(focusMode ? 'writeFocusModeExit' : 'writeFocusModeEnter')}
+        aria-pressed={focusMode}
+      >
+        {focusMode
+          ? <Minimize2 className="h-4 w-4" strokeWidth={1.85} />
+          : <Maximize2 className="h-4 w-4" strokeWidth={1.85} />}
+      </button>
       {renderSafety.notice !== 'none' ? (
         <div className="shrink-0 border-b border-amber-200/80 bg-amber-50/90 px-5 py-3 text-[12.5px] leading-5 text-amber-900 dark:border-amber-800/60 dark:bg-amber-950/35 dark:text-amber-100 sm:px-6">
           <div className="font-semibold">{fileGuardMessage}</div>

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -2788,6 +2788,9 @@
   "description": "Description",
   "color": "Color",
   "mode": "Mode",
+  "writeFocusModeEnter": "Enter focus mode",
+  "writeFocusModeExit": "Exit focus mode",
+  "writeFocusModeShortcut": "⌘/Ctrl + Shift + F",
   "systemPrompt": "System prompt",
   "toolPolicy": "Tool access"
 }

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -2788,6 +2788,9 @@
   "description": "描述",
   "color": "颜色",
   "mode": "模式",
+  "writeFocusModeEnter": "进入专注模式",
+  "writeFocusModeExit": "退出专注模式",
+  "writeFocusModeShortcut": "⌘/Ctrl + Shift + F",
   "systemPrompt": "系统提示词",
   "toolPolicy": "工具权限"
 }

--- a/src/renderer/src/write/write-focus-mode.test.ts
+++ b/src/renderer/src/write/write-focus-mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { isWriteFocusModeShortcut } from './write-focus-mode'
+
+describe('isWriteFocusModeShortcut', () => {
+  const event = (overrides: Partial<KeyboardEvent> = {}) => ({
+    code: 'KeyF',
+    ctrlKey: true,
+    metaKey: false,
+    shiftKey: true,
+    altKey: false,
+    repeat: false,
+    isComposing: false,
+    ...overrides
+  }) as KeyboardEvent
+
+  it('accepts Ctrl/Command + Shift + F once', () => {
+    expect(isWriteFocusModeShortcut(event())).toBe(true)
+    expect(isWriteFocusModeShortcut(event({ ctrlKey: false, metaKey: true }))).toBe(true)
+  })
+
+  it('rejects incomplete, repeated, composing, and Alt-modified shortcuts', () => {
+    expect(isWriteFocusModeShortcut(event({ shiftKey: false }))).toBe(false)
+    expect(isWriteFocusModeShortcut(event({ repeat: true }))).toBe(false)
+    expect(isWriteFocusModeShortcut(event({ isComposing: true }))).toBe(false)
+    expect(isWriteFocusModeShortcut(event({ altKey: true }))).toBe(false)
+  })
+})

--- a/src/renderer/src/write/write-focus-mode.ts
+++ b/src/renderer/src/write/write-focus-mode.ts
@@ -1,0 +1,10 @@
+export function isWriteFocusModeShortcut(
+  event: Pick<KeyboardEvent, 'code' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'altKey' | 'repeat' | 'isComposing'>
+): boolean {
+  return event.code === 'KeyF' &&
+    event.shiftKey &&
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey &&
+    !event.repeat &&
+    !event.isComposing
+}


### PR DESCRIPTION
## Summary
Add a distraction-free focus mode to the Write document surface.

## Changes
- expand the active text document over the workbench without remounting the editor
- preserve cursor, scroll, preview mode, and assistant/sidebar state for restoration on exit
- provide a visible enter/exit control, `Cmd/Ctrl + Shift + F`, and Escape-to-exit
- automatically leave focus mode when the active document is no longer a text file
- support light and dark surfaces with accessible pressed state and labels

## Tests
- `npm.cmd test -- src/renderer/src/write/write-focus-mode.test.ts`
- `npm.cmd run typecheck`
- focused ESLint for the document pane and shortcut helper
- `npm.cmd run build`
- conflict prechecks against #852 and #855 using `git merge-tree --write-tree`

Part of #841

## CI note
The branch intentionally excludes the unrelated baseline TypeScript fix from #854. Until #854 merges, PR CI may inherit the existing Kun runtime test type error.