### PR TITLE
feat(sse): persist bounded resume cursors

### DIFF
--- a/src/main/services/sse-resume-cursor-store.test.ts
+++ b/src/main/services/sse-resume-cursor-store.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import { SseResumeCursorStore } from './sse-resume-cursor-store'
+
+const cursor = (scopeId: string, lastSequence: number, updatedAt: string, runtimeGeneration = 'g1') => ({
+  scopeId,
+  streamId: 'stream-1',
+  lastSequence,
+  runtimeGeneration,
+  updatedAt
+})
+
+describe('SseResumeCursorStore', () => {
+  it('persists acknowledged cursors atomically and restores them', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    const path = join(root, 'nested', 'cursors.json')
+    try {
+      const store = new SseResumeCursorStore(path)
+      expect(await store.save(cursor('thread-1', 4, '2026-07-14T00:00:00.000Z'))).toBe(true)
+      expect(await store.get('thread-1')).toEqual(cursor('thread-1', 4, '2026-07-14T00:00:00.000Z'))
+      const restored = new SseResumeCursorStore(path)
+      expect(await restored.get('thread-1')).toEqual(cursor('thread-1', 4, '2026-07-14T00:00:00.000Z'))
+      expect(JSON.parse(await readFile(path, 'utf8')).version).toBe(1)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not move a cursor backwards within the same runtime generation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    try {
+      const store = new SseResumeCursorStore(join(root, 'cursors.json'))
+      expect(await store.save(cursor('thread-1', 10, '2026-07-14T00:00:01.000Z'))).toBe(true)
+      expect(await store.save(cursor('thread-1', 9, '2026-07-14T00:00:02.000Z'))).toBe(false)
+      expect(await store.get('thread-1')).toEqual(cursor('thread-1', 10, '2026-07-14T00:00:01.000Z'))
+      expect(await store.save(cursor('thread-1', 1, '2026-07-14T00:00:03.000Z', 'g2'))).toBe(true)
+      expect(await store.get('thread-1')).toEqual(cursor('thread-1', 1, '2026-07-14T00:00:03.000Z', 'g2'))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('serializes concurrent writes and trims oldest scopes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    try {
+      const store = new SseResumeCursorStore(join(root, 'cursors.json'), { maxEntries: 2 })
+      await Promise.all([
+        store.save(cursor('old', 1, '2026-07-14T00:00:00.000Z')),
+        store.save(cursor('newer', 2, '2026-07-14T00:00:02.000Z')),
+        store.save(cursor('newest', 3, '2026-07-14T00:00:03.000Z'))
+      ])
+      expect(await store.get('old')).toBeNull()
+      expect(await store.list()).toHaveLength(2)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails open on malformed data without overwriting the evidence', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    const path = join(root, 'cursors.json')
+    try {
+      await writeFile(path, '{not-json', 'utf8')
+      const store = new SseResumeCursorStore(path)
+      expect(await store.get('thread-1')).toBeNull()
+      expect(await readFile(path, 'utf8')).toBe('{not-json')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores entries whose storage key does not match the cursor scope', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    const path = join(root, 'cursors.json')
+    try {
+      await writeFile(path, JSON.stringify({
+        version: 1,
+        cursors: {
+          'wrong-key': cursor('thread-1', 7, '2026-07-14T00:00:00.000Z')
+        }
+      }), 'utf8')
+      const store = new SseResumeCursorStore(path)
+      expect(await store.get('thread-1')).toBeNull()
+      expect(await store.list()).toEqual([])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/services/sse-resume-cursor-store.ts
+++ b/src/main/services/sse-resume-cursor-store.ts
@@ -1,0 +1,131 @@
+import { mkdir, readFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { atomicWriteFile } from '../../../kun/src/adapters/file/atomic-write.js'
+import {
+  SSE_RESUME_CURSOR_SCHEMA_VERSION,
+  SseResumeCursorFileSchema,
+  SseResumeCursorSchema,
+  type SseResumeCursor
+} from '../../shared/sse-cursor'
+
+const DEFAULT_MAX_ENTRIES = 256
+
+function sameGeneration(left: SseResumeCursor, right: SseResumeCursor): boolean {
+  return !left.runtimeGeneration || !right.runtimeGeneration || left.runtimeGeneration === right.runtimeGeneration
+}
+
+/**
+ * Small, bounded, single-writer store for renderer resume cursors.
+ *
+ * It deliberately does not delete a malformed file: a corrupt cursor file is
+ * evidence for diagnostics, while a fresh in-memory state lets the app recover
+ * without losing the authoritative thread history.
+ */
+export class SseResumeCursorStore {
+  private readonly maxEntries: number
+  private loaded = false
+  private entries = new Map<string, SseResumeCursor>()
+  private operationTail: Promise<void> = Promise.resolve()
+
+  constructor(
+    private readonly filePath: string,
+    options: { maxEntries?: number } = {}
+  ) {
+    const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
+    if (!Number.isSafeInteger(maxEntries) || maxEntries < 1 || maxEntries > 10_000) {
+      throw new Error('maxEntries must be a safe integer between 1 and 10000')
+    }
+    this.maxEntries = maxEntries
+  }
+
+  async get(scopeId: string): Promise<SseResumeCursor | null> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded()
+      const cursor = this.entries.get(scopeId)
+      return cursor ? { ...cursor } : null
+    })
+  }
+
+  async list(): Promise<SseResumeCursor[]> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded()
+      return [...this.entries.values()]
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+        .map((cursor) => ({ ...cursor }))
+    })
+  }
+
+  async save(cursor: SseResumeCursor): Promise<boolean> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded()
+      const normalized = SseResumeCursorSchema.parse(cursor)
+      const previous = this.entries.get(normalized.scopeId)
+      if (
+        previous &&
+        sameGeneration(previous, normalized) &&
+        normalized.lastSequence < previous.lastSequence
+      ) {
+        return false
+      }
+      this.entries.set(normalized.scopeId, normalized)
+      this.trim()
+      await this.persist()
+      return true
+    })
+  }
+
+  async clear(scopeId: string): Promise<boolean> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded()
+      const removed = this.entries.delete(scopeId)
+      if (removed) await this.persist()
+      return removed
+    })
+  }
+
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const next = this.operationTail.then(task, task)
+    this.operationTail = next.then(() => undefined, () => undefined)
+    return next
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return
+    this.loaded = true
+    let raw: string
+    try {
+      raw = await readFile(this.filePath, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+      throw error
+    }
+    try {
+      const parsed = SseResumeCursorFileSchema.parse(JSON.parse(raw))
+      this.entries = new Map(
+        Object.entries(parsed.cursors)
+          .filter(([scopeId, cursor]) => scopeId === cursor.scopeId)
+      )
+      this.trim()
+    } catch {
+      // Keep the malformed file untouched and start from a recoverable cursor set.
+      this.entries = new Map()
+    }
+  }
+
+  private trim(): void {
+    if (this.entries.size <= this.maxEntries) return
+    const sorted = [...this.entries.values()]
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      .slice(0, this.maxEntries)
+    this.entries = new Map(sorted.map((cursor) => [cursor.scopeId, cursor]))
+  }
+
+  private async persist(): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true })
+    const cursors = Object.fromEntries(this.entries)
+    await atomicWriteFile(this.filePath, JSON.stringify({
+      version: SSE_RESUME_CURSOR_SCHEMA_VERSION,
+      cursors
+    }, null, 2))
+  }
+}

--- a/src/shared/sse-cursor.ts
+++ b/src/shared/sse-cursor.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+/** A renderer-owned acknowledgement cursor persisted across process restarts. */
+export const SseResumeCursorSchema = z.object({
+  scopeId: z.string().trim().min(1).max(128),
+  streamId: z.string().trim().min(1).max(128),
+  lastSequence: z.number().int().nonnegative().safe(),
+  runtimeGeneration: z.string().trim().min(1).max(128).optional(),
+  updatedAt: z.string().datetime({ offset: true })
+}).strict()
+
+export type SseResumeCursor = z.infer<typeof SseResumeCursorSchema>
+
+export const SSE_RESUME_CURSOR_SCHEMA_VERSION = 1 as const
+
+export const SseResumeCursorFileSchema = z.object({
+  version: z.literal(SSE_RESUME_CURSOR_SCHEMA_VERSION),
+  cursors: z.record(z.string().min(1).max(128), SseResumeCursorSchema)
+}).strict()
+
+export type SseResumeCursorFile = z.infer<typeof SseResumeCursorFileSchema>

--- a/src/shared/sse-gap.test.ts
+++ b/src/shared/sse-gap.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { inspectSseSequence, SseSequenceDecision, type SseSequenceCursor } from './sse-gap'
+
+const event = (sequence: number, streamId = 'stream_1') => ({
+  streamId,
+  sequence,
+  eventId: `event_${sequence}`,
+  occurredAt: '2026-07-14T00:00:00.000Z'
+})
+
+describe('inspectSseSequence', () => {
+  it('accepts the first event and creates a cursor', () => {
+    const result = inspectSseSequence(null, event(0))
+    expect(result.decision).toBe(SseSequenceDecision.Accepted)
+    expect(result.nextCursor).toEqual({ streamId: 'stream_1', lastSequence: 0 })
+  })
+
+  it('accepts the next contiguous event and advances only the returned cursor', () => {
+    const cursor: SseSequenceCursor = { streamId: 'stream_1', lastSequence: 0 }
+    const result = inspectSseSequence(cursor, event(1))
+    expect(result.decision).toBe(SseSequenceDecision.Accepted)
+    expect(result.nextCursor?.lastSequence).toBe(1)
+    expect(cursor.lastSequence).toBe(0)
+  })
+
+  it('classifies duplicate and out-of-order events without moving the cursor', () => {
+    const cursor = { streamId: 'stream_1', lastSequence: 4 }
+    expect(inspectSseSequence(cursor, event(4)).decision).toBe(SseSequenceDecision.Duplicate)
+    expect(inspectSseSequence(cursor, event(2)).decision).toBe(SseSequenceDecision.OutOfOrder)
+    expect(inspectSseSequence(cursor, event(4)).nextCursor).toEqual(cursor)
+  })
+
+  it('reports a gap and leaves projection at the last confirmed sequence', () => {
+    const cursor = { streamId: 'stream_1', lastSequence: 4 }
+    const result = inspectSseSequence(cursor, event(7))
+    expect(result.decision).toBe(SseSequenceDecision.Gap)
+    expect(result.expectedSequence).toBe(5)
+    expect(result.nextCursor).toEqual(cursor)
+  })
+
+  it('rejects events from an old or replaced stream', () => {
+    const cursor = { streamId: 'stream_2', lastSequence: 4 }
+    const result = inspectSseSequence(cursor, event(5, 'stream_1'))
+    expect(result.decision).toBe(SseSequenceDecision.OldStream)
+    expect(result.nextCursor).toEqual(cursor)
+  })
+
+  it('validates event metadata before making a projection decision', () => {
+    expect(() => inspectSseSequence(null, { ...event(0), eventId: '' })).toThrow()
+  })
+})

