### PR TITLE
feat(sse): plan bounded gap recovery

### DIFF
--- a/src/shared/sse-gap.test.ts
+++ b/src/shared/sse-gap.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { inspectSseSequence, SseSequenceDecision, type SseSequenceCursor } from './sse-gap'
+
+const event = (sequence: number, streamId = 'stream_1') => ({
+  streamId,
+  sequence,
+  eventId: `event_${sequence}`,
+  occurredAt: '2026-07-14T00:00:00.000Z'
+})
+
+describe('inspectSseSequence', () => {
+  it('accepts the first event and creates a cursor', () => {
+    const result = inspectSseSequence(null, event(0))
+    expect(result.decision).toBe(SseSequenceDecision.Accepted)
+    expect(result.nextCursor).toEqual({ streamId: 'stream_1', lastSequence: 0 })
+  })
+
+  it('accepts the next contiguous event and advances only the returned cursor', () => {
+    const cursor: SseSequenceCursor = { streamId: 'stream_1', lastSequence: 0 }
+    const result = inspectSseSequence(cursor, event(1))
+    expect(result.decision).toBe(SseSequenceDecision.Accepted)
+    expect(result.nextCursor?.lastSequence).toBe(1)
+    expect(cursor.lastSequence).toBe(0)
+  })
+
+  it('classifies duplicate and out-of-order events without moving the cursor', () => {
+    const cursor = { streamId: 'stream_1', lastSequence: 4 }
+    expect(inspectSseSequence(cursor, event(4)).decision).toBe(SseSequenceDecision.Duplicate)
+    expect(inspectSseSequence(cursor, event(2)).decision).toBe(SseSequenceDecision.OutOfOrder)
+    expect(inspectSseSequence(cursor, event(4)).nextCursor).toEqual(cursor)
+  })
+
+  it('reports a gap and leaves projection at the last confirmed sequence', () => {
+    const cursor = { streamId: 'stream_1', lastSequence: 4 }
+    const result = inspectSseSequence(cursor, event(7))
+    expect(result.decision).toBe(SseSequenceDecision.Gap)
+    expect(result.expectedSequence).toBe(5)
+    expect(result.nextCursor).toEqual(cursor)
+  })
+
+  it('rejects events from an old or replaced stream', () => {
+    const cursor = { streamId: 'stream_2', lastSequence: 4 }
+    const result = inspectSseSequence(cursor, event(5, 'stream_1'))
+    expect(result.decision).toBe(SseSequenceDecision.OldStream)
+    expect(result.nextCursor).toEqual(cursor)
+  })
+
+  it('validates event metadata before making a projection decision', () => {
+    expect(() => inspectSseSequence(null, { ...event(0), eventId: '' })).toThrow()
+  })
+})

--- a/src/shared/sse-gap.ts
+++ b/src/shared/sse-gap.ts
@@ -1,0 +1,90 @@
+import {
+  SequencedRuntimeEventSchema,
+  type SequencedRuntimeEvent
+} from './sse-sequence'
+
+export type SseSequenceCursor = {
+  streamId: string
+  lastSequence: number
+}
+
+export const SseSequenceDecision = {
+  Accepted: 'accepted',
+  Duplicate: 'duplicate',
+  Gap: 'gap',
+  OutOfOrder: 'out-of-order',
+  OldStream: 'old-stream'
+} as const
+export type SseSequenceDecision = typeof SseSequenceDecision[keyof typeof SseSequenceDecision]
+
+export type SseSequenceInspection = {
+  decision: SseSequenceDecision
+  streamId: string
+  receivedSequence: number
+  expectedSequence: number | null
+  nextCursor: SseSequenceCursor | null
+}
+
+/**
+ * Compares one validated event with a renderer cursor without mutating it.
+ * A gap must stop projection until a bounded replay or authoritative reload runs.
+ */
+export function inspectSseSequence(
+  cursor: SseSequenceCursor | null,
+  rawEvent: SequencedRuntimeEvent
+): SseSequenceInspection {
+  const event = SequencedRuntimeEventSchema.parse(rawEvent)
+  if (!cursor) {
+    return {
+      decision: SseSequenceDecision.Accepted,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence: event.sequence,
+      nextCursor: { streamId: event.streamId, lastSequence: event.sequence }
+    }
+  }
+  if (event.streamId !== cursor.streamId) {
+    return {
+      decision: SseSequenceDecision.OldStream,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence: null,
+      nextCursor: cursor
+    }
+  }
+  const expectedSequence = cursor.lastSequence + 1
+  if (event.sequence === expectedSequence) {
+    return {
+      decision: SseSequenceDecision.Accepted,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: { streamId: cursor.streamId, lastSequence: event.sequence }
+    }
+  }
+  if (event.sequence === cursor.lastSequence) {
+    return {
+      decision: SseSequenceDecision.Duplicate,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: cursor
+    }
+  }
+  if (event.sequence > expectedSequence) {
+    return {
+      decision: SseSequenceDecision.Gap,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: cursor
+    }
+  }
+  return {
+    decision: SseSequenceDecision.OutOfOrder,
+    streamId: event.streamId,
+    receivedSequence: event.sequence,
+    expectedSequence,
+    nextCursor: cursor
+  }
+}

