### PR TITLE
ci: add local packaging reproduction entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "smoke:packaged-extension-appimage": "node ./scripts/smoke-packaged-extension-appimage.cjs",
     "evidence:extension-native": "node ./scripts/write-extension-native-evidence.mjs",
     "check:extensions": "npm run check:extension-schema && npm run check:extension-docs && npm run check:extension-examples && npm run check:extension-release-gate",
+    "ci:reproduce": "node ./scripts/ci-reproduce.cjs",
     "lint": "eslint .",
     "test": "npm run test:extensions && vitest run",
     "test:watch": "vitest",

--- a/scripts/ci-reproduce.cjs
+++ b/scripts/ci-reproduce.cjs
@@ -1,0 +1,144 @@
+'use strict'
+
+const { execFileSync, spawnSync } = require('node:child_process')
+const { existsSync } = require('node:fs')
+const { join } = require('node:path')
+
+const JOBS = Object.freeze({
+  'linux-package': { commandArgs: ['run', 'dist:linux'] },
+  'windows-package': { commandArgs: ['run', 'dist:win'] },
+  'macos-package': { commandArgs: ['run', 'dist:mac'] }
+})
+
+class UsageError extends Error {}
+
+function npmCommand() {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm'
+}
+
+function parseArgs(argv) {
+  let job
+  let dryRun = false
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--dry-run') {
+      dryRun = true
+      continue
+    }
+    if (arg === '--job') {
+      job = argv[index + 1]
+      index += 1
+      continue
+    }
+    throw new UsageError(`Unknown argument: ${arg}`)
+  }
+  if (!job) throw new UsageError('Missing required --job (linux-package, windows-package, or macos-package).')
+  if (!Object.hasOwn(JOBS, job)) throw new UsageError(`Unknown job: ${job}`)
+  return { job, dryRun }
+}
+
+function buildPlan(job, root = process.cwd()) {
+  const definition = JOBS[job]
+  if (!definition) throw new UsageError(`Unknown job: ${job}`)
+  return {
+    job,
+    root,
+    command: npmCommand(),
+    args: definition.commandArgs,
+    requiredFiles: ['package.json', 'package-lock.json'],
+    requiredDirectories: ['node_modules']
+  }
+}
+
+function readVersion(command, args) {
+  try {
+    return execFileSync(command, args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: process.platform === 'win32'
+    }).trim() || 'unknown'
+  } catch {
+    return 'unavailable'
+  }
+}
+
+function collectEnvironment(root) {
+  const electronCli = join(root, 'node_modules', 'electron', 'cli.js')
+  return {
+    node: process.version,
+    npm: readVersion(npmCommand(), ['--version']),
+    electron: existsSync(electronCli)
+      ? readVersion(process.execPath, [electronCli, '--version'])
+      : 'missing'
+  }
+}
+
+function checkDependencies(plan) {
+  return {
+    files: Object.fromEntries(plan.requiredFiles.map((file) => [file, existsSync(join(plan.root, file))])),
+    directories: Object.fromEntries(plan.requiredDirectories.map((directory) => [directory, existsSync(join(plan.root, directory))]))
+  }
+}
+
+function missingDependencies(status) {
+  return [
+    ...Object.entries(status.files).filter(([, present]) => !present).map(([name]) => name),
+    ...Object.entries(status.directories).filter(([, present]) => !present).map(([name]) => name)
+  ]
+}
+
+function printPlan(plan, environment, dependencies, dryRun) {
+  console.log(`ci-reproduce: job=${plan.job}`)
+  console.log(`ci-reproduce: node=${environment.node}`)
+  console.log(`ci-reproduce: npm=${environment.npm}`)
+  console.log(`ci-reproduce: electron=${environment.electron}`)
+  console.log(`ci-reproduce: package.json=${dependencies.files['package.json'] ? 'present' : 'missing'}`)
+  console.log(`ci-reproduce: package-lock.json=${dependencies.files['package-lock.json'] ? 'present' : 'missing'}`)
+  console.log(`ci-reproduce: node_modules=${dependencies.directories.node_modules ? 'present' : 'missing'}`)
+  console.log(`ci-reproduce: command=${plan.command} ${plan.args.join(' ')}`)
+  if (dryRun) console.log('ci-reproduce: dry-run=true; command was not executed')
+}
+
+function run(argv, root = process.cwd()) {
+  let parsed
+  try {
+    parsed = parseArgs(argv)
+  } catch (error) {
+    console.error(`ci-reproduce: ${error instanceof Error ? error.message : String(error)}`)
+    return 2
+  }
+  const plan = buildPlan(parsed.job, root)
+  const environment = collectEnvironment(root)
+  const dependencies = checkDependencies(plan)
+  printPlan(plan, environment, dependencies, parsed.dryRun)
+  if (parsed.dryRun) return 0
+  const missing = missingDependencies(dependencies)
+  if (missing.length > 0) {
+    console.error(`ci-reproduce: missing prerequisites: ${missing.join(', ')}; run npm ci before reproducing CI.`)
+    return 2
+  }
+  const result = spawnSync(plan.command, plan.args, {
+    cwd: plan.root,
+    stdio: 'inherit',
+    // npm.cmd is a Windows command shim; arguments are fixed by JOBS and
+    // never include user-provided text, so shell mode is only for .cmd support.
+    shell: process.platform === 'win32'
+  })
+  if (result.error) {
+    console.error(`ci-reproduce: failed to start command: ${result.error.message}`)
+    return 1
+  }
+  return result.status ?? 1
+}
+
+if (require.main === module) process.exitCode = run(process.argv.slice(2))
+
+module.exports = {
+  JOBS,
+  UsageError,
+  buildPlan,
+  checkDependencies,
+  collectEnvironment,
+  parseArgs,
+  run
+}

