### PR TITLE
fix(permissions): request approval for external workspace paths

### DIFF
--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -100,11 +100,7 @@ export async function resolveWorkspacePath(
   // danger-full-access, and lets read/ls/find/grep/lsp reach system paths
   // (e.g. C:\Windows on Windows, /etc on POSIX) instead of failing with
   // "path escapes the workspace root".
-  if (
-    !options.enforceWorkspaceBoundary &&
-    (effectiveSandboxMode(context) === 'danger-full-access' ||
-      context.approvedExternalPaths?.some((path) => samePath(path, lexicalAbsolutePath)) === true)
-  ) {
+  if (!options.enforceWorkspaceBoundary && effectiveSandboxMode(context) === 'danger-full-access') {
     return {
       workspaceRoot: root,
       absolutePath: lexicalAbsolutePath,
@@ -119,19 +115,30 @@ export async function resolveWorkspacePath(
   }
   const resolvedAbsolute = await resolveSymlinkSafe(lexicalAbsolutePath)
   const resolvedRelative = relative(resolvedRoot, resolvedAbsolute)
-  if (resolvedRelative === '..' || resolvedRelative.startsWith(`..${sep}`) || isAbsolute(resolvedRelative)) {
+  const isInsideWorkspace = resolvedRelative !== '..' &&
+    !resolvedRelative.startsWith(`..${sep}`) &&
+    !isAbsolute(resolvedRelative)
+  // External grants contain the target resolved at approval time. Compare the
+  // current physical target here so a file or parent directory swapped for a
+  // symlink/junction while the approval prompt was open cannot redirect a write.
+  const isApprovedExternalPath = !options.enforceWorkspaceBoundary &&
+    context.approvedExternalPaths?.some((path) => samePath(path, resolvedAbsolute)) === true
+  if (!isInsideWorkspace && !isApprovedExternalPath) {
     throw new Error(`path escapes the workspace root: ${inputPath}`)
   }
-  // Return LEXICAL paths to callers. The realpath-resolved pair is only used
-  // for the escape check above; downstream code (subprocess cwd, display
-  // paths, language-server init) expects the user-facing workspace path,
-  // which on symlinked roots (e.g. macOS `/tmp` -> `/private/tmp`) would
-  // otherwise diverge from what the user typed and break display layers.
+  // Keep lexical paths for workspace callers so display layers and subprocess
+  // cwd values preserve the path the user selected. An approved external path
+  // uses its resolved target instead, so the checked target is also the path
+  // handed to the file operation.
   return {
     workspaceRoot: root,
-    absolutePath: lexicalAbsolutePath,
+    absolutePath: isApprovedExternalPath ? resolvedAbsolute : lexicalAbsolutePath,
     relativePath: normalizeToolPath(relative(root, lexicalAbsolutePath) || '.')
   }
+}
+
+export async function resolvePathThroughSymlinks(path: string): Promise<string> {
+  return resolveSymlinkSafe(resolve(path))
 }
 
 function samePath(left: string, right: string): boolean {

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -102,7 +102,8 @@ export async function resolveWorkspacePath(
   // "path escapes the workspace root".
   if (
     !options.enforceWorkspaceBoundary &&
-    (effectiveSandboxMode(context) === 'danger-full-access' || context.allowExternalPaths === true)
+    (effectiveSandboxMode(context) === 'danger-full-access' ||
+      context.approvedExternalPaths?.some((path) => samePath(path, lexicalAbsolutePath)) === true)
   ) {
     return {
       workspaceRoot: root,
@@ -131,6 +132,15 @@ export async function resolveWorkspacePath(
     absolutePath: lexicalAbsolutePath,
     relativePath: normalizeToolPath(relative(root, lexicalAbsolutePath) || '.')
   }
+}
+
+function samePath(left: string, right: string): boolean {
+  const normalize = (value: string) => resolve(value).replace(/[\\/]+$/, '')
+  const normalizedLeft = normalize(left)
+  const normalizedRight = normalize(right)
+  return process.platform === 'win32'
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight
 }
 
 async function safeRealpath(target: string): Promise<string | null> {

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -100,7 +100,10 @@ export async function resolveWorkspacePath(
   // danger-full-access, and lets read/ls/find/grep/lsp reach system paths
   // (e.g. C:\Windows on Windows, /etc on POSIX) instead of failing with
   // "path escapes the workspace root".
-  if (!options.enforceWorkspaceBoundary && effectiveSandboxMode(context) === 'danger-full-access') {
+  if (
+    !options.enforceWorkspaceBoundary &&
+    (effectiveSandboxMode(context) === 'danger-full-access' || context.allowExternalPaths === true)
+  ) {
     return {
       workspaceRoot: root,
       absolutePath: lexicalAbsolutePath,

--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -1,7 +1,9 @@
+import { resolve as resolvePath } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { LocalToolHost, echoTool, userInputTool } from './local-tool-host.js'
 import type { ToolHostContext } from '../../ports/tool-host.js'
 import { InMemoryArtifactStore } from '../../artifacts/artifact-store.js'
+import { resolveWorkspacePath } from './builtin-tool-utils.js'
 
 describe('LocalToolHost approval policy', () => {
   it('asks before auto tools when approval policy is always', async () => {
@@ -151,8 +153,11 @@ describe('LocalToolHost approval policy', () => {
 
   it('asks before an external workspace-write path and scopes the grant to that call', async () => {
     const awaitApproval = vi.fn(async () => 'allow' as const)
-    const execute = vi.fn(async (_args: Record<string, unknown>, context: ToolHostContext) => ({
-      output: { allowExternalPaths: context.allowExternalPaths === true }
+    const execute = vi.fn(async (args: Record<string, unknown>, context: ToolHostContext) => ({
+      output: {
+        approvedExternalPaths: context.approvedExternalPaths,
+        requestedPath: args.path
+      }
     }))
     const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
       name: 'write_external',
@@ -182,10 +187,15 @@ describe('LocalToolHost approval policy', () => {
     )
     expect(execute).toHaveBeenCalledWith(
       { path: '../outside.txt' },
-      expect.objectContaining({ allowExternalPaths: true }),
+      expect.objectContaining({ approvedExternalPaths: [resolvePath('/tmp/outside.txt')] }),
       expect.any(Function)
     )
-    expect(result.item).toMatchObject({ output: { allowExternalPaths: true } })
+    expect(result.item).toMatchObject({
+      output: {
+        approvedExternalPaths: [resolvePath('/tmp/outside.txt')],
+        requestedPath: '../outside.txt'
+      }
+    })
   })
 
   it('does not execute an external path when the per-operation approval is denied', async () => {
@@ -214,6 +224,40 @@ describe('LocalToolHost approval policy', () => {
 
     expect(execute).not.toHaveBeenCalled()
     expect(result.item).toMatchObject({ isError: true, output: { code: 'approval_denied', reason: 'not now' } })
+  })
+
+  it('does not expand an approved external path to a sibling path', async () => {
+    const execute = vi.fn(async (_args: Record<string, unknown>, context: ToolHostContext) => {
+      await expect(resolveWorkspacePath('../outside.txt', context)).resolves.toMatchObject({
+        absolutePath: resolvePath('/tmp/outside.txt')
+      })
+      await expect(resolveWorkspacePath('../sibling.txt', context)).rejects.toThrow()
+      return { output: { ok: true } }
+    })
+    const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
+      name: 'write_external_exact',
+      description: 'checks that an external approval remains path-scoped',
+      inputSchema: { type: 'object' },
+      toolKind: 'file_change',
+      policy: 'auto',
+      execute
+    })] })
+
+    const result = await host.execute(
+      { callId: 'call_external_exact', toolName: 'write_external_exact', arguments: { path: '../outside.txt' } },
+      {
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        workspace: '/tmp/workspace',
+        approvalPolicy: 'auto',
+        sandboxMode: 'workspace-write',
+        abortSignal: new AbortController().signal,
+        awaitApproval: vi.fn(async () => 'allow' as const)
+      }
+    )
+
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(result.item).toMatchObject({ output: { ok: true } })
   })
 
   it('keeps user input tools advertised without a GUI gate but rejects execution', async () => {

--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -230,40 +230,50 @@ describe('LocalToolHost approval policy', () => {
   })
 
   it('does not expand an approved external path to a sibling path', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-approval-'))
+    const workspace = join(parent, 'workspace')
+    const approvedTarget = join(parent, 'outside.txt')
+    const siblingTarget = join(parent, 'sibling.txt')
     let approvedPath = ''
-    const execute = vi.fn(async (_args: Record<string, unknown>, context: ToolHostContext) => {
-      approvedPath = context.approvedExternalPaths?.[0] ?? ''
-      await expect(resolveWorkspacePath('../outside.txt', context)).resolves.toMatchObject({
-        absolutePath: approvedPath
+    try {
+      await mkdir(workspace)
+      const execute = vi.fn(async (_args: Record<string, unknown>, context: ToolHostContext) => {
+        approvedPath = context.approvedExternalPaths?.[0] ?? ''
+        await expect(resolveWorkspacePath('../outside.txt', context)).resolves.toMatchObject({
+          absolutePath: approvedPath
+        })
+        await expect(resolveWorkspacePath('../sibling.txt', context)).rejects.toThrow()
+        return { output: { ok: true } }
       })
-      await expect(resolveWorkspacePath('../sibling.txt', context)).rejects.toThrow()
-      return { output: { ok: true } }
-    })
-    const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
-      name: 'write_external_exact',
-      description: 'checks that an external approval remains path-scoped',
-      inputSchema: { type: 'object' },
-      toolKind: 'file_change',
-      policy: 'auto',
-      execute
-    })] })
+      const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
+        name: 'write_external_exact',
+        description: 'checks that an external approval remains path-scoped',
+        inputSchema: { type: 'object' },
+        toolKind: 'file_change',
+        policy: 'auto',
+        execute
+      })] })
 
-    const result = await host.execute(
-      { callId: 'call_external_exact', toolName: 'write_external_exact', arguments: { path: '../outside.txt' } },
-      {
-        threadId: 'thread_1',
-        turnId: 'turn_1',
-        workspace: '/tmp/workspace',
-        approvalPolicy: 'auto',
-        sandboxMode: 'workspace-write',
-        abortSignal: new AbortController().signal,
-        awaitApproval: vi.fn(async () => 'allow' as const)
-      }
-    )
+      const result = await host.execute(
+        { callId: 'call_external_exact', toolName: 'write_external_exact', arguments: { path: '../outside.txt' } },
+        {
+          threadId: 'thread_1',
+          turnId: 'turn_1',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: vi.fn(async () => 'allow' as const)
+        }
+      )
 
-    expect(execute).toHaveBeenCalledTimes(1)
-    expect(approvedPath).toBeTruthy()
-    expect(result.item).toMatchObject({ output: { ok: true } })
+      expect(execute).toHaveBeenCalledTimes(1)
+      expect(approvedPath).toBe(approvedTarget)
+      expect(approvedPath).not.toBe(siblingTarget)
+      expect(result.item).toMatchObject({ output: { ok: true } })
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
   })
 
   it('writes a real external target only after a per-call approval', async () => {

--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -149,6 +149,73 @@ describe('LocalToolHost approval policy', () => {
     })
   })
 
+  it('asks before an external workspace-write path and scopes the grant to that call', async () => {
+    const awaitApproval = vi.fn(async () => 'allow' as const)
+    const execute = vi.fn(async (_args: Record<string, unknown>, context: ToolHostContext) => ({
+      output: { allowExternalPaths: context.allowExternalPaths === true }
+    }))
+    const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
+      name: 'write_external',
+      description: 'simulates a file change outside the workspace',
+      inputSchema: { type: 'object' },
+      toolKind: 'file_change',
+      policy: 'auto',
+      execute
+    })] })
+
+    const result = await host.execute(
+      { callId: 'call_external', toolName: 'write_external', arguments: { path: '../outside.txt' } },
+      {
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        workspace: '/tmp/workspace',
+        approvalPolicy: 'auto',
+        sandboxMode: 'workspace-write',
+        abortSignal: new AbortController().signal,
+        awaitApproval
+      }
+    )
+
+    expect(awaitApproval).toHaveBeenCalledTimes(1)
+    expect(awaitApproval).toHaveBeenCalledWith(
+      expect.objectContaining({ summary: expect.stringContaining('outside the workspace') })
+    )
+    expect(execute).toHaveBeenCalledWith(
+      { path: '../outside.txt' },
+      expect.objectContaining({ allowExternalPaths: true }),
+      expect.any(Function)
+    )
+    expect(result.item).toMatchObject({ output: { allowExternalPaths: true } })
+  })
+
+  it('does not execute an external path when the per-operation approval is denied', async () => {
+    const execute = vi.fn(async () => ({ output: { ran: true } }))
+    const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
+      name: 'write_external_denied',
+      description: 'simulates a denied external file change',
+      inputSchema: { type: 'object' },
+      toolKind: 'file_change',
+      policy: 'auto',
+      execute
+    })] })
+
+    const result = await host.execute(
+      { callId: 'call_external_denied', toolName: 'write_external_denied', arguments: { path: '../outside.txt' } },
+      {
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        workspace: '/tmp/workspace',
+        approvalPolicy: 'auto',
+        sandboxMode: 'workspace-write',
+        abortSignal: new AbortController().signal,
+        awaitApproval: vi.fn(async () => ({ decision: 'deny' as const, reason: 'not now' }))
+      }
+    )
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(result.item).toMatchObject({ isError: true, output: { code: 'approval_denied', reason: 'not now' } })
+  })
+
   it('keeps user input tools advertised without a GUI gate but rejects execution', async () => {
     const host = new LocalToolHost({ tools: [echoTool, userInputTool] })
     const context = {

--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -1,9 +1,12 @@
-import { resolve as resolvePath } from 'node:path'
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve as resolvePath } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { LocalToolHost, echoTool, userInputTool } from './local-tool-host.js'
 import type { ToolHostContext } from '../../ports/tool-host.js'
 import { InMemoryArtifactStore } from '../../artifacts/artifact-store.js'
 import { resolveWorkspacePath } from './builtin-tool-utils.js'
+import { createWriteLocalTool } from './builtin-file-tools.js'
 
 describe('LocalToolHost approval policy', () => {
   it('asks before auto tools when approval policy is always', async () => {
@@ -227,9 +230,11 @@ describe('LocalToolHost approval policy', () => {
   })
 
   it('does not expand an approved external path to a sibling path', async () => {
+    let approvedPath = ''
     const execute = vi.fn(async (_args: Record<string, unknown>, context: ToolHostContext) => {
+      approvedPath = context.approvedExternalPaths?.[0] ?? ''
       await expect(resolveWorkspacePath('../outside.txt', context)).resolves.toMatchObject({
-        absolutePath: resolvePath('/tmp/outside.txt')
+        absolutePath: approvedPath
       })
       await expect(resolveWorkspacePath('../sibling.txt', context)).rejects.toThrow()
       return { output: { ok: true } }
@@ -257,7 +262,93 @@ describe('LocalToolHost approval policy', () => {
     )
 
     expect(execute).toHaveBeenCalledTimes(1)
+    expect(approvedPath).toBeTruthy()
     expect(result.item).toMatchObject({ output: { ok: true } })
+  })
+
+  it('writes a real external target only after a per-call approval', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'kun-workspace-'))
+    const external = await mkdtemp(join(tmpdir(), 'kun-external-'))
+    const target = join(external, 'approved.txt')
+    try {
+      const awaitApproval = vi.fn(async () => 'allow' as const)
+      const host = new LocalToolHost({ tools: [createWriteLocalTool()] })
+      const result = await host.execute(
+        { callId: 'call_write_external_file', toolName: 'write', arguments: { path: target, content: 'approved' } },
+        {
+          threadId: 'thread_1',
+          turnId: 'turn_1',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval
+        } satisfies ToolHostContext
+      )
+
+      expect(awaitApproval).toHaveBeenCalledTimes(1)
+      expect(result.item).toMatchObject({ isError: false })
+      await expect(readFile(target, 'utf8')).resolves.toBe('approved')
+    } finally {
+      await Promise.all([
+        rm(workspace, { recursive: true, force: true }),
+        rm(external, { recursive: true, force: true })
+      ])
+    }
+  })
+
+  it('rejects an approved external path when it is replaced by a symlink before execution', async (ctx) => {
+    const workspace = await mkdtemp(join(tmpdir(), 'kun-workspace-'))
+    const external = await mkdtemp(join(tmpdir(), 'kun-external-'))
+    const approvedDirectory = join(external, 'approved')
+    const protectedDirectory = join(external, 'protected')
+    const target = join(approvedDirectory, 'target.txt')
+    const protectedTarget = join(protectedDirectory, 'target.txt')
+    let symlinkError: unknown
+    try {
+      await Promise.all([mkdir(approvedDirectory), mkdir(protectedDirectory)])
+      await Promise.all([
+        writeFile(target, 'original'),
+        writeFile(protectedTarget, 'must survive')
+      ])
+      const host = new LocalToolHost({ tools: [createWriteLocalTool()] })
+      const result = await host.execute(
+        { callId: 'call_write_swapped_link', toolName: 'write', arguments: { path: target, content: 'overwrite' } },
+        {
+          threadId: 'thread_1',
+          turnId: 'turn_1',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: async () => {
+            await rm(approvedDirectory, { recursive: true, force: true })
+            try {
+              await symlink(protectedDirectory, approvedDirectory, process.platform === 'win32' ? 'junction' : 'dir')
+            } catch (error) {
+              symlinkError = error
+              return 'deny'
+            }
+            return 'allow'
+          }
+        } satisfies ToolHostContext
+      )
+
+      if (symlinkError) {
+        ctx.skip()
+        return
+      }
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { error: expect.stringContaining('path escapes the workspace root') }
+      })
+      await expect(readFile(protectedTarget, 'utf8')).resolves.toBe('must survive')
+    } finally {
+      await Promise.all([
+        rm(workspace, { recursive: true, force: true }),
+        rm(external, { recursive: true, force: true })
+      ])
+    }
   })
 
   it('keeps user input tools advertised without a GUI gate but rejects execution', async () => {

--- a/kun/src/adapters/tool/local-tool-host.ts
+++ b/kun/src/adapters/tool/local-tool-host.ts
@@ -29,7 +29,7 @@ import {
   ReadTracker,
   type ReadTrackerOptions
 } from './read-tracker.js'
-import { sandboxBlockForTool, type SandboxBlock } from './sandbox-policy.js'
+import { externalPathForApproval, sandboxBlockForTool, type SandboxBlock } from './sandbox-policy.js'
 import {
   createToolOperationIdentity,
   ToolOperationJournal
@@ -205,7 +205,10 @@ export class LocalToolHost implements ToolHost {
     }
     // A configured hook may auto-approve ordinary tool calls, but it must not
     // bypass an explicit user decision for an external side effect.
+    const externalPath = externalPathForApproval(tool, activeCall, context)
+    const externalPathApproval = externalPath && context.approvalPolicy !== 'never'
     const needsApproval = tool.requiresExplicitApproval ||
+      Boolean(externalPathApproval) ||
       (!preHooks.autoApproved && this.requiresApproval(tool, activeCall, context))
     if (needsApproval) {
       const approvalId = `appr_${randomUUID().replaceAll('-', '')}`
@@ -214,7 +217,9 @@ export class LocalToolHost implements ToolHost {
         threadId: context.threadId,
         turnId: context.turnId,
         toolName: activeCall.toolName,
-        summary: this.buildApprovalSummary(activeCall)
+        summary: externalPathApproval
+          ? `Request access outside the workspace, then ${this.buildApprovalSummary(activeCall)}`
+          : this.buildApprovalSummary(activeCall)
       })
       const resolution = await context.awaitApproval(approval)
       const decision = typeof resolution === 'string' ? resolution : resolution.decision
@@ -285,9 +290,12 @@ export class LocalToolHost implements ToolHost {
       }
     }
     this.operationJournal.begin(operationIdentity)
+    const executionContext = externalPathApproval
+      ? { ...context, allowExternalPaths: true }
+      : context
     let result: Awaited<ReturnType<LocalTool['execute']>>
     try {
-      result = await tool.execute(activeCall.arguments, context, async (update) => {
+      result = await tool.execute(activeCall.arguments, executionContext, async (update) => {
         if (!onUpdate) return
         const partialItem = makeToolResultItem({
           id: `item_${activeCall.callId}`,

--- a/kun/src/adapters/tool/local-tool-host.ts
+++ b/kun/src/adapters/tool/local-tool-host.ts
@@ -205,8 +205,8 @@ export class LocalToolHost implements ToolHost {
     }
     // A configured hook may auto-approve ordinary tool calls, but it must not
     // bypass an explicit user decision for an external side effect.
-    const externalPath = externalPathForApproval(tool, activeCall, context)
-    const externalPathApproval = externalPath && context.approvalPolicy !== 'never'
+    const externalPaths = externalPathForApproval(tool, activeCall, context)
+    const externalPathApproval = externalPaths.length > 0 && context.approvalPolicy !== 'never'
     const needsApproval = tool.requiresExplicitApproval ||
       Boolean(externalPathApproval) ||
       (!preHooks.autoApproved && this.requiresApproval(tool, activeCall, context))
@@ -291,7 +291,7 @@ export class LocalToolHost implements ToolHost {
     }
     this.operationJournal.begin(operationIdentity)
     const executionContext = externalPathApproval
-      ? { ...context, allowExternalPaths: true }
+      ? { ...context, approvedExternalPaths: externalPaths }
       : context
     let result: Awaited<ReturnType<LocalTool['execute']>>
     try {

--- a/kun/src/adapters/tool/local-tool-host.ts
+++ b/kun/src/adapters/tool/local-tool-host.ts
@@ -205,7 +205,7 @@ export class LocalToolHost implements ToolHost {
     }
     // A configured hook may auto-approve ordinary tool calls, but it must not
     // bypass an explicit user decision for an external side effect.
-    const externalPaths = externalPathForApproval(tool, activeCall, context)
+    const externalPaths = await externalPathForApproval(tool, activeCall, context)
     const externalPathApproval = externalPaths.length > 0 && context.approvalPolicy !== 'never'
     const needsApproval = tool.requiresExplicitApproval ||
       Boolean(externalPathApproval) ||

--- a/kun/src/adapters/tool/sandbox-policy.test.ts
+++ b/kun/src/adapters/tool/sandbox-policy.test.ts
@@ -1,4 +1,6 @@
-import { resolve } from 'node:path'
+import { mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { canWritePath, externalPathForApproval, sandboxBlockForTool } from './sandbox-policy.js'
 
@@ -18,17 +20,24 @@ describe('sandbox policy', () => {
     })
   })
 
-  it('identifies an external file path for per-operation approval', () => {
-    expect(externalPathForApproval(
-      { toolKind: 'file_change' },
-      { arguments: { path: '../outside.txt' } },
-      { workspace: '/repo/workspace', sandboxMode: 'workspace-write' }
-    )).toEqual([resolve('/repo/outside.txt')])
-    expect(externalPathForApproval(
-      { toolKind: 'file_change' },
-      { arguments: { path: 'src/app.ts' } },
-      { workspace: '/repo/workspace', sandboxMode: 'workspace-write' }
-    )).toEqual([])
+  it('identifies an external file path for per-operation approval', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-sandbox-policy-'))
+    const workspace = join(parent, 'workspace')
+    try {
+      await mkdir(workspace)
+      await expect(externalPathForApproval(
+        { toolKind: 'file_change' },
+        { arguments: { path: '../outside.txt' } },
+        { workspace, sandboxMode: 'workspace-write' }
+      )).resolves.toEqual([resolve(parent, 'outside.txt')])
+      await expect(externalPathForApproval(
+        { toolKind: 'file_change' },
+        { arguments: { path: 'src/app.ts' } },
+        { workspace, sandboxMode: 'workspace-write' }
+      )).resolves.toEqual([])
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
   })
 
   it('allows a path only when the current call carries an approved grant', () => {

--- a/kun/src/adapters/tool/sandbox-policy.test.ts
+++ b/kun/src/adapters/tool/sandbox-policy.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { canWritePath, externalPathForApproval, sandboxBlockForTool } from './sandbox-policy.js'
 
@@ -22,20 +23,25 @@ describe('sandbox policy', () => {
       { toolKind: 'file_change' },
       { arguments: { path: '../outside.txt' } },
       { workspace: '/repo/workspace', sandboxMode: 'workspace-write' }
-    )).toBe('../outside.txt')
+    )).toEqual([resolve('/repo/outside.txt')])
     expect(externalPathForApproval(
       { toolKind: 'file_change' },
       { arguments: { path: 'src/app.ts' } },
       { workspace: '/repo/workspace', sandboxMode: 'workspace-write' }
-    )).toBeUndefined()
+    )).toEqual([])
   })
 
   it('allows a path only when the current call carries an approved grant', () => {
     expect(canWritePath('/repo/other/app.ts', {
       workspace: '/repo/workspace',
       sandboxMode: 'workspace-write',
-      allowExternalPaths: true
+      approvedExternalPaths: ['/repo/other/app.ts']
     })).toEqual({ ok: true })
+    expect(canWritePath('/repo/other/second.ts', {
+      workspace: '/repo/workspace',
+      sandboxMode: 'workspace-write',
+      approvedExternalPaths: ['/repo/other/app.ts']
+    })).toMatchObject({ ok: false })
   })
 
   it('keeps command execution blocked in workspace-write mode', () => {

--- a/kun/src/adapters/tool/sandbox-policy.test.ts
+++ b/kun/src/adapters/tool/sandbox-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { canWritePath, sandboxBlockForTool } from './sandbox-policy.js'
+import { canWritePath, externalPathForApproval, sandboxBlockForTool } from './sandbox-policy.js'
 
 describe('sandbox policy', () => {
   it('limits workspace-write file mutations to the workspace', () => {
@@ -15,6 +15,27 @@ describe('sandbox policy', () => {
         code: 'sandbox_write_blocked'
       }
     })
+  })
+
+  it('identifies an external file path for per-operation approval', () => {
+    expect(externalPathForApproval(
+      { toolKind: 'file_change' },
+      { arguments: { path: '../outside.txt' } },
+      { workspace: '/repo/workspace', sandboxMode: 'workspace-write' }
+    )).toBe('../outside.txt')
+    expect(externalPathForApproval(
+      { toolKind: 'file_change' },
+      { arguments: { path: 'src/app.ts' } },
+      { workspace: '/repo/workspace', sandboxMode: 'workspace-write' }
+    )).toBeUndefined()
+  })
+
+  it('allows a path only when the current call carries an approved grant', () => {
+    expect(canWritePath('/repo/other/app.ts', {
+      workspace: '/repo/workspace',
+      sandboxMode: 'workspace-write',
+      allowExternalPaths: true
+    })).toEqual({ ok: true })
   })
 
   it('keeps command execution blocked in workspace-write mode', () => {

--- a/kun/src/adapters/tool/sandbox-policy.ts
+++ b/kun/src/adapters/tool/sandbox-policy.ts
@@ -6,7 +6,7 @@ import {
 } from '../../contracts/policy.js'
 import type { ToolCallLike, ToolHostContext } from '../../ports/tool-host.js'
 import type { LocalTool } from './local-tool-host.js'
-import { workspaceRoot } from './builtin-tool-utils.js'
+import { resolvePathThroughSymlinks, workspaceRoot } from './builtin-tool-utils.js'
 
 export type SandboxBlock = {
   code: 'sandbox_read_only' | 'sandbox_command_blocked' | 'sandbox_write_blocked'
@@ -25,16 +25,16 @@ const PATH_ARGUMENT_NAMES = [
 ] as const
 
 /**
- * Returns the first lexical path that escapes the workspace for a file
- * mutation call. Symlink escapes remain fail-closed in resolveWorkspacePath;
- * this helper only decides whether an approval prompt is needed before the
- * tool is executed.
+ * Returns the resolved targets outside the workspace for a file mutation
+ * call. Capturing the resolved target before approval lets execution reject a
+ * path whose file or parent directory was replaced by a symlink/junction
+ * while the prompt was open.
  */
-export function externalPathForApproval(
+export async function externalPathForApproval(
   tool: Pick<LocalTool, 'toolKind'>,
   call: Pick<ToolCallLike, 'arguments'>,
   context: Pick<ToolHostContext, 'workspace' | 'sandboxMode'>
-): string[] {
+): Promise<string[]> {
   if (tool.toolKind !== 'file_change' || effectiveSandboxMode(context) !== 'workspace-write') {
     return []
   }
@@ -44,8 +44,11 @@ export function externalPathForApproval(
     const value = call.arguments[name]
     if (typeof value !== 'string' || !value.trim()) continue
     const candidate = isAbsolute(value) ? resolve(value) : resolve(root, value)
-    if (!isPathInsideOrEqual(root, candidate) && !externalPaths.some((path) => samePath(path, candidate))) {
-      externalPaths.push(candidate)
+    if (!isPathInsideOrEqual(root, candidate)) {
+      const resolvedCandidate = await resolvePathThroughSymlinks(candidate)
+      if (!externalPaths.some((path) => samePath(path, resolvedCandidate))) {
+        externalPaths.push(resolvedCandidate)
+      }
     }
   }
   return externalPaths

--- a/kun/src/adapters/tool/sandbox-policy.ts
+++ b/kun/src/adapters/tool/sandbox-policy.ts
@@ -34,18 +34,21 @@ export function externalPathForApproval(
   tool: Pick<LocalTool, 'toolKind'>,
   call: Pick<ToolCallLike, 'arguments'>,
   context: Pick<ToolHostContext, 'workspace' | 'sandboxMode'>
-): string | undefined {
+): string[] {
   if (tool.toolKind !== 'file_change' || effectiveSandboxMode(context) !== 'workspace-write') {
-    return undefined
+    return []
   }
   const root = workspaceRoot(context.workspace)
+  const externalPaths: string[] = []
   for (const name of PATH_ARGUMENT_NAMES) {
     const value = call.arguments[name]
     if (typeof value !== 'string' || !value.trim()) continue
     const candidate = isAbsolute(value) ? resolve(value) : resolve(root, value)
-    if (!isPathInsideOrEqual(root, candidate)) return value
+    if (!isPathInsideOrEqual(root, candidate) && !externalPaths.some((path) => samePath(path, candidate))) {
+      externalPaths.push(candidate)
+    }
   }
-  return undefined
+  return externalPaths
 }
 
 export function effectiveSandboxMode(
@@ -97,7 +100,7 @@ export function sandboxBlockForTool(
 
 export function canWritePath(
   absolutePath: string,
-  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode' | 'allowExternalPaths'>
+  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode' | 'approvedExternalPaths'>
 ): { ok: true } | { ok: false; block: SandboxBlock } {
   const mode = effectiveSandboxMode(context)
   if (mode === 'danger-full-access') return { ok: true }
@@ -120,11 +123,10 @@ export function canWritePath(
     }
   }
 
-  if (context.allowExternalPaths === true) return { ok: true }
-
   const root = workspaceRoot(context.workspace)
   const resolvedPath = isAbsolute(absolutePath) ? resolve(absolutePath) : resolve(root, absolutePath)
   if (isPathInsideOrEqual(root, resolvedPath)) return { ok: true }
+  if (context.approvedExternalPaths?.some((path) => samePath(path, resolvedPath))) return { ok: true }
   return {
     ok: false,
     block: {
@@ -136,10 +138,19 @@ export function canWritePath(
 
 export function assertCanWritePath(
   absolutePath: string,
-  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode' | 'allowExternalPaths'>
+  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode' | 'approvedExternalPaths'>
 ): void {
   const decision = canWritePath(absolutePath, context)
   if (!decision.ok) throw new Error(decision.block.message)
+}
+
+function samePath(left: string, right: string): boolean {
+  const normalize = (value: string) => resolve(value).replace(/[\\/]+$/, '')
+  const normalizedLeft = normalize(left)
+  const normalizedRight = normalize(right)
+  return process.platform === 'win32'
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight
 }
 
 function isPathInsideOrEqual(root: string, candidate: string): boolean {

--- a/kun/src/adapters/tool/sandbox-policy.ts
+++ b/kun/src/adapters/tool/sandbox-policy.ts
@@ -4,13 +4,48 @@ import {
   SandboxModeSchema,
   type SandboxMode
 } from '../../contracts/policy.js'
-import type { ToolHostContext } from '../../ports/tool-host.js'
+import type { ToolCallLike, ToolHostContext } from '../../ports/tool-host.js'
 import type { LocalTool } from './local-tool-host.js'
 import { workspaceRoot } from './builtin-tool-utils.js'
 
 export type SandboxBlock = {
   code: 'sandbox_read_only' | 'sandbox_command_blocked' | 'sandbox_write_blocked'
   message: string
+}
+
+const PATH_ARGUMENT_NAMES = [
+  'path',
+  'filePath',
+  'sourcePath',
+  'targetPath',
+  'outputPath',
+  'destinationPath',
+  'projectPath',
+  'root'
+] as const
+
+/**
+ * Returns the first lexical path that escapes the workspace for a file
+ * mutation call. Symlink escapes remain fail-closed in resolveWorkspacePath;
+ * this helper only decides whether an approval prompt is needed before the
+ * tool is executed.
+ */
+export function externalPathForApproval(
+  tool: Pick<LocalTool, 'toolKind'>,
+  call: Pick<ToolCallLike, 'arguments'>,
+  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode'>
+): string | undefined {
+  if (tool.toolKind !== 'file_change' || effectiveSandboxMode(context) !== 'workspace-write') {
+    return undefined
+  }
+  const root = workspaceRoot(context.workspace)
+  for (const name of PATH_ARGUMENT_NAMES) {
+    const value = call.arguments[name]
+    if (typeof value !== 'string' || !value.trim()) continue
+    const candidate = isAbsolute(value) ? resolve(value) : resolve(root, value)
+    if (!isPathInsideOrEqual(root, candidate)) return value
+  }
+  return undefined
 }
 
 export function effectiveSandboxMode(
@@ -62,7 +97,7 @@ export function sandboxBlockForTool(
 
 export function canWritePath(
   absolutePath: string,
-  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode'>
+  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode' | 'allowExternalPaths'>
 ): { ok: true } | { ok: false; block: SandboxBlock } {
   const mode = effectiveSandboxMode(context)
   if (mode === 'danger-full-access') return { ok: true }
@@ -85,6 +120,8 @@ export function canWritePath(
     }
   }
 
+  if (context.allowExternalPaths === true) return { ok: true }
+
   const root = workspaceRoot(context.workspace)
   const resolvedPath = isAbsolute(absolutePath) ? resolve(absolutePath) : resolve(root, absolutePath)
   if (isPathInsideOrEqual(root, resolvedPath)) return { ok: true }
@@ -99,7 +136,7 @@ export function canWritePath(
 
 export function assertCanWritePath(
   absolutePath: string,
-  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode'>
+  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode' | 'allowExternalPaths'>
 ): void {
   const decision = canWritePath(absolutePath, context)
   if (!decision.ok) throw new Error(decision.block.message)

--- a/kun/src/ports/tool-host.ts
+++ b/kun/src/ports/tool-host.ts
@@ -112,8 +112,8 @@ export type ToolHostContext = {
   approvalPolicy: ApprovalPolicy
   /** Filesystem/command sandbox selected for this turn. Defaults at execution time for old callers. */
   sandboxMode?: SandboxMode
-  /** Set only for one call after the user approved an outside-workspace path. */
-  allowExternalPaths?: boolean
+  /** Exact lexical paths approved for this call; never a directory-wide grant. */
+  approvedExternalPaths?: readonly string[]
   /** Kun runtime data root; used to allow sandbox-safe reads of background shell output files. */
   runtimeDataDir?: string
   /** Store used to offload oversized tool results from model context. */

--- a/kun/src/ports/tool-host.ts
+++ b/kun/src/ports/tool-host.ts
@@ -112,6 +112,8 @@ export type ToolHostContext = {
   approvalPolicy: ApprovalPolicy
   /** Filesystem/command sandbox selected for this turn. Defaults at execution time for old callers. */
   sandboxMode?: SandboxMode
+  /** Set only for one call after the user approved an outside-workspace path. */
+  allowExternalPaths?: boolean
   /** Kun runtime data root; used to allow sandbox-safe reads of background shell output files. */
   runtimeDataDir?: string
   /** Store used to offload oversized tool results from model context. */


### PR DESCRIPTION
## Problem

Workspace-write rejected every mutation outside the selected workspace, even when the user explicitly approved that one operation. The original implementation fixed that by passing a broad `allowExternalPaths` flag into the tool context, which could let a tool write to a different external path during the same call.

## Root cause

The approval result was represented as a boolean rather than as the exact canonical targets that were shown to the user.

## Scope

This PR keeps the per-operation approval flow and makes the grant path-scoped. It does not change the persisted sandbox mode or grant command execution/network access.

## Changes

- Detect all supported external file-mutation path arguments and normalize them to absolute paths.
- Pass only `approvedExternalPaths` for the approved invocation.
- Allow an external write only when its resolved lexical path exactly matches one of those targets (case-insensitive on Windows).
- Keep workspace boundaries, read-only mode, external-sandbox mode, and symlink checks fail-closed.
- Add regression coverage for sibling-path expansion and the full local tool-host path.

## Safety

- Approval is single-call and is not persisted.
- A parent directory is never approved implicitly.
- Changing a tool argument to another external path requires another approval.
- The global `danger-full-access` mode remains the only mode that intentionally removes the workspace boundary.

## Typecheck

```bash
npm.cmd --prefix kun run typecheck
npm.cmd run typecheck
```

Both passed locally.

## Tests

```bash
npm.cmd --prefix kun test -- src/adapters/tool/sandbox-policy.test.ts src/adapters/tool/local-tool-host.test.ts src/adapters/tool/builtin-tool-utils.test.ts src/adapters/tool/builtin-tool-utils.symlink.test.ts
npm.cmd --prefix kun test -- tests/loop.test.ts tests/skill-tool-provider.test.ts
npm.cmd run lint -- --quiet
npm.cmd run build
```

Results: 4 files / 52 permission tests passed; 2 files / 96 Kun integration tests passed; lint and build passed.

## Issue

Fixes #869
