### PR TITLE
feat(terminal): register PTY processes for lifecycle cleanup

### DIFF
--- a/src/main/services/managed-child-process-registry.test.ts
+++ b/src/main/services/managed-child-process-registry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ManagedChildProcessRegistry,
+  ManagedChildProcessRegistryError
+} from './managed-child-process-registry'
+
+const record = (id: string, ownerId = 'turn_1') => ({
+  id,
+  ownerKind: 'shell',
+  ownerId,
+  pid: 1234,
+  startedAt: '2026-07-14T00:00:00.000Z',
+  detached: false,
+  cleanupPolicy: 'terminate-tree' as const
+})
+
+describe('ManagedChildProcessRegistry', () => {
+  it('registers, filters, updates, and returns defensive snapshots', () => {
+    const registry = new ManagedChildProcessRegistry()
+    registry.register(record('child_1'))
+    registry.register({ ...record('child_2', 'turn_2'), ownerKind: 'lsp' })
+
+    expect(registry.list({ ownerKind: 'shell' }).map((item) => item.id)).toEqual(['child_1'])
+    const updated = registry.update('child_1', { detached: true, cleanupPolicy: 'preserve' })
+    expect(updated.detached).toBe(true)
+    expect(Object.isFrozen(updated)).toBe(true)
+    expect(registry.get('child_1')?.detached).toBe(true)
+  })
+
+  it('rejects duplicate IDs and missing updates', () => {
+    const registry = new ManagedChildProcessRegistry()
+    registry.register(record('child_1'))
+    expect(() => registry.register(record('child_1'))).toThrowError(
+      new ManagedChildProcessRegistryError('DUPLICATE', 'Managed child process is already registered: child_1')
+    )
+    expect(() => registry.update('missing', { detached: true })).toThrowError(
+      new ManagedChildProcessRegistryError('NOT_FOUND', 'Managed child process was not found: missing')
+    )
+  })
+
+  it('makes remove and drain idempotent and returns cleanup snapshots', () => {
+    const registry = new ManagedChildProcessRegistry()
+    registry.register(record('child_1'))
+    registry.register(record('child_2'))
+
+    expect(registry.remove('missing')).toBe(false)
+    expect(registry.remove('child_1')).toBe(true)
+    expect(registry.remove('child_1')).toBe(false)
+    expect(registry.drain().map((item) => item.id)).toEqual(['child_2'])
+    expect(registry.drain()).toEqual([])
+    expect(registry.size()).toBe(0)
+  })
+
+  it('validates records before registration and does not leak invalid state', () => {
+    const registry = new ManagedChildProcessRegistry()
+    expect(() => registry.register({ ...record('child_1'), pid: 0 })).toThrow()
+    expect(registry.size()).toBe(0)
+  })
+})

--- a/src/main/services/managed-child-process-registry.ts
+++ b/src/main/services/managed-child-process-registry.ts
@@ -1,0 +1,81 @@
+import {
+  ManagedChildProcessSchema,
+  type ManagedChildCleanupPolicy,
+  type ManagedChildProcess
+} from '../../shared/managed-child-process'
+
+export type ManagedChildProcessUpdate = Partial<
+  Pick<ManagedChildProcess, 'pid' | 'detached' | 'cleanupPolicy'>
+>
+
+export class ManagedChildProcessRegistryError extends Error {
+  constructor(readonly code: 'DUPLICATE' | 'NOT_FOUND', message: string) {
+    super(message)
+    this.name = 'ManagedChildProcessRegistryError'
+  }
+}
+
+/** Main-owned registry for live OS children; it never starts or terminates a process. */
+export class ManagedChildProcessRegistry {
+  private readonly records = new Map<string, ManagedChildProcess>()
+
+  register(input: ManagedChildProcess): ManagedChildProcess {
+    if (this.records.has(input.id)) {
+      throw new ManagedChildProcessRegistryError(
+        'DUPLICATE',
+        `Managed child process is already registered: ${input.id}`
+      )
+    }
+    const record = ManagedChildProcessSchema.parse(input)
+    this.records.set(record.id, record)
+    return this.snapshot(record)
+  }
+
+  get(id: string): ManagedChildProcess | undefined {
+    const record = this.records.get(id)
+    return record ? this.snapshot(record) : undefined
+  }
+
+  list(filter?: { ownerKind?: string; ownerId?: string }): ManagedChildProcess[] {
+    return [...this.records.values()]
+      .filter((record) => filter?.ownerKind === undefined || record.ownerKind === filter.ownerKind)
+      .filter((record) => filter?.ownerId === undefined || record.ownerId === filter.ownerId)
+      .map((record) => this.snapshot(record))
+  }
+
+  update(id: string, patch: ManagedChildProcessUpdate): ManagedChildProcess {
+    const current = this.records.get(id)
+    if (!current) {
+      throw new ManagedChildProcessRegistryError('NOT_FOUND', `Managed child process was not found: ${id}`)
+    }
+    const next = ManagedChildProcessSchema.parse({ ...current, ...patch })
+    this.records.set(id, next)
+    return this.snapshot(next)
+  }
+
+  /** Removing an already-removed child is intentionally idempotent for shutdown paths. */
+  remove(id: string): boolean {
+    return this.records.delete(id)
+  }
+
+  /** Returns the records that require caller-owned cleanup and empties the registry. */
+  drain(): ManagedChildProcess[] {
+    const records = this.list()
+    this.records.clear()
+    return records
+  }
+
+  clear(): void {
+    this.records.clear()
+  }
+
+  size(): number {
+    return this.records.size
+  }
+
+  private snapshot(record: ManagedChildProcess): ManagedChildProcess {
+    return Object.freeze({ ...record })
+  }
+}
+
+export type { ManagedChildCleanupPolicy }

