### PR TITLE
feat(runtime): define managed child process contract

### DIFF
--- a/src/shared/managed-child-process.test.ts
+++ b/src/shared/managed-child-process.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { ManagedChildProcessSchema } from './managed-child-process'
+
+describe('ManagedChildProcessSchema', () => {
+  it('defaults cleanup to terminating the process tree', () => {
+    expect(ManagedChildProcessSchema.parse({
+      id: 'child_1',
+      ownerKind: 'shell',
+      ownerId: 'turn_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: false
+    }).cleanupPolicy).toBe('terminate-tree')
+  })
+
+  it('accepts an explicitly preserved detached child', () => {
+    expect(ManagedChildProcessSchema.parse({
+      id: 'child_2',
+      ownerKind: 'extension-host',
+      ownerId: 'extension_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: true,
+      cleanupPolicy: 'preserve'
+    }).detached).toBe(true)
+  })
+
+  it('rejects invalid PIDs, timestamps, cleanup policies, and extra fields', () => {
+    const base = {
+      id: 'child_1',
+      ownerKind: 'shell',
+      ownerId: 'turn_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: false
+    }
+
+    expect(() => ManagedChildProcessSchema.parse({ ...base, pid: 0 })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, startedAt: 'now' })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, cleanupPolicy: 'ignore' })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, command: 'secret' })).toThrow()
+  })
+})

--- a/src/shared/managed-child-process.ts
+++ b/src/shared/managed-child-process.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const ManagedChildCleanupPolicy = z.enum([
+  'terminate',
+  'terminate-tree',
+  'preserve'
+])
+export type ManagedChildCleanupPolicy = z.infer<typeof ManagedChildCleanupPolicy>
+
+/** Cross-module identity and lifecycle metadata for a real child process. */
+export const ManagedChildProcessSchema = z.object({
+  id: z.string().min(1).max(128),
+  ownerKind: z.string().min(1).max(64),
+  ownerId: z.string().min(1).max(128),
+  pid: z.number().int().positive().safe(),
+  startedAt: z.string().datetime({ offset: true }),
+  detached: z.boolean(),
+  cleanupPolicy: ManagedChildCleanupPolicy.default('terminate-tree')
+}).strict()
+
+export type ManagedChildProcess = z.infer<typeof ManagedChildProcessSchema>


### PR DESCRIPTION
## Problem

Shell, LSP, Whisper, extension host, and subagent processes need one bounded lifecycle record before they can share shutdown, cancellation, and crash-recovery handling.

## Root cause

The existing background shell record describes a user-facing session, but there is no cross-module contract for the actual OS child process. Reusing that record for process cleanup would mix business state with process ownership.

## Scope

This PR defines and tests the shared `ManagedChildProcess` contract only. It does not register or terminate processes yet.

## Changes

- Add strict Zod validation for process identity, owner, PID, start time, detach state, and cleanup policy.
- Bound identifiers and reject unknown fields so commands, environment values, and secrets cannot be smuggled into the lifecycle record.
- Default cleanup to terminating the process tree; explicit `preserve` remains available for detached owners such as extension hosts.

## Safety

- No command line, environment, token, path, or raw process output is stored.
- PID and timestamp inputs are validated and unknown fields are rejected.
- Runtime integration and platform-specific termination remain follow-up PRs with their own lifecycle tests.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
npm.cmd exec vitest run src/shared/managed-child-process.test.ts
npm.cmd run lint
npm.cmd run build
git diff --check
```

Passed: 3 contract tests; root lint and build passed; diff check passed.

## Review performed

- Functional correctness
- Architecture and ownership boundaries
- Concurrency/lifecycle field semantics
- Data and secret safety
- Cross-platform compatibility of the contract
- Test quality and PR scope

## Non-goals

- Process registry storage
- Shell/LSP/Whisper/extension-host/subagent integration
- Platform-specific process-tree termination

## Follow-ups

The registry and runtime integration should land as separate PRs after this contract is reviewed.
