### PR TITLE
feat(write): reveal files in system manager

### DIFF
--- a/src/renderer/src/components/write/WriteFileTree.tsx
+++ b/src/renderer/src/components/write/WriteFileTree.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react'
-import { ChevronDown, ChevronRight, FileText, FilePlus2, Folder, FolderPlus, Image, Pencil, RefreshCw, Trash2 } from 'lucide-react'
+import { ChevronDown, ChevronRight, FileText, FilePlus2, Folder, FolderPlus, FolderSearch, Image, Pencil, RefreshCw, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { WorkspaceEntry } from '@shared/workspace-file'
 import { isWriteImageFileExtension, isWriteWorkspaceEntry } from '@shared/write-text-file'
@@ -23,6 +23,7 @@ type Props = {
   onCreateDirectory: (directoryPath?: string) => void
   onRenameEntry: (entry: WorkspaceEntry) => void
   onDeleteEntry: (entry: WorkspaceEntry) => void
+  onRevealEntry: (entry: WorkspaceEntry) => void
   onRefresh: () => void
   showHeader?: boolean
   showRootLabel?: boolean
@@ -100,6 +101,7 @@ export function WriteFileTree({
   onCreateDirectory,
   onRenameEntry,
   onDeleteEntry,
+  onRevealEntry,
   onRefresh,
   showHeader = true,
   showRootLabel = true
@@ -143,6 +145,14 @@ export function WriteFileTree({
                     </TreeActionButton>
                   </>
                 ) : null}
+                <TreeActionButton
+                  title={window.kunGui?.platform === 'darwin'
+                    ? t('fileTreeRevealInFinder')
+                    : t('fileTreeRevealInFileManager')}
+                  onClick={() => onRevealEntry(entry)}
+                >
+                  <FolderSearch className="h-3.5 w-3.5" strokeWidth={1.85} />
+                </TreeActionButton>
                 <TreeActionButton
                   title={t('writeRenameEntry')}
                   onClick={() => onRenameEntry(entry)}

--- a/src/renderer/src/components/write/WriteSidebar.tsx
+++ b/src/renderer/src/components/write/WriteSidebar.tsx
@@ -8,6 +8,7 @@ import {
   Folder,
   FolderOpen,
   FolderPlus,
+  FolderSearch,
   Plus,
   RefreshCw,
   Settings,
@@ -18,6 +19,7 @@ import { useTranslation } from 'react-i18next'
 import type { WorkspaceEntry } from '@shared/workspace-file'
 import { confirmDialog } from '../../lib/confirm-dialog'
 import { formatWorkspacePickerError } from '../../lib/format-workspace-picker-error'
+import { revealWorkspacePathInFileManager } from '../../lib/open-workspace-path'
 import { useChatStore, type SettingsRouteSection } from '../../store/chat-store'
 import {
   useWriteWorkspaceStore,
@@ -363,6 +365,18 @@ export function WriteSidebar({
                   actions={
                     active || removable ? (
                       <>
+                        <SidebarIconButton
+                          onClick={() => void revealWorkspacePathInFileManager(workspacePath, workspacePath)}
+                          title={window.kunGui?.platform === 'darwin'
+                            ? t('fileTreeRevealInFinder')
+                            : t('fileTreeRevealInFileManager')}
+                          ariaLabel={window.kunGui?.platform === 'darwin'
+                            ? t('fileTreeRevealInFinder')
+                            : t('fileTreeRevealInFileManager')}
+                          stopPropagation
+                        >
+                          <FolderSearch className="h-3.5 w-3.5" strokeWidth={1.8} />
+                        </SidebarIconButton>
                         {active ? (
                           <>
                             <SidebarIconButton
@@ -442,6 +456,7 @@ export function WriteSidebar({
                       onCreateDirectory={(directoryPath) => void openCreateDirectoryDialog(directoryPath)}
                       onRenameEntry={openRenameEntryDialog}
                       onDeleteEntry={openDeleteEntryDialog}
+                      onRevealEntry={(entry) => void revealWorkspacePathInFileManager(entry.path, workspaceRoot)}
                       onRefresh={() => void refreshWorkspace(workspaceRoot)}
                       showHeader={false}
                       showRootLabel={false}

--- a/src/renderer/src/lib/open-workspace-path.test.ts
+++ b/src/renderer/src/lib/open-workspace-path.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { openWorkspacePathInEditor } from './open-workspace-path'
+import {
+  openWorkspacePathInEditor,
+  revealWorkspacePathInFileManager
+} from './open-workspace-path'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -24,6 +27,41 @@ describe('openWorkspacePathInEditor', () => {
     await expect(openWorkspacePathInEditor({ path: '/tmp/demo.ts' })).resolves.toEqual({
       ok: false,
       message: 'editor launch failed'
+    })
+  })
+})
+
+describe('revealWorkspacePathInFileManager', () => {
+  it('opens the requested path with the platform file manager', async () => {
+    const openEditorPath = vi.fn(async () => ({
+      ok: true as const,
+      path: '/tmp/workspace/notes.md',
+      editorId: 'file-manager'
+    }))
+    vi.stubGlobal('window', { kunGui: { openEditorPath } })
+
+    await expect(
+      revealWorkspacePathInFileManager('/tmp/workspace/notes.md', '/tmp/workspace')
+    ).resolves.toMatchObject({ ok: true })
+    expect(openEditorPath).toHaveBeenCalledWith({
+      path: '/tmp/workspace/notes.md',
+      workspaceRoot: '/tmp/workspace',
+      editorId: 'file-manager'
+    })
+  })
+
+  it('returns a failed result when the bridge rejects the request', async () => {
+    vi.stubGlobal('window', {
+      kunGui: {
+        openEditorPath: vi.fn(async () => {
+          throw new Error('reveal failed')
+        })
+      }
+    })
+
+    await expect(revealWorkspacePathInFileManager('/tmp/workspace')).resolves.toEqual({
+      ok: false,
+      message: 'reveal failed'
     })
   })
 })

--- a/src/renderer/src/lib/open-workspace-path.ts
+++ b/src/renderer/src/lib/open-workspace-path.ts
@@ -1,4 +1,4 @@
-import type { EditorOpenResult } from '@shared/editor'
+import type { EditorOpenResult, OpenEditorPathOptions } from '@shared/editor'
 import { readPreferredEditorId } from './editor-preferences'
 
 export type WorkspacePathTarget = {
@@ -7,25 +7,40 @@ export type WorkspacePathTarget = {
   column?: number
 }
 
-export async function openWorkspacePathInEditor(
-  target: WorkspacePathTarget,
-  workspaceRoot?: string
-): Promise<EditorOpenResult> {
+async function invokeOpenEditorPath(options: OpenEditorPathOptions): Promise<EditorOpenResult> {
   if (typeof window === 'undefined' || typeof window.kunGui?.openEditorPath !== 'function') {
     return { ok: false, message: 'Editor bridge is unavailable.' }
   }
 
   try {
-    return await window.kunGui.openEditorPath({
-      path: target.path,
-      line: target.line,
-      column: target.column,
-      workspaceRoot,
-      editorId: readPreferredEditorId()
-    })
+    return await window.kunGui.openEditorPath(options)
   } catch (error) {
     return { ok: false, message: error instanceof Error ? error.message : String(error) }
   }
 }
 
+export async function openWorkspacePathInEditor(
+  target: WorkspacePathTarget,
+  workspaceRoot?: string
+): Promise<EditorOpenResult> {
+  return invokeOpenEditorPath({
+    path: target.path,
+    line: target.line,
+    column: target.column,
+    workspaceRoot,
+    editorId: readPreferredEditorId()
+  })
+}
+
 export const openWorkspacePath = openWorkspacePathInEditor
+
+export async function revealWorkspacePathInFileManager(
+  targetPath: string,
+  workspaceRoot?: string
+): Promise<EditorOpenResult> {
+  return invokeOpenEditorPath({
+    path: targetPath,
+    workspaceRoot,
+    editorId: 'file-manager'
+  })
+}


### PR DESCRIPTION
## Summary

Adds a direct way to reveal Write workspaces, folders, and files in Finder or the platform file manager.

## Changes

- reuses the existing validated `editor:open-path` bridge with the `file-manager` target
- adds reveal actions to Write workspace rows and file-tree entries
- keeps the workspace root in the request so the existing path boundary checks remain active
- shares bridge error handling with the existing external-editor helper

## Tests

- `npm.cmd test -- src/renderer/src/lib/open-workspace-path.test.ts`
- `npm.cmd run typecheck`
- focused ESLint for the four changed files
- `npm.cmd run build`
- merge-tree checks against #830, #831, #852, #855, #856, and #857

Part of #841.