### PR TITLE
fix(release): preserve Windows rooted path semantics

### DIFF
--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -79,7 +79,7 @@ test('selects host-native packaged resources and never launches desktop Electron
   assert.equal(desktopApplicationEntry('/packaged/Resources', '/packaged/Kun', '/packaged/Kun'), undefined)
   assert.equal(
     desktopApplicationEntry('/packaged/Resources', '/host/Electron', '/packaged/Kun'),
-    resolve('/packaged/Resources', 'app.asar')
+    join('/packaged/Resources', 'app.asar')
   )
   assert.equal(
     desktopSmokeSettings(43123, '/isolated-home/.kun/default_workspace').workspaceRoot,
@@ -92,7 +92,11 @@ test('selects host-native packaged resources and never launches desktop Electron
       appData: '/isolated-app-data',
       explicitUserData: '/isolated-user-data'
     }),
-    ['/isolated-user-data', '/isolated-app-data/Kun', '/isolated-home/.config/Kun']
+    [
+      '/isolated-user-data',
+      join('/isolated-app-data', 'Kun'),
+      join('/isolated-home', '.config', 'Kun')
+    ]
   )
 
   const native = createDesktopLaunchPlan({


### PR DESCRIPTION
## Summary

Fix the final Windows Extension public release-gate assertion exposed by the 0.2.26-1 Release workflow.

## Root cause

The production helper joins a Windows rooted path without a drive letter, while the test used `resolve()` and incorrectly injected the runner drive (`D:`).

## Change

Use `join()` in the expected value so the assertion matches the production path semantics on every host platform.

## Tests

- `node --test scripts/smoke-packaged-extension-desktop.test.cjs`
- `npm run check:extension-release-gate`
- `git diff --check`