--- a/scripts/ci-reproduce.test.cjs
+++ b/scripts/ci-reproduce.test.cjs
@@ -1,0 +1,34 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { buildPlan, parseArgs, run } = require('./ci-reproduce.cjs')
+
+test('parses one explicit package job and dry-run flag', () => {
+  assert.deepEqual(parseArgs(['--job', 'linux-package', '--dry-run']), {
+    job: 'linux-package',
+    dryRun: true
+  })
+})
+
+test('rejects missing and unknown jobs', () => {
+  assert.throws(() => parseArgs([]), /Missing required --job/)
+  assert.throws(() => parseArgs(['--job', 'storybook']), /Unknown job/)
+  assert.throws(() => parseArgs(['--job', 'linux-package', '--unexpected']), /Unknown argument/)
+})
+
+test('builds a fixed command plan for each supported platform job', () => {
+  assert.deepEqual(buildPlan('windows-package', 'C:/repo').args, ['run', 'dist:win'])
+  assert.deepEqual(buildPlan('macos-package', 'C:/repo').args, ['run', 'dist:mac'])
+  assert.equal(buildPlan('linux-package', 'C:/repo').root, 'C:/repo')
+})
+
+test('dry-run reports missing prerequisites without executing a package command', () => {
+  const exitCode = run(['--job', 'linux-package', '--dry-run'], 'C:/definitely-missing-kun-root')
+  assert.equal(exitCode, 0)
+})
+
+test('real execution fails explicitly when prerequisites are missing', () => {
+  const exitCode = run(['--job', 'linux-package'], 'C:/definitely-missing-kun-root')
+  assert.equal(exitCode, 2)
+})


### PR DESCRIPTION
## Problem

Native packaging failures were difficult to reproduce locally because each CI job used a different command and the required Node/npm/Electron/dependency state was not shown consistently.

## Scope

This PR adds the `ci:reproduce` entry point for the three native package jobs. It does not change CI workflows or retry policy.

## Usage

```bash
npm run ci:reproduce -- --job linux-package
npm run ci:reproduce -- --job windows-package
npm run ci:reproduce -- --job macos-package
npm run ci:reproduce -- --job linux-package --dry-run
```

## Changes

- Accept only the three explicit package jobs.
- Print Node, npm, Electron, package-lock, and `node_modules` state before execution.
- Fail with a clear non-zero status when prerequisites are missing; never silently skip a step.
- Support Windows `npm.cmd` shims without interpolating user input into a shell command.
- Provide dry-run output for command review without executing packaging.

## Safety

- Commands and arguments come from a fixed job table.
- Windows shell mode exists only for the fixed `npm.cmd` shim; no user-provided text is passed to the shell.
- No secrets, logs, or artifacts are uploaded or persisted.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
node --test scripts/ci-reproduce.test.cjs
npm.cmd run lint
npm.cmd run build
git diff --check
```

Passed: 5 local reproduction tests; root typecheck, lint, and build passed; diff check passed.

## Review performed

- Argument validation and command allow-list
- Windows `.cmd` compatibility
- Missing dependency behavior
- Dry-run vs real execution semantics
- Test quality and PR scope

## Non-goals

- GitHub Actions workflow changes
- Automatic dependency installation
- Artifact upload or smoke execution beyond the selected package command
