### PR TITLE
feat(ipc): define cancellation lifecycle contract

### DIFF
--- a/src/shared/ipc-cancellation.test.ts
+++ b/src/shared/ipc-cancellation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IpcCancellationAckSchema,
+  IpcCancellationRequestSchema,
+  IpcOperationRequestSchema,
+  IpcOperationTerminalSchema
+} from './ipc-cancellation'
+
+const timestamp = '2026-07-14T00:00:00.000Z'
+
+describe('IPC cancellation contract', () => {
+  it('uses one bounded request identity across the lifecycle', () => {
+    const request = IpcOperationRequestSchema.parse({
+      requestId: 'transfer_1',
+      operation: 'project-export'
+    })
+    const cancel = IpcCancellationRequestSchema.parse({
+      requestId: request.requestId,
+      reason: 'user-requested',
+      requestedAt: timestamp
+    })
+    const ack = IpcCancellationAckSchema.parse({
+      requestId: cancel.requestId,
+      status: 'accepted',
+      acknowledgedAt: timestamp
+    })
+    expect(ack.requestId).toBe(request.requestId)
+  })
+
+  it('allows an idempotent acknowledgement for an already terminal request', () => {
+    expect(IpcCancellationAckSchema.parse({
+      requestId: 'probe_1',
+      status: 'already-terminal',
+      acknowledgedAt: timestamp
+    }).status).toBe('already-terminal')
+  })
+
+  it('represents cancellation as a terminal outcome, not as an error-only response', () => {
+    expect(IpcOperationTerminalSchema.parse({
+      requestId: 'index_1',
+      status: 'cancelled',
+      finishedAt: timestamp
+    }).status).toBe('cancelled')
+  })
+
+  it('rejects invalid timestamps, empty identities, and unbounded extra fields', () => {
+    expect(() => IpcOperationRequestSchema.parse({ requestId: '', operation: 'probe' })).toThrow()
+    expect(() => IpcCancellationRequestSchema.parse({
+      requestId: 'probe_1',
+      requestedAt: 'now'
+    })).toThrow()
+    expect(() => IpcOperationTerminalSchema.parse({
+      requestId: 'probe_1',
+      status: 'cancelled',
+      finishedAt: timestamp,
+      stack: 'secret'
+    })).toThrow()
+  })
+})

--- a/src/shared/ipc-cancellation.ts
+++ b/src/shared/ipc-cancellation.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+const RequestId = z.string().trim().min(1).max(128)
+const Timestamp = z.string().datetime({ offset: true })
+
+/** A bounded request identity shared by the start, cancel, and terminal events. */
+export const IpcOperationRequestSchema = z.object({
+  requestId: RequestId,
+  operation: z.string().trim().min(1).max(128)
+}).strict()
+export type IpcOperationRequest = z.infer<typeof IpcOperationRequestSchema>
+
+/** Cancellation is a separate message so every long-running operation can acknowledge it. */
+export const IpcCancellationRequestSchema = z.object({
+  requestId: RequestId,
+  reason: z.string().trim().min(1).max(256).optional(),
+  requestedAt: Timestamp
+}).strict()
+export type IpcCancellationRequest = z.infer<typeof IpcCancellationRequestSchema>
+
+export const IpcCancellationAckStatus = z.enum([
+  'accepted',
+  'already-terminal',
+  'unknown-request'
+])
+export type IpcCancellationAckStatus = z.infer<typeof IpcCancellationAckStatus>
+
+/** Acknowledgement confirms that the cancellation message was observed, not that work stopped. */
+export const IpcCancellationAckSchema = z.object({
+  requestId: RequestId,
+  status: IpcCancellationAckStatus,
+  acknowledgedAt: Timestamp
+}).strict()
+export type IpcCancellationAck = z.infer<typeof IpcCancellationAckSchema>
+
+export const IpcOperationTerminalStatus = z.enum(['completed', 'failed', 'cancelled'])
+export type IpcOperationTerminalStatus = z.infer<typeof IpcOperationTerminalStatus>
+
+/** Exactly one terminal event is expected for a request; consumers must treat it as idempotent. */
+export const IpcOperationTerminalSchema = z.object({
+  requestId: RequestId,
+  status: IpcOperationTerminalStatus,
+  finishedAt: Timestamp,
+  errorCode: z.string().trim().min(1).max(128).optional()
+}).strict()
+export type IpcOperationTerminal = z.infer<typeof IpcOperationTerminalSchema>


### PR DESCRIPTION
## Problem

Long-running IPC operations need a common cancellation lifecycle. Existing operations expose unrelated cancellation shapes, so a caller cannot reliably distinguish an observed cancel request from work that has actually stopped.

## Root cause

There was no shared contract linking an operation request, its cancellation message, the cancellation acknowledgement, and the final terminal result.

## Scope

This PR defines and tests the shared IPC cancellation contract only. It does not change any IPC handler or business operation.

## Changes

- Add bounded `requestId` and operation request schemas.
- Add explicit cancellation request and acknowledgement statuses (`accepted`, `already-terminal`, `unknown-request`).
- Add a terminal response schema with `completed`, `failed`, and `cancelled` outcomes.
- Reject unbounded or unknown fields so stacks, parameters, and secrets cannot enter the contract accidentally.

## Safety

- Cancellation acknowledgement means the request was observed; it does not claim that the operation has stopped.
- Consumers can treat terminal events idempotently by `requestId`.
- The contract carries no command, path, token, raw error stack, or operation payload.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
npm.cmd exec vitest run src/shared/ipc-cancellation.test.ts
npm.cmd run lint
npm.cmd run build
git diff --check
```

Passed: 4 contract tests; root lint and build passed; diff check passed.

## Review performed

- Functional correctness
- Lifecycle and idempotency semantics
- Data and secret safety
- Cross-platform contract compatibility
- Test quality and PR scope

## Non-goals

- IPC handler changes
- Runtime cancellation implementation
- Project transfer, diagnostics, provider probe, index, or extension-install integration

## Follow-ups

Each long-running operation should adopt this contract in a separate, focused PR.
