### PR TITLE
ci: classify native packaging failures

### DIFF
--- a/scripts/packaging-failure-classifier.cjs
+++ b/scripts/packaging-failure-classifier.cjs
@@ -1,0 +1,143 @@
+'use strict'
+
+const MAX_LOG_BYTES = 256 * 1024
+const MAX_SUMMARY_LINES = 3
+const MAX_LINE_LENGTH = 512
+
+const PACKAGING_FAILURE_KINDS = Object.freeze([
+  'dependency-install',
+  'native-rebuild',
+  'typescript',
+  'unit-test',
+  'bundle',
+  'electron-package',
+  'artifact-layout',
+  'runtime-smoke',
+  'renderer-smoke',
+  'signature',
+  'notarization',
+  'cleanup',
+  'infrastructure'
+])
+
+const PATTERNS = [
+  ['infrastructure', [
+    /failed to resolve action download info/i,
+    /service unavailable/i,
+    /runner (?:is )?(?:offline|unavailable|failure)/i,
+    /github (?:api|actions).*(?:unavailable|failure|timeout)/i
+  ]],
+  ['notarization', [/notariz/i, /gatekeeper/i]],
+  ['signature', [/codesign/i, /code signing/i, /signing credentials/i, /(?:sign|signing).*certificate/i, /developer id/i]],
+  ['renderer-smoke', [/smoke.*(?:desktop|chromium|renderer)/i, /guest target/i, /renderer.*(?:did not load|failed to start)/i]],
+  ['runtime-smoke', [/smoke.*(?:runtime|backend|health)/i, /health check.*(?:failed|timeout)/i]],
+  ['artifact-layout', [/if-no-files-found/i, /artifact.*(?:missing|not found)/i, /no files found/i, /expected artifact/i]],
+  ['cleanup', [/cleanup.*failed/i, /failed.*cleanup/i, /unlink.*(?:busy|failed)/i, /EPERM.*(?:remove|rmdir)/i]],
+  ['native-rebuild', [/node-gyp/i, /prebuild-install/i, /better-sqlite3.*(?:binding|load)/i, /native.*rebuild/i]],
+  ['dependency-install', [/npm (?:ci|install).*failed/i, /npm ERR!/i, /electron failed to install/i, /unable to resolve (?:dependency|package)/i]],
+  ['typescript', [/tsc/i, /typecheck/i, /typescript error/i]],
+  ['unit-test', [/vitest/i, /jest/i, /(?:unit )?tests?.*(?:failed|failing)/i, /test run.*failed/i]],
+  ['bundle', [/electron-vite/i, /vite.*(?:failed|error)/i, /rollup.*(?:failed|error)/i]],
+  ['electron-package', [/electron-builder/i, /packaging.*failed/i, /appimage.*failed/i, /nsis.*failed/i]
+  ]
+]
+
+const REPRO_COMMANDS = {
+  package: {
+    linux: 'npm run dist:linux',
+    darwin: 'npm run dist:mac',
+    win32: 'npm.cmd run dist:win',
+    unknown: 'npm run dist'
+  },
+  'renderer-smoke': 'npm run smoke:packaged-extension-desktop',
+  'runtime-smoke': 'npm run smoke:packaged-extensions',
+  typescript: 'npm run typecheck',
+  'unit-test': 'npm test',
+  bundle: 'npm run build',
+  'electron-package': 'npm run dist',
+  'dependency-install': 'npm ci',
+  'native-rebuild': 'npm rebuild',
+  'artifact-layout': 'npm run dist',
+  cleanup: 'npm run dist',
+  signature: 'npm run verify:apple',
+  notarization: 'npm run verify:apple',
+  infrastructure: 'rerun the failed GitHub Actions job after service recovery'
+}
+
+function normalizePlatform(platform) {
+  if (platform === 'linux') return 'linux'
+  if (platform === 'darwin' || platform === 'macos' || platform === 'osx') return 'darwin'
+  if (platform === 'win32' || platform === 'windows' || platform === 'win') return 'win32'
+  return 'unknown'
+}
+
+function boundedLog(log) {
+  const text = typeof log === 'string' ? log : ''
+  return Buffer.byteLength(text, 'utf8') <= MAX_LOG_BYTES
+    ? text
+    : text.slice(-MAX_LOG_BYTES)
+}
+
+function redact(text) {
+  return text
+    .replace(/(authorization|bearer|token|password|secret|api[_-]?key)\s*[:=]\s*\S+/gi, '$1=[REDACTED]')
+    .replace(/Bearer\s+\S+/gi, 'Bearer [REDACTED]')
+}
+
+function summary(log) {
+  const candidates = boundedLog(log)
+    .split(/\r?\n/)
+    .filter((line) => /error|failed|failure|exception|timed out|missing|unavailable/i.test(line))
+    .slice(-MAX_SUMMARY_LINES)
+  return candidates.map((line) => redact(line).slice(0, MAX_LINE_LENGTH))
+}
+
+function classifyKind(log) {
+  for (const [kind, patterns] of PATTERNS) {
+    if (patterns.some((pattern) => pattern.test(log))) return kind
+  }
+  return 'electron-package'
+}
+
+function isLikelyCodeFailure(kind) {
+  return !['infrastructure', 'dependency-install', 'native-rebuild', 'cleanup', 'signature', 'notarization'].includes(kind)
+}
+
+function localReproductionCommand(kind, platform) {
+  if (kind === 'infrastructure') return REPRO_COMMANDS.infrastructure
+  const commandForPlatform = (command) => platform === 'win32'
+    ? command.replace(/^npm /, 'npm.cmd ')
+    : command
+  if (kind in REPRO_COMMANDS) {
+    const command = REPRO_COMMANDS[kind]
+    if (typeof command === 'string') return commandForPlatform(command)
+  }
+  return commandForPlatform(REPRO_COMMANDS.package[platform])
+}
+
+function classifyPackagingFailure(input = {}) {
+  const platform = normalizePlatform(input.platform)
+  const log = boundedLog(input.log)
+  const kind = classifyKind(log)
+  const artifactPath = typeof input.artifactPath === 'string' && input.artifactPath.length <= 512
+    ? input.artifactPath
+    : undefined
+  return {
+    kind,
+    platform,
+    artifactExists: input.artifactExists === true,
+    ...(artifactPath ? { artifactPath } : {}),
+    lastSuccessfulStep: typeof input.lastSuccessfulStep === 'string'
+      ? redact(input.lastSuccessfulStep).slice(0, MAX_LINE_LENGTH)
+      : undefined,
+    keyLog: summary(log),
+    localReproductionCommand: localReproductionCommand(kind, platform),
+    isLikelyCodeFailure: isLikelyCodeFailure(kind)
+  }
+}
+
+module.exports = {
+  MAX_LOG_BYTES,
+  PACKAGING_FAILURE_KINDS,
+  classifyPackagingFailure
+}

