### PR TITLE
fix(renderer): recover from bounded process failures

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -126,6 +126,7 @@ import {
   classifyManagedRuntimeHotApplyResponse
 } from './runtime/kun-runtime-config-service'
 import { ManagedRuntimeShutdownCoordinator } from './runtime/managed-runtime-shutdown-coordinator'
+import { attachRendererProcessRecovery } from './renderer-process-recovery'
 import {
   registerKunExtensionProtocol,
   registerKunExtensionSchemeAsPrivileged
@@ -1095,6 +1096,9 @@ function createWindow(options: { suppressInitialShow?: boolean } = {}): void {
       additionalArguments: [`--kun-home-dir=${homedir()}`]
     }
   })
+  const disposeRendererRecovery = attachRendererProcessRecovery(mainWindow, {
+    log: (message, details) => logWarn('renderer-recovery', message, details)
+  })
   bindExtensionMainWindow?.(mainWindow)
   if (usesDesktopTitleBar) {
     mainWindow.setMenu(null)
@@ -1121,6 +1125,7 @@ function createWindow(options: { suppressInitialShow?: boolean } = {}): void {
     handleMainWindowClose(mainWindow, event)
   })
   mainWindow.on('closed', () => {
+    disposeRendererRecovery()
     mainWindow = null
   })
   const devUrl = devServerHintUrl()

