### PR TITLE
feat(storage): add bounded storage usage report

### DIFF
--- a/src/main/services/storage-usage-report.test.ts
+++ b/src/main/services/storage-usage-report.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { scanStorageUsage } from './storage-usage-report'
+
+async function tempRoot() {
+  return mkdtemp(join(tmpdir(), 'kun-storage-usage-'))
+}
+
+describe('scanStorageUsage', () => {
+  it('reports category sizes, files, directories, and latest modification', async () => {
+    const root = await tempRoot()
+    await mkdir(join(root, 'nested'), { recursive: true })
+    await writeFile(join(root, 'one.txt'), '1234')
+    await writeFile(join(root, 'nested', 'two.txt'), '12')
+
+    const report = await scanStorageUsage({
+      roots: { threads: root },
+      now: () => new Date('2026-07-14T00:00:00.000Z')
+    })
+    const threads = report.entries.find((entry) => entry.category === 'threads')!
+
+    expect(threads).toMatchObject({ bytes: 6, files: 2, directories: 2, truncated: false })
+    expect(threads).not.toHaveProperty('error')
+    expect(threads.lastModifiedAt).toEqual(expect.any(String))
+    expect(report.totalBytes).toBe(6)
+    expect(report.totalFiles).toBe(2)
+    expect(report.generatedAt).toBe('2026-07-14T00:00:00.000Z')
+  })
+
+  it('does not follow symlinks and treats missing roots as empty', async () => {
+    const root = await tempRoot()
+    const outside = await tempRoot()
+    await writeFile(join(outside, 'secret.txt'), 'secret')
+    await symlink(outside, join(root, 'linked')).catch(() => undefined)
+
+    const report = await scanStorageUsage({
+      roots: { attachments: root, logs: join(root, 'missing') }
+    })
+    const attachments = report.entries.find((entry) => entry.category === 'attachments')!
+    const logs = report.entries.find((entry) => entry.category === 'logs')!
+
+    expect(attachments.files).toBe(0)
+    expect(attachments.bytes).toBe(0)
+    expect(logs).toMatchObject({ bytes: 0, files: 0, directories: 0 })
+    expect(logs).not.toHaveProperty('error')
+  })
+
+  it('stops at the per-category entry budget and rejects invalid limits', async () => {
+    const root = await tempRoot()
+    await Promise.all(Array.from({ length: 5 }, (_, index) => writeFile(join(root, `file-${index}`), '123')))
+
+    const report = await scanStorageUsage({ roots: { models: root }, maxEntriesPerCategory: 2 })
+    const models = report.entries.find((entry) => entry.category === 'models')!
+    expect(models.truncated).toBe(true)
+    expect(report.truncated).toBe(true)
+    await expect(scanStorageUsage({ roots: {}, maxEntriesPerCategory: 0 })).rejects.toThrow(/between 1 and/)
+    await expect(scanStorageUsage({ roots: {}, maxEntriesPerCategory: 50_001 })).rejects.toThrow(/between 1 and/)
+  })
+})