--- a/src/main/terminal/terminal-pty-ipc.test.ts
+++ b/src/main/terminal/terminal-pty-ipc.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ManagedChildProcessRegistry } from '../services/managed-child-process-registry'
+import { registerTerminalProcess, terminalProcessRecord } from './terminal-pty-ipc'
+
+describe('terminalProcessRecord', () => {
+  it('uses a namespaced owner identity and safe default cleanup policy', () => {
+    expect(terminalProcessRecord('session_1', 4321, '2026-07-14T00:00:00.000Z')).toEqual({
+      id: 'terminal:session_1',
+      ownerKind: 'terminal',
+      ownerId: 'session_1',
+      pid: 4321,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: false,
+      cleanupPolicy: 'terminate-tree'
+    })
+  })
+
+  it('does not depend on wall-clock mocking when a timestamp is supplied', () => {
+    const now = vi.spyOn(Date.prototype, 'toISOString').mockReturnValue('2026-07-14T01:02:03.000Z')
+    try {
+      expect(terminalProcessRecord('session_2', 4322).startedAt).toBe('2026-07-14T01:02:03.000Z')
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('registers the terminal lifecycle in the shared registry', () => {
+    const registry = new ManagedChildProcessRegistry()
+    const processId = registerTerminalProcess(
+      registry,
+      'session_3',
+      4323,
+      '2026-07-14T02:03:04.000Z'
+    )
+
+    expect(registry.get(processId)).toMatchObject({
+      id: 'terminal:session_3',
+      ownerKind: 'terminal',
+      ownerId: 'session_3',
+      pid: 4323
+    })
+    expect(registry.remove(processId)).toBe(true)
+    expect(registry.get(processId)).toBeUndefined()
+  })
+})

--- a/src/main/terminal/terminal-pty-ipc.ts
+++ b/src/main/terminal/terminal-pty-ipc.ts
@@ -32,13 +32,42 @@ import {
   terminalSessionIdSchema,
   terminalWritePayloadSchema
 } from '../ipc/app-ipc-schemas'
+import { ManagedChildProcessRegistry } from '../services/managed-child-process-registry'
 
 type TerminalSession = {
   pty: IPty
   sender: WebContents
+  processId: string
   /** Last ~64KB of output, replayed when a panel re-attaches. */
   ringBuffer: string
   exited: boolean
+}
+
+export function terminalProcessRecord(
+  sessionId: string,
+  pid: number,
+  startedAt = new Date().toISOString()
+) {
+  return {
+    id: `terminal:${sessionId}`,
+    ownerKind: 'terminal',
+    ownerId: sessionId,
+    pid,
+    startedAt,
+    detached: false,
+    cleanupPolicy: 'terminate-tree' as const
+  }
+}
+
+export function registerTerminalProcess(
+  registry: ManagedChildProcessRegistry,
+  sessionId: string,
+  pid: number,
+  startedAt?: string
+): string {
+  const record = terminalProcessRecord(sessionId, pid, startedAt)
+  registry.register(record)
+  return record.id
 }
 
 let nodePty: typeof import('node-pty') | null | undefined
@@ -164,11 +193,13 @@ export type RegisterTerminalPtyIpcOptions = {
    * when not provided.
    */
   getTerminalColorMode?: () => TerminalColorMode | Promise<TerminalColorMode>
+  processRegistry?: ManagedChildProcessRegistry
 }
 
 export function registerTerminalPtyIpc(options: RegisterTerminalPtyIpcOptions): void {
   const { ipcMain, getMainWindow, logError, getTerminalColorMode } = options
   const sessions = new Map<string, TerminalSession>()
+  const processRegistry = options.processRegistry ?? new ManagedChildProcessRegistry()
 
   const disposeSession = (sessionId: string, killedByClient: boolean): boolean => {
     const session = sessions.get(sessionId)
@@ -181,6 +212,7 @@ export function registerTerminalPtyIpc(options: RegisterTerminalPtyIpcOptions): 
         message: error instanceof Error ? error.message : String(error)
       })
     }
+    processRegistry.remove(session.processId)
     sessions.delete(sessionId)
     if (!killedByClient && !session.sender.isDestroyed()) {
       sendToSender(session.sender, 'terminal:exit', { sessionId, exitCode: null })
@@ -266,9 +298,21 @@ export function registerTerminalPtyIpc(options: RegisterTerminalPtyIpcOptions): 
         useConpty: true
       })
 
+      let processId: string
+      try {
+        processId = registerTerminalProcess(processRegistry, request.sessionId, pty.pid)
+      } catch (error) {
+        try {
+          pty.kill()
+        } catch {
+          // The registration failure is already the actionable error.
+        }
+        throw error
+      }
       const session: TerminalSession = {
         pty,
         sender: event.sender,
+        processId,
         ringBuffer: '',
         exited: false
       }
@@ -283,6 +327,7 @@ export function registerTerminalPtyIpc(options: RegisterTerminalPtyIpcOptions): 
 
       pty.onExit(({ exitCode }) => {
         session.exited = true
+        processRegistry.remove(session.processId)
         sendToSender(session.sender, 'terminal:exit', { sessionId: request.sessionId, exitCode })
         // Keep the entry briefly so a slow re-attach can still replay; the
         // next create disposes it. Full cleanup also happens on app quit.

--- a/src/shared/managed-child-process.test.ts
+++ b/src/shared/managed-child-process.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { ManagedChildProcessSchema } from './managed-child-process'
+
+describe('ManagedChildProcessSchema', () => {
+  it('defaults cleanup to terminating the process tree', () => {
+    expect(ManagedChildProcessSchema.parse({
+      id: 'child_1',
+      ownerKind: 'shell',
+      ownerId: 'turn_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: false
+    }).cleanupPolicy).toBe('terminate-tree')
+  })
+
+  it('accepts an explicitly preserved detached child', () => {
+    expect(ManagedChildProcessSchema.parse({
+      id: 'child_2',
+      ownerKind: 'extension-host',
+      ownerId: 'extension_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: true,
+      cleanupPolicy: 'preserve'
+    }).detached).toBe(true)
+  })
+
+  it('rejects invalid PIDs, timestamps, cleanup policies, and extra fields', () => {
+    const base = {
+      id: 'child_1',
+      ownerKind: 'shell',
+      ownerId: 'turn_1',
+      pid: 1234,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      detached: false
+    }
+
+    expect(() => ManagedChildProcessSchema.parse({ ...base, pid: 0 })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, startedAt: 'now' })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, cleanupPolicy: 'ignore' })).toThrow()
+    expect(() => ManagedChildProcessSchema.parse({ ...base, command: 'secret' })).toThrow()
+  })
+})