--- a/scripts/packaging-failure-classifier.test.cjs
+++ b/scripts/packaging-failure-classifier.test.cjs
@@ -1,0 +1,63 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const {
+  MAX_LOG_BYTES,
+  PACKAGING_FAILURE_KINDS,
+  classifyPackagingFailure
+} = require('./packaging-failure-classifier.cjs')
+
+test('classifies runner service failures separately from code failures', () => {
+  const result = classifyPackagingFailure({
+    platform: 'windows',
+    log: 'Failed to resolve action download info: Service Unavailable'
+  })
+  assert.equal(result.kind, 'infrastructure')
+  assert.equal(result.platform, 'win32')
+  assert.equal(result.isLikelyCodeFailure, false)
+  assert.match(result.localReproductionCommand, /rerun/)
+})
+
+test('classifies renderer and runtime smoke failures with focused commands', () => {
+  assert.equal(classifyPackagingFailure({
+    platform: 'linux',
+    log: 'Timed out waiting for kun-extension guest target'
+  }).kind, 'renderer-smoke')
+  assert.equal(classifyPackagingFailure({
+    platform: 'linux',
+    log: 'backend health check failed after launch'
+  }).kind, 'runtime-smoke')
+})
+
+test('reports artifact state and a platform-specific package command', () => {
+  const result = classifyPackagingFailure({
+    platform: 'win32',
+    log: 'Error: expected artifact was not found',
+    artifactExists: false,
+    artifactPath: 'dist/Kun-0.1.0-win-x64.exe',
+    lastSuccessfulStep: 'Build Windows installer'
+  })
+  assert.equal(result.kind, 'artifact-layout')
+  assert.equal(result.artifactExists, false)
+  assert.equal(result.artifactPath, 'dist/Kun-0.1.0-win-x64.exe')
+  assert.equal(result.localReproductionCommand, 'npm.cmd run dist')
+  assert.equal(result.lastSuccessfulStep, 'Build Windows installer')
+})
+
+test('redacts secrets and bounds large log summaries', () => {
+  const result = classifyPackagingFailure({
+    platform: 'darwin',
+    log: `${'x'.repeat(MAX_LOG_BYTES + 100)}\nError: token=super-secret-value`
+  })
+  assert.ok(result.keyLog.every((line) => !line.includes('super-secret-value')))
+  assert.ok(result.keyLog.every((line) => line.length <= 512))
+})
+
+test('keeps the classifier vocabulary stable', () => {
+  assert.deepEqual(PACKAGING_FAILURE_KINDS, [
+    'dependency-install', 'native-rebuild', 'typescript', 'unit-test', 'bundle',
+    'electron-package', 'artifact-layout', 'runtime-smoke', 'renderer-smoke',
+    'signature', 'notarization', 'cleanup', 'infrastructure'
+  ])
+})


### PR DESCRIPTION
## Problem

Packaging failures currently require reading the full CI log to decide whether the cause is code, packaging, artifact layout, or a GitHub runner outage. This has already caused code changes to be blamed for infrastructure failures.

## Scope

This PR adds a pure packaging-failure classifier and tests. It does not change CI workflows or rerun policy.

## Changes

- Classify failures into the documented packaging kinds: dependency install, native rebuild, TypeScript, tests, bundle, electron package, artifact layout, runtime/renderer smoke, signing, notarization, cleanup, and infrastructure.
- Return normalized platform, artifact presence, last successful step, a bounded redacted key-log summary, a local reproduction command, and a code-failure hint.
- Recognize Windows/macOS aliases and emit `npm.cmd` on Windows.
- Bound input logs to 256 KiB and summaries to three 512-character lines; never return full logs.

## Safety

- The classifier is pure and does not execute commands, upload logs, or persist credentials.
- Token, password, secret, API key, and bearer values are redacted from returned summaries and metadata.
- Infrastructure failures are explicitly separated from likely code failures to avoid masking runner outages with retries.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
node --test scripts/packaging-failure-classifier.test.cjs
npm.cmd run lint
npm.cmd run build
git diff --check
```

Passed: 5 classifier tests; root lint and build passed; diff check passed.

## Review performed

- Functional classification precedence
- Secret and log-size boundaries
- Cross-platform reproduction commands
- Backward compatibility (standalone script, no workflow changes)
- Test quality and PR scope

## Non-goals

- GitHub Actions integration
- Automatic retries or quarantine
- Artifact upload/download
- Native package execution

## Follow-ups

H2 can consume this classifier for path-based native smoke reporting, and H3 can expose the same reproduction commands locally.
