### PR TITLE
feat(runtime): add pure crash-loop breaker policy

### DIFF
--- a/src/main/runtime/crash-loop-breaker.test.ts
+++ b/src/main/runtime/crash-loop-breaker.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createCrashLoopState,
+  DEFAULT_CRASH_LOOP_POLICY,
+  reduceCrashLoop,
+  type CrashLoopPolicy,
+  type CrashLoopState
+} from './crash-loop-breaker'
+
+const policy: CrashLoopPolicy = {
+  ...DEFAULT_CRASH_LOOP_POLICY,
+  windowMs: 5 * 60 * 1_000,
+  maxUnexpectedCrashes: 3,
+  stableRuntimeMs: 2 * 60 * 1_000
+}
+
+function unexpected(state: CrashLoopState, at: number): CrashLoopState {
+  return reduceCrashLoop(
+    state,
+    { type: 'runtime-exit', record: { at, classification: 'unexpected' } },
+    policy
+  )
+}
+
+describe('crash-loop breaker', () => {
+  it('trips on the third unexpected exit in the five-minute window', () => {
+    let state = createCrashLoopState()
+    state = unexpected(state, 0)
+    state = unexpected(state, 60_000)
+    expect(state.tripped).toBe(false)
+
+    state = unexpected(state, 120_000)
+    expect(state.tripped).toBe(true)
+    expect(state.unexpectedExits).toHaveLength(3)
+  })
+
+  it('does not count expected exits toward the threshold', () => {
+    let state = createCrashLoopState()
+    state = reduceCrashLoop(
+      state,
+      { type: 'runtime-exit', record: { at: 0, classification: 'expected' } },
+      policy
+    )
+    state = reduceCrashLoop(
+      state,
+      { type: 'runtime-exit', record: { at: 60_000, classification: 'expected' } },
+      policy
+    )
+    state = reduceCrashLoop(
+      state,
+      { type: 'runtime-exit', record: { at: 120_000, classification: 'expected' } },
+      policy
+    )
+
+    expect(state.tripped).toBe(false)
+    expect(state.unexpectedExits).toHaveLength(0)
+    expect(state.lastExit?.classification).toBe('expected')
+  })
+
+  it('clears a tripped state after the runtime remains ready for two minutes', () => {
+    let state = unexpected(createCrashLoopState(), 0)
+    state = unexpected(state, 1_000)
+    state = unexpected(state, 2_000)
+    expect(state.tripped).toBe(true)
+
+    state = reduceCrashLoop(state, { type: 'runtime-ready', at: 10_000 }, policy)
+    state = reduceCrashLoop(state, { type: 'runtime-stable', at: 129_999 }, policy)
+    expect(state.tripped).toBe(true)
+    expect(state.unexpectedExits).toHaveLength(3)
+
+    state = reduceCrashLoop(state, { type: 'runtime-stable', at: 130_000 }, policy)
+    expect(state).toEqual(createCrashLoopState())
+  })
+
+  it('does not count exits outside the sliding window', () => {
+    let state = unexpected(createCrashLoopState(), 0)
+    state = unexpected(state, 60_000)
+    state = unexpected(state, policy.windowMs + 1)
+
+    expect(state.tripped).toBe(false)
+    expect(state.unexpectedExits.map((record) => record.at)).toEqual([60_000, policy.windowMs + 1])
+  })
+
+  it('keeps reducer calls immutable and ignores stable before ready', () => {
+    const initial = createCrashLoopState()
+    const after = reduceCrashLoop(initial, { type: 'runtime-stable', at: 10_000 }, policy)
+
+    expect(after).toEqual(initial)
+    expect(after).not.toBe(initial)
+  })
+
+  it('does not clear history when the clock moves backwards', () => {
+    let state = unexpected(createCrashLoopState(), 10_000)
+    state = reduceCrashLoop(state, { type: 'runtime-ready', at: 20_000 }, policy)
+    state = reduceCrashLoop(state, { type: 'runtime-stable', at: 19_999 }, policy)
+
+    expect(state.unexpectedExits).toHaveLength(1)
+    expect(state.stableSince).toBe(20_000)
+  })
+
+  it('normalizes invalid policy values to safe defaults', () => {
+    let state = createCrashLoopState()
+    const invalid = { windowMs: Number.NaN, maxUnexpectedCrashes: 0, stableRuntimeMs: -1 }
+    state = reduceCrashLoop(
+      state,
+      { type: 'runtime-exit', record: { at: 0, classification: 'unexpected' } },
+      invalid
+    )
+    state = reduceCrashLoop(
+      state,
+      { type: 'runtime-exit', record: { at: 1, classification: 'unexpected' } },
+      invalid
+    )
+    state = reduceCrashLoop(
+      state,
+      { type: 'runtime-exit', record: { at: 2, classification: 'unexpected' } },
+      invalid
+    )
+
+    expect(state.tripped).toBe(true)
+  })
+})

