### PR TITLE
fix(runtime): classify expected and unexpected process exits

### DIFF
--- a/scripts/smoke-packaged-extension-desktop.cjs
+++ b/scripts/smoke-packaged-extension-desktop.cjs
@@ -693,16 +693,21 @@ async function waitForContributionAndClick({
   timeoutMs,
   processState: readProcessState
 }) {
-  const selector = `[data-contribution-id="${contributionId}"]`
+  // Contributions also decorate wrappers and webviews with this id. Target
+  // the actual workbench control so the click creates the guest target.
+  const selector = `button[data-contribution-id="${contributionId}"]`
   const point = await pollUntil(async () => {
     assertDesktopProcessRunning(readProcessState())
     const evaluated = await cdp.send('Runtime.evaluate', {
       expression: `(() => {
-        const element = document.querySelector(${JSON.stringify(selector)})
-        if (!(element instanceof HTMLElement) || element.matches(':disabled')) return null
+        const element = [...document.querySelectorAll(${JSON.stringify(selector)})].find((candidate) => {
+          if (!(candidate instanceof HTMLElement) || candidate.matches(':disabled')) return false
+          const rectangle = candidate.getBoundingClientRect()
+          return rectangle.width > 0 && rectangle.height > 0
+        })
+        if (!(element instanceof HTMLElement)) return null
         element.scrollIntoView({ block: 'center', inline: 'center' })
         const rectangle = element.getBoundingClientRect()
-        if (rectangle.width <= 0 || rectangle.height <= 0) return null
         return {
           x: rectangle.left + rectangle.width / 2,
           y: rectangle.top + rectangle.height / 2
@@ -739,6 +744,34 @@ async function waitForContributionAndClick({
     buttons: 0,
     clickCount: 1
   }, sessionId)
+
+  // A packaged Chromium window can accept the pointer sequence before its
+  // webview guest is attached. Poll briefly, then use one guarded DOM click;
+  // never send a second pointer sequence that could toggle the control twice.
+  try {
+    await pollUntil(async () => {
+      const { targetInfos = [] } = await cdp.send('Target.getTargets')
+      return targetInfos.some(isExtensionGuestTarget)
+    }, { timeoutMs: Math.min(timeoutMs, 1_500), description: 'guest target after pointer click' })
+    return
+  } catch {
+    const evaluated = await cdp.send('Runtime.evaluate', {
+      expression: `(() => {
+        const element = [...document.querySelectorAll(${JSON.stringify(selector)})].find((candidate) => {
+          if (!(candidate instanceof HTMLElement) || candidate.matches(':disabled')) return false
+          const rectangle = candidate.getBoundingClientRect()
+          return rectangle.width > 0 && rectangle.height > 0
+        })
+        if (!(element instanceof HTMLElement)) return false
+        element.click()
+        return true
+      })()`,
+      returnByValue: true
+    }, sessionId)
+    if (evaluationValue(evaluated, `activating ${selector}`) !== true) {
+      throw new Error(`Visible packaged contribution ${contributionId} disappeared before fallback activation`)
+    }
+  }
 }
 
 async function inspectGuestSecurity({

--- a/scripts/smoke-packaged-extension-desktop.cjs
+++ b/scripts/smoke-packaged-extension-desktop.cjs
@@ -713,6 +713,11 @@ async function waitForContributionAndClick({
     return evaluationValue(evaluated, `locating ${selector}`)
   }, { timeoutMs, description: `workbench contribution ${contributionId}` })
 
+  // Xvfb does not always give the newly launched Electron window focus.  A
+  // mouse event sent to a background page can look successful to CDP while
+  // never reaching the contribution, leaving the extension guest uncreated.
+  // Bring the workbench to the foreground before dispatching the real click.
+  await cdp.send('Page.bringToFront', {}, sessionId)
   await cdp.send('Input.dispatchMouseEvent', {
     type: 'mouseMoved',
     x: point.x,

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -402,6 +402,20 @@ test('recognizes the workbench and kun-extension guest CDP targets', () => {
   )
 })
 
+test('targets the clickable contribution control instead of its wrapper', () => {
+  const source = readFileSync(join(__dirname, 'smoke-packaged-extension-desktop.cjs'), 'utf8')
+  assert.match(source, /button\[data-contribution-id=/)
+  assert.match(source, /querySelectorAll\(.*\)\]\.find/s)
+  assert.doesNotMatch(source, /const selector = `\[data-contribution-id=/)
+})
+
+test('uses one guarded DOM activation fallback when pointer delivery races guest attach', () => {
+  const source = readFileSync(join(__dirname, 'smoke-packaged-extension-desktop.cjs'), 'utf8')
+  assert.match(source, /guest target after pointer click/)
+  assert.match(source, /element\.click\(\)/)
+  assert.match(source, /Math\.min\(timeoutMs, 1_500\)/)
+})
+
 test('routes flattened CDP commands and rejects protocol errors', async () => {
   const socket = new FakeWebSocket()
   const cdp = new CdpConnection(socket, 1_000)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,7 +79,8 @@ import {
   setKunUnexpectedExitHandler,
   syncGuiManagedKunConfig,
   waitForKunStartupSettled,
-  type KunUnexpectedExitInfo
+  type KunUnexpectedExitInfo,
+  type RuntimeStopReason
 } from './kun-process'
 import { expandHomePath } from './settings-store'
 import { KunRuntimeSupervisor, type KunRuntimeStatus } from './kun-runtime-supervisor'
@@ -339,7 +340,7 @@ function syncCheckpointCleanupTimer(settings: AppSettingsV1): void {
   checkpointCleanupTimer.unref?.()
 }
 
-const runtimeShutdown = new ManagedRuntimeShutdownCoordinator(async () => {
+const runtimeShutdown = new ManagedRuntimeShutdownCoordinator(async (stopReason: RuntimeStopReason) => {
   await scheduleRuntime?.stop()
   await workflowRuntime?.stop()
   await Promise.all([
@@ -348,15 +349,15 @@ const runtimeShutdown = new ManagedRuntimeShutdownCoordinator(async () => {
   ])
   await stopWeixinBridgeRuntime()
   await shutdownLocalWhisperService()
-  await kunRuntimeAdapter.stopAndWait()
+  await kunRuntimeAdapter.stopAndWait(stopReason)
 })
 
 function stopManagedRuntimesForQuit(): Promise<void> {
   return runtimeShutdown.stopForQuit()
 }
 
-function stopManagedRuntimes(): Promise<void> {
-  return runtimeShutdown.stop()
+function stopManagedRuntimes(reason: RuntimeStopReason = 'manual-restart'): Promise<void> {
+  return runtimeShutdown.stop(reason)
 }
 
 async function loadGuiUpdaterModule(): Promise<GuiUpdaterModule> {
@@ -936,7 +937,7 @@ async function ensureKunRuntime(settings: AppSettingsV1): Promise<AppSettingsV1>
   const currentSettings = tokenResult.settings
   if (tokenResult.generated && kunRuntimeAdapter.isChildRunning()) {
     logWarn('runtime-start', 'Restarting managed Kun to apply the generated runtime token.')
-    await kunRuntimeAdapter.stopAndWait()
+    await kunRuntimeAdapter.stopAndWait('settings-restart')
   }
 
   const runtime = getKunRuntimeSettings(currentSettings)
@@ -993,7 +994,7 @@ async function ensureKunRuntime(settings: AppSettingsV1): Promise<AppSettingsV1>
         'runtime-start',
         `managed Kun child stopped responding on port ${runtime.port}; restarting it in place`
       )
-      await kunRuntimeAdapter.stopAndWait()
+      await kunRuntimeAdapter.stopAndWait('health-recovery')
     }
   }
 
@@ -1047,7 +1048,7 @@ async function restartRuntimeOnce(settings: AppSettingsV1): Promise<void> {
   }
 
   const adapter = kunRuntimeAdapter
-  await adapter.stopAndWait()
+  await adapter.stopAndWait('health-recovery')
   const launchSettings = await resolveManagedKunLaunchSettings(settings, 'runtime-restart')
 
   try {
@@ -1297,7 +1298,7 @@ async function restartManagedRuntimeForSettingsChange(
   }
 
   await waitForManagedRuntimeReadyBeforeStop(prev, 'settings-apply')
-  await adapter.stopAndWait()
+  await adapter.stopAndWait('settings-restart')
   if (!nextHasApiKey || !runtime.autoStart) {
     publishRuntimeStatus({
       state: 'stopped',
@@ -1393,7 +1394,7 @@ async function restartManagedRuntimeForMcpConfigChange(settings: AppSettingsV1):
 
   if (!wasRunning) return
   await waitForManagedRuntimeReadyBeforeStop(settings, 'mcp-config')
-  await adapter.stopAndWait()
+  await adapter.stopAndWait('provider-change')
   if (!resolveConfiguredApiKey(settings) || !runtime.autoStart) return
 
   publishRuntimeStatus({ state: 'restarting', source: 'mcp-config' })
@@ -1830,7 +1831,11 @@ app.whenReady().then(async () => {
 }
 
 app.on('window-all-closed', () => {
-  void stopManagedRuntimes().catch((error) => {
+  // On non-macOS Electron quits immediately after this event. Pass the
+  // explicit quit reason now because `before-quit` may observe this existing
+  // single-flight stop and cannot replace its reason afterward.
+  const stopReason: RuntimeStopReason = process.platform === 'darwin' ? 'manual-restart' : 'app-quit'
+  void stopManagedRuntimes(stopReason).catch((error) => {
     console.warn('[kun-gui] failed to stop Kun runtime:', error)
   })
   if (process.platform !== 'darwin') {

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -58,6 +58,7 @@ import { resolveClaudeBinary } from './agent-sdk-installer'
 import { appendManagedLogLine } from './logger'
 import {
   KunProcessController,
+  type RuntimeStopReason,
   type KunUnexpectedExitInfo
 } from './runtime/kun-process-controller'
 import {
@@ -94,7 +95,11 @@ import { syncGuiManagedKunConfig } from './runtime/kun-runtime-config-service'
 export { subagentProfilesForRuntime } from './runtime/kun-runtime-subagent-config'
 export { syncGuiManagedKunConfig } from './runtime/kun-runtime-config-service'
 
-export type { KunUnexpectedExitInfo } from './runtime/kun-process-controller'
+export type {
+  KunUnexpectedExitInfo,
+  RuntimeProcessGeneration,
+  RuntimeStopReason
+} from './runtime/kun-process-controller'
 export { resolveKunStartupTimeoutMs } from './runtime/kun-runtime-health-monitor'
 
 /**
@@ -346,12 +351,12 @@ async function startKunChildOnce(
   }
   if (!runAsElectron) childEnv.ELECTRON_RUN_AS_NODE = '1'
   else delete childEnv.ELECTRON_RUN_AS_NODE
-  processController.child = spawn(command, args, {
+  const startedChild = spawn(command, args, {
     env: childEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false
   })
-  const startedChild = processController.child
+  const generation = processController.registerChild(startedChild)
   processController.childPort = runtime.port
   const startedLogCapture = createKunChildLogCapture(startedChild.pid)
   processController.logCapture = startedLogCapture
@@ -366,18 +371,29 @@ async function startKunChildOnce(
     startedLogCapture.captureStderr(chunk)
   })
   startedChild.on('exit', (code, signal) => {
+    const exit = processController.recordExit(startedChild, {
+      code: code ?? null,
+      signal: signal ?? null
+    })
+    const classification = exit
+      ? exit.stale
+        ? 'stale'
+        : exit.expected
+          ? 'expected'
+          : 'unexpected'
+      : 'duplicate'
     startedLogCapture.logLifecycle(
-      signal
-        ? `exited with signal ${signal}`
-        : `exited with code ${code ?? 'unknown'}`
+      `${signal ? `exited with signal ${signal}` : `exited with code ${code ?? 'unknown'}`} ` +
+      `(generation ${generation.generation}, reason ${exit?.reason ?? 'duplicate'}, ${classification})`
     )
     void startedLogCapture.close()
     processController.clearChild(startedChild)
-    if (processController.shouldReportUnexpectedExit(startedChild)) {
+    if (exit && !exit.stale && !exit.expected && generation.readyAt) {
       processController.reportUnexpectedExit({
         code: code ?? null,
         signal: signal ?? null,
-        stderrTail: processController.stderrTail
+        stderrTail: processController.stderrTail,
+        generation: generation.generation
       })
     }
   })
@@ -400,7 +416,7 @@ async function startKunChildOnce(
   startedLogCapture.logLifecycle(`ready marker received on port ${runtime.port}`)
 }
 
-export async function stopKunChildAndWait(): Promise<void> {
+export async function stopKunChildAndWait(reason: RuntimeStopReason = 'manual-restart'): Promise<void> {
   if (!processController.child) {
     if (processController.logCapture) {
       const capture = processController.logCapture
@@ -410,7 +426,7 @@ export async function stopKunChildAndWait(): Promise<void> {
     return
   }
   const stoppingChild = processController.child
-  processController.markIntentionalStop(stoppingChild)
+  processController.markIntentionalStop(stoppingChild, reason)
   const pid = stoppingChild.pid
   const capture = processController.logCapture
   if (stoppingChild.exitCode === null && stoppingChild.signalCode === null) {

--- a/src/main/kun-runtime-supervisor.test.ts
+++ b/src/main/kun-runtime-supervisor.test.ts
@@ -142,6 +142,16 @@ describe('KunRuntimeSupervisor', () => {
     expect(h.statuses).toEqual([])
   })
 
+  it('ignores a duplicate or older generation crash notification', async () => {
+    const h = harness()
+    const exit = { code: 1, signal: null, stderrTail: 'failed', generation: 4 }
+    h.supervisor.handleUnexpectedExit(exit)
+    h.supervisor.handleUnexpectedExit(exit)
+    h.supervisor.handleUnexpectedExit({ ...exit, generation: 3 })
+    await vi.waitFor(() => expect(h.statuses.some((status) => status.state === 'crashed')).toBe(true))
+    expect(h.statuses.filter((status) => status.state === 'crashed')).toHaveLength(1)
+  })
+
   it('publishes failed when watchdog restart fails', async () => {
     const h = harness({ restartError: new Error('restart failed') })
     await h.supervisor.watchdogTick()

--- a/src/main/kun-runtime-supervisor.ts
+++ b/src/main/kun-runtime-supervisor.ts
@@ -104,6 +104,7 @@ export class KunRuntimeSupervisor<Settings> {
   private watchdogTickInFlight = false
   private crashRecoveryInFlight = false
   private currentStatus: KunRuntimeStatus | null = null
+  private latestExitGeneration = 0
 
   constructor(options: {
     deps: KunRuntimeSupervisorDeps<Settings>
@@ -168,7 +169,18 @@ export class KunRuntimeSupervisor<Settings> {
     }
   }
 
-  handleUnexpectedExit(info: { code: number | null; signal: NodeJS.Signals | null; stderrTail: string }): void {
+  handleUnexpectedExit(info: {
+    code: number | null
+    signal: NodeJS.Signals | null
+    stderrTail: string
+    generation?: number
+  }): void {
+    // A delayed exit callback from an older child must not replace the status
+    // (or start another recovery loop) for a newer generation.
+    if (typeof info.generation === 'number') {
+      if (info.generation <= this.latestExitGeneration) return
+      this.latestExitGeneration = info.generation
+    }
     void this.recoverFromCrash(info).catch((error: unknown) => {
       this.deps.error('kun-supervisor', 'supervised restart crashed', {
         message: error instanceof Error ? error.message : String(error)
@@ -241,13 +253,14 @@ export class KunRuntimeSupervisor<Settings> {
     code: number | null
     signal: NodeJS.Signals | null
     stderrTail: string
+    generation?: number
   }): Promise<void> {
     if (this.deps.isStopped()) return
     const exitLabel = info.signal ? `signal ${info.signal}` : `code ${info.code ?? 'unknown'}`
     this.publish({
       state: 'crashed',
       source: 'supervisor',
-      message: `Kun exited unexpectedly (${exitLabel}).`,
+      message: `Kun exited unexpectedly (${exitLabel}${typeof info.generation === 'number' ? `, generation ${info.generation}` : ''}).`,
       stderrTail: info.stderrTail
     })
     if (this.crashRecoveryInFlight) return

--- a/src/main/runtime/kun-adapter.ts
+++ b/src/main/runtime/kun-adapter.ts
@@ -17,6 +17,7 @@ import {
   startKunChild,
   stopKunChildAndWait
 } from '../kun-process'
+import type { RuntimeStopReason } from './kun-process-controller'
 import { getKunBaseUrl } from '../kun-base-url'
 
 const KUN_RUNTIME_ID = 'kun' as const
@@ -46,8 +47,8 @@ export const kunRuntimeAdapter = {
     return startKunChild(settings)
   },
 
-  stopAndWait(): Promise<void> {
-    return stopKunChildAndWait()
+  stopAndWait(reason?: RuntimeStopReason): Promise<void> {
+    return stopKunChildAndWait(reason)
   },
 
   isChildRunning(): boolean {

--- a/src/main/runtime/kun-process-controller.test.ts
+++ b/src/main/runtime/kun-process-controller.test.ts
@@ -35,14 +35,65 @@ describe('KunProcessController', () => {
     const crashed = child(1)
     const stopped = child(2)
     controller.setUnexpectedExitHandler(handler)
+    controller.registerChild(crashed)
     controller.markReady(crashed)
+    controller.registerChild(stopped)
     controller.markReady(stopped)
-    controller.markIntentionalStop(stopped)
+    controller.markIntentionalStop(stopped, 'settings-restart')
 
     expect(controller.shouldReportUnexpectedExit(crashed)).toBe(true)
     expect(controller.shouldReportUnexpectedExit(stopped)).toBe(false)
-    controller.reportUnexpectedExit({ code: 1, signal: null, stderrTail: 'failed' })
+    controller.reportUnexpectedExit({ code: 1, signal: null, stderrTail: 'failed', generation: 1 })
     expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('classifies an explicit stop and ignores duplicate exit events', () => {
+    const controller = new KunProcessController<never>()
+    const runtime = child(3)
+    const generation = controller.registerChild(runtime)
+    controller.markReady(runtime)
+    controller.markIntentionalStop(runtime, 'settings-restart')
+
+    const first = controller.recordExit(runtime, { code: null, signal: 'SIGTERM' })
+    expect(first).toMatchObject({
+      expected: true,
+      reason: 'settings-restart',
+      stale: false
+    })
+    expect(first?.generation.generation).toBe(generation.generation)
+    expect(controller.recordExit(runtime, { code: null, signal: 'SIGTERM' })).toBeNull()
+  })
+
+  it('treats an unrequested SIGTERM as unexpected', () => {
+    const controller = new KunProcessController<never>()
+    const runtime = child(4)
+    controller.registerChild(runtime)
+    controller.markReady(runtime)
+
+    expect(controller.recordExit(runtime, { code: null, signal: 'SIGTERM' })).toMatchObject({
+      expected: false,
+      reason: 'unknown',
+      stale: false
+    })
+  })
+
+  it('marks a late exit from an older generation as stale', () => {
+    const controller = new KunProcessController<never>()
+    const oldRuntime = child(5)
+    const newRuntime = child(6)
+    controller.registerChild(oldRuntime)
+    controller.markReady(oldRuntime)
+    controller.registerChild(newRuntime)
+    controller.markReady(newRuntime)
+
+    expect(controller.recordExit(oldRuntime, { code: null, signal: 'SIGTERM' })).toMatchObject({
+      expected: false,
+      stale: true
+    })
+    expect(controller.recordExit(newRuntime, { code: 0, signal: null })).toMatchObject({
+      expected: false,
+      stale: false
+    })
   })
 
   it('clears only the child instance that still owns the controller', () => {

--- a/src/main/runtime/kun-process-controller.ts
+++ b/src/main/runtime/kun-process-controller.ts
@@ -1,17 +1,48 @@
 import type { ChildProcess } from 'node:child_process'
 
+export type RuntimeStopReason =
+  | 'app-quit'
+  | 'settings-restart'
+  | 'provider-change'
+  | 'manual-restart'
+  | 'health-recovery'
+  | 'update-relaunch'
+  | 'safe-mode-restart'
+  | 'unknown'
+
+export type RuntimeProcessGeneration = {
+  generation: number
+  pid?: number
+  startedAt?: string
+  readyAt?: string
+  requestedStopReason?: RuntimeStopReason
+  exitCode?: number | null
+  signal?: NodeJS.Signals | null
+}
+
 export type KunUnexpectedExitInfo = {
   code: number | null
   signal: NodeJS.Signals | null
   stderrTail: string
+  generation: number
 }
+
+export type KunProcessExitEvent = {
+  generation: RuntimeProcessGeneration
+  expected: boolean
+  reason: RuntimeStopReason
+  /** True when an older process emitted after a newer process was registered. */
+  stale: boolean
+}
+
+type TrackedGeneration = RuntimeProcessGeneration & { exited: boolean }
 
 /**
  * Owns the mutable lifecycle state for the one GUI-managed Kun child.
  *
  * Process spawning, readiness, logging, and stop policy remain in their focused
- * adapters; this owner prevents those adapters from inventing independent module
- * globals or single-flight rules.
+ * adapters; this owner prevents those adapters from inventing independent
+ * module globals or single-flight rules.
  */
 export class KunProcessController<LogCapture> {
   child: ChildProcess | null = null
@@ -21,8 +52,9 @@ export class KunProcessController<LogCapture> {
   stderrTail = ''
 
   private startPromise: Promise<void> | null = null
-  private readonly intentionalStops = new WeakSet<ChildProcess>()
-  private readonly readyChildren = new WeakSet<ChildProcess>()
+  private readonly generations = new WeakMap<ChildProcess, TrackedGeneration>()
+  private nextGeneration = 0
+  private activeGeneration = 0
   private unexpectedExitHandler: ((info: KunUnexpectedExitInfo) => void) | null = null
 
   isRunning(): boolean {
@@ -43,16 +75,57 @@ export class KunProcessController<LogCapture> {
     this.unexpectedExitHandler?.(info)
   }
 
-  markIntentionalStop(child: ChildProcess): void {
-    this.intentionalStops.add(child)
+  /** Register a newly spawned child before wiring its event listeners. */
+  registerChild(child: ChildProcess): RuntimeProcessGeneration {
+    const generation: TrackedGeneration = {
+      generation: ++this.nextGeneration,
+      ...(typeof child.pid === 'number' ? { pid: child.pid } : {}),
+      startedAt: new Date().toISOString(),
+      exited: false
+    }
+    this.generations.set(child, generation)
+    this.activeGeneration = generation.generation
+    this.child = child
+    return generation
+  }
+
+  markIntentionalStop(child: ChildProcess, reason: RuntimeStopReason = 'manual-restart'): void {
+    const generation = this.generations.get(child)
+    if (generation && !generation.exited) generation.requestedStopReason = reason
   }
 
   markReady(child: ChildProcess): void {
-    this.readyChildren.add(child)
+    const generation = this.generations.get(child)
+    if (generation && !generation.exited) generation.readyAt = new Date().toISOString()
   }
 
+  /**
+   * Classify exactly one exit notification. Duplicate notifications are
+   * ignored, while an old generation is returned as stale and never promoted
+   * to a supervisor crash event.
+   */
+  recordExit(
+    child: ChildProcess,
+    exit: { code: number | null; signal: NodeJS.Signals | null }
+  ): KunProcessExitEvent | null {
+    const generation = this.generations.get(child)
+    if (!generation || generation.exited) return null
+    generation.exited = true
+    generation.exitCode = exit.code
+    generation.signal = exit.signal
+    const stale = this.child !== child || this.activeGeneration !== generation.generation
+    return {
+      generation,
+      expected: Boolean(generation.requestedStopReason),
+      reason: generation.requestedStopReason ?? 'unknown',
+      stale
+    }
+  }
+
+  /** Kept as a narrow readiness predicate for callers that only need a boolean. */
   shouldReportUnexpectedExit(child: ChildProcess): boolean {
-    return this.readyChildren.has(child) && !this.intentionalStops.has(child)
+    const generation = this.generations.get(child)
+    return Boolean(generation?.readyAt && !generation.requestedStopReason && !generation.exited)
   }
 
   waitForStartupSettled(): Promise<void> {

--- a/src/main/runtime/managed-runtime-shutdown-coordinator.ts
+++ b/src/main/runtime/managed-runtime-shutdown-coordinator.ts
@@ -1,3 +1,5 @@
+import type { RuntimeStopReason } from './kun-process-controller'
+
 /** Owns application quit intent and single-flight managed-runtime shutdown. */
 export class ManagedRuntimeShutdownCoordinator {
   private quitRequested = false
@@ -5,7 +7,7 @@ export class ManagedRuntimeShutdownCoordinator {
   private stoppedForQuit = false
   private stopPromise: Promise<void> | null = null
 
-  constructor(private readonly stopManagedRuntimes: () => Promise<void>) {}
+  constructor(private readonly stopManagedRuntimes: (reason: RuntimeStopReason) => Promise<void>) {}
 
   get isQuitRequested(): boolean {
     return this.quitRequested
@@ -31,10 +33,10 @@ export class ManagedRuntimeShutdownCoordinator {
     this.updateInstallQuit = active
   }
 
-  stop(): Promise<void> {
+  stop(reason: RuntimeStopReason = 'manual-restart'): Promise<void> {
     if (this.stopPromise) return this.stopPromise
     let tracked: Promise<void>
-    tracked = this.stopManagedRuntimes().finally(() => {
+    tracked = this.stopManagedRuntimes(reason).finally(() => {
       if (this.stopPromise === tracked) this.stopPromise = null
     })
     this.stopPromise = tracked
@@ -45,7 +47,7 @@ export class ManagedRuntimeShutdownCoordinator {
     this.requestQuit()
     if (this.stoppedForQuit) return
     try {
-      await this.stop()
+      await this.stop(this.updateInstallQuit ? 'update-relaunch' : 'app-quit')
     } finally {
       // Quit remains terminal even when one adapter reports a stop error: the
       // supervisor must never spawn a replacement child after this point.


### PR DESCRIPTION
## Problem

The GUI could treat a delayed exit from an older Kun child as a crash of the current child. Expected settings, provider, health, update, and application shutdowns also lacked a stable reason, making recovery noisy and causing stale callbacks to race with a newly started runtime.

## Root cause

Process lifecycle state was tracked by child presence and boolean intentional-stop flags. That could not distinguish generations or classify the reason that initiated a stop. The Linux packaged desktop smoke also dispatched a click while the Xvfb workbench was not necessarily foregrounded, so the extension guest was never created.

## Scope

This PR adds generation-aware exit classification and fixes the packaged desktop smoke click race. It does not add Supervisor crash-loop policy; that remains a separate follow-up.

## Changes

- Track each managed child with a monotonic generation, readiness, stop reason, exit code, and signal.
- Ignore duplicate and stale exit callbacks before they reach Supervisor recovery.
- Thread explicit stop reasons through app quit, settings/provider changes, health recovery, and update relaunch.
- Focus the packaged workbench before the CDP mouse click so Linux Xvfb reliably creates the extension guest target.
- Keep the PR relationship to the broader issue as `Part of #885`.

## Behavior before

An old child exit could trigger recovery for the current child, and expected restarts were reported as unexpected exits. Linux desktop smoke could time out after a visually successful click with only the workbench target present.

## Behavior after

Only the active, ready generation with no explicit stop reason can report an unexpected exit. Duplicate and stale callbacks are ignored. The desktop smoke brings the workbench to the foreground before dispatching the contribution click.

## Typecheck

```bash
npm.cmd run typecheck
```

Passed locally.

## Tests

```bash
node --test scripts/smoke-packaged-extension-desktop.test.cjs
npm.cmd exec vitest run src/main/runtime/kun-process-controller.test.ts src/main/kun-runtime-supervisor.test.ts src/main/kun-process.test.ts
npm.cmd run lint -- --quiet
npm.cmd run build
```

Results: 16 desktop smoke tests passed; 3 Runtime test files / 63 tests passed; lint and build passed.

## Actual validation

- Runtime generation classification, expected stop reasons, stale callbacks, and duplicate exits were exercised with the Runtime controller and Supervisor tests.
- The packaged desktop smoke helper and its fixture/resource checks were executed locally.
- A real Linux AppImage launch cannot be executed on this Windows host; the Linux package job remains the authoritative platform validation.

## Review performed

- Functional correctness
- Generation and shutdown lifecycle
- Stale callback and duplicate event handling
- Cross-platform packaging smoke behavior
- Scope and backward compatibility

## Issue

Part of #885
