### PR TITLE
fix(mcp): freeze tool schemas within each turn

### DIFF
--- a/kun/src/loop/agent-loop.ts
+++ b/kun/src/loop/agent-loop.ts
@@ -132,6 +132,12 @@ import {
   todoContinuationInstruction,
   userInputUnavailableInstruction
 } from './continuation-instructions.js'
+import {
+  TurnToolCatalogFreezer,
+  isAdditiveToolCatalogChange,
+  type ToolCatalogDrift,
+  type ToolCatalogSnapshot
+} from './turn-tool-catalog.js'
 export {
   PLAN_MODE_INSTRUCTION,
   isPlanClarifyingQuestion,
@@ -249,22 +255,11 @@ const PIPELINE_STAGE_LABELS: Record<PipelineStage, string> = {
   response_received: 'Response Received'
 }
 
-type ToolCatalogSnapshot = {
-  fingerprint: string
-  toolNames: string[]
-  toolHashes: Record<string, string>
-}
-
 type GoalElapsedTimer = {
   startedAtMs: number
   createdAt: string
   objective: string
 }
-
-type ToolCatalogDrift =
-  | { kind: 'none' }
-  | { kind: 'additive'; previous: ToolCatalogSnapshot }
-  | { kind: 'breaking'; previous: ToolCatalogSnapshot }
 
 export type AgentLoopOptions = {
   threadStore: ThreadStore
@@ -384,6 +379,7 @@ export class AgentLoop {
   private readonly hydratedPressureThreads = new Set<string>()
   private readonly toolStormBreakers = new Map<string, ToolStormBreaker>()
   private readonly toolCatalogSnapshots = new Map<string, ToolCatalogSnapshot>()
+  private readonly turnToolCatalogs = new TurnToolCatalogFreezer(MAX_TOOL_CATALOG_SNAPSHOTS)
   private readonly lastNoToolTextByTurn = new Map<string, string>()
   private readonly goalNoToolRecoveryStepsByTurn = new Map<string, number>()
   private readonly emptyPostToolRecoveryStepsByTurn = new Map<string, number>()
@@ -1076,13 +1072,15 @@ export class AgentLoop {
         ? {}
         : { awaitUserInput: (input) => this.awaitUserInput(threadId, turnId, input, signal) })
     }
-    const tools = await this.opts.toolHost.listTools(toolContext)
+    const liveTools = await this.opts.toolHost.listTools(toolContext)
+    const frozenToolCatalog = this.turnToolCatalogs.resolve(threadId, turnId, liveTools)
+    const tools = frozenToolCatalog.tools
     const toolSpecs: ModelToolSpec[] = tools
     const toolProviderMetadata = new Map(
       tools.map((tool) => [tool.name, { providerId: tool.providerId, providerKind: tool.providerKind }])
     )
     const toolCatalog = buildToolCatalogFingerprint(toolSpecs)
-    const toolCatalogDrift = this.recordToolCatalogFingerprint({
+    const previousTurnDrift = this.recordToolCatalogFingerprint({
       threadId,
       workspace: thread?.workspace ?? '',
       mode: effectiveMode ?? 'agent',
@@ -1095,16 +1093,24 @@ export class AgentLoop {
       toolNames: toolCatalog.toolNames,
       toolHashes: toolCatalog.toolHashes
     })
+    const toolCatalogDrift = frozenToolCatalog.pendingDrift.kind !== 'none'
+      ? frozenToolCatalog.pendingDrift
+      : previousTurnDrift
+    const diagnosticCatalog = frozenToolCatalog.pendingCatalog ?? toolCatalog
     const toolCatalogDriftMessage = toolCatalogDrift.kind !== 'none'
-      ? buildToolCatalogDriftMessage(toolCatalog, toolCatalogDrift.kind)
+      ? buildToolCatalogDriftMessage(
+          diagnosticCatalog,
+          toolCatalogDrift.kind,
+          frozenToolCatalog.pendingCatalog ? 'deferred' : 'applied'
+        )
       : undefined
     if (toolCatalogDrift.kind !== 'none' && toolCatalogDriftMessage) {
       await this.recordToolCatalogDrift({
         threadId,
         turnId,
-        fingerprint: toolCatalog.fingerprint,
-        toolCount: toolCatalog.toolCount,
-        toolNames: toolCatalog.toolNames,
+        fingerprint: diagnosticCatalog.fingerprint,
+        toolCount: diagnosticCatalog.toolCount,
+        toolNames: diagnosticCatalog.toolNames,
         changeKind: toolCatalogDrift.kind,
         message: toolCatalogDriftMessage
       })
@@ -1125,7 +1131,6 @@ export class AgentLoop {
         toolCatalogDrift: toolCatalogDrift.kind !== 'none'
       })
     }
-    if (toolCatalogDrift.kind === 'breaking') return 'stop'
     const toolKinds = new Map(toolSpecs.map((tool) => [tool.name, tool.toolKind]))
     const createPlanSatisfied = planTurnActive
       ? hasSuccessfulCreatePlanResult(historyItems, turnId)
@@ -2941,30 +2946,18 @@ function normalizeSandboxMode(
   }
 }
 
-function isAdditiveToolCatalogChange(previous: ToolCatalogSnapshot, current: ToolCatalogSnapshot): boolean {
-  let added = false
-  for (const name of current.toolNames) {
-    if (!previous.toolHashes[name]) added = true
-  }
-  if (!added) return false
-  for (const name of previous.toolNames) {
-    const previousHash = previous.toolHashes[name]
-    const currentHash = current.toolHashes[name]
-    if (!previousHash || !currentHash || previousHash !== currentHash) return false
-  }
-  return true
-}
-
 function buildToolCatalogDriftMessage(toolCatalog: {
   fingerprint: string
   toolCount: number
   toolNames: string[]
-}, changeKind: 'additive' | 'breaking'): string {
+}, changeKind: 'additive' | 'breaking', phase: 'deferred' | 'applied'): string {
   const sample = toolCatalog.toolNames.slice(0, 12).join(', ')
   const suffix = toolCatalog.toolNames.length > 12 ? `, +${toolCatalog.toolNames.length - 12} more` : ''
-  const policy = changeKind === 'additive'
-    ? 'Only additive tool changes are allowed in-place; Kun will continue with the refreshed tool list.'
-    : 'Non-additive tool changes can invalidate prompt-cache assumptions; Kun stopped this turn. Start a new thread after editing, removing, or reordering tool schemas.'
+  const policy = phase === 'deferred'
+    ? 'The active turn keeps its frozen tool schemas; this update will be available on the next turn.'
+    : changeKind === 'additive'
+      ? 'The additive update is active from the start of this turn.'
+      : 'The updated catalog is active from the start of this turn; earlier turns keep their original schema fingerprints.'
   return [
     `Tool catalog changed for this thread (${toolCatalog.toolCount} tools, fingerprint ${toolCatalog.fingerprint}).`,
     policy,

--- a/kun/src/loop/turn-tool-catalog.test.ts
+++ b/kun/src/loop/turn-tool-catalog.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import type { ListedTool } from './turn-tool-catalog.js'
+import { TurnToolCatalogFreezer } from './turn-tool-catalog.js'
+
+describe('TurnToolCatalogFreezer', () => {
+  it('deep-freezes schemas within a turn and reports drift once per live version', () => {
+    const freezer = new TurnToolCatalogFreezer()
+    const tools = [tool('read', { path: { type: 'string' } })]
+    const first = freezer.resolve('thread-1', 'turn-1', tools)
+
+    const liveProperties = tools[0].inputSchema.properties as Record<string, unknown>
+    liveProperties.extra = { type: 'boolean' }
+    const changed = freezer.resolve('thread-1', 'turn-1', tools)
+    const repeated = freezer.resolve('thread-1', 'turn-1', tools)
+
+    expect(changed.pendingDrift.kind).toBe('breaking')
+    expect(repeated.pendingDrift.kind).toBe('none')
+    expect(changed.tools[0].inputSchema).toEqual(first.tools[0].inputSchema)
+    expect(JSON.stringify(changed.tools[0].inputSchema)).not.toContain('extra')
+  })
+
+  it('adopts the current catalog at the start of a new turn', () => {
+    const freezer = new TurnToolCatalogFreezer()
+    const initial = [tool('read')]
+    freezer.resolve('thread-1', 'turn-1', initial)
+
+    const next = freezer.resolve('thread-1', 'turn-2', [...initial, tool('search')])
+
+    expect(next.pendingDrift.kind).toBe('none')
+    expect(next.tools.map((entry) => entry.name)).toEqual(['read', 'search'])
+  })
+
+  it('classifies a pure addition without changing the frozen list', () => {
+    const freezer = new TurnToolCatalogFreezer()
+    const initial = [tool('read')]
+    freezer.resolve('thread-1', 'turn-1', initial)
+
+    const changed = freezer.resolve('thread-1', 'turn-1', [...initial, tool('search')])
+
+    expect(changed.pendingDrift.kind).toBe('additive')
+    expect(changed.tools.map((entry) => entry.name)).toEqual(['read'])
+    expect(changed.pendingCatalog?.toolNames).toEqual(['read', 'search'])
+  })
+})
+
+function tool(name: string, properties: Record<string, unknown> = {}): ListedTool {
+  return {
+    name,
+    description: `${name} tool`,
+    inputSchema: { type: 'object', properties }
+  }
+}

--- a/kun/src/loop/turn-tool-catalog.ts
+++ b/kun/src/loop/turn-tool-catalog.ts
@@ -1,0 +1,75 @@
+import { buildToolCatalogFingerprint, type ToolCatalogFingerprint } from '../cache/tool-catalog-fingerprint.js'
+import type { ToolHost } from '../ports/tool-host.js'
+
+export type ListedTool = Awaited<ReturnType<ToolHost['listTools']>>[number]
+export type ToolCatalogSnapshot = Pick<ToolCatalogFingerprint, 'fingerprint' | 'toolNames' | 'toolHashes'>
+export type ToolCatalogDrift =
+  | { kind: 'none' }
+  | { kind: 'additive'; previous: ToolCatalogSnapshot }
+  | { kind: 'breaking'; previous: ToolCatalogSnapshot }
+
+type FrozenTurnToolCatalog = {
+  tools: ListedTool[]
+  snapshot: ToolCatalogSnapshot
+  lastReportedLiveFingerprint?: string
+}
+
+export class TurnToolCatalogFreezer {
+  private readonly catalogs = new Map<string, FrozenTurnToolCatalog>()
+
+  constructor(private readonly maxCatalogs = 256) {}
+
+  resolve(threadId: string, turnId: string, liveTools: ListedTool[]): {
+    tools: ListedTool[]
+    pendingDrift: ToolCatalogDrift
+    pendingCatalog?: ToolCatalogFingerprint
+  } {
+    const key = JSON.stringify([threadId, turnId])
+    const liveCatalog = buildToolCatalogFingerprint(liveTools)
+    const existing = this.catalogs.get(key)
+    if (existing) {
+      this.catalogs.delete(key)
+      this.catalogs.set(key, existing)
+      if (
+        existing.snapshot.fingerprint === liveCatalog.fingerprint ||
+        existing.lastReportedLiveFingerprint === liveCatalog.fingerprint
+      ) {
+        return { tools: existing.tools, pendingDrift: { kind: 'none' } }
+      }
+      existing.lastReportedLiveFingerprint = liveCatalog.fingerprint
+      const pendingDrift = isAdditiveToolCatalogChange(existing.snapshot, liveCatalog)
+        ? { kind: 'additive' as const, previous: existing.snapshot }
+        : { kind: 'breaking' as const, previous: existing.snapshot }
+      return { tools: existing.tools, pendingDrift, pendingCatalog: liveCatalog }
+    }
+
+    const tools = liveTools.map((tool) => ({
+      ...tool,
+      inputSchema: structuredClone(tool.inputSchema)
+    }))
+    const snapshot = buildToolCatalogFingerprint(tools)
+    this.catalogs.set(key, { tools, snapshot })
+    if (this.catalogs.size > this.maxCatalogs) {
+      const oldest = this.catalogs.keys().next().value
+      if (oldest !== undefined) this.catalogs.delete(oldest)
+    }
+    return { tools, pendingDrift: { kind: 'none' } }
+  }
+}
+
+export function isAdditiveToolCatalogChange(
+  previous: ToolCatalogSnapshot,
+  current: ToolCatalogSnapshot
+): boolean {
+  let added = false
+  for (const name of current.toolNames) {
+    if (!previous.toolHashes[name]) added = true
+  }
+  if (!added) return false
+  for (const name of previous.toolNames) {
+    const previousHash = previous.toolHashes[name]
+    const currentHash = current.toolHashes[name]
+    if (!previousHash || !currentHash || previousHash !== currentHash) return false
+  }
+  return true
+}

--- a/kun/tests/loop.test.ts
+++ b/kun/tests/loop.test.ts
@@ -601,8 +601,9 @@ describe('AgentLoop', () => {
     })
   })
 
-  it('surfaces tool catalog drift to the UI and next model request', async () => {
+  it('defers additive tool catalog changes until the next turn', async () => {
     const seenInstructions: string[][] = []
+    const seenToolNames: string[][] = []
     let modelCalls = 0
     let advertiseExtra = false
     const echoTool = LocalToolHost.defineTool({
@@ -633,6 +634,7 @@ describe('AgentLoop', () => {
         model: 'catalog-drift',
         async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
           seenInstructions.push(request.contextInstructions ?? [])
+          seenToolNames.push((request.tools ?? []).map((tool) => tool.name))
           modelCalls += 1
           if (modelCalls === 1) {
             yield {
@@ -662,10 +664,14 @@ describe('AgentLoop', () => {
 	    })
 	    expect(items.some((item) => item.kind === 'error' && item.code === 'tool_catalog_changed')).toBe(true)
 	    expect(seenInstructions[1]?.some((text) => text.includes('Tool catalog changed'))).toBe(true)
+	    expect(seenInstructions[1]?.some((text) => text.includes('next turn'))).toBe(true)
+	    expect(seenToolNames[0]).toEqual(['echo'])
+	    expect(seenToolNames[1]).toEqual(['echo'])
 	  })
 
-	  it('stops the turn when an existing tool schema mutates in-place', async () => {
+	  it('deep-freezes an existing tool schema for every model step in a turn', async () => {
 	    let modelCalls = 0
+	    const seenSchemas: Record<string, unknown>[] = []
 	    const inputSchema: Record<string, unknown> = {
 	      type: 'object',
 	      properties: { text: { type: 'string' } },
@@ -688,8 +694,13 @@ describe('AgentLoop', () => {
 	      {
 	        provider: 'catalog-breaking-drift',
 	        model: 'catalog-breaking-drift',
-	        async *stream(): AsyncIterable<ModelStreamChunk> {
+	        async *stream(request: ModelRequest): AsyncIterable<ModelStreamChunk> {
 	          modelCalls += 1
+	          seenSchemas.push(structuredClone(request.tools?.[0]?.inputSchema ?? {}))
+	          if (modelCalls > 1) {
+	            yield { kind: 'completed', stopReason: 'stop' }
+	            return
+	          }
 	          yield {
 	            kind: 'tool_call_complete',
 	            callId: 'call_echo',
@@ -708,7 +719,9 @@ describe('AgentLoop', () => {
 	    const items = await h.sessionStore.loadItems(h.threadId)
 
 	    expect(status).toBe('completed')
-	    expect(modelCalls).toBe(1)
+	    expect(modelCalls).toBe(2)
+	    expect(seenSchemas[1]).toEqual(seenSchemas[0])
+	    expect(JSON.stringify(seenSchemas[1])).not.toContain('unexpected')
 	    expect(events.find((event) => event.kind === 'tool_catalog_changed')).toMatchObject({
 	      kind: 'tool_catalog_changed',
 	      changeKind: 'breaking'
@@ -716,7 +729,7 @@ describe('AgentLoop', () => {
 	    expect(items.find((item) => item.kind === 'error' && item.code === 'tool_catalog_changed'))
 	      .toMatchObject({
 	        kind: 'error',
-	        message: expect.stringContaining('Kun stopped this turn')
+	        message: expect.stringContaining('next turn')
 	      })
 	  })
 


### PR DESCRIPTION
## Summary
- freeze the complete advertised tool schema on the first model step of each turn
- defer MCP/provider catalog changes until the next turn instead of mutating the prompt prefix or stopping active work
- keep catalog drift visible in runtime diagnostics while preserving the frozen request schema

## Changes
- add a bounded TurnToolCatalogFreezer outside agent-loop.ts
- deep-clone input schemas so in-place provider mutations cannot leak into later model steps
- suppress duplicate drift events for the same pending catalog version
- adopt the current catalog normally at the start of a new turn
- change breaking drift from stop-the-turn behavior to defer-until-next-turn behavior

## Tests
- npm.cmd --prefix kun test -- src/loop/turn-tool-catalog.test.ts tests/loop.test.ts (80 passed)
- npm.cmd run typecheck
- npm.cmd --prefix kun run typecheck (passes with #854 applied temporarily and removed before commit)
- npm.cmd --prefix kun run build
- merge-tree check against #833 (no conflicts)
- git diff --check

## CI note
Develop currently fails Kun typecheck in local-tool-host.test.ts. This PR intentionally does not duplicate the independent fix in #854.