### PR TITLE
feat(sse): define sequenced event contract

### DIFF
--- a/src/shared/sse-sequence.test.ts
+++ b/src/shared/sse-sequence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { SequencedRuntimeEventSchema } from './sse-sequence'
+
+describe('SequencedRuntimeEventSchema', () => {
+  it('accepts a stable stream sequence envelope', () => {
+    const event = {
+      streamId: 'stream_123',
+      sequence: 42,
+      eventId: 'evt_42',
+      occurredAt: '2026-07-14T00:00:00.000Z'
+    }
+
+    expect(SequencedRuntimeEventSchema.parse(event)).toEqual(event)
+  })
+
+  it('accepts sequence zero for a newly-created stream', () => {
+    expect(SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 0,
+      eventId: 'evt_0',
+      occurredAt: '2026-07-14T00:00:00+00:00'
+    }).sequence).toBe(0)
+  })
+
+  it('rejects unsafe sequences, invalid timestamps, and unknown fields', () => {
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: Number.MAX_SAFE_INTEGER + 1,
+      eventId: 'evt',
+      occurredAt: '2026-07-14T00:00:00.000Z'
+    })).toThrow()
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 1,
+      eventId: 'evt',
+      occurredAt: 'yesterday'
+    })).toThrow()
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 1,
+      eventId: 'evt',
+      occurredAt: '2026-07-14T00:00:00.000Z',
+      payload: {}
+    })).toThrow()
+  })
+})

--- a/src/shared/sse-sequence.ts
+++ b/src/shared/sse-sequence.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+/** Metadata required to detect duplicate, stale, and missing SSE events. */
+export const SequencedRuntimeEventSchema = z.object({
+  streamId: z.string().min(1).max(128),
+  sequence: z.number().int().nonnegative().safe(),
+  eventId: z.string().min(1).max(128),
+  occurredAt: z.string().datetime({ offset: true })
+}).strict()
+
+export type SequencedRuntimeEvent = z.infer<typeof SequencedRuntimeEventSchema>


### PR DESCRIPTION
## Problem

Renderer SSE handling currently receives unversioned event arrays. There is no shared metadata contract for detecting duplicate, stale, or missing stream events before projection.

## Root cause

The existing `SseEventPayload` carries opaque events and a stream ID, but it does not freeze a per-event stream sequence, event identity, or occurrence timestamp.

## Scope

This PR defines the sequenced event metadata contract only. It does not change the SSE transport, reducer, reconnect, replay, or cursor behavior.

## Changes

- Add `SequencedRuntimeEventSchema` and its inferred TypeScript type.
- Bound stream/event IDs and require a safe non-negative sequence number.
- Require an offset-aware occurrence timestamp.
- Add tests for valid envelopes, sequence zero, unsafe values, invalid timestamps, and unknown fields.

## Safety

- Strict schema rejects unrecognized payload fields at this metadata boundary.
- Sequence values are safe integers and cannot silently lose precision.
- No renderer state or network behavior changes in this PR.

## Typecheck

```bash
npm.cmd run typecheck
```

Result: passed.

## Tests

```bash
npm.cmd exec vitest run src/shared/sse-sequence.test.ts
```

Result: 1 file, 3 tests passed.

## Actual validation

`npm.cmd run lint` and `npm.cmd run build` passed.

## Review performed

- Functional correctness
- Protocol compatibility
- Sequence precision and timestamp validation
- Cross-process safety
- Test quality and PR scope

## PR size

```text
Production files: 1
Test files: 1
Production LOC: 11
Total diff: 57 lines
```

## Follow-ups

Gap detection, bounded replay, persistent resume cursors, and reducer integration remain separate PRs.
