### PR TITLE
feat(telemetry): export sanitized spans over OTLP

### DIFF
--- a/kun/README.md
+++ b/kun/README.md
@@ -476,6 +476,27 @@ cross-thread recall, create an explicit memory record through the
 GUI memory review surface or the `memory_create` tool. If it should
 stay local to one thread, leave it as a pinned constraint.
 
+## Agent observability
+
+Sanitized agent spans can stay in the default local JSONL file or be
+exported to an OpenTelemetry collector with OTLP/HTTP JSON. The OTLP
+exporter is opt-in, bounded, batched, and runs outside the runtime event
+persistence path. Set the standard variables below before starting Kun:
+
+```sh
+OTEL_TRACES_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is used as-is when set. Otherwise
+Kun appends `/v1/traces` to `OTEL_EXPORTER_OTLP_ENDPOINT`. Standard
+`OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_TIMEOUT` values are
+also supported, including their trace-specific variants. Prompts,
+assistant text, tool arguments, tool output, commands, and arbitrary
+error messages are excluded by default. `includeSensitiveContent` must
+be explicitly enabled before arbitrary error messages are exported.
+
 ## Troubleshooting
 
 - MCP server does not appear: check `capabilities.mcp.enabled`, the

--- a/kun/src/cli/serve.ts
+++ b/kun/src/cli/serve.ts
@@ -11,6 +11,7 @@ import {
   readOptionalKunConfigFile,
   type LoadedKunConfig
 } from '../config/kun-config.js'
+import { parseOtlpHeaders, resolveOtlpTracesEndpoint } from '../telemetry/otlp-http-json-sink.js'
 
 /**
  * Parse the `kun serve` command line into validated options.
@@ -58,6 +59,31 @@ export function parseServeOptions(
     stringFlag(raw, 'observabilityOutput') ??
     env.KUN_OBSERVABILITY_OUTPUT_PATH ??
     configServe.observability?.outputPath
+  const observabilityExporterValue =
+    stringFlag(raw, 'observability-exporter') ??
+    env.KUN_OBSERVABILITY_EXPORTER ??
+    configServe.observability?.exporter
+  const observabilityExporter = observabilityExporterValue as
+    | 'jsonl'
+    | 'otlp-http-json'
+    | undefined
+  const otlpProtocol = env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL ?? env.OTEL_EXPORTER_OTLP_PROTOCOL
+  const standardOtlpEnabled = env.OTEL_TRACES_EXPORTER
+    ?.split(',')
+    .map((entry) => entry.trim())
+    .includes('otlp') && otlpProtocol === 'http/json'
+  const resolvedObservabilityExporter = observabilityExporter ?? (standardOtlpEnabled ? 'otlp-http-json' : undefined)
+  const observabilityEndpoint =
+    env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ??
+    (standardOtlpEnabled
+      ? resolveOtlpTracesEndpoint({ commonEndpoint: env.OTEL_EXPORTER_OTLP_ENDPOINT })
+      : configServe.observability?.endpoint)
+  const observabilityHeaders = parseOtlpHeaders(
+    env.OTEL_EXPORTER_OTLP_TRACES_HEADERS ?? env.OTEL_EXPORTER_OTLP_HEADERS
+  ) ?? configServe.observability?.headers
+  const observabilityTimeoutMs = numberEnv(
+    env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT ?? env.OTEL_EXPORTER_OTLP_TIMEOUT
+  ) ?? configServe.observability?.timeoutMs
   const merged: ServeOptions = {
     ...DEFAULT_SERVE_OPTIONS,
     ...(loadedConfig ? { configPath: loadedConfig.path } : {}),
@@ -151,11 +177,15 @@ export function parseServeOptions(
         : {})
     },
     observability:
-      observabilityEnabled !== undefined || observabilityOutputPath
+      observabilityEnabled !== undefined || observabilityOutputPath || resolvedObservabilityExporter
         ? {
             ...(configServe.observability ?? {}),
-            ...(observabilityEnabled !== undefined ? { enabled: observabilityEnabled } : {}),
-            ...(observabilityOutputPath ? { outputPath: observabilityOutputPath } : {})
+            enabled: observabilityEnabled ?? Boolean(standardOtlpEnabled),
+            ...(observabilityOutputPath ? { outputPath: observabilityOutputPath } : {}),
+            ...(resolvedObservabilityExporter ? { exporter: resolvedObservabilityExporter } : {}),
+            ...(observabilityEndpoint ? { endpoint: observabilityEndpoint } : {}),
+            ...(observabilityHeaders ? { headers: observabilityHeaders } : {}),
+            ...(observabilityTimeoutMs ? { timeoutMs: observabilityTimeoutMs } : {})
           }
         : configServe.observability,
     headers: configServe.headers,
@@ -169,6 +199,12 @@ export function parseServeOptions(
     quality: loadedConfig?.config.quality
   }
   return ServeOptionsSchema.parse(merged)
+}
+
+function numberEnv(value: string | undefined): number | undefined {
+  if (!value?.trim()) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
 }
 
 /**
@@ -201,6 +237,8 @@ Options:
   --observability          Write sanitized OpenTelemetry-style agent spans
   --observability-output <path>
                            JSONL span output path (default {data-dir}/observability/agent-spans.jsonl)
+  --observability-exporter <exporter>
+                           jsonl | otlp-http-json
 `
 
 export const ServeExitCode = {

--- a/kun/src/config/kun-config.ts
+++ b/kun/src/config/kun-config.ts
@@ -238,8 +238,13 @@ export const ObservabilityConfigSchema = z
   .object({
     enabled: z.boolean().default(false).optional(),
     outputPath: z.string().min(1).optional(),
-    // Reserved for future trace payload sampling. The current exporter never
-    // records prompts, tool arguments, tool output, command text, or secrets.
+    exporter: z.enum(['jsonl', 'otlp-http-json']).optional(),
+    endpoint: z.string().url().optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    timeoutMs: z.number().int().min(1).max(300_000).optional(),
+    batchSize: z.number().int().min(1).max(512).optional(),
+    maxQueueSize: z.number().int().min(1).max(16_384).optional(),
+    // Prompt/tool payloads remain excluded unless this explicit opt-in is set.
     includeSensitiveContent: z.boolean().default(false).optional()
   })
   .strict()

--- a/kun/src/telemetry/agent-observability.test.ts
+++ b/kun/src/telemetry/agent-observability.test.ts
@@ -184,7 +184,28 @@ describe('AgentObservabilityRecorder', () => {
     }))
 
     expect(sink.spans.map((span) => span.name)).toEqual(['kun.tool bash', 'kun.turn'])
-    expect(sink.spans[0].status).toEqual({ code: 'ERROR', message: 'interrupted' })
+    expect(sink.spans[0].status).toEqual({ code: 'ERROR' })
+  })
+
+  it('exports arbitrary error messages only after explicit opt-in', async () => {
+    const sink = new CaptureSink()
+    const recorder = new AgentObservabilityRecorder(sink, { includeSensitiveContent: true })
+
+    await recorder.record(event({
+      kind: 'turn_started',
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      timestamp: '2026-07-09T00:00:00.000Z'
+    }))
+    await recorder.record(event({
+      kind: 'turn_failed',
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      timestamp: '2026-07-09T00:00:00.400Z',
+      message: 'provider response may contain sensitive content'
+    }))
+
+    expect(sink.spans[0].status.message).toBe('provider response may contain sensitive content')
   })
 })
 

--- a/kun/src/telemetry/agent-observability.ts
+++ b/kun/src/telemetry/agent-observability.ts
@@ -5,6 +5,7 @@ import type { RuntimeEvent } from '../contracts/events.js'
 import type { UsageSnapshot } from '../contracts/usage.js'
 import type { ObservabilityConfig } from '../config/kun-config.js'
 import type { RuntimeEventObserver } from '../services/runtime-event-recorder.js'
+import { OtlpHttpJsonAgentObservabilitySink } from './otlp-http-json-sink.js'
 
 export type AgentObservabilityAttributeValue = string | number | boolean | string[]
 