--- a/src/shared/sse-recovery.test.ts
+++ b/src/shared/sse-recovery.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { inspectSseSequence } from './sse-gap'
+import { planSseRecovery } from './sse-recovery'
+
+const event = (sequence: number, streamId = 'stream_1') => ({
+  streamId,
+  sequence,
+  eventId: `event_${sequence}`,
+  occurredAt: '2026-07-14T00:00:00.000Z'
+})
+
+describe('planSseRecovery', () => {
+  it('does nothing for accepted, duplicate, and out-of-order events', () => {
+    const accepted = inspectSseSequence({ streamId: 'stream_1', lastSequence: 0 }, event(1))
+    const duplicate = inspectSseSequence({ streamId: 'stream_1', lastSequence: 1 }, event(1))
+    const stale = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(0))
+    expect(planSseRecovery(accepted).action).toBe('none')
+    expect(planSseRecovery(duplicate).action).toBe('none')
+    expect(planSseRecovery(stale).action).toBe('none')
+  })
+
+  it('plans a bounded replay for a small gap', () => {
+    const inspection = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(5))
+    expect(planSseRecovery(inspection, { maxReplayEvents: 8 })).toEqual({
+      action: 'replay',
+      streamId: 'stream_1',
+      fromSequence: 3,
+      toSequence: 4,
+      maxEvents: 8
+    })
+  })
+
+  it('reloads when a gap exceeds the replay budget or replay failed', () => {
+    const inspection = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(10))
+    expect(planSseRecovery(inspection, { maxReplayEvents: 3 })).toMatchObject({
+      action: 'reload',
+      reason: 'gap-too-large'
+    })
+    expect(planSseRecovery(inspection, { replayFailed: true })).toMatchObject({
+      action: 'reload',
+      reason: 'replay-failed'
+    })
+  })
+
+  it('reloads for an old stream and caps unsafe replay budgets', () => {
+    const oldStream = inspectSseSequence({ streamId: 'stream_2', lastSequence: 2 }, event(3, 'stream_1'))
+    expect(planSseRecovery(oldStream)).toEqual({
+      action: 'reload',
+      streamId: 'stream_1',
+      reason: 'old-stream'
+    })
+    const gap = inspectSseSequence({ streamId: 'stream_1', lastSequence: 0 }, event(2))
+    expect(planSseRecovery(gap, { maxReplayEvents: 99999 })).toMatchObject({ maxEvents: 1000 })
+  })
+})

--- a/src/shared/sse-recovery.ts
+++ b/src/shared/sse-recovery.ts
@@ -1,0 +1,51 @@
+import {
+  SseSequenceDecision,
+  type SseSequenceInspection
+} from './sse-gap'
+
+export type SseRecoveryPlan =
+  | { action: 'none'; reason: 'accepted' | 'duplicate' | 'out-of-order'; streamId: string }
+  | { action: 'replay'; streamId: string; fromSequence: number; toSequence: number; maxEvents: number }
+  | { action: 'reload'; streamId: string; reason: 'old-stream' | 'gap-too-large' | 'replay-failed' }
+
+export type SseRecoveryOptions = {
+  maxReplayEvents?: number
+  replayFailed?: boolean
+}
+
+/** Chooses a bounded recovery action; it never performs I/O or mutates the projection. */
+export function planSseRecovery(
+  inspection: SseSequenceInspection,
+  options: SseRecoveryOptions = {}
+): SseRecoveryPlan {
+  if (inspection.decision === SseSequenceDecision.OldStream) {
+    return { action: 'reload', streamId: inspection.streamId, reason: 'old-stream' }
+  }
+  if (inspection.decision !== SseSequenceDecision.Gap) {
+    return {
+      action: 'none',
+      reason: inspection.decision,
+      streamId: inspection.streamId
+    }
+  }
+  const maxEvents = Number.isSafeInteger(options.maxReplayEvents) && (options.maxReplayEvents ?? 0) > 0
+    ? Math.min(options.maxReplayEvents as number, 1000)
+    : 128
+  const fromSequence = inspection.expectedSequence
+  const toSequence = inspection.receivedSequence - 1
+  if (
+    options.replayFailed === true ||
+    fromSequence === null ||
+    toSequence < fromSequence ||
+    toSequence - fromSequence + 1 > maxEvents
+  ) {
+    return { action: 'reload', streamId: inspection.streamId, reason: options.replayFailed ? 'replay-failed' : 'gap-too-large' }
+  }
+  return {
+    action: 'replay',
+    streamId: inspection.streamId,
+    fromSequence,
+    toSequence,
+    maxEvents
+  }
+}

