### PR TITLE
feat(runtime): add managed child process registry

### DIFF
--- a/src/main/services/managed-child-process-registry.test.ts
+++ b/src/main/services/managed-child-process-registry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ManagedChildProcessRegistry,
+  ManagedChildProcessRegistryError
+} from './managed-child-process-registry'
+
+const record = (id: string, ownerId = 'turn_1') => ({
+  id,
+  ownerKind: 'shell',
+  ownerId,
+  pid: 1234,
+  startedAt: '2026-07-14T00:00:00.000Z',
+  detached: false,
+  cleanupPolicy: 'terminate-tree' as const
+})
+
+describe('ManagedChildProcessRegistry', () => {
+  it('registers, filters, updates, and returns defensive snapshots', () => {
+    const registry = new ManagedChildProcessRegistry()
+    registry.register(record('child_1'))
+    registry.register({ ...record('child_2', 'turn_2'), ownerKind: 'lsp' })
+
+    expect(registry.list({ ownerKind: 'shell' }).map((item) => item.id)).toEqual(['child_1'])
+    const updated = registry.update('child_1', { detached: true, cleanupPolicy: 'preserve' })
+    expect(updated.detached).toBe(true)
+    expect(Object.isFrozen(updated)).toBe(true)
+    expect(registry.get('child_1')?.detached).toBe(true)
+  })
+
+  it('rejects duplicate IDs and missing updates', () => {
+    const registry = new ManagedChildProcessRegistry()
+    registry.register(record('child_1'))
+    expect(() => registry.register(record('child_1'))).toThrowError(
+      new ManagedChildProcessRegistryError('DUPLICATE', 'Managed child process is already registered: child_1')
+    )
+    expect(() => registry.update('missing', { detached: true })).toThrowError(
+      new ManagedChildProcessRegistryError('NOT_FOUND', 'Managed child process was not found: missing')
+    )
+  })
+
+  it('makes remove and drain idempotent and returns cleanup snapshots', () => {
+    const registry = new ManagedChildProcessRegistry()
+    registry.register(record('child_1'))
+    registry.register(record('child_2'))
+
+    expect(registry.remove('missing')).toBe(false)
+    expect(registry.remove('child_1')).toBe(true)
+    expect(registry.remove('child_1')).toBe(false)
+    expect(registry.drain().map((item) => item.id)).toEqual(['child_2'])
+    expect(registry.drain()).toEqual([])
+    expect(registry.size()).toBe(0)
+  })
+
+  it('validates records before registration and does not leak invalid state', () => {
+    const registry = new ManagedChildProcessRegistry()
+    expect(() => registry.register({ ...record('child_1'), pid: 0 })).toThrow()
+    expect(registry.size()).toBe(0)
+  })
+})

--- a/src/main/services/managed-child-process-registry.ts
+++ b/src/main/services/managed-child-process-registry.ts
@@ -1,0 +1,81 @@
+import {
+  ManagedChildProcessSchema,
+  type ManagedChildCleanupPolicy,
+  type ManagedChildProcess
+} from '../../shared/managed-child-process'
+
+export type ManagedChildProcessUpdate = Partial<
+  Pick<ManagedChildProcess, 'pid' | 'detached' | 'cleanupPolicy'>
+>
+
+export class ManagedChildProcessRegistryError extends Error {
+  constructor(readonly code: 'DUPLICATE' | 'NOT_FOUND', message: string) {
+    super(message)
+    this.name = 'ManagedChildProcessRegistryError'
+  }
+}
+
+/** Main-owned registry for live OS children; it never starts or terminates a process. */
+export class ManagedChildProcessRegistry {
+  private readonly records = new Map<string, ManagedChildProcess>()
+
+  register(input: ManagedChildProcess): ManagedChildProcess {
+    if (this.records.has(input.id)) {
+      throw new ManagedChildProcessRegistryError(
+        'DUPLICATE',
+        `Managed child process is already registered: ${input.id}`
+      )
+    }
+    const record = ManagedChildProcessSchema.parse(input)
+    this.records.set(record.id, record)
+    return this.snapshot(record)
+  }
+
+  get(id: string): ManagedChildProcess | undefined {
+    const record = this.records.get(id)
+    return record ? this.snapshot(record) : undefined
+  }
+
+  list(filter?: { ownerKind?: string; ownerId?: string }): ManagedChildProcess[] {
+    return [...this.records.values()]
+      .filter((record) => filter?.ownerKind === undefined || record.ownerKind === filter.ownerKind)
+      .filter((record) => filter?.ownerId === undefined || record.ownerId === filter.ownerId)
+      .map((record) => this.snapshot(record))
+  }
+
+  update(id: string, patch: ManagedChildProcessUpdate): ManagedChildProcess {
+    const current = this.records.get(id)
+    if (!current) {
+      throw new ManagedChildProcessRegistryError('NOT_FOUND', `Managed child process was not found: ${id}`)
+    }
+    const next = ManagedChildProcessSchema.parse({ ...current, ...patch })
+    this.records.set(id, next)
+    return this.snapshot(next)
+  }
+
+  /** Removing an already-removed child is intentionally idempotent for shutdown paths. */
+  remove(id: string): boolean {
+    return this.records.delete(id)
+  }
+
+  /** Returns the records that require caller-owned cleanup and empties the registry. */
+  drain(): ManagedChildProcess[] {
+    const records = this.list()
+    this.records.clear()
+    return records
+  }
+
+  clear(): void {
+    this.records.clear()
+  }
+
+  size(): number {
+    return this.records.size
+  }
+
+  private snapshot(record: ManagedChildProcess): ManagedChildProcess {
+    return Object.freeze({ ...record })
+  }
+}
+
+export type { ManagedChildCleanupPolicy }

