### PR TITLE
fix(release): make extension gate cross-platform

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Install root dependencies
         run: npm ci
 
+      - name: Check Extension public release gate (host-native macOS)
+        run: npm run check:extension-release-gate
+
       - name: Build ad-hoc macOS packages (x64 and arm64)
         run: npm run dist:mac
 
@@ -202,6 +205,9 @@ jobs:
 
       - name: Install root dependencies
         run: npm ci
+
+      - name: Check Extension public release gate (host-native Windows)
+        run: npm run check:extension-release-gate
 
       - name: Build Windows NSIS installer
         run: npm run dist:win

--- a/scripts/after-pack.test.cjs
+++ b/scripts/after-pack.test.cjs
@@ -65,7 +65,9 @@ function executableLauncherFixture(t) {
   return { appOutDir, executable, realExecutable }
 }
 
-test('installs an executable Linux product launcher over a preserved ELF payload', (t) => {
+test('installs an executable Linux product launcher over a preserved ELF payload', {
+  skip: process.platform === 'win32' && 'requires POSIX executable modes'
+}, (t) => {
   const paths = fixture(t)
   installLinuxElectronLauncher(paths.context)
 
@@ -83,7 +85,9 @@ test('installs an executable Linux product launcher over a preserved ELF payload
   assert.deepEqual([...readFileSync(realExecutable).subarray(0, 4)], [0x7f, 0x45, 0x4c, 0x46])
 })
 
-test('GUI prepends the sandbox flag without parsing or swallowing user arguments', (t) => {
+test('GUI prepends the sandbox flag without parsing or swallowing user arguments', {
+  skip: process.platform === 'win32' && 'requires executing a POSIX shell launcher'
+}, (t) => {
   const paths = executableLauncherFixture(t)
   assert.deepEqual(runLauncher(paths.executable, ['--user-argument']).args, [
     LINUX_SANDBOX_LAUNCHER_FLAG,
@@ -100,14 +104,18 @@ test('GUI prepends the sandbox flag without parsing or swallowing user arguments
   ])
 })
 
-test('does not add a Chromium flag to ELECTRON_RUN_AS_NODE commands', (t) => {
+test('does not add a Chromium flag to ELECTRON_RUN_AS_NODE commands', {
+  skip: process.platform === 'win32' && 'requires executing a POSIX shell launcher'
+}, (t) => {
   const paths = executableLauncherFixture(t)
   const result = runLauncher(paths.executable, ['runtime-entry.js', 'extension', 'list'], '1')
   assert.deepEqual(result.args, ['runtime-entry.js', 'extension', 'list'])
   assert.equal(result.runAsNode, '1')
 })
 
-test('fails closed for unsafe names, non-executables, and payload collisions', (t) => {
+test('fails closed for unsafe names, non-executables, and payload collisions', {
+  skip: process.platform === 'win32' && 'requires POSIX executable modes'
+}, (t) => {
   const unsafe = fixture(t)
   unsafe.context.packager.executableName = '../escape'
   assert.throws(() => installLinuxElectronLauncher(unsafe.context), /Unsafe Linux executable name/)

--- a/scripts/smoke-packaged-extension-appimage.test.cjs
+++ b/scripts/smoke-packaged-extension-appimage.test.cjs
@@ -118,7 +118,9 @@ test('builds FUSE-free validation and direct-AppImage desktop invocations', () =
   assert.ok(!smoke.args.some((argument) => argument.endsWith('app.asar')))
 })
 
-test('extracts and validates before launching the final AppImage itself', (t) => {
+test('extracts and validates before launching the final AppImage itself', {
+  skip: process.platform === 'win32' && 'requires POSIX executable modes'
+}, (t) => {
   assert.doesNotThrow(() => assertLinuxX64('linux', 'x64'))
   assert.throws(() => assertLinuxX64('darwin', 'arm64'), /native linux\/x64/)
   assert.throws(() => assertLinuxX64('linux', 'arm64'), /native linux\/x64/)
@@ -229,7 +231,9 @@ test('rejects symlinked extracted resources, app.asar, launcher, payload, and de
   }
 })
 
-test('requires executable AppRun and exact sandbox-safe desktop entry', async (t) => {
+test('requires executable AppRun and exact sandbox-safe desktop entry', {
+  skip: process.platform === 'win32' && 'requires POSIX executable modes'
+}, async (t) => {
   await t.test('executable AppRun', (subtest) => {
     const extraction = temporaryDirectory(subtest)
     const root = writeExtractedBundle(extraction)

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -65,11 +65,16 @@ test('selects host-native packaged resources and never launches desktop Electron
   assert.deepEqual(desktopResourceCandidates('linux', 'x64'), ['dist/linux-unpacked/resources'])
   assert.deepEqual(packagedResourceCandidates('darwin', 'arm64'), ['dist/mac-arm64/Kun.app/Contents/Resources'])
   assert.deepEqual(packagedResourceCandidates('darwin', 'x64'), ['dist/mac/Kun.app/Contents/Resources'])
-  assert.deepEqual(resolvedPackagedResourceCandidates('darwin', 'arm64', '/workspace'), [
-    '/workspace/dist/mac-arm64/Kun.app/Contents/Resources'
+  const workspaceRoot = resolve('/workspace')
+  const macArm64Resources = resolve(
+    workspaceRoot,
+    'dist/mac-arm64/Kun.app/Contents/Resources'
+  )
+  assert.deepEqual(resolvedPackagedResourceCandidates('darwin', 'arm64', workspaceRoot), [
+    macArm64Resources
   ])
-  assert.deepEqual(resolvedDesktopResourceCandidates('darwin', 'arm64', '/workspace'), [
-    '/workspace/dist/mac-arm64/Kun.app/Contents/Resources'
+  assert.deepEqual(resolvedDesktopResourceCandidates('darwin', 'arm64', workspaceRoot), [
+    macArm64Resources
   ])
   assert.equal(desktopApplicationEntry('/packaged/Resources', '/packaged/Kun', '/packaged/Kun'), undefined)
   assert.equal(
@@ -679,6 +684,7 @@ test('every automated and local release path gates uploads behind packaged Exten
   ])
   assertStepAfter(pr.jobs.package, 'Upload Linux package', nativeEvidenceCommand)
   assertOrderedCommands(pr.jobs['package-macos'], [
+    'npm run check:extension-release-gate',
     'npm run dist:mac',
     'npm run smoke:packaged-extensions -- --resources dist/mac/Kun.app/Contents/Resources',
     'npm run smoke:packaged-extensions -- --resources dist/mac-arm64/Kun.app/Contents/Resources',
@@ -687,6 +693,7 @@ test('every automated and local release path gates uploads behind packaged Exten
   ])
   assertStepAfter(pr.jobs['package-macos'], 'Upload ad-hoc macOS PR packages', nativeEvidenceCommand)
   assertOrderedCommands(pr.jobs['package-windows'], [
+    'npm run check:extension-release-gate',
     'npm run dist:win',
     'npm run smoke:packaged-extensions -- --resources dist/win-unpacked/resources',
     desktopCommand,
@@ -942,6 +949,7 @@ function assertPublishDependencies(workflow, label) {
 }
 
 function assertOrderedSourceMarkers(source, markers) {
+  source = source.replace(/\r\n/gu, '\n')
   let prior = -1
   for (const marker of markers) {
     const index = source.indexOf(marker, prior + 1)


### PR DESCRIPTION
## Summary

Fix the stable Release workflow failure observed after #866.

## Changes

- skip POSIX executable-mode and shell-launcher tests on Windows while retaining them on Linux/macOS
- make packaged resource expectations use host-native resolved paths
- normalize CRLF before checking release script marker ordering

## Tests

- `node --test scripts/after-pack.test.cjs scripts/smoke-packaged-extension-appimage.test.cjs scripts/smoke-packaged-extension-desktop.test.cjs`
- `npm run check:extension-release-gate`

The Linux Release job also showed a one-off final AppImage smoke exit 127 after the same commit passed PR Linux validation; this PR keeps that fail-closed validation intact so CI can distinguish a transient runner failure from a reproducible launcher issue.