--- a/src/main/services/storage-usage-report.ts
+++ b/src/main/services/storage-usage-report.ts
@@ -1,0 +1,139 @@
+import { lstat, opendir } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+
+export const STORAGE_USAGE_CATEGORIES = [
+  'threads',
+  'attachments',
+  'checkpoints',
+  'worktrees',
+  'logs',
+  'diagnostics',
+  'extensions',
+  'models'
+] as const
+
+export type StorageUsageCategory = typeof STORAGE_USAGE_CATEGORIES[number]
+
+export type StorageUsageEntry = {
+  category: StorageUsageCategory
+  root: string | null
+  bytes: number
+  files: number
+  directories: number
+  lastModifiedAt: string | null
+  truncated: boolean
+  error?: string
+}
+
+export type StorageUsageReport = {
+  schemaVersion: 1
+  generatedAt: string
+  entries: StorageUsageEntry[]
+  totalBytes: number
+  totalFiles: number
+  truncated: boolean
+}
+
+export type StorageUsageOptions = {
+  roots: Partial<Record<StorageUsageCategory, string | undefined>>
+  maxEntriesPerCategory?: number
+  now?: () => Date
+}
+
+const DEFAULT_MAX_ENTRIES = 50_000
+
+/** Read-only, bounded disk usage scan. Symlinks are counted as entries but never followed. */
+export async function scanStorageUsage(options: StorageUsageOptions): Promise<StorageUsageReport> {
+  const maxEntries = normalizeLimit(options.maxEntriesPerCategory)
+  const generatedAt = (options.now?.() ?? new Date()).toISOString()
+  const entries = await Promise.all(STORAGE_USAGE_CATEGORIES.map(async (category) => {
+    const rawRoot = options.roots[category]
+    return scanCategory(category, rawRoot, maxEntries)
+  }))
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    entries,
+    totalBytes: entries.reduce((sum, entry) => sum + entry.bytes, 0),
+    totalFiles: entries.reduce((sum, entry) => sum + entry.files, 0),
+    truncated: entries.some((entry) => entry.truncated)
+  }
+}
+
+async function scanCategory(
+  category: StorageUsageCategory,
+  rawRoot: string | undefined,
+  maxEntries: number
+): Promise<StorageUsageEntry> {
+  const root = rawRoot?.trim() ? resolve(rawRoot) : null
+  const result: StorageUsageEntry = {
+    category,
+    root,
+    bytes: 0,
+    files: 0,
+    directories: 0,
+    lastModifiedAt: null,
+    truncated: false
+  }
+  if (!root) return result
+
+  const queue = [root]
+  let visited = 0
+  let latestMtime = 0
+  while (queue.length > 0) {
+    const current = queue.pop()!
+    let directory
+    try {
+      directory = await opendir(current)
+    } catch (error) {
+      if (!isMissing(error)) result.error = result.error ?? describeError(error)
+      continue
+    }
+    result.directories += 1
+    try {
+      for await (const child of directory) {
+        if (visited >= maxEntries) {
+          result.truncated = true
+          break
+        }
+        visited += 1
+        const path = join(current, child.name)
+        let metadata
+        try {
+          metadata = await lstat(path)
+        } catch (error) {
+          result.error = result.error ?? describeError(error)
+          continue
+        }
+        latestMtime = Math.max(latestMtime, metadata.mtimeMs)
+        if (metadata.isDirectory()) {
+          queue.push(path)
+        } else if (metadata.isFile()) {
+          result.files += 1
+          result.bytes += metadata.size
+        }
+      }
+    } finally {
+      await directory.close().catch(() => undefined)
+    }
+    if (result.truncated) break
+  }
+  result.lastModifiedAt = latestMtime > 0 ? new Date(latestMtime).toISOString() : null
+  return result
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_MAX_ENTRIES
+  if (!Number.isSafeInteger(value) || value < 1 || value > DEFAULT_MAX_ENTRIES) {
+    throw new Error(`maxEntriesPerCategory must be an integer between 1 and ${DEFAULT_MAX_ENTRIES}`)
+  }
+  return value
+}
+
+function isMissing(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message.slice(0, 256) : String(error).slice(0, 256)
+}


### PR DESCRIPTION
## Problem
Storage governance needs a read-only, bounded usage report before cleanup or retention work can be safely added.

## Scope
This PR adds only the storage usage scanner and its contract-level tests. It does not add UI, automatic cleanup, retention, or IPC wiring.

## Changes
- Report threads, attachments, checkpoints, worktrees, logs, diagnostics, extensions, and models.
- Count bytes, files, directories, latest modification time, errors, and truncation per category.
- Use bounded per-category traversal with opendir and lstat; symlinks are never followed.
- Missing roots are reported as empty and malformed limits fail closed.

## Validation
- 
pm.cmd exec vitest run src/main/services/storage-usage-report.test.ts (3 passed)
- 
pm.cmd run typecheck (passed)
- 
pm.cmd --prefix kun run typecheck (passed)
- 
pm.cmd run lint (passed)
- 
pm.cmd run build (passed)
- git diff --check (passed)

## Review
Completed functional, lifecycle, data integrity, security, cross-platform, performance, compatibility, and scope review. The scanner performs no writes or deletes.

## Follow-ups
IPC/UI exposure and cleanup policy should be separate PRs.
