### PR TITLE
ci: gate native smoke by changed paths

### DIFF
--- a/scripts/native-smoke-path-gate.cjs
+++ b/scripts/native-smoke-path-gate.cjs
@@ -1,0 +1,64 @@
+'use strict'
+
+const NATIVE_SMOKE_RULES = Object.freeze([
+  { id: 'main', test: (path) => path.startsWith('src/main/'), reason: 'main-process code can change packaged runtime behavior' },
+  { id: 'preload', test: (path) => path.startsWith('src/preload/'), reason: 'preload bridge changes require packaged IPC validation' },
+  { id: 'builder', test: (path) => /^electron-builder(?:\.|\/)/.test(path), reason: 'electron-builder configuration changes package layout' },
+  { id: 'scripts', test: (path) => path.startsWith('scripts/'), reason: 'packaging or smoke scripts changed' },
+  { id: 'icons', test: (path) => path.startsWith('assets/icons/'), reason: 'packaged icon assets changed' },
+  { id: 'kun-runtime', test: (path) => path.startsWith('kun/src/'), reason: 'Kun runtime changes require packaged backend validation' },
+  { id: 'native-dependencies', test: (path) => path === 'package.json' || path === 'package-lock.json' || path.startsWith('packages/'), reason: 'native or extension dependencies may change packaged behavior' }
+])
+
+function normalizePath(path) {
+  if (typeof path !== 'string') return ''
+  return path.replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/+/g, '/').replace(/\/$/, '')
+}
+
+function evaluateNativeSmoke(paths, options = {}) {
+  const safeOptions = options && typeof options === 'object' ? options : {}
+  const normalizedPaths = [...new Set((Array.isArray(paths) ? paths : []).map(normalizePath).filter(Boolean))]
+  const manual = safeOptions.event === 'workflow_dispatch' || safeOptions.force === true
+  const matches = []
+  for (const path of normalizedPaths) {
+    for (const rule of NATIVE_SMOKE_RULES) {
+      if (rule.test(path)) matches.push({ path, ruleId: rule.id, reason: rule.reason })
+    }
+  }
+  const uniqueMatches = matches.filter((match, index, all) =>
+    all.findIndex((candidate) => candidate.path === match.path && candidate.ruleId === match.ruleId) === index
+  )
+  if (manual) {
+    return {
+      decision: 'native-smoke-required',
+      required: true,
+      reason: safeOptions.event === 'workflow_dispatch' ? 'manual workflow dispatch requested native smoke' : 'native smoke explicitly forced',
+      changedPaths: normalizedPaths,
+      matches: uniqueMatches
+    }
+  }
+  if (uniqueMatches.length > 0) {
+    return {
+      decision: 'native-smoke-required',
+      required: true,
+      reason: 'one or more changed paths affect packaged behavior',
+      changedPaths: normalizedPaths,
+      matches: uniqueMatches
+    }
+  }
+  return {
+    decision: 'native-smoke-skipped-with-reason',
+    required: false,
+    reason: normalizedPaths.length === 0
+      ? 'no changed paths were supplied'
+      : 'changed paths do not affect native packaging or packaged runtime behavior',
+    changedPaths: normalizedPaths,
+    matches: []
+  }
+}
+
+module.exports = {
+  NATIVE_SMOKE_RULES,
+  evaluateNativeSmoke,
+  normalizePath
+}

--- a/scripts/native-smoke-path-gate.test.cjs
+++ b/scripts/native-smoke-path-gate.test.cjs
@@ -1,0 +1,56 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { evaluateNativeSmoke, normalizePath } = require('./native-smoke-path-gate.cjs')
+
+test('normalizes Windows separators and duplicate paths', () => {
+  assert.equal(normalizePath('.\\src\\main\\index.ts'), 'src/main/index.ts')
+  assert.deepEqual(evaluateNativeSmoke([
+    '.\\src\\main\\index.ts',
+    'src/main/index.ts'
+  ]).changedPaths, ['src/main/index.ts'])
+})
+
+test('requires native smoke for all high-risk path families', () => {
+  for (const path of [
+    'src/main/index.ts',
+    'src/preload/index.ts',
+    'electron-builder.config.cjs',
+    'scripts/after-pack.cjs',
+    'assets/icons/icon.png',
+    'kun/src/config/provider.ts',
+    'package-lock.json'
+  ]) {
+    const result = evaluateNativeSmoke([path])
+    assert.equal(result.decision, 'native-smoke-required', path)
+    assert.equal(result.required, true, path)
+    assert.ok(result.matches.length > 0, path)
+  }
+})
+
+test('skips native smoke for documentation-only changes with an explicit reason', () => {
+  const result = evaluateNativeSmoke(['README.md', 'docs/architecture.md'])
+  assert.equal(result.decision, 'native-smoke-skipped-with-reason')
+  assert.equal(result.required, false)
+  assert.match(result.reason, /do not affect/i)
+  assert.deepEqual(result.matches, [])
+})
+
+test('manual dispatch and force always require smoke', () => {
+  assert.equal(evaluateNativeSmoke(['README.md'], { event: 'workflow_dispatch' }).required, true)
+  assert.equal(evaluateNativeSmoke(['README.md'], { force: true }).required, true)
+})
+
+test('reports every matched rule without duplicate entries', () => {
+  const result = evaluateNativeSmoke(['src/main/runtime.ts', 'src/main/runtime.ts', 'kun/src/server.ts'])
+  assert.equal(result.matches.length, 2)
+  assert.deepEqual(result.matches.map((match) => match.ruleId), ['main', 'kun-runtime'])
+})
+
+test('empty or invalid input is a safe skip, never an accidental pass', () => {
+  const result = evaluateNativeSmoke([null, '', undefined])
+  assert.equal(result.required, false)
+  assert.equal(result.decision, 'native-smoke-skipped-with-reason')
+  assert.equal(result.reason, 'no changed paths were supplied')
+})


### PR DESCRIPTION
## Problem

Native packaging is expensive, but skipping it for runtime or packaging changes can let Linux/Windows/macOS regressions reach main. Conversely, documentation-only changes should not trigger a full package smoke run.

## Scope

This PR adds a pure changed-path gate. It does not modify GitHub workflow YAML or execute any smoke command.

## Changes

- Classify changed paths as `native-smoke-required` or `native-smoke-skipped-with-reason`.
- Require smoke for main/preload, electron-builder configuration, packaging scripts, icons, Kun runtime, and dependency/extension package changes.
- Normalize Windows separators and duplicate paths.
- Force smoke for `workflow_dispatch` or an explicit `force` flag.
- Return matched rule IDs and human-readable reasons for CI diagnostics.

## Safety

- Unknown and documentation-only paths produce an explicit skip reason, never a silent pass.
- The gate is deterministic and side-effect free.
- It does not read repository contents, call GitHub, or run shell commands.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
node --test scripts/native-smoke-path-gate.test.cjs
npm.cmd run lint
npm.cmd run build
git diff --check
```

Passed: 6 path-gate tests; root typecheck, lint, and build passed; diff check passed.

## Review performed

- Path matching and normalization
- Manual dispatch/force behavior
- CI diagnostic output
- Cross-platform path handling
- Test quality and PR scope

## Non-goals

- Editing GitHub Actions workflows
- Computing Git diffs
- Running or uploading native package artifacts
- Packaging smoke implementation

## Follow-ups

H2 workflow integration can consume this result to set `native-smoke-required` and skip only low-risk changes with the returned reason.