--- a/src/shared/managed-child-process.ts
+++ b/src/shared/managed-child-process.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const ManagedChildCleanupPolicy = z.enum([
+  'terminate',
+  'terminate-tree',
+  'preserve'
+])
+export type ManagedChildCleanupPolicy = z.infer<typeof ManagedChildCleanupPolicy>
+
+/** Cross-module identity and lifecycle metadata for a real child process. */
+export const ManagedChildProcessSchema = z.object({
+  id: z.string().min(1).max(128),
+  ownerKind: z.string().min(1).max(64),
+  ownerId: z.string().min(1).max(128),
+  pid: z.number().int().positive().safe(),
+  startedAt: z.string().datetime({ offset: true }),
+  detached: z.boolean(),
+  cleanupPolicy: ManagedChildCleanupPolicy.default('terminate-tree')
+}).strict()
+
+export type ManagedChildProcess = z.infer<typeof ManagedChildProcessSchema>


### PR DESCRIPTION
## Problem

The built-in terminal owns real PTY child processes, but those PIDs were only held inside the terminal session map. Shared shutdown, cancellation, and diagnostics could not see the live process lifecycle.

## Root cause

Terminal session state and OS child ownership were not connected to the managed-child registry.

## Scope

This PR wires only the built-in terminal PTY path to the registry. LSP, Whisper, extension-host, and subagent integrations remain separate follow-ups.

## Changes

- Register each PTY after spawn with a namespaced `terminal:<sessionId>` identity.
- Remove the record on PTY exit and all existing dispose paths, including renderer destruction and app shutdown.
- If registration fails, kill the newly spawned PTY before returning the error.
- Add a small lifecycle helper and tests that exercise registration and removal against a real registry instance.

## Safety

- No command, environment, token, path, or output is added to the registry record.
- Registry cleanup is bookkeeping only; the existing terminal dispose path remains responsible for killing the PTY.
- Existing terminal IPC payloads and replay behavior are unchanged.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
npm.cmd run build:extensions
npm.cmd exec vitest run src/main/terminal/terminal-pty-ipc.test.ts
npm.cmd run lint
npm.cmd run build
git diff --check
```

Passed: 3 terminal lifecycle tests; root lint and build passed; diff check passed. The first test attempt before building extension workspaces was an environment resolution failure; the same test passed after the required extension build.

## Review performed

- Functional PTY lifecycle
- Cleanup and stale process handling
- Failure rollback when registration fails
- Data and secret safety
- Cross-platform behavior
- Test quality and PR scope

## Non-goals

- LSP, Whisper, extension-host, or subagent process registration
- Persisting records across application restarts
- Changing terminal UI or IPC payloads

## Dependency

Depends on #905 for the managed child process registry. After #905 merges, rebase this branch onto `develop` and drop dependency commits.
