### PR TITLE
feat(replay): add model-aware comparison policy

### DIFF
--- a/.github/workflows/replay-benchmark.yml
+++ b/.github/workflows/replay-benchmark.yml
@@ -30,6 +30,10 @@ on:
         description: Optional baseline report JSON path
         required: false
         type: string
+      comparison_policy:
+        description: Optional default and per-model comparison policy JSON path
+        required: false
+        type: string
       budget:
         description: Optional replay budget JSON path
         required: false
@@ -81,6 +85,7 @@ jobs:
           REPEAT_COUNT: ${{ inputs.repeat }}
           CONCURRENCY: ${{ inputs.concurrency }}
           BASELINE_PATH: ${{ inputs.baseline }}
+          COMPARISON_POLICY_PATH: ${{ inputs.comparison_policy }}
           BUDGET_PATH: ${{ inputs.budget }}
           FAIL_ON_REGRESSION: ${{ inputs.fail_on_regression }}
           FAIL_ON_BUDGET: ${{ inputs.fail_on_budget }}
@@ -101,6 +106,9 @@ jobs:
           fi
           if [[ -n "${BASELINE_PATH}" ]]; then
             args+=(--baseline "${BASELINE_PATH}")
+            if [[ -n "${COMPARISON_POLICY_PATH}" ]]; then
+              args+=(--comparison-policy "${COMPARISON_POLICY_PATH}")
+            fi
             if [[ "${FAIL_ON_REGRESSION}" == "true" ]]; then
               args+=(--fail-on-regression)
             fi