@@ -65,7 +66,10 @@ export class AgentObservabilityRecorder implements RuntimeEventObserver {
   private readonly turns = new Map<string, PendingSpan>()
   private readonly tools = new Map<string, PendingSpan>()
 
-  constructor(private readonly sink: AgentObservabilitySink) {}
+  constructor(
+    private readonly sink: AgentObservabilitySink,
+    private readonly options: { includeSensitiveContent?: boolean } = {}
+  ) {}
 
   async record(event: RuntimeEvent): Promise<void> {
     switch (event.kind) {
@@ -106,8 +110,8 @@ export class AgentObservabilityRecorder implements RuntimeEventObserver {
         return
       case 'error':
         this.addTurnEvent(event.threadId, event.turnId, 'exception', {
-          'exception.message': event.message,
-          ...(event.code ? { 'exception.type': event.code } : {}),
+          'exception.type': event.code ?? 'runtime_error',
+          ...(this.options.includeSensitiveContent ? { 'exception.message': event.message } : {}),
           ...(event.severity ? { 'kun.error.severity': event.severity } : {})
         }, event.timestamp)
         return
@@ -207,9 +211,10 @@ export class AgentObservabilityRecorder implements RuntimeEventObserver {
     if (!event.turnId) return
     const key = turnKey(event.threadId, event.turnId)
     const span = this.turns.get(key)
-    await this.finishDanglingToolSpans(event.threadId, event.turnId, event.timestamp, code === 'OK' ? 'UNSET' : 'ERROR', message)
+    const safeMessage = this.options.includeSensitiveContent ? message : undefined
+    await this.finishDanglingToolSpans(event.threadId, event.turnId, event.timestamp, code === 'OK' ? 'UNSET' : 'ERROR', safeMessage)
     if (!span) return
-    await this.emitSpan(span, event.timestamp, code, message)
+    await this.emitSpan(span, event.timestamp, code, safeMessage)
     this.turns.delete(key)
   }
 
@@ -273,10 +278,22 @@ export function createAgentObservabilityRecorder(input: {
   dataDir: string
 }): AgentObservabilityRecorder | undefined {
   if (!input.config?.enabled) return undefined
+  if (input.config.exporter === 'otlp-http-json') {
+    return new AgentObservabilityRecorder(new OtlpHttpJsonAgentObservabilitySink({
+      endpoint: input.config.endpoint,
+      headers: input.config.headers,
+      timeoutMs: input.config.timeoutMs,
+      batchSize: input.config.batchSize,
+      maxQueueSize: input.config.maxQueueSize
+    }), { includeSensitiveContent: input.config.includeSensitiveContent })
+  }
   const outputPath = input.config.outputPath
     ? resolveOutputPath(input.config.outputPath, input.dataDir)
     : join(input.dataDir, 'observability', 'agent-spans.jsonl')
-  return new AgentObservabilityRecorder(new JsonlAgentObservabilitySink(outputPath))
+  return new AgentObservabilityRecorder(
+    new JsonlAgentObservabilitySink(outputPath),
+    { includeSensitiveContent: input.config.includeSensitiveContent }
+  )
 }
 
 function usageAttributes(usage: UsageSnapshot, model: string | undefined): Record<string, AgentObservabilityAttributeValue> {

--- a/kun/src/telemetry/index.ts
+++ b/kun/src/telemetry/index.ts
@@ -1,3 +1,4 @@
 export * from './usage-counter.js'
 export * from './cache-telemetry.js'
 export * from './agent-observability.js'
+export * from './otlp-http-json-sink.js'

--- a/kun/src/telemetry/otlp-http-json-sink.test.ts
+++ b/kun/src/telemetry/otlp-http-json-sink.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentObservabilitySpan } from './agent-observability.js'
+import {
+  OtlpHttpJsonAgentObservabilitySink,
+  parseOtlpHeaders,
+  resolveOtlpTracesEndpoint
+} from './otlp-http-json-sink.js'
+
+describe('OtlpHttpJsonAgentObservabilitySink', () => {
+  it('exports valid OTLP JSON without adding content fields', async () => {
+    const calls: Array<Parameters<typeof globalThis.fetch>> = []
+    const fetch: typeof globalThis.fetch = vi.fn(async (input, init) => {
+      calls.push([input, init])
+      return new Response(null, { status: 200 })
+    })
+    const sink = new OtlpHttpJsonAgentObservabilitySink({
+      endpoint: 'https://collector.example/v1/traces',
+      headers: { authorization: 'Bearer token' },
+      fetch
+    })
+
+    sink.emit(span())
+    await sink.flush()
+
+    expect(fetch).toHaveBeenCalledOnce()
+    const [url, init] = calls[0]!
+    expect(url).toBe('https://collector.example/v1/traces')
+    expect(init?.headers).toMatchObject({
+      'content-type': 'application/json',
+      authorization: 'Bearer token'
+    })
+    const payload = JSON.parse(String(init?.body))
+    const exported = payload.resourceSpans[0].scopeSpans[0].spans[0]
+    expect(exported).toMatchObject({
+      traceId: '1'.repeat(32),
+      spanId: '2'.repeat(16),
+      kind: 1,
+      status: { code: 1 }
+    })
+    expect(exported.attributes).toContainEqual({
+      key: 'gen_ai.usage.input_tokens',
+      value: { intValue: '42' }
+    })
+    expect(JSON.stringify(payload)).not.toContain('prompt')
+    expect(JSON.stringify(payload)).not.toContain('secret')
+  })
+
+  it('uses signal endpoint as-is and appends the traces path to common endpoints', () => {
+    expect(resolveOtlpTracesEndpoint({ tracesEndpoint: 'https://a.test/custom' })).toBe('https://a.test/custom')
+    expect(resolveOtlpTracesEndpoint({ commonEndpoint: 'https://a.test/otel/' })).toBe('https://a.test/otel/v1/traces')
+    expect(resolveOtlpTracesEndpoint({})).toBe('http://localhost:4318/v1/traces')
+  })
+
+  it('parses percent-encoded standard OTLP headers', () => {
+    expect(parseOtlpHeaders('api-key=hello%20world,x-tenant=kun')).toEqual({
+      'api-key': 'hello world',
+      'x-tenant': 'kun'
+    })
+  })
+
+  it('does not retry a permanently rejected batch', async () => {
+    const fetch: typeof globalThis.fetch = vi.fn(async () => new Response(null, { status: 400 }))
+    const sink = new OtlpHttpJsonAgentObservabilitySink({ fetch })
+
+    sink.emit(span())
+    await sink.flush()
+    await sink.flush()
+
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+})
+
+function span(): AgentObservabilitySpan {
+  return {
+    schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
+    traceId: '1'.repeat(32),
+    spanId: '2'.repeat(16),
+    name: 'kun.turn',
+    kind: 'internal',
+    startTimeUnixNano: '1000000',
+    endTimeUnixNano: '2000000',
+    durationMs: 1,
+    status: { code: 'OK' },
+    attributes: {
+      'gen_ai.usage.input_tokens': 42,
+      'kun.cache.hit_rate': 0.5
+    }
+  }
+}

--- a/kun/src/telemetry/otlp-http-json-sink.ts
+++ b/kun/src/telemetry/otlp-http-json-sink.ts
@@ -1,0 +1,226 @@
+import type {
+  AgentObservabilityAttributeValue,
+  AgentObservabilitySink,
+  AgentObservabilitySpan
+} from './agent-observability.js'
+
+const DEFAULT_OTLP_ENDPOINT = 'http://localhost:4318/v1/traces'
+const DEFAULT_TIMEOUT_MS = 10_000
+const DEFAULT_BATCH_SIZE = 64
+const DEFAULT_MAX_QUEUE_SIZE = 2_048
+const MAX_RETRY_DELAY_MS = 30_000
+
+class PermanentOtlpExportError extends Error {}
+
+export type OtlpHttpJsonSinkOptions = {
+  endpoint?: string
+  headers?: Record<string, string>
+  timeoutMs?: number
+  batchSize?: number
+  maxQueueSize?: number
+  fetch?: typeof globalThis.fetch
+}
+
+/**
+ * A bounded, non-blocking OTLP/HTTP JSON exporter. Runtime event persistence
+ * must never wait for an external collector, so emit only queues work and a
+ * single background worker owns delivery and retry ordering.
+ */
+export class OtlpHttpJsonAgentObservabilitySink implements AgentObservabilitySink {
+  private readonly endpoint: string
+  private readonly headers: Record<string, string>
+  private readonly timeoutMs: number
+  private readonly batchSize: number
+  private readonly maxQueueSize: number
+  private readonly fetchImpl: typeof globalThis.fetch
+  private queue: AgentObservabilitySpan[] = []
+  private scheduled = false
+  private inFlight: Promise<void> | undefined
+  private retryAttempt = 0
+  private retryTimer: ReturnType<typeof setTimeout> | undefined
+  private warnedAboutOverflow = false
+
+  constructor(options: OtlpHttpJsonSinkOptions = {}) {
+    this.endpoint = options.endpoint ?? DEFAULT_OTLP_ENDPOINT
+    this.headers = options.headers ?? {}
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE
+    this.maxQueueSize = options.maxQueueSize ?? DEFAULT_MAX_QUEUE_SIZE
+    this.fetchImpl = options.fetch ?? globalThis.fetch
+  }
+
+  emit(span: AgentObservabilitySpan): void {
+    if (this.queue.length >= this.maxQueueSize) {
+      this.queue.shift()
+      if (!this.warnedAboutOverflow) {
+        this.warnedAboutOverflow = true
+        console.warn('[kun] OTLP trace queue full; dropping oldest spans')
+      }
+    }
+    this.queue.push(span)
+    this.scheduleFlush()
+  }
+
+  async flush(): Promise<void> {
+    if (this.inFlight) return this.inFlight
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer)
+      this.retryTimer = undefined
+    }
+    if (this.queue.length === 0) return
+
+    const batch = this.queue.splice(0, this.batchSize)
+    this.inFlight = this.exportBatch(batch)
+      .then(() => {
+        this.retryAttempt = 0
+        this.warnedAboutOverflow = false
+      })
+      .catch((error: unknown) => {
+        if (error instanceof PermanentOtlpExportError) {
+          console.warn(`[kun] OTLP trace export rejected; dropping batch: ${error.message}`)
+          return
+        }
+        this.requeue(batch)
+        const delayMs = Math.min(1_000 * 2 ** this.retryAttempt, MAX_RETRY_DELAY_MS)
+        this.retryAttempt += 1
+        const message = error instanceof Error ? error.message : String(error)
+        console.warn(`[kun] OTLP trace export failed; retrying in ${delayMs}ms: ${message}`)
+        this.retryTimer = setTimeout(() => {
+          this.retryTimer = undefined
+          this.scheduleFlush()
+        }, delayMs)
+        this.retryTimer.unref?.()
+      })
+      .finally(() => {
+        this.inFlight = undefined
+        if (!this.retryTimer && this.queue.length > 0) this.scheduleFlush()
+      })
+    return this.inFlight
+  }
+
+  private scheduleFlush(): void {
+    if (this.scheduled || this.inFlight || this.retryTimer) return
+    this.scheduled = true
+    queueMicrotask(() => {
+      this.scheduled = false
+      void this.flush()
+    })
+  }
+
+  private requeue(batch: AgentObservabilitySpan[]): void {
+    const available = Math.max(0, this.maxQueueSize - this.queue.length)
+    this.queue = [...batch.slice(Math.max(0, batch.length - available)), ...this.queue]
+  }
+
+  private async exportBatch(batch: AgentObservabilitySpan[]): Promise<void> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs)
+    timeout.unref?.()
+    try {
+      const response = await this.fetchImpl(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...this.headers
+        },
+        body: JSON.stringify(toExportTraceServiceRequest(batch)),
+        signal: controller.signal
+      })
+      if (!response.ok) {
+        const message = `collector returned HTTP ${response.status}`
+        if (response.status !== 408 && response.status !== 429 && response.status < 500) {
+          throw new PermanentOtlpExportError(message)
+        }
+        throw new Error(message)
+      }
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+export function resolveOtlpTracesEndpoint(input: {
+  tracesEndpoint?: string
+  commonEndpoint?: string
+}): string {
+  if (input.tracesEndpoint) return input.tracesEndpoint
+  if (!input.commonEndpoint) return DEFAULT_OTLP_ENDPOINT
+  return input.commonEndpoint.replace(/\/$/, '') + '/v1/traces'
+}
+
+export function parseOtlpHeaders(value: string | undefined): Record<string, string> | undefined {
+  if (!value?.trim()) return undefined
+  const headers: Record<string, string> = {}
+  for (const entry of value.split(',')) {
+    const separator = entry.indexOf('=')
+    if (separator <= 0) continue
+    const key = safeDecodeURIComponent(entry.slice(0, separator).trim())
+    const headerValue = safeDecodeURIComponent(entry.slice(separator + 1).trim())
+    if (key) headers[key] = headerValue
+  }
+  return Object.keys(headers).length > 0 ? headers : undefined
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function toExportTraceServiceRequest(spans: AgentObservabilitySpan[]): Record<string, unknown> {
+  return {
+    resourceSpans: [{
+      resource: {
+        attributes: [attribute('service.name', 'kun-runtime')]
+      },
+      scopeSpans: [{
+        scope: { name: 'kun.agent-observability' },
+        spans: spans.map(toOtlpSpan),
+        schemaUrl: spans[0]?.schemaUrl
+      }]
+    }]
+  }
+}
+
+function toOtlpSpan(span: AgentObservabilitySpan): Record<string, unknown> {
+  return {
+    traceId: span.traceId,
+    spanId: span.spanId,
+    ...(span.parentSpanId ? { parentSpanId: span.parentSpanId } : {}),
+    name: span.name,
+    kind: span.kind === 'client' ? 3 : 1,
+    startTimeUnixNano: span.startTimeUnixNano,
+    endTimeUnixNano: span.endTimeUnixNano,
+    attributes: Object.entries(span.attributes).map(([key, value]) => attribute(key, value)),
+    status: {
+      code: span.status.code === 'OK' ? 1 : span.status.code === 'ERROR' ? 2 : 0,
+      ...(span.status.message ? { message: span.status.message } : {})
+    },
+    ...(span.events?.length
+      ? {
+          events: span.events.map((event) => ({
+            name: event.name,
+            timeUnixNano: event.timeUnixNano,
+            attributes: Object.entries(event.attributes ?? {}).map(([key, value]) => attribute(key, value))
+          }))
+        }
+      : {})
+  }
+}
+
+function attribute(key: string, value: AgentObservabilityAttributeValue): Record<string, unknown> {
+  return { key, value: anyValue(value) }
+}
+
+function anyValue(value: AgentObservabilityAttributeValue): Record<string, unknown> {
+  if (Array.isArray(value)) {
+    return { arrayValue: { values: value.map((entry) => ({ stringValue: entry })) } }
+  }
+  if (typeof value === 'boolean') return { boolValue: value }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value }
+  }
+  return { stringValue: value }
+}

--- a/kun/tests/contracts.test.ts
+++ b/kun/tests/contracts.test.ts
@@ -352,6 +352,24 @@ describe('cli', () => {
     })
   })
 