--- a/src/shared/sse-sequence.test.ts
+++ b/src/shared/sse-sequence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { SequencedRuntimeEventSchema } from './sse-sequence'
+
+describe('SequencedRuntimeEventSchema', () => {
+  it('accepts a stable stream sequence envelope', () => {
+    const event = {
+      streamId: 'stream_123',
+      sequence: 42,
+      eventId: 'evt_42',
+      occurredAt: '2026-07-14T00:00:00.000Z'
+    }
+
+    expect(SequencedRuntimeEventSchema.parse(event)).toEqual(event)
+  })
+
+  it('accepts sequence zero for a newly-created stream', () => {
+    expect(SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 0,
+      eventId: 'evt_0',
+      occurredAt: '2026-07-14T00:00:00+00:00'
+    }).sequence).toBe(0)
+  })
+
+  it('rejects unsafe sequences, invalid timestamps, and unknown fields', () => {
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: Number.MAX_SAFE_INTEGER + 1,
+      eventId: 'evt',
+      occurredAt: '2026-07-14T00:00:00.000Z'
+    })).toThrow()
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 1,
+      eventId: 'evt',
+      occurredAt: 'yesterday'
+    })).toThrow()
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 1,
+      eventId: 'evt',
+      occurredAt: '2026-07-14T00:00:00.000Z',
+      payload: {}
+    })).toThrow()
+  })
+})

--- a/src/shared/sse-sequence.ts
+++ b/src/shared/sse-sequence.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+/** Metadata required to detect duplicate, stale, and missing SSE events. */
+export const SequencedRuntimeEventSchema = z.object({
+  streamId: z.string().min(1).max(128),
+  sequence: z.number().int().nonnegative().safe(),
+  eventId: z.string().min(1).max(128),
+  occurredAt: z.string().datetime({ offset: true })
+}).strict()
+
+export type SequencedRuntimeEvent = z.infer<typeof SequencedRuntimeEventSchema>


### PR DESCRIPTION
## Problem

Detecting an SSE gap is not enough: the client needs a bounded, fail-closed recovery decision. Unbounded replay can amplify a reconnect storm, while applying events after a failed replay can corrupt the projection.

## Scope

This PR adds a pure recovery planner on top of #910. It does not perform replay, reload state, or mutate the renderer.

## Changes

- Return `none` for accepted, duplicate, and out-of-order events.
- Plan a bounded sequence replay for a small gap.
- Fall back to authoritative reload for old streams, oversized gaps, or replay failure.
- Default replay budget to 128 events and cap caller budgets at 1000.

## Safety

- The planner never performs I/O or advances a cursor.
- Replay ranges are explicit and bounded by `fromSequence`/`toSequence`.
- Failure and stream replacement are fail-closed reload decisions rather than silent projection.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
npm.cmd exec vitest run src/shared/sse-recovery.test.ts
npm.cmd run lint
npm.cmd run build
git diff --check
```

Passed: 4 recovery-plan tests; root typecheck, lint, and build passed; diff check passed.

## Review performed

- Replay budget and integer boundaries
- Old stream and failed replay handling
- No-op behavior for non-gap events
- Side-effect and state ownership boundaries
- Test quality and PR scope

## Non-goals

- SSE transport/replay requests
- Renderer reducer integration
- Persistent cursor storage
- Network retries

## Dependency

Depends on #910 (and its #902 sequence contract). After the dependency PRs merge, rebase this branch onto `develop` and drop dependency commits.