--- a/kun/README.md
+++ b/kun/README.md
@@ -68,6 +68,33 @@ npm run benchmark:replay -- --suite benchmarks/agent-core.json --repeat 2 \
   --baseline replay-baseline.json --output replay-current.json --fail-on-regression
 ```
 
+Use a comparison policy when providers or local models need different variance tolerances:
+
+```bash
+npm run benchmark:replay -- --suite benchmarks/agent-core.json \
+  --baseline replay-baseline.json --comparison-policy replay-policy.json \
+  --output replay-current.json --fail-on-regression
+```
+
+```json
+{
+  "defaults": {
+    "maxSuccessRateDrop": 0,
+    "maxTtftRelativeIncrease": 0.2,
+    "maxTtftAbsoluteIncreaseMs": 300
+  },
+  "models": {
+    "local-model": {
+      "maxTtftRelativeIncrease": 0.5,
+      "maxTtftAbsoluteIncreaseMs": 800
+    }
+  }
+}
+```
+
+Reports must use the same suite, task count, repeat count, and tag. Model changes are rejected unless the policy
+sets `allowModelChange` to `true`; per-model thresholds are resolved against the current report model.
+
 Replay threads always use the `read-only` sandbox and disable interactive input. Reports include success rate,
 TTFT, full latency, tool time, SSE delivery delay, token/cache/cost counters, and Kun process peak RSS. The runtime
 token is accepted only through `KUN_RUNTIME_TOKEN`, so it does not leak through process arguments.

--- a/kun/src/benchmark/replay-benchmark.test.ts
+++ b/kun/src/benchmark/replay-benchmark.test.ts
@@ -173,6 +173,70 @@ describe('replay benchmark', () => {
     ]))
   })
 
+  it('uses per-model comparison tolerances without changing global defaults', () => {
+    const baseline = report([replayRun('passed', 100, 1_000, 0.8)], '2026-06-28T00:00:00.000Z')
+    const current = report([replayRun('passed', 450, 1_900, 0.8)], '2026-06-29T00:00:00.000Z')
+    current.runtime.model = 'local-model'
+
+    const comparison = compareReplayReports(current, baseline, {
+      allowModelChange: true,
+      defaults: {},
+      models: {
+        'local-model': {
+          maxTtftRelativeIncrease: 5,
+          maxTotalRelativeIncrease: 5
+        }
+      }
+    })
+
+    expect(comparison.model).toBe('local-model')
+    expect(comparison.policy.maxTtftRelativeIncrease).toBe(5)
+    expect(comparison.regressions).not.toEqual(expect.arrayContaining([
+      expect.stringContaining('TTFT'),
+      expect.stringContaining('total latency')
+    ]))
+  })
+
+  it('supports explicit token and memory regression thresholds', () => {
+    const baseline = report([replayRun('passed', 100, 1_000, 0.8)], '2026-06-28T00:00:00.000Z')
+    const current = report([replayRun('passed', 100, 1_000, 0.8)], '2026-06-29T00:00:00.000Z')
+    baseline.summary.promptTokens = 1_000
+    current.summary.promptTokens = 1_500
+    baseline.summary.peakRssBytes = 100_000
+    current.summary.peakRssBytes = 200_000
+
+    const comparison = compareReplayReports(current, baseline, {
+      defaults: {
+        maxPromptTokensRelativeIncrease: 0.1,
+        maxPromptTokensAbsoluteIncrease: 100,
+        maxPeakRssRelativeIncrease: 0.1,
+        maxPeakRssAbsoluteIncreaseBytes: 10_000
+      }
+    })
+
+    expect(comparison.regressions).toEqual(expect.arrayContaining([
+      expect.stringContaining('prompt tokens'),
+      expect.stringContaining('peak RSS')
+    ]))
+  })
+
+  it('rejects an incompatible baseline unless model changes are explicit', () => {
+    const baseline = report([replayRun('passed', 100, 1_000, 0.8)], '2026-06-28T00:00:00.000Z')
+    const current = report([replayRun('passed', 100, 1_000, 0.8)], '2026-06-29T00:00:00.000Z')
+    baseline.runtime.model = 'model-a'
+    current.runtime.model = 'model-b'
+
+    expect(() => compareReplayReports(current, baseline)).toThrow('runtime model')
+    expect(() => compareReplayReports(current, baseline, {
+      allowModelChange: true
+    })).not.toThrow()
+
+    current.suite.taskCount += 1
+    expect(() => compareReplayReports(current, baseline, {
+      allowModelChange: true
+    })).toThrow('task count')
+  })
+
   it('evaluates explicit replay budget gates', () => {
     const passing = report([
       replayRun('passed', 100, 1_000, 0.8),

--- a/kun/src/benchmark/replay-benchmark.ts
+++ b/kun/src/benchmark/replay-benchmark.ts
@@ -138,6 +138,8 @@ export type ReplayReportSummary = {
 
 export type ReplayComparison = {
   baselineGeneratedAt: string
+  model?: string
+  policy: ReplayComparisonThresholds
   successRateDelta: number
   ttftP95MsDelta: number | null
   totalP95MsDelta: number | null
@@ -147,6 +149,30 @@ export type ReplayComparison = {
   peakRssBytesDelta: number | null
   regressions: string[]
 }
+
+const ReplayComparisonThresholdsSchema = z.object({
+  maxSuccessRateDrop: z.number().min(0).max(1).default(0),
+  maxTtftRelativeIncrease: z.number().nonnegative().default(0.2),
+  maxTtftAbsoluteIncreaseMs: z.number().nonnegative().default(300),
+  maxTotalRelativeIncrease: z.number().nonnegative().default(0.2),
+  maxTotalAbsoluteIncreaseMs: z.number().nonnegative().default(500),
+  maxCacheHitRateDrop: z.number().min(0).max(1).default(0.05),
+  maxCostRelativeIncrease: z.number().nonnegative().default(0.1),
+  maxCostAbsoluteIncreaseUsd: z.number().nonnegative().optional(),
+  maxPromptTokensRelativeIncrease: z.number().nonnegative().optional(),
+  maxPromptTokensAbsoluteIncrease: z.number().int().nonnegative().optional(),
+  maxPeakRssRelativeIncrease: z.number().nonnegative().optional(),
+  maxPeakRssAbsoluteIncreaseBytes: z.number().int().nonnegative().optional()
+}).strict()
+
+export const ReplayComparisonPolicySchema = z.object({
+  defaults: ReplayComparisonThresholdsSchema.default(() => ReplayComparisonThresholdsSchema.parse({})),
+  models: z.record(z.string().min(1), ReplayComparisonThresholdsSchema.partial()).default({}),
+  allowModelChange: z.boolean().default(false)
+}).strict()
+
+export type ReplayComparisonThresholds = z.infer<typeof ReplayComparisonThresholdsSchema>
+export type ReplayComparisonPolicy = z.infer<typeof ReplayComparisonPolicySchema>
 
 const ReplayBudgetSchema = z.object({
   minSuccessRate: z.number().min(0).max(1).optional(),
@@ -532,28 +558,92 @@ export function summarizeReplayRuns(runs: ReplayRunResult[]): ReplayReportSummar
   }
 }
 
-export function compareReplayReports(current: ReplayReport, baseline: ReplayReport): ReplayComparison {
+export function parseReplayComparisonPolicy(input: unknown): ReplayComparisonPolicy {
+  return ReplayComparisonPolicySchema.parse(input ?? {})
+}
+
+export function compareReplayReports(
+  current: ReplayReport,
+  baseline: ReplayReport,
+  policyInput: unknown = {}
+): ReplayComparison {
+  const configuredPolicy = parseReplayComparisonPolicy(policyInput)
+  assertReplayReportsComparable(current, baseline, configuredPolicy)
+  const model = current.runtime.model
+  const policy = ReplayComparisonThresholdsSchema.parse({
+    ...configuredPolicy.defaults,
+    ...(model ? configuredPolicy.models[model] : {})
+  })
   const successRateDelta = current.summary.successRate - baseline.summary.successRate
   const ttftP95MsDelta = nullableDelta(current.summary.ttftP95Ms, baseline.summary.ttftP95Ms)
   const totalP95MsDelta = nullableDelta(current.summary.totalP95Ms, baseline.summary.totalP95Ms)
   const cacheHitRateDelta = nullableDelta(current.summary.cacheHitRate, baseline.summary.cacheHitRate)
   const peakRssBytesDelta = nullableDelta(current.summary.peakRssBytes, baseline.summary.peakRssBytes)
   const regressions: string[] = []
-  if (successRateDelta < 0) regressions.push(`success rate dropped by ${formatPercent(-successRateDelta)}`)
-  if (isRelativeRegression(current.summary.ttftP95Ms, baseline.summary.ttftP95Ms, 0.2, 300)) {
+  if (successRateDelta < -policy.maxSuccessRateDrop) {
+    regressions.push(`success rate dropped by ${formatPercent(-successRateDelta)}`)
+  }
+  if (isRelativeRegression(
+    current.summary.ttftP95Ms,
+    baseline.summary.ttftP95Ms,
+    policy.maxTtftRelativeIncrease,
+    policy.maxTtftAbsoluteIncreaseMs
+  )) {
     regressions.push(`TTFT p95 increased by ${ttftP95MsDelta}ms`)
   }
-  if (isRelativeRegression(current.summary.totalP95Ms, baseline.summary.totalP95Ms, 0.2, 500)) {
+  if (isRelativeRegression(
+    current.summary.totalP95Ms,
+    baseline.summary.totalP95Ms,
+    policy.maxTotalRelativeIncrease,
+    policy.maxTotalAbsoluteIncreaseMs
+  )) {
     regressions.push(`total latency p95 increased by ${totalP95MsDelta}ms`)
   }
-  if (cacheHitRateDelta !== null && cacheHitRateDelta < -0.05) {
+  if (cacheHitRateDelta !== null && cacheHitRateDelta < -policy.maxCacheHitRateDrop) {
     regressions.push(`cache hit rate dropped by ${formatPercent(-cacheHitRateDelta)}`)
   }
-  if (baseline.summary.costUsd > 0 && current.summary.costUsd > baseline.summary.costUsd * 1.1) {
+  if (isRelativeRegression(
+    current.summary.costUsd,
+    baseline.summary.costUsd,
+    policy.maxCostRelativeIncrease,
+    policy.maxCostAbsoluteIncreaseUsd ?? 0
+  )) {
     regressions.push(`cost increased by $${(current.summary.costUsd - baseline.summary.costUsd).toFixed(6)}`)
+  } else if (
+    baseline.summary.costUsd <= 0 &&
+    policy.maxCostAbsoluteIncreaseUsd !== undefined &&
+    current.summary.costUsd - baseline.summary.costUsd > policy.maxCostAbsoluteIncreaseUsd
+  ) {
+    regressions.push(`cost increased by $${(current.summary.costUsd - baseline.summary.costUsd).toFixed(6)}`)
+  }
+  if (
+    (policy.maxPromptTokensRelativeIncrease !== undefined ||
+      policy.maxPromptTokensAbsoluteIncrease !== undefined) &&
+    isRelativeRegression(
+      current.summary.promptTokens,
+      baseline.summary.promptTokens,
+      policy.maxPromptTokensRelativeIncrease ?? 0,
+      policy.maxPromptTokensAbsoluteIncrease ?? 0
+    )
+  ) {
+    regressions.push(`prompt tokens increased by ${current.summary.promptTokens - baseline.summary.promptTokens}`)
+  }
+  if (
+    (policy.maxPeakRssRelativeIncrease !== undefined ||
+      policy.maxPeakRssAbsoluteIncreaseBytes !== undefined) &&
+    isRelativeRegression(
+      current.summary.peakRssBytes,
+      baseline.summary.peakRssBytes,
+      policy.maxPeakRssRelativeIncrease ?? 0,
+      policy.maxPeakRssAbsoluteIncreaseBytes ?? 0
+    )
+  ) {
+    regressions.push(`peak RSS increased by ${formatBytes(peakRssBytesDelta ?? 0)}`)
   }
   return {
     baselineGeneratedAt: baseline.generatedAt,
+    ...(model ? { model } : {}),
+    policy,
     successRateDelta,
     ttftP95MsDelta,
     totalP95MsDelta,
@@ -562,6 +652,24 @@ export function compareReplayReports(current: ReplayReport, baseline: ReplayRepo
     costUsdDelta: current.summary.costUsd - baseline.summary.costUsd,
     peakRssBytesDelta,
     regressions
+  }
+}
+
+function assertReplayReportsComparable(
+  current: ReplayReport,
+  baseline: ReplayReport,
+  policy: ReplayComparisonPolicy
+): void {
+  const mismatches: string[] = []
+  if (current.suite.name !== baseline.suite.name) mismatches.push('suite name')
+  if (current.suite.taskCount !== baseline.suite.taskCount) mismatches.push('task count')
+  if (current.suite.repeat !== baseline.suite.repeat) mismatches.push('repeat count')
+  if ((current.suite.tag ?? '') !== (baseline.suite.tag ?? '')) mismatches.push('tag filter')
+  if (!policy.allowModelChange && (current.runtime.model ?? '') !== (baseline.runtime.model ?? '')) {
+    mismatches.push('runtime model')
+  }
+  if (mismatches.length > 0) {
+    throw new Error(`replay baseline is not comparable: ${mismatches.join(', ')} differ`)
   }
 }
 
@@ -612,6 +720,7 @@ export function formatReplayReportMarkdown(report: ReplayReport): string {
   if (report.comparison) {
     lines.push('## Baseline Comparison', '')
     lines.push(`- Baseline: ${report.comparison.baselineGeneratedAt}`)
+    lines.push(`- Comparison model: ${report.comparison.model ?? 'n/a'}`)
     lines.push(`- Success rate delta: ${formatSignedPercent(report.comparison.successRateDelta)}`)
     lines.push(`- TTFT p95 delta: ${formatSignedOptionalMs(report.comparison.ttftP95MsDelta)}`)
     lines.push(`- Total p95 delta: ${formatSignedOptionalMs(report.comparison.totalP95MsDelta)}`)

--- a/kun/src/cli/replay-entry.ts
+++ b/kun/src/cli/replay-entry.ts
@@ -19,6 +19,7 @@ type CliOptions = {
   outputPath?: string
   summaryPath?: string
   baselinePath?: string
+  comparisonPolicyPath?: string
   budgetPath?: string
   repeat: number
   concurrency: number
@@ -37,6 +38,9 @@ if (options.help) {
 if (!options.suitePath) {
   printUsage()
   process.exit(2)
+}
+if (options.comparisonPolicyPath && !options.baselinePath) {
+  throw new Error('--comparison-policy requires --baseline')
 }
 
 const suitePath = resolve(options.suitePath)
@@ -60,7 +64,10 @@ const report = await runReplaySuite(suite, {
 
 if (options.baselinePath) {
   const baseline = JSON.parse(await readFile(resolve(options.baselinePath), 'utf8')) as ReplayReport
-  report.comparison = compareReplayReports(report, baseline)
+  const comparisonPolicy = options.comparisonPolicyPath
+    ? JSON.parse(await readFile(resolve(options.comparisonPolicyPath), 'utf8')) as unknown
+    : undefined
+  report.comparison = compareReplayReports(report, baseline, comparisonPolicy)
 }
 if (options.budgetPath) {
   const budget = JSON.parse(await readFile(resolve(options.budgetPath), 'utf8')) as unknown
@@ -122,6 +129,9 @@ function parseArgs(args: string[]): CliOptions {
       case '--baseline':
         options.baselinePath = requiredValue(args, ++index, arg)
         break
+      case '--comparison-policy':
+        options.comparisonPolicyPath = requiredValue(args, ++index, arg)
+        break
       case '--budget':
         options.budgetPath = requiredValue(args, ++index, arg)
         break
@@ -177,6 +187,7 @@ function printUsage(): void {
   console.log('  --repeat <n>              Repeat each selected task (default 1)')
   console.log('  --concurrency <n>         Parallel tasks, capped at 8 (default 1)')
   console.log('  --baseline <report.json>  Compare against an earlier report')
+  console.log('  --comparison-policy <file> Configure default and per-model regression tolerances')
   console.log('  --budget <budget.json>    Evaluate explicit CI budget thresholds')
   console.log('  --output <report.json>    Write the full machine-readable report')
   console.log('  --summary-output <file>   Write a Markdown summary report')


### PR DESCRIPTION
## Summary

Makes replay baseline comparisons reproducible and model-aware instead of relying on one set of hard-coded variance thresholds.

## Changes

- adds strict comparison-policy validation with default thresholds and per-model overrides
- records the resolved policy and model in JSON/Markdown reports
- rejects incomparable baselines when suite, task count, repeat count, tag, or model differ
- allows cross-model comparisons only through an explicit `allowModelChange` opt-in
- supports configurable success, latency, cache, cost, prompt-token, and peak-memory tolerances
- exposes `--comparison-policy` in the replay CLI and workflow dispatch
- documents a ready-to-use policy example

## Tests

- `npm.cmd --prefix kun test -- src/benchmark/replay-benchmark.test.ts` (13 passed)
- `npm.cmd run typecheck`
- `npm.cmd --prefix kun run typecheck` with the exact #854 baseline fix applied temporarily
- `npm.cmd run build:kun`
- focused ESLint
- `git diff --check`

The unrelated #854 test fix is not included in this branch.