### PR TITLE
0.2.26-2

### DIFF
--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -79,7 +79,7 @@ test('selects host-native packaged resources and never launches desktop Electron
   assert.equal(desktopApplicationEntry('/packaged/Resources', '/packaged/Kun', '/packaged/Kun'), undefined)
   assert.equal(
     desktopApplicationEntry('/packaged/Resources', '/host/Electron', '/packaged/Kun'),
-    resolve('/packaged/Resources', 'app.asar')
+    join('/packaged/Resources', 'app.asar')
   )
   assert.equal(
     desktopSmokeSettings(43123, '/isolated-home/.kun/default_workspace').workspaceRoot,
@@ -92,7 +92,11 @@ test('selects host-native packaged resources and never launches desktop Electron
       appData: '/isolated-app-data',
       explicitUserData: '/isolated-user-data'
     }),
-    ['/isolated-user-data', '/isolated-app-data/Kun', '/isolated-home/.config/Kun']
+    [
+      '/isolated-user-data',
+      join('/isolated-app-data', 'Kun'),
+      join('/isolated-home', '.config', 'Kun')
+    ]
   )
 
   const native = createDesktopLaunchPlan({


### PR DESCRIPTION
## Summary

Second patch release for the Windows Extension public release-gate failures found during the 0.2.26-1 Release workflow.

## Changes

- preserve Windows rooted-path semantics in packaged desktop test expectations
- use host-native separators for derived user-data paths
- retain POSIX-only test isolation and Windows/macOS host-native release-gate coverage from the preceding fixes

## Validation

- local `node --test scripts/smoke-packaged-extension-desktop.test.cjs` passes
- local `npm run check:extension-release-gate` passes
- #872 is merged into develop; its latest native PR workflow is still completing and should be checked before merging this release PR

This release must use a new merge commit; rerunning the failed 0.2.26-1 workflow remains pinned to its old SHA.