--- a/src/main/renderer-process-recovery.test.ts
+++ b/src/main/renderer-process-recovery.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  attachRendererProcessRecovery,
+  DEFAULT_RENDERER_RECOVERY_POLICY,
+  INITIAL_RENDERER_RECOVERY_STATE,
+  reduceRendererRecovery
+} from './renderer-process-recovery'
+
+describe('renderer process recovery', () => {
+  it('reloads once for a failure and ignores duplicate events while recovering', () => {
+    const first = reduceRendererRecovery(INITIAL_RENDERER_RECOVERY_STATE, {
+      type: 'failure', reason: 'render-process-gone', at: 100
+    })
+    expect(first.action).toBe('reload')
+    const duplicate = reduceRendererRecovery(first.state, {
+      type: 'failure', reason: 'unresponsive', at: 101
+    })
+    expect(duplicate.action).toBe('none')
+    expect(duplicate.state.attempts).toBe(1)
+  })
+
+  it('does not count clean exits and resets after a stable load', () => {
+    const clean = reduceRendererRecovery(INITIAL_RENDERER_RECOVERY_STATE, {
+      type: 'failure', reason: 'render-process-gone', at: 100, cleanExit: true
+    })
+    expect(clean).toEqual({ state: INITIAL_RENDERER_RECOVERY_STATE, action: 'none' })
+    const failed = reduceRendererRecovery(INITIAL_RENDERER_RECOVERY_STATE, {
+      type: 'failure', reason: 'render-process-gone', at: 100
+    })
+    const loaded = reduceRendererRecovery(failed.state, {
+      type: 'loaded', at: 100 + DEFAULT_RENDERER_RECOVERY_POLICY.stableMs
+    })
+    expect(loaded).toEqual({ state: INITIAL_RENDERER_RECOVERY_STATE, action: 'none' })
+  })
+
+  it('stops reloading after the bounded crash window', () => {
+    let state = INITIAL_RENDERER_RECOVERY_STATE
+    for (let attempt = 0; attempt < DEFAULT_RENDERER_RECOVERY_POLICY.maxAttempts; attempt++) {
+      const decision = reduceRendererRecovery(state, {
+        type: 'failure', reason: 'render-process-gone', at: 100 + attempt
+      })
+      expect(decision.action).toBe('reload')
+      state = { ...decision.state, recovering: false }
+    }
+    const blocked = reduceRendererRecovery(state, {
+      type: 'failure', reason: 'render-process-gone', at: 200
+    })
+    expect(blocked.action).toBe('notify')
+  })
+
+  it('cancels a pending retry when disposed', () => {
+    const listeners = new Map<string, (...args: unknown[]) => void>()
+    const reload = vi.fn()
+    const cancel = vi.fn()
+    const window = {
+      isDestroyed: () => false,
+      webContents: {
+        on: (event: string, listener: (...args: unknown[]) => void) => listeners.set(event, listener),
+        reload
+      }
+    }
+    const timer = {} as ReturnType<typeof setTimeout>
+    const dispose = attachRendererProcessRecovery(
+      window as unknown as Parameters<typeof attachRendererProcessRecovery>[0],
+      {
+      log: vi.fn(),
+      schedule: vi.fn(() => timer),
+      cancel
+      }
+    )
+    listeners.get('render-process-gone')?.({}, { reason: 'crashed' })
+    listeners.get('responsive')?.()
+    dispose()
+    expect(cancel).toHaveBeenCalledWith(timer)
+    expect(reload).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/renderer-process-recovery.ts
+++ b/src/main/renderer-process-recovery.ts
@@ -1,0 +1,151 @@
+export type RendererRecoveryReason = 'render-process-gone' | 'unresponsive'
+
+export type RendererRecoveryPolicy = {
+  maxAttempts: number
+  windowMs: number
+  stableMs: number
+  retryDelayMs: number
+}
+
+export const DEFAULT_RENDERER_RECOVERY_POLICY: RendererRecoveryPolicy = {
+  maxAttempts: 3,
+  windowMs: 5 * 60_000,
+  stableMs: 2 * 60_000,
+  retryDelayMs: 750
+}
+
+export type RendererRecoveryState = {
+  attempts: number
+  windowStartedAt: number | null
+  lastFailureAt: number | null
+  recovering: boolean
+}
+
+export type RendererRecoveryEvent =
+  | { type: 'failure'; reason: RendererRecoveryReason; at: number; cleanExit?: boolean }
+  | { type: 'responsive' }
+  | { type: 'loaded'; at: number }
+
+export type RendererRecoveryDecision = {
+  state: RendererRecoveryState
+  action: 'reload' | 'notify' | 'none'
+}
+
+export const INITIAL_RENDERER_RECOVERY_STATE: RendererRecoveryState = {
+  attempts: 0,
+  windowStartedAt: null,
+  lastFailureAt: null,
+  recovering: false
+}
+
+export function reduceRendererRecovery(
+  state: RendererRecoveryState,
+  event: RendererRecoveryEvent,
+  policy: RendererRecoveryPolicy = DEFAULT_RENDERER_RECOVERY_POLICY
+): RendererRecoveryDecision {
+  if (event.type === 'responsive') {
+    return { state: { ...state, recovering: false }, action: 'none' }
+  }
+  if (event.type === 'loaded') {
+    const stable = state.lastFailureAt !== null && event.at - state.lastFailureAt >= policy.stableMs
+    return {
+      state: stable
+        ? INITIAL_RENDERER_RECOVERY_STATE
+        : { ...state, recovering: false },
+      action: 'none'
+    }
+  }
+  if (event.cleanExit) return { state, action: 'none' }
+  if (state.recovering) return { state, action: 'none' }
+
+  const withinWindow = state.windowStartedAt !== null &&
+    event.at - state.windowStartedAt >= 0 &&
+    event.at - state.windowStartedAt < policy.windowMs
+  const attempts = withinWindow ? state.attempts : 0
+  const windowStartedAt = withinWindow ? state.windowStartedAt : event.at
+  if (attempts >= policy.maxAttempts) {
+    return {
+      state: { attempts, windowStartedAt, lastFailureAt: event.at, recovering: false },
+      action: 'notify'
+    }
+  }
+  return {
+    state: {
+      attempts: attempts + 1,
+      windowStartedAt,
+      lastFailureAt: event.at,
+      recovering: true
+    },
+    action: 'reload'
+  }
+}
+
+type RecoveryWindow = Pick<BrowserWindow, 'isDestroyed'> & {
+  webContents: Pick<WebContents, 'on' | 'reload'>
+}
+
+export function attachRendererProcessRecovery(
+  window: RecoveryWindow,
+  options: {
+    log: (message: string, details?: Record<string, unknown>) => void
+    policy?: RendererRecoveryPolicy
+    now?: () => number
+    schedule?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>
+    cancel?: (timer: ReturnType<typeof setTimeout>) => void
+  }
+): () => void {
+  const policy = options.policy ?? DEFAULT_RENDERER_RECOVERY_POLICY
+  const now = options.now ?? Date.now
+  const schedule = options.schedule ?? ((callback, delay) => setTimeout(callback, delay))
+  const cancel = options.cancel ?? ((timer) => clearTimeout(timer))
+  let state = INITIAL_RENDERER_RECOVERY_STATE
+  let retryTimer: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  const dispatch = (event: RendererRecoveryEvent): void => {
+    if (disposed || window.isDestroyed()) return
+    if ((event.type === 'responsive' || event.type === 'loaded') && retryTimer) {
+      cancel(retryTimer)
+      retryTimer = null
+    }
+    const decision = reduceRendererRecovery(state, event, policy)
+    state = decision.state
+    if (decision.action === 'reload') {
+      options.log('Renderer process recovery scheduled', { reason: event.type, attempt: state.attempts })
+      if (retryTimer) cancel(retryTimer)
+      retryTimer = schedule(() => {
+        retryTimer = null
+        if (!disposed && !window.isDestroyed()) window.webContents.reload()
+      }, policy.retryDelayMs)
+    } else if (decision.action === 'notify') {
+      options.log('Renderer process recovery limit reached', {
+        reason: event.type,
+        attempts: state.attempts
+      })
+    }
+  }
+
+  window.webContents.on('render-process-gone', (_event, rawDetails) => {
+    const details = rawDetails && typeof rawDetails === 'object'
+      ? rawDetails as { reason?: string }
+      : undefined
+    dispatch({
+      type: 'failure',
+      reason: 'render-process-gone',
+      at: now(),
+      cleanExit: details?.reason === 'clean-exit'
+    })
+  })
+  window.webContents.on('unresponsive', () => {
+    dispatch({ type: 'failure', reason: 'unresponsive', at: now() })
+  })
+  window.webContents.on('responsive', () => dispatch({ type: 'responsive' }))
+  window.webContents.on('did-finish-load', () => dispatch({ type: 'loaded', at: now() }))
+
+  return () => {
+    disposed = true
+    if (retryTimer) cancel(retryTimer)
+    retryTimer = null
+  }
+}
+import type { BrowserWindow, WebContents } from 'electron'


### PR DESCRIPTION
﻿## Summary
Add bounded renderer-process recovery for the white-screen failure tracked by #885.

## Changes
- Handle Electron `render-process-gone` and `unresponsive` events in the main process.
- Reload at most three times inside a five-minute window with a short delay.
- Ignore clean exits, deduplicate concurrent failures, cancel pending reloads when the renderer responds or finishes loading, and stop retrying after the budget is exhausted.
- Keep the policy and reducer pure/testable; only the small BrowserWindow adapter owns timers and reload side effects.

Part of #885. This is intentionally separate from the React ErrorBoundary and Kun runtime lifecycle PRs.

## Tests
- `npm.cmd exec vitest run src/main/renderer-process-recovery.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run lint -- --quiet`
- `npm.cmd run build`
- `git diff --check`