--- a/src/shared/managed-child-process.test.ts
+++ b/src/shared/managed-child-process.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { ManagedChildProcessSchema } from './managed-child-process'
+
+describe('ManagedChildProcessSchema', () => {
+  it('defaults cleanup to terminating the process tree', () => {
+    expect(ManagedChildProcessSchema.parse({
+      id: 'child_1',
+      ownerKind: 'shell',
+      ownerId: 'turn_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: false
+    }).cleanupPolicy).toBe('terminate-tree')
+  })
+
+  it('accepts an explicitly preserved detached child', () => {
+    expect(ManagedChildProcessSchema.parse({
+      id: 'child_2',
+      ownerKind: 'extension-host',
+      ownerId: 'extension_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: true,
+      cleanupPolicy: 'preserve'
+    }).detached).toBe(true)
+  })
+
+  it('rejects invalid PIDs, timestamps, cleanup policies, and extra fields', () => {
+    const base = {
+      id: 'child_1',
+      ownerKind: 'shell',
+      ownerId: 'turn_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: false
+    }
+
+    expect(() => ManagedChildProcessSchema.parse({ ...base, pid: 0 })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, startedAt: 'now' })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, cleanupPolicy: 'ignore' })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, command: 'secret' })).toThrow()
+  })
+})

--- a/src/shared/managed-child-process.ts
+++ b/src/shared/managed-child-process.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const ManagedChildCleanupPolicy = z.enum([
+  'terminate',
+  'terminate-tree',
+  'preserve'
+])
+export type ManagedChildCleanupPolicy = z.infer<typeof ManagedChildCleanupPolicy>
+
+/** Cross-module identity and lifecycle metadata for a real child process. */
+export const ManagedChildProcessSchema = z.object({
+  id: z.string().min(1).max(128),
+  ownerKind: z.string().min(1).max(64),
+  ownerId: z.string().min(1).max(128),
+  pid: z.number().int().positive().safe(),
+  startedAt: z.string().datetime({ offset: true }),
+  detached: z.boolean(),
+  cleanupPolicy: ManagedChildCleanupPolicy.default('terminate-tree')
+}).strict()
+
+export type ManagedChildProcess = z.infer<typeof ManagedChildProcessSchema>


### PR DESCRIPTION
## Problem

The new managed-child contract needs a single owner for live child records before shell, LSP, Whisper, extension-host, and subagent integrations can share shutdown and cancellation handling.

## Scope

This PR adds the in-memory registry on top of the contract from #903. It does not start, signal, or terminate OS processes.

## Changes

- Register validated child records and reject duplicate IDs.
- Support owner-scoped listing and lifecycle updates for PID, detach state, and cleanup policy.
- Return defensive snapshots so callers cannot mutate registry state.
- Make remove and drain idempotent for repeated shutdown paths.

## Safety

- Records are validated by the strict shared contract before insertion.
- No command, environment, token, path, or process output is stored.
- `drain()` only returns records for caller-owned cleanup; it never performs termination itself.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
npm.cmd exec vitest run src/main/services/managed-child-process-registry.test.ts
npm.cmd run lint
npm.cmd run build
git diff --check
```

Passed: 4 registry tests; root lint and build passed; diff check passed.

## Review performed

- Functional correctness
- Registry ownership and lifecycle boundaries
- Idempotent cleanup behavior
- Data and secret safety
- Cross-platform contract compatibility
- Test quality and PR scope

## Non-goals

- Process spawning or termination
- Shell, LSP, Whisper, extension-host, or subagent integration
- Persistence across application restarts

## Dependency

Depends on #903 for `ManagedChildProcess` contract. After #903 merges, this branch should be rebased onto `develop` and the dependency commit dropped.