+  it('enables the OTLP HTTP JSON exporter from standard environment variables', () => {
+    const parsed = parseServeOptions(['--data-dir=/srv/ca'], {
+      OTEL_TRACES_EXPORTER: 'otlp',
+      OTEL_EXPORTER_OTLP_PROTOCOL: 'http/json',
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'https://collector.example/otel',
+      OTEL_EXPORTER_OTLP_HEADERS: 'api-key=hello%20world',
+      OTEL_EXPORTER_OTLP_TIMEOUT: '2500'
+    })
+    expect(parsed.observability).toEqual({
+      enabled: true,
+      exporter: 'otlp-http-json',
+      endpoint: 'https://collector.example/otel/v1/traces',
+      headers: { 'api-key': 'hello world' },
+      timeoutMs: 2500,
+      includeSensitiveContent: false
+    })
+  })
+
   it('loads serve and context compaction settings from an explicit config file', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'kun-config-'))
     try {


### PR DESCRIPTION
## Summary
- add an opt-in OTLP/HTTP JSON exporter for the sanitized agent spans introduced in #812
- keep runtime event persistence independent from collector latency with a bounded background queue, batching, timeout, and retry policy
- make arbitrary error messages follow the existing explicit sensitive-content opt-in instead of exporting them by default

## Changes
- support standard OTEL traces exporter, protocol, endpoint, header, and timeout environment variables
- encode spans as OTLP ExportTraceServiceRequest JSON without adding prompts, assistant text, tool arguments, output, or commands
- retry network errors, 408, 429, and 5xx; drop permanently rejected batches instead of retrying forever
- document endpoint precedence and privacy behavior

## Tests
- npm.cmd --prefix kun test -- src/telemetry/agent-observability.test.ts src/telemetry/otlp-http-json-sink.test.ts tests/contracts.test.ts (44 passed)
- npm.cmd run typecheck
- npm.cmd --prefix kun run typecheck (passes with the independent develop baseline fix from #854 applied temporarily)
- npm.cmd run build
- git diff --check

## CI note
Current develop fails Kun typecheck in local-tool-host.test.ts. This PR intentionally does not duplicate #854; it was validated locally with that exact patch applied temporarily and removed before commit.