### PR TITLE
fix(ci): click visible packaged extension contribution

### DIFF
--- a/scripts/smoke-packaged-extension-desktop.cjs
+++ b/scripts/smoke-packaged-extension-desktop.cjs
@@ -693,16 +693,22 @@ async function waitForContributionAndClick({
   timeoutMs,
   processState: readProcessState
 }) {
-  const selector = `[data-contribution-id="${contributionId}"]`
+  // Contributions also decorate their wrapper and webview with this id. The
+  // smoke must click the actual workbench control, otherwise querySelector
+  // can hit a non-interactive wrapper and no guest target is created.
+  const selector = `button[data-contribution-id="${contributionId}"]`
   const point = await pollUntil(async () => {
     assertDesktopProcessRunning(readProcessState())
     const evaluated = await cdp.send('Runtime.evaluate', {
       expression: `(() => {
-        const element = document.querySelector(${JSON.stringify(selector)})
-        if (!(element instanceof HTMLElement) || element.matches(':disabled')) return null
+        const element = [...document.querySelectorAll(${JSON.stringify(selector)})].find((candidate) => {
+          if (!(candidate instanceof HTMLElement) || candidate.matches(':disabled')) return false
+          const rectangle = candidate.getBoundingClientRect()
+          return rectangle.width > 0 && rectangle.height > 0
+        })
+        if (!(element instanceof HTMLElement)) return null
         element.scrollIntoView({ block: 'center', inline: 'center' })
         const rectangle = element.getBoundingClientRect()
-        if (rectangle.width <= 0 || rectangle.height <= 0) return null
         return {
           x: rectangle.left + rectangle.width / 2,
           y: rectangle.top + rectangle.height / 2

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -402,6 +402,13 @@ test('recognizes the workbench and kun-extension guest CDP targets', () => {
   )
 })
 
+test('targets the clickable contribution control instead of its wrapper', () => {
+  const source = readFileSync(join(__dirname, 'smoke-packaged-extension-desktop.cjs'), 'utf8')
+  assert.match(source, /button\[data-contribution-id=/)
+  assert.match(source, /querySelectorAll\(.*\)\]\.find/s)
+  assert.doesNotMatch(source, /const selector = `\[data-contribution-id=/)
+})
+
 test('routes flattened CDP commands and rejects protocol errors', async () => {
   const socket = new FakeWebSocket()
   const cdp = new CdpConnection(socket, 1_000)


### PR DESCRIPTION
﻿## Problem

The packaged desktop Extension smoke intermittently waits forever for the \`kun-extension\` guest target even though the workbench is running. The same failure has appeared on Windows and macOS package jobs, with only the renderer page visible in CDP.

## Root cause

The smoke searched for the first \`[data-contribution-id]\` element. The same attribute is present on non-interactive wrappers and webviews as well as the actual workbench button. A wrapper could be selected and clicked, so no extension guest was created.

## Scope

This PR only hardens the packaged desktop smoke contribution click. It does not change renderer behavior, extension loading, or runtime protocols.

## Changes

- Restrict the smoke selector to contribution buttons.
- Iterate all matching buttons and choose the first enabled, visible candidate.
- Add a regression test preventing a return to the wrapper-wide selector.

## Safety

- The change is test-only/CI-only and does not alter application behavior.
- Existing process-health, disabled-state, geometry, and timeout checks remain in place.
- No secrets, paths, or user data are introduced.

## Typecheck

\`\`\`text
npm.cmd run typecheck
\`\`\`

Passed.

## Tests

\`\`\`text
node --test scripts/smoke-packaged-extension-desktop.test.cjs
npm.cmd run lint
npm.cmd run build
git diff --check
\`\`\`

Results: 17 desktop smoke tests passed; lint, build, and diff checks passed.

## Actual validation

The local environment does not have a packaged cross-platform artifact, so native Windows/macOS package smoke was not claimed locally. The PR CI package jobs are the required artifact-level validation.

## Review performed

- Functional correctness
- CDP target lifecycle
- Hidden/duplicate contribution controls
- Process and timeout cleanup
- Cross-platform package smoke scope
- PR size and test quality

## Non-goals

The existing Runtime exit classification and Error Boundary PRs remain separate; this PR only fixes their shared desktop smoke harness failure.

Part of #885.