--- a/src/main/runtime/crash-loop-breaker.test.ts
+++ b/src/main/runtime/crash-loop-breaker.test.ts
@@ -72,6 +72,19 @@ describe('crash-loop breaker', () => {
     expect(state).toEqual(createCrashLoopState())
   })
 
+  it('does not reset the stable window on repeated readiness probes', () => {
+    let state = unexpected(createCrashLoopState(), 0)
+    state = unexpected(state, 1_000)
+    state = unexpected(state, 2_000)
+
+    state = reduceCrashLoop(state, { type: 'runtime-ready', at: 10_000 }, policy)
+    state = reduceCrashLoop(state, { type: 'runtime-ready', at: 60_000 }, policy)
+    expect(state.stableSince).toBe(10_000)
+
+    state = reduceCrashLoop(state, { type: 'runtime-stable', at: 130_000 }, policy)
+    expect(state).toEqual(createCrashLoopState())
+  })
+
   it('does not count exits outside the sliding window', () => {
     let state = unexpected(createCrashLoopState(), 0)
     state = unexpected(state, 60_000)

--- a/src/main/runtime/crash-loop-breaker.ts
+++ b/src/main/runtime/crash-loop-breaker.ts
@@ -97,7 +97,10 @@ export function reduceCrashLoop(
     case 'runtime-ready':
       return {
         ...withTripState(next, normalizedPolicy),
-        stableSince: now
+        // Readiness is normally reported by every health probe. Preserve the
+        // first ready timestamp so repeated probes cannot postpone the stable
+        // window indefinitely.
+        stableSince: next.stableSince ?? now
       }
 
     case 'runtime-stable': {

--- a/src/main/runtime/crash-loop-breaker.ts
+++ b/src/main/runtime/crash-loop-breaker.ts
@@ -1,0 +1,183 @@
+/**
+ * Pure crash-loop policy for the GUI-managed runtime.
+ *
+ * The process supervisor owns process lifecycle and exit classification. It
+ * can feed the resulting expected/unexpected observations into this reducer
+ * without coupling the policy to Electron, timers, or logging. That keeps the
+ * policy reusable when the supervisor's exit contract evolves.
+ */
+
+export const DEFAULT_CRASH_LOOP_POLICY = {
+  /** Keep only unexpected exits observed in the last five minutes. */
+  windowMs: 5 * 60 * 1_000,
+  /** Trip after three unexpected exits in the active window. */
+  maxUnexpectedCrashes: 3,
+  /** A runtime must stay ready for two minutes before clearing history. */
+  stableRuntimeMs: 2 * 60 * 1_000
+} as const
+
+export type CrashLoopPolicy = {
+  windowMs: number
+  maxUnexpectedCrashes: number
+  stableRuntimeMs: number
+}
+
+export type CrashExitClassification = 'expected' | 'unexpected'
+
+/**
+ * Exit observations are deliberately classified before reaching this module.
+ * Runtime exit reasons and process metadata belong to the supervisor's
+ * contract (for example #889); this policy only needs the safe disposition.
+ */
+export type CrashExitRecord = {
+  at: number
+  classification: CrashExitClassification
+}
+
+export type CrashLoopEvent =
+  | { type: 'runtime-exit'; record: CrashExitRecord }
+  | { type: 'runtime-ready'; at: number }
+  | { type: 'runtime-stable'; at: number }
+
+export type CrashLoopState = {
+  /** Recent unexpected exits, retained for diagnostics and threshold checks. */
+  unexpectedExits: readonly CrashExitRecord[]
+  /** The most recent classified exit, including expected exits. */
+  lastExit: CrashExitRecord | null
+  /** Start of the current ready period, or null while the runtime is stopped. */
+  stableSince: number | null
+  /** True while the unexpected-exit threshold is reached in the active window. */
+  tripped: boolean
+}
+
+export function createCrashLoopState(): CrashLoopState {
+  return {
+    unexpectedExits: [],
+    lastExit: null,
+    stableSince: null,
+    tripped: false
+  }
+}
+
+/**
+ * Apply one observation without side effects.
+ *
+ * `runtime-ready` starts the stable-runtime timer. A caller should dispatch
+ * `runtime-stable` from its health/readiness path; the reducer then clears
+ * crash history only after `stableRuntimeMs` has elapsed. This avoids clearing
+ * a crash loop merely because a process briefly bound its port.
+ */
+export function reduceCrashLoop(
+  state: CrashLoopState,
+  event: CrashLoopEvent,
+  policy: CrashLoopPolicy = DEFAULT_CRASH_LOOP_POLICY
+): CrashLoopState {
+  const normalizedPolicy = normalizePolicy(policy)
+  const at = event.type === 'runtime-exit' ? event.record.at : event.at
+  const now = finiteTimestamp(at)
+  let next = pruneState(state, now, normalizedPolicy)
+
+  switch (event.type) {
+    case 'runtime-exit': {
+      const record = normalizeRecord(event.record, now)
+      next = {
+        ...next,
+        lastExit: record,
+        // An expected stop is not a stable runtime period. Keep existing
+        // history so an expected settings restart cannot hide prior crashes.
+        stableSince: null,
+        unexpectedExits:
+          record.classification === 'unexpected'
+            ? [...next.unexpectedExits, record]
+            : next.unexpectedExits
+      }
+      return withTripState(next, normalizedPolicy)
+    }
+
+    case 'runtime-ready':
+      return {
+        ...withTripState(next, normalizedPolicy),
+        stableSince: now
+      }
+
+    case 'runtime-stable': {
+      // Stable events before readiness (or with a backwards clock) must not
+      // clear crash history.
+      if (
+        next.stableSince === null ||
+        now < next.stableSince ||
+        now - next.stableSince < normalizedPolicy.stableRuntimeMs
+      ) {
+        return withTripState(next, normalizedPolicy)
+      }
+      return createCrashLoopState()
+    }
+  }
+}
+
+function normalizeRecord(record: CrashExitRecord, fallbackAt: number): CrashExitRecord {
+  return {
+    at: finiteTimestamp(record.at, fallbackAt),
+    classification: record.classification === 'unexpected' ? 'unexpected' : 'expected'
+  }
+}
+
+function normalizePolicy(policy: CrashLoopPolicy): Required<CrashLoopPolicy> {
+  return {
+    windowMs: positiveFinite(policy.windowMs, DEFAULT_CRASH_LOOP_POLICY.windowMs),
+    maxUnexpectedCrashes: positiveInteger(
+      policy.maxUnexpectedCrashes,
+      DEFAULT_CRASH_LOOP_POLICY.maxUnexpectedCrashes
+    ),
+    stableRuntimeMs: nonNegativeFinite(
+      policy.stableRuntimeMs,
+      DEFAULT_CRASH_LOOP_POLICY.stableRuntimeMs
+    )
+  }
+}
+
+function pruneState(
+  state: CrashLoopState,
+  now: number,
+  policy: Required<CrashLoopPolicy>
+): CrashLoopState {
+  const unexpectedExits = state.unexpectedExits.filter((record) => {
+    const age = now - record.at
+    // Keep future-dated records when clocks move backwards. Dropping them
+    // would silently erase crash history; the next monotonic observation will
+    // prune them once they are genuinely outside the window.
+    return age < policy.windowMs
+  })
+  return {
+    unexpectedExits,
+    lastExit: state.lastExit,
+    stableSince: state.stableSince,
+    tripped: state.tripped
+  }
+}
+
+function withTripState(
+  state: CrashLoopState,
+  policy: Required<CrashLoopPolicy>
+): CrashLoopState {
+  return {
+    ...state,
+    tripped: state.unexpectedExits.length >= policy.maxUnexpectedCrashes
+  }
+}
+
+function finiteTimestamp(value: number, fallback = 0): number {
+  return Number.isFinite(value) ? value : fallback
+}
+
+function positiveFinite(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function nonNegativeFinite(value: number, fallback: number): number {
+  return Number.isFinite(value) && value >= 0 ? value : fallback
+}
+
+function positiveInteger(value: number, fallback: number): number {
+  return Number.isFinite(value) && value >= 1 ? Math.floor(value) : fallback
+}


### PR DESCRIPTION
## Summary

- Add a side-effect-free crash-loop reducer that can be reused by the runtime supervisor.
- Count only classified unexpected exits in the default five-minute window.
- Trip at three unexpected exits and clear history after two minutes of confirmed stability.
- Retain expected-exit records for diagnostics without counting them toward the breaker.
- Preserve the first `runtime-ready` timestamp across repeated health probes so the stable window cannot be postponed indefinitely.

## Scope

This PR intentionally does not change process exit classification, supervisor restart behavior, UI, or timers. It provides the isolated policy contract for the runtime-exit classification work in #889 to consume without duplicating lifecycle logic. Supervisor integration remains a separate follow-up.

## Tests

```bash
npm.cmd exec vitest run src/main/runtime/crash-loop-breaker.test.ts
git diff --check
```

Results: 8 policy tests passed. The original PR CI also passed root/Kun checks and Linux, macOS, and Windows package validation. A local root typecheck rerun in this legacy worktree is blocked by a broken dependency junction missing `node_modules/@kun/extension-api`; no production code or package files are changed by that environment issue.

## Review

- Pure reducer with no Electron/runtime side effects.
- Expected exits never count toward the threshold.
- Duplicate readiness probes do not reset the stability timer.
- Backward timestamps and invalid policy values are handled conservatively.

## Issue

Part of #885