--- a/src/shared/sse-gap.ts
+++ b/src/shared/sse-gap.ts
@@ -1,0 +1,90 @@
+import {
+  SequencedRuntimeEventSchema,
+  type SequencedRuntimeEvent
+} from './sse-sequence'
+
+export type SseSequenceCursor = {
+  streamId: string
+  lastSequence: number
+}
+
+export const SseSequenceDecision = {
+  Accepted: 'accepted',
+  Duplicate: 'duplicate',
+  Gap: 'gap',
+  OutOfOrder: 'out-of-order',
+  OldStream: 'old-stream'
+} as const
+export type SseSequenceDecision = typeof SseSequenceDecision[keyof typeof SseSequenceDecision]
+
+export type SseSequenceInspection = {
+  decision: SseSequenceDecision
+  streamId: string
+  receivedSequence: number
+  expectedSequence: number | null
+  nextCursor: SseSequenceCursor | null
+}
+
+/**
+ * Compares one validated event with a renderer cursor without mutating it.
+ * A gap must stop projection until a bounded replay or authoritative reload runs.
+ */
+export function inspectSseSequence(
+  cursor: SseSequenceCursor | null,
+  rawEvent: SequencedRuntimeEvent
+): SseSequenceInspection {
+  const event = SequencedRuntimeEventSchema.parse(rawEvent)
+  if (!cursor) {
+    return {
+      decision: SseSequenceDecision.Accepted,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence: event.sequence,
+      nextCursor: { streamId: event.streamId, lastSequence: event.sequence }
+    }
+  }
+  if (event.streamId !== cursor.streamId) {
+    return {
+      decision: SseSequenceDecision.OldStream,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence: null,
+      nextCursor: cursor
+    }
+  }
+  const expectedSequence = cursor.lastSequence + 1
+  if (event.sequence === expectedSequence) {
+    return {
+      decision: SseSequenceDecision.Accepted,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: { streamId: cursor.streamId, lastSequence: event.sequence }
+    }
+  }
+  if (event.sequence === cursor.lastSequence) {
+    return {
+      decision: SseSequenceDecision.Duplicate,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: cursor
+    }
+  }
+  if (event.sequence > expectedSequence) {
+    return {
+      decision: SseSequenceDecision.Gap,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: cursor
+    }
+  }
+  return {
+    decision: SseSequenceDecision.OutOfOrder,
+    streamId: event.streamId,
+    receivedSequence: event.sequence,
+    expectedSequence,
+    nextCursor: cursor
+  }
+}

