### PR TITLE
fix(runtime): preserve the workbench across reconnects

### DIFF
--- a/src/main/kun-runtime-supervisor.test.ts
+++ b/src/main/kun-runtime-supervisor.test.ts
@@ -129,9 +129,9 @@ describe('KunRuntimeSupervisor', () => {
   it('restarts after the configured consecutive watchdog failures', async () => {
     const h = harness()
     await h.supervisor.watchdogTick()
-    expect(h.statuses).toEqual([])
+    expect(h.statuses.map((status) => status.state)).toEqual(['degraded'])
     await h.supervisor.watchdogTick()
-    expect(h.statuses.map((status) => status.state)).toEqual(['restarting', 'running'])
+    expect(h.statuses.map((status) => status.state)).toEqual(['degraded', 'restarting', 'running'])
   })
 
   it('does not recover or restart after shutdown begins', async () => {
@@ -145,6 +145,8 @@ describe('KunRuntimeSupervisor', () => {
   it('publishes failed when watchdog restart fails', async () => {
     const h = harness({ restartError: new Error('restart failed') })
     await h.supervisor.watchdogTick()
+    await h.supervisor.watchdogTick()
+    expect(h.statuses.at(-1)).toMatchObject({ state: 'failed', source: 'watchdog' })
     await h.supervisor.watchdogTick()
     expect(h.statuses.at(-1)).toMatchObject({ state: 'failed', source: 'watchdog' })
   })

--- a/src/main/kun-runtime-supervisor.ts
+++ b/src/main/kun-runtime-supervisor.ts
@@ -200,6 +200,10 @@ export class KunRuntimeSupervisor<Settings> {
   async watchdogTick(): Promise<void> {
     if (this.watchdogTickInFlight || this.deps.isStopped()) return
     if (this.crashRecoveryInFlight || this.operations.hasPendingOperation()) return
+    // A failed/stopped status is a deliberate terminal state until the user
+    // asks for a reconnect. Do not let later watchdog ticks downgrade it back
+    // to degraded and silently re-enter automatic recovery.
+    if (this.currentStatus?.state === 'failed' || this.currentStatus?.state === 'stopped') return
     if (!this.deps.isChildRunning()) return
     this.watchdogTickInFlight = true
     try {
@@ -213,7 +217,20 @@ export class KunRuntimeSupervisor<Settings> {
         'kun-watchdog',
         `health probe failed (${this.watchdogFailures}/${this.watchdogFailureThreshold})`
       )
-      if (this.watchdogFailures < this.watchdogFailureThreshold) return
+      if (this.watchdogFailures < this.watchdogFailureThreshold) {
+        // Keep the renderer informed while the runtime is still alive but no
+        // longer healthy. This is deliberately separate from crash recovery:
+        // a transient probe failure must not be treated as a process crash or
+        // consume the restart budget.
+        if (this.currentStatus?.state !== 'degraded') {
+          this.publish({
+            state: 'degraded',
+            source: 'watchdog',
+            message: 'Kun is responding slowly; waiting for the runtime to recover.'
+          })
+        }
+        return
+      }
       this.watchdogFailures = 0
       this.publish({
         state: 'restarting',

--- a/src/renderer/src/components/RuntimeStatusBanner.test.ts
+++ b/src/renderer/src/components/RuntimeStatusBanner.test.ts
@@ -6,17 +6,22 @@ import type { KunRuntimeStatusPayload } from '@shared/kun-gui-api'
 import { RuntimeStatusBanner } from './RuntimeStatusBanner'
 
 const storeState = vi.hoisted(() => ({
-  runtimeStatus: null as KunRuntimeStatusPayload | null
+  runtimeStatus: null as KunRuntimeStatusPayload | null,
+  probeRuntime: vi.fn(async () => undefined)
 }))
 
 vi.mock('../store/chat-store', () => ({
-  useChatStore: (selector: (state: { runtimeStatus: KunRuntimeStatusPayload | null }) => unknown) =>
+  useChatStore: (selector: (state: {
+    runtimeStatus: KunRuntimeStatusPayload | null
+    probeRuntime: typeof storeState.probeRuntime
+  }) => unknown) =>
     selector(storeState)
 }))
 
 describe('RuntimeStatusBanner', () => {
   afterEach(() => {
     storeState.runtimeStatus = null
+    storeState.probeRuntime.mockClear()
   })
 
   it('renders automatic restarts as an informational status banner', () => {
@@ -49,5 +54,33 @@ describe('RuntimeStatusBanner', () => {
     expect(html).toContain('data-variant="warning"')
     expect(html).toContain('role="alert"')
     expect(html).toContain('border-amber-200')
+  })
+
+  it('keeps the workbench mounted while the runtime is degraded', () => {
+    storeState.runtimeStatus = {
+      state: 'degraded',
+      source: 'watchdog',
+      at: '2026-06-18T15:02:00.000Z'
+    }
+
+    const html = renderToStaticMarkup(createElement(RuntimeStatusBanner))
+
+    expect(html).toContain('data-variant="warning"')
+    expect(html).toContain('runtimeStatusDegraded')
+    expect(html).not.toContain('retryConnection')
+  })
+
+  it('offers an explicit reconnect action for an offline runtime', async () => {
+    storeState.runtimeStatus = {
+      state: 'offline',
+      source: 'health-check',
+      at: '2026-06-18T15:03:00.000Z'
+    }
+
+    const html = renderToStaticMarkup(createElement(RuntimeStatusBanner))
+
+    expect(html).toContain('runtimeStatusOffline')
+    expect(html).toContain('aria-label="retryConnection"')
+    expect(html).toContain('role="alert"')
   })
 })

--- a/src/renderer/src/components/RuntimeStatusBanner.tsx
+++ b/src/renderer/src/components/RuntimeStatusBanner.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AlertTriangle, Loader2, X } from 'lucide-react'
+import { AlertTriangle, Loader2, RefreshCw, WifiOff, X } from 'lucide-react'
 import { useChatStore } from '../store/chat-store'
 
 /**
@@ -13,44 +13,71 @@ import { useChatStore } from '../store/chat-store'
 export function RuntimeStatusBanner(): ReactElement | null {
   const { t } = useTranslation('common')
   const status = useChatStore((s) => s.runtimeStatus)
+  const probeRuntime = useChatStore((s) => s.probeRuntime)
   const [dismissedAt, setDismissedAt] = useState<string | null>(null)
+  const [retrying, setRetrying] = useState(false)
   if (!status) return null
   const recoveredWithRollback = status.state === 'running' && status.rolledBack === true
   const transient = status.state === 'restarting' || status.state === 'crashed'
-  if (!transient && !recoveredWithRollback) return null
+  const degraded = status.state === 'degraded'
+  const disconnected = status.state === 'offline' || status.state === 'failed' || status.state === 'stopped'
+  if (!transient && !degraded && !disconnected && !recoveredWithRollback) return null
   if (dismissedAt === status.at) return null
   const label = recoveredWithRollback
     ? t('runtimeStatusRolledBack')
-    : status.state === 'restarting'
+    : status.state === 'degraded'
+      ? t('runtimeStatusDegraded')
+      : status.state === 'restarting'
       ? typeof status.attempt === 'number'
         ? t('runtimeStatusRestartingAttempt', {
             attempt: status.attempt,
             max: status.maxAttempts ?? 3
           })
         : t('runtimeStatusRestarting')
-      : t('runtimeStatusCrashed')
-  const tone = recoveredWithRollback ? 'warning' : 'info'
+      : status.state === 'crashed'
+        ? t('runtimeStatusCrashed')
+        : status.state === 'offline'
+          ? t('runtimeStatusOffline')
+          : t('runtimeStatusFailed')
+  const tone = recoveredWithRollback || disconnected || status.state === 'degraded' ? 'warning' : 'info'
   const bannerClass = recoveredWithRollback
     ? 'border-amber-200/70 bg-[rgba(255,248,235,0.82)] dark:border-amber-800/50 dark:bg-amber-950/35'
-    : 'border-sky-200/70 bg-[rgba(239,248,255,0.82)] dark:border-sky-900/60 dark:bg-sky-950/30'
+    : disconnected || status.state === 'degraded'
+      ? 'border-amber-200/70 bg-[rgba(255,248,235,0.82)] dark:border-amber-800/50 dark:bg-amber-950/35'
+      : 'border-sky-200/70 bg-[rgba(239,248,255,0.82)] dark:border-sky-900/60 dark:bg-sky-950/30'
   const iconClass = recoveredWithRollback
     ? 'text-amber-700 dark:text-amber-300'
-    : 'text-sky-700 dark:text-sky-300'
+    : disconnected || status.state === 'degraded'
+      ? 'text-amber-700 dark:text-amber-300'
+      : 'text-sky-700 dark:text-sky-300'
   const textClass = recoveredWithRollback
     ? 'text-amber-950 dark:text-amber-100'
-    : 'text-sky-950 dark:text-sky-100'
+    : disconnected || status.state === 'degraded'
+      ? 'text-amber-950 dark:text-amber-100'
+      : 'text-sky-950 dark:text-sky-100'
+  const retry = async (): Promise<void> => {
+    if (retrying) return
+    setRetrying(true)
+    try {
+      await probeRuntime('user', { restart: true })
+    } finally {
+      setRetrying(false)
+    }
+  }
   return (
     <div
       className={`ds-no-drag shrink-0 border-b backdrop-blur-lg ${bannerClass}`}
       data-variant={tone}
-      role={recoveredWithRollback ? 'alert' : 'status'}
+      role={recoveredWithRollback || disconnected ? 'alert' : 'status'}
     >
       <div className="flex w-full min-w-0 items-center gap-2 px-4 py-1.5">
-        {recoveredWithRollback ? (
+        {recoveredWithRollback || degraded ? (
           <AlertTriangle className={`h-3.5 w-3.5 shrink-0 ${iconClass}`} strokeWidth={2} />
+        ) : disconnected ? (
+          <WifiOff className={`h-3.5 w-3.5 shrink-0 ${iconClass}`} strokeWidth={2} />
         ) : (
           <Loader2
-            className={`h-3.5 w-3.5 shrink-0 animate-spin ${iconClass}`}
+            className={`h-3.5 w-3.5 shrink-0 ${transient ? 'animate-spin' : ''} ${iconClass}`}
             strokeWidth={2}
           />
         )}
@@ -60,6 +87,18 @@ export function RuntimeStatusBanner(): ReactElement | null {
         >
           {label}
         </p>
+        {disconnected ? (
+          <button
+            type="button"
+            aria-label={t('retryConnection')}
+            disabled={retrying}
+            className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-300/70 bg-white/80 px-2.5 py-1 text-[12px] font-medium text-amber-900/85 transition hover:bg-amber-100/70 disabled:cursor-wait disabled:opacity-60 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-100 dark:hover:bg-amber-900/40"
+            onClick={() => void retry()}
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${retrying ? 'animate-spin' : ''}`} strokeWidth={2} />
+            {t('retryConnection')}
+          </button>
+        ) : null}
         {recoveredWithRollback ? (
           <button
             type="button"

--- a/src/renderer/src/components/workbench/useWorkbenchComposerSubmitController.test.ts
+++ b/src/renderer/src/components/workbench/useWorkbenchComposerSubmitController.test.ts
@@ -127,6 +127,31 @@ describe('useWorkbenchComposerSubmitController', () => {
     await vi.waitFor(() => expect(input.getValue()).toBe('keep this prompt'))
   })
 
+  it('keeps a chat draft and attachments when the runtime rejects a send', async () => {
+    const input = inputHarness('keep this chat prompt')
+    const sendMessage = vi.fn(async () => false)
+    const removeComposerAttachments = vi.fn()
+    const controller = useWorkbenchComposerSubmitController(controllerParams({
+      input: 'keep this chat prompt',
+      route: 'chat',
+      composerAttachments: [{
+        id: 'attachment-1',
+        kind: 'image',
+        name: 'screen.png',
+        mimeType: 'image/png'
+      }],
+      removeComposerAttachments,
+      sendMessage,
+      setInput: input.setInput
+    }))
+
+    controller.handleSend()
+
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce())
+    expect(input.getValue()).toBe('keep this chat prompt')
+    expect(removeComposerAttachments).not.toHaveBeenCalled()
+  })
+
   it('saves the captured draft before sending it to the writing assistant', async () => {
     const write = deferred<{ ok: true; path: string; savedAt: string }>()
     const writeWorkspaceFile = vi.fn(() => write.promise)

--- a/src/renderer/src/components/workbench/useWorkbenchComposerSubmitController.ts
+++ b/src/renderer/src/components/workbench/useWorkbenchComposerSubmitController.ts
@@ -137,7 +137,6 @@ export function useWorkbenchComposerSubmitController({
   activeThreadId,
   attachmentUploadEnabled,
   buildCodeCanvasOutboundPrompt,
-  clearComposerAttachments,
   removeComposerAttachments,
   clearComposerFileReferences,
   composerAttachments,
@@ -541,16 +540,17 @@ export function useWorkbenchComposerSubmitController({
       if (route === 'chat' && composerMode === 'plan') {
         const prepared = await prepareChatMessage()
         if (!prepared) return
-        setInput('')
-        clearComposerAttachments(attachmentScope)
-        clearComposerFileReferences()
-        void sendPlanTurn(prepared.text, {
+        const sent = await sendPlanTurn(prepared.text, {
           ...(prepared.displayText ? { displayText: prepared.displayText } : {}),
           ...(reasoningEffort ? { reasoningEffort } : {}),
           ...(attachmentIds.length ? { attachmentIds } : {}),
           ...(publicAttachments.length ? { attachments: publicAttachments } : {}),
           ...(userFileReferences.length ? { fileReferences: userFileReferences } : {})
         })
+        if (!sent) return
+        setInput((current) => current.trim() === v ? '' : current)
+        if (attachmentIds.length > 0) removeComposerAttachments(attachmentIds, attachmentScope)
+        clearComposerFileReferences()
         return
       }
       if (route === 'write') {
@@ -653,9 +653,6 @@ export function useWorkbenchComposerSubmitController({
       }
       const prepared = await prepareChatMessage()
       if (!prepared) return
-      setInput('')
-      clearComposerAttachments(attachmentScope)
-      clearComposerFileReferences()
       let outboundText = prepared.text
       let outboundDisplay = prepared.displayText
       let outboundGuiDesignCanvas = false
@@ -677,7 +674,7 @@ export function useWorkbenchComposerSubmitController({
         outboundDisplay = codeCanvasRoute.displayText
         outboundGuiDesignCanvas = true
       }
-      void sendMessage(outboundText, composerMode === 'plan' ? 'plan' : 'agent', {
+      const sent = await sendMessage(outboundText, composerMode === 'plan' ? 'plan' : 'agent', {
         ...(outboundDisplay ? { displayText: outboundDisplay } : {}),
         ...(outboundGuiDesignCanvas ? { guiDesignCanvas: true } : {}),
         ...(reasoningEffort ? { reasoningEffort } : {}),
@@ -685,6 +682,13 @@ export function useWorkbenchComposerSubmitController({
         ...(publicAttachments.length ? { attachments: publicAttachments } : {}),
         ...(userFileReferences.length ? { fileReferences: userFileReferences } : {})
       })
+      // Keep the draft and attachments available when a health transition
+      // races the send. Only consume the captured composer inputs after the
+      // runtime has accepted the turn; this makes reconnect a safe retry.
+      if (!sent) return
+      setInput((current) => current.trim() === v ? '' : current)
+      if (attachmentIds.length > 0) removeComposerAttachments(attachmentIds, attachmentScope)
+      clearComposerFileReferences()
     })()
   }, [
     activeClawChannelId,
@@ -695,7 +699,6 @@ export function useWorkbenchComposerSubmitController({
     attachmentUploadEnabled,
     buildCodeCanvasOutboundPrompt,
     clawHelpText,
-    clearComposerAttachments,
     clearComposerFileReferences,
     clawModelListText,
     composerAttachments,
@@ -708,6 +711,7 @@ export function useWorkbenchComposerSubmitController({
     input,
     mirrorClawCommand,
     readComposerFileContextEntries,
+    removeComposerAttachments,
     resetClawChannelSession,
     rightPanelMode,
     route,

--- a/src/renderer/src/lib/runtime-banner-visibility.test.ts
+++ b/src/renderer/src/lib/runtime-banner-visibility.test.ts
@@ -4,6 +4,11 @@ import { shouldSuppressRuntimeErrorBanner } from './runtime-banner-visibility'
 describe('shouldSuppressRuntimeErrorBanner', () => {
   it('suppresses the main error banner while Kun is auto-restarting or recovering', () => {
     expect(shouldSuppressRuntimeErrorBanner({
+      state: 'degraded',
+      source: 'watchdog',
+      at: '2026-06-18T14:59:59.000Z'
+    })).toBe(true)
+    expect(shouldSuppressRuntimeErrorBanner({
       state: 'restarting',
       source: 'settings-apply',
       at: '2026-06-18T15:00:00.000Z'

--- a/src/renderer/src/lib/runtime-banner-visibility.ts
+++ b/src/renderer/src/lib/runtime-banner-visibility.ts
@@ -3,5 +3,5 @@ import type { KunRuntimeStatusPayload } from '@shared/kun-gui-api'
 export function shouldSuppressRuntimeErrorBanner(
   status: KunRuntimeStatusPayload | null | undefined
 ): boolean {
-  return status?.state === 'restarting' || status?.state === 'crashed'
+  return status?.state === 'degraded' || status?.state === 'restarting' || status?.state === 'crashed'
 }

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -3,6 +3,8 @@
   "runtimeStatusRestarting": "Kun is restarting automatically…",
   "runtimeStatusRestartingAttempt": "Kun is restarting automatically (attempt {{attempt}}/{{max}})…",
   "runtimeStatusCrashed": "Kun exited unexpectedly; recovering…",
+  "runtimeStatusDegraded": "Kun is temporarily unhealthy; your conversation stays here while it recovers.",
+  "runtimeStatusOffline": "Kun is offline. Your conversation and draft are preserved; reconnect to continue.",
   "runtimeStatusRolledBack": "The new settings failed to apply; rolled back to the previous working configuration",
   "runtimeStatusFailed": "Kun keeps failing to start; automatic restarts are paused",
   "runtimeStatusDismiss": "Dismiss",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -3,6 +3,8 @@
   "runtimeStatusRestarting": "Kun 正在自动重启…",
   "runtimeStatusRestartingAttempt": "Kun 正在自动重启(第 {{attempt}}/{{max}} 次)…",
   "runtimeStatusCrashed": "Kun 意外退出,正在自动恢复…",
+  "runtimeStatusDegraded": "Kun 暂时不健康,正在恢复中; 当前会话会保留。",
+  "runtimeStatusOffline": "Kun 当前离线。会话和草稿已保留,重新连接后即可继续。",
   "runtimeStatusRolledBack": "新设置应用失败,已自动回滚到之前可用的配置",
   "runtimeStatusFailed": "Kun 多次启动失败,已暂停自动重启",
   "runtimeStatusDismiss": "关闭",

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -134,6 +134,32 @@ let clawChannelActivityUnsubscribe: (() => void) | null = null
 let runtimeStatusUnsubscribe: (() => void) | null = null
 let trayActionUnsubscribe: (() => void) | null = null
 
+function connectionForRuntimeStatus(
+  state: NonNullable<ChatState['runtimeStatus']>['state']
+): ChatState['runtimeConnection'] | undefined {
+  switch (state) {
+    case 'degraded':
+    case 'restarting':
+    case 'crashed':
+      // Keep the workbench mounted while the runtime recovers. `checking`
+      // disables new sends without throwing away the active thread or draft.
+      return 'checking'
+    case 'offline':
+    case 'failed':
+    case 'stopped':
+      return 'offline'
+    case 'starting':
+      return 'checking'
+    case 'running':
+      // The supervisor's health event only proves the HTTP runtime is alive;
+      // the renderer still needs to re-establish its provider/SSE connection.
+      // Stay in `checking` until probeRuntime confirms that handshake.
+      return 'checking'
+    default:
+      return undefined
+  }
+}
+
 export function createNavigationActions(
   { set, get, sseAbortRef }: StoreActionContext
 ): Pick<ChatState, 'openCode' | 'openWrite' | 'openDesign' | 'clearActiveThreadSelection' | 'ensureWriteThreadForWorkspace' | 'createWriteThread' | 'selectWriteThread' | 'ensureDesignThreadForWorkspace' | 'createDesignThread' | 'probeRuntime' | 'boot' | 'chooseWorkspace' | 'selectWorkspaceRoot' | 'clearWorkspace' | 'deleteWorkspace' | 'refreshThreads' | 'setThreadSearch' | 'setShowArchivedThreads'> {
@@ -503,7 +529,7 @@ export function createNavigationActions(
             ? { route: 'settings' as const, settingsSection: 'agents' as const }
             : {})
         })
-      } else if (prev === 'ready') {
+      } else if (prev === 'ready' || (prev === 'checking' && get().runtimeStatus?.state === 'running')) {
         stopTurnCompletionPoll()
         set({
           runtimeConnection: 'offline',
@@ -557,12 +583,13 @@ export function createNavigationActions(
         await get().applyI18nFromSettings(settings.locale)
         if (!runtimeStatusUnsubscribe && typeof window.kunGui.onRuntimeStatus === 'function') {
           runtimeStatusUnsubscribe = window.kunGui.onRuntimeStatus((status) => {
-            set({ runtimeStatus: status })
-            if (status.state === 'restarting' || status.state === 'crashed') {
+            const runtimeConnection = connectionForRuntimeStatus(status.state)
+            set({ runtimeStatus: status, ...(runtimeConnection ? { runtimeConnection } : {}) })
+            if (status.state === 'starting' || status.state === 'degraded' || status.state === 'restarting' || status.state === 'crashed') {
               set({ error: null, runtimeErrorDetail: null })
               return
             }
-            if (status.state === 'failed' || status.state === 'stopped') {
+            if (status.state === 'offline' || status.state === 'failed' || status.state === 'stopped') {
               // Terminal states reuse the main error banner, which carries
               // the full diagnostics UI (details, log path, settings).
               set({ error: status.message ?? i18n.t('common:runtimeStatusFailed') })

--- a/src/renderer/src/store/chat-store-thread-actions.test.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.test.ts
@@ -775,6 +775,35 @@ describe('chat-store-thread-actions recoverActiveTurn settles interrupted work',
     const tool = state.blocks.find((block) => block.kind === 'tool')
     expect(tool?.status).toBe('running')
   })
+
+  it('coalesces concurrent recovery requests so reconnect cannot duplicate a turn', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const provider = providerWith('running')
+    provider.getThreadDetail.mockImplementation(async () => {
+      await gate
+      return {
+        blocks: [
+          { id: 'u1', kind: 'user', text: 'do the big thing' },
+          { id: 'tool1', kind: 'tool', name: 'delegate_task', status: 'running' }
+        ],
+        latestSeq: 3,
+        threadStatus: 'running',
+        latestTurnId: 'turn_1',
+        latestUserMessageId: 'u1'
+      }
+    })
+    registryMock.getProvider.mockReturnValue(provider)
+
+    const { actions } = buildHarness()
+    const first = actions.recoverActiveTurn()
+    const second = actions.recoverActiveTurn()
+    expect(provider.getThreadDetail).toHaveBeenCalledOnce()
+    release()
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+    expect(provider.getThreadDetail).toHaveBeenCalledOnce()
+  })
 })
 
 describe('chat-store-thread-actions createThread conversation mode', () => {

--- a/src/renderer/src/store/chat-store-thread-actions.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.ts
@@ -145,6 +145,8 @@ function activeWriteMessageContextMatches(context: WriteAssistantMessageContext)
 export function createThreadActions(
   { set, get, sseAbortRef }: StoreActionContext
 ): Pick<ChatState, 'createThread' | 'createConversation' | 'recoverActiveTurn' | 'selectThread' | 'subscribeThreadEventsLive' | 'drainQueuedMessages' | 'removeQueuedMessage' | 'sendMessage' | 'reviewActiveThread'> {
+  let recoverActiveTurnInFlight: Promise<boolean> | null = null
+
   return {
   createThread: async (options = {}) => {
     if (get().runtimeConnection !== 'ready') {
@@ -322,7 +324,9 @@ export function createThreadActions(
     await get().createThread({ conversation: true })
   },
 
-  recoverActiveTurn: async () => {
+  recoverActiveTurn: () => {
+    if (recoverActiveTurnInFlight) return recoverActiveTurnInFlight
+    recoverActiveTurnInFlight = (async () => {
     const state = get()
     if (!state.activeThreadId) return false
     const { activeThreadId } = state
@@ -396,6 +400,12 @@ export function createThreadActions(
       if (state.busy) armBusyWatchdog(set, get)
       return state.busy
     }
+    })()
+    const result = recoverActiveTurnInFlight.finally(() => {
+      recoverActiveTurnInFlight = null
+    })
+    recoverActiveTurnInFlight = result
+    return result
   },
 
   selectThread: async (id) => {

--- a/src/shared/kun-gui-api.ts
+++ b/src/shared/kun-gui-api.ts
@@ -121,7 +121,13 @@ import type {
 import type { ExtensionIpcApi } from './extension-ipc'
 
 export type KunRuntimeStatusPayload = {
-  state: 'starting' | 'running' | 'restarting' | 'crashed' | 'failed' | 'stopped'
+  /**
+   * `degraded` means the health probe has failed but recovery has not started
+   * yet. `offline` is a terminal connection state for the renderer; the
+   * legacy `crashed`/`stopped` values remain accepted for older main-process
+   * builds and are normalized by the renderer.
+   */
+  state: 'starting' | 'running' | 'degraded' | 'restarting' | 'offline' | 'crashed' | 'failed' | 'stopped'
   source: string
   message?: string
   stderrTail?: string


### PR DESCRIPTION
## Summary
- surface an explicit degraded state while health checks are failing without treating it as a crash loop
- keep the workbench, thread history, and composer draft mounted through restarting/offline/failed runtime states
- add a reconnect action for terminal runtime connection states
- coalesce concurrent active-turn recovery requests so a reconnect cannot replay the same turn twice
- only consume composer text and attachments after the runtime accepts the turn

## Validation
- `npm.cmd exec -- vitest run src/main/kun-runtime-supervisor.test.ts src/renderer/src/components/RuntimeStatusBanner.test.ts src/renderer/src/lib/runtime-banner-visibility.test.ts src/renderer/src/store/chat-store-thread-actions.test.ts src/renderer/src/components/workbench/useWorkbenchComposerSubmitController.test.ts`
- `npm.cmd run lint -- --no-warn-ignored`
- `npm.cmd run typecheck`
- `npm.cmd run build`

The Kun package typecheck was also attempted; this checkout's borrowed dependency tree is missing existing packages (`@xmldom/xmldom`, `yazl`, etc.), while the targeted Kun tests pass.