--- a/src/shared/sse-recovery.test.ts
+++ b/src/shared/sse-recovery.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { inspectSseSequence } from './sse-gap'
+import { planSseRecovery } from './sse-recovery'
+
+const event = (sequence: number, streamId = 'stream_1') => ({
+  streamId,
+  sequence,
+  eventId: `event_${sequence}`,
+  occurredAt: '2026-07-14T00:00:00.000Z'
+})
+
+describe('planSseRecovery', () => {
+  it('does nothing for accepted, duplicate, and out-of-order events', () => {
+    const accepted = inspectSseSequence({ streamId: 'stream_1', lastSequence: 0 }, event(1))
+    const duplicate = inspectSseSequence({ streamId: 'stream_1', lastSequence: 1 }, event(1))
+    const stale = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(0))
+    expect(planSseRecovery(accepted).action).toBe('none')
+    expect(planSseRecovery(duplicate).action).toBe('none')
+    expect(planSseRecovery(stale).action).toBe('none')
+  })
+
+  it('plans a bounded replay for a small gap', () => {
+    const inspection = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(5))
+    expect(planSseRecovery(inspection, { maxReplayEvents: 8 })).toEqual({
+      action: 'replay',
+      streamId: 'stream_1',
+      fromSequence: 3,
+      toSequence: 4,
+      maxEvents: 8
+    })
+  })
+
+  it('reloads when a gap exceeds the replay budget or replay failed', () => {
+    const inspection = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(10))
+    expect(planSseRecovery(inspection, { maxReplayEvents: 3 })).toMatchObject({
+      action: 'reload',
+      reason: 'gap-too-large'
+    })
+    expect(planSseRecovery(inspection, { replayFailed: true })).toMatchObject({
+      action: 'reload',
+      reason: 'replay-failed'
+    })
+  })
+
+  it('reloads for an old stream and caps unsafe replay budgets', () => {
+    const oldStream = inspectSseSequence({ streamId: 'stream_2', lastSequence: 2 }, event(3, 'stream_1'))
+    expect(planSseRecovery(oldStream)).toEqual({
+      action: 'reload',
+      streamId: 'stream_1',
+      reason: 'old-stream'
+    })
+    const gap = inspectSseSequence({ streamId: 'stream_1', lastSequence: 0 }, event(2))
+    expect(planSseRecovery(gap, { maxReplayEvents: 99999 })).toMatchObject({ maxEvents: 1000 })
+  })
+})

--- a/src/shared/sse-recovery.ts
+++ b/src/shared/sse-recovery.ts
@@ -1,0 +1,51 @@
+import {
+  SseSequenceDecision,
+  type SseSequenceInspection
+} from './sse-gap'
+
+export type SseRecoveryPlan =
+  | { action: 'none'; reason: 'accepted' | 'duplicate' | 'out-of-order'; streamId: string }
+  | { action: 'replay'; streamId: string; fromSequence: number; toSequence: number; maxEvents: number }
+  | { action: 'reload'; streamId: string; reason: 'old-stream' | 'gap-too-large' | 'replay-failed' }
+
+export type SseRecoveryOptions = {
+  maxReplayEvents?: number
+  replayFailed?: boolean
+}
+
+/** Chooses a bounded recovery action; it never performs I/O or mutates the projection. */
+export function planSseRecovery(
+  inspection: SseSequenceInspection,
+  options: SseRecoveryOptions = {}
+): SseRecoveryPlan {
+  if (inspection.decision === SseSequenceDecision.OldStream) {
+    return { action: 'reload', streamId: inspection.streamId, reason: 'old-stream' }
+  }
+  if (inspection.decision !== SseSequenceDecision.Gap) {
+    return {
+      action: 'none',
+      reason: inspection.decision,
+      streamId: inspection.streamId
+    }
+  }
+  const maxEvents = Number.isSafeInteger(options.maxReplayEvents) && (options.maxReplayEvents ?? 0) > 0
+    ? Math.min(options.maxReplayEvents as number, 1000)
+    : 128
+  const fromSequence = inspection.expectedSequence
+  const toSequence = inspection.receivedSequence - 1
+  if (
+    options.replayFailed === true ||
+    fromSequence === null ||
+    toSequence < fromSequence ||
+    toSequence - fromSequence + 1 > maxEvents
+  ) {
+    return { action: 'reload', streamId: inspection.streamId, reason: options.replayFailed ? 'replay-failed' : 'gap-too-large' }
+  }
+  return {
+    action: 'replay',
+    streamId: inspection.streamId,
+    fromSequence,
+    toSequence,
+    maxEvents
+  }
+}

--- a/src/shared/sse-sequence.test.ts
+++ b/src/shared/sse-sequence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { SequencedRuntimeEventSchema } from './sse-sequence'
+
+describe('SequencedRuntimeEventSchema', () => {
+  it('accepts a stable stream sequence envelope', () => {
+    const event = {
+      streamId: 'stream_123',
+      sequence: 42,
+      eventId: 'evt_42',
+      occurredAt: '2026-07-14T00:00:00.000Z'
+    }
+
+    expect(SequencedRuntimeEventSchema.parse(event)).toEqual(event)
+  })
+
+  it('accepts sequence zero for a newly-created stream', () => {
+    expect(SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 0,
+      eventId: 'evt_0',
+      occurredAt: '2026-07-14T00:00:00+00:00'
+    }).sequence).toBe(0)
+  })
+
+  it('rejects unsafe sequences, invalid timestamps, and unknown fields', () => {
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: Number.MAX_SAFE_INTEGER + 1,
+      eventId: 'evt',
+      occurredAt: '2026-07-14T00:00:00.000Z'
+    })).toThrow()
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 1,
+      eventId: 'evt',
+      occurredAt: 'yesterday'
+    })).toThrow()
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 1,
+      eventId: 'evt',
+      occurredAt: '2026-07-14T00:00:00.000Z',
+      payload: {}
+    })).toThrow()
+  })
+})

--- a/src/shared/sse-sequence.ts
+++ b/src/shared/sse-sequence.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+/** Metadata required to detect duplicate, stale, and missing SSE events. */
+export const SequencedRuntimeEventSchema = z.object({
+  streamId: z.string().min(1).max(128),
+  sequence: z.number().int().nonnegative().safe(),
+  eventId: z.string().min(1).max(128),
+  occurredAt: z.string().datetime({ offset: true })
+}).strict()
+
+export type SequencedRuntimeEvent = z.infer<typeof SequencedRuntimeEventSchema>


### PR DESCRIPTION
## Problem

Renderer SSE acknowledgement state is currently in-memory. A renderer/runtime restart loses the last confirmed sequence and can replay an unnecessarily large thread window.

## Root cause

There is no bounded, atomic persistence layer for per-scope resume cursors.

## Scope

This PR adds only the shared cursor contract and a main-process persistence service. It is intentionally independent from IPC and renderer recovery wiring.

## Changes

- Add strict, versioned `SseResumeCursor` and file envelope schemas.
- Persist at most 256 scopes with atomic writes and serialized mutations.
- Reject same-generation cursor regressions.
- Allow a new runtime generation to reset its sequence.
- Keep malformed files untouched and fail open to authoritative replay.
- Ignore storage entries whose key does not match their scope.

## Non-goals

- No preload/IPC bridge changes.
- No renderer subscription changes.
- No automatic cursor restore yet; that is the follow-up integration PR.

## Safety

- Cursor data contains only bounded IDs, sequence numbers, generation metadata, and timestamps.
- Writes use the existing atomic file helper.
- Corrupt data is never overwritten automatically.
- Entries are capped to prevent unbounded user-data growth.

## Typecheck

```text
npm.cmd run typecheck
npm.cmd --prefix kun run typecheck
```

Both passed.

## Tests

```text
npm.cmd exec vitest run src/main/services/sse-resume-cursor-store.test.ts
```

Result: 1 file, 5 tests passed.

Also passed:

```text
npm.cmd run lint
npm.cmd run build
git diff --check
```

## Review performed

- Functional correctness
- Concurrency and lifecycle
- Data integrity and atomic writes
- Corrupt-file and generation-boundary handling
- Cross-platform path handling
- PR scope and diff cleanliness

## Dependency

Depends on #911 (and its sequence/gap contracts in #902/#910).

## Issue

Part of #885
