### PR TITLE
feat(storage): define safe cleanup policy

### DIFF
--- a/src/main/services/storage-cleanup-policy.test.ts
+++ b/src/main/services/storage-cleanup-policy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateStorageCleanupCandidate } from './storage-cleanup-policy'
+
+const now = new Date('2026-07-14T00:00:00.000Z')
+
+function candidate(overrides: Record<string, unknown> = {}) {
+  return {
+    category: 'logs' as const,
+    id: 'log-1',
+    bytes: 128,
+    lastUsedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('evaluateStorageCleanupCandidate', () => {
+  it('allows an old unprotected candidate and honors per-category retention', () => {
+    expect(evaluateStorageCleanupCandidate(candidate(), { now })).toEqual({
+      safeToDelete: true,
+      reason: 'eligible'
+    })
+    expect(evaluateStorageCleanupCandidate(candidate(), {
+      now,
+      minAgeMs: { logs: 14 * 24 * 60 * 60 * 1000 }
+    })).toEqual({ safeToDelete: false, reason: 'not-old-enough' })
+  })
+
+  it('protects active threads, unmerged worktrees, pinned checkpoints, and recent rescue snapshots', () => {
+    expect(evaluateStorageCleanupCandidate(candidate({ activeThread: true }), { now }).reason)
+      .toBe('protected-active-thread')
+    expect(evaluateStorageCleanupCandidate(candidate({ unmergedWorktree: true }), { now }).reason)
+      .toBe('protected-unmerged-worktree')
+    expect(evaluateStorageCleanupCandidate(candidate({ pinnedCheckpoint: true }), { now }).reason)
+      .toBe('protected-pinned-checkpoint')
+    expect(evaluateStorageCleanupCandidate(candidate({ rescueSnapshot: true, lastUsedAt: '2026-07-13T12:00:00.000Z' }), { now }).reason)
+      .toBe('protected-recent-rescue-snapshot')
+    expect(evaluateStorageCleanupCandidate(candidate({ rescueSnapshot: true }), { now }).reason)
+      .toBe('eligible')
+  })
+
+  it('fails closed for malformed, future, and invalid retention inputs', () => {
+    expect(evaluateStorageCleanupCandidate(candidate({ id: '' }), { now }).reason).toBe('invalid-candidate')
+    expect(evaluateStorageCleanupCandidate(candidate({ bytes: -1 }), { now }).reason).toBe('invalid-candidate')
+    expect(evaluateStorageCleanupCandidate(candidate({ extra: true }), { now }).reason).toBe('invalid-candidate')
+    expect(evaluateStorageCleanupCandidate(candidate({ activeThread: 'yes' }), { now }).reason).toBe('invalid-candidate')
+    expect(evaluateStorageCleanupCandidate(candidate({ lastUsedAt: 'July 1, 2026' }), { now }).reason)
+      .toBe('invalid-candidate')
+    expect(evaluateStorageCleanupCandidate(candidate({ lastUsedAt: '2026-02-31T00:00:00.000Z' }), { now }).reason)
+      .toBe('invalid-candidate')
+    expect(evaluateStorageCleanupCandidate(candidate({ lastUsedAt: '2026-07-15T00:00:00.000Z' }), { now }).reason)
+      .toBe('invalid-candidate')
+    expect(evaluateStorageCleanupCandidate(candidate(), { now, minAgeMs: { logs: -1 } }).reason)
+      .toBe('eligible')
+  })
+})

--- a/src/main/services/storage-cleanup-policy.ts
+++ b/src/main/services/storage-cleanup-policy.ts
@@ -1,0 +1,119 @@
+export const STORAGE_CLEANUP_CATEGORIES = [
+  'threads',
+  'attachments',
+  'checkpoints',
+  'worktrees',
+  'logs',
+  'diagnostics',
+  'extensions',
+  'models'
+] as const
+
+export type StorageCleanupCategory = typeof STORAGE_CLEANUP_CATEGORIES[number]
+
+export type StorageCleanupCandidate = {
+  category: StorageCleanupCategory
+  id: string
+  bytes: number
+  lastUsedAt: string
+  activeThread?: boolean
+  unmergedWorktree?: boolean
+  pinnedCheckpoint?: boolean
+  rescueSnapshot?: boolean
+}
+
+export type StorageCleanupDecisionReason =
+  | 'eligible'
+  | 'protected-active-thread'
+  | 'protected-unmerged-worktree'
+  | 'protected-pinned-checkpoint'
+  | 'protected-recent-rescue-snapshot'
+  | 'not-old-enough'
+  | 'invalid-candidate'
+
+export type StorageCleanupDecision = {
+  safeToDelete: boolean
+  reason: StorageCleanupDecisionReason
+}
+
+export type StorageCleanupPolicyOptions = {
+  now?: Date
+  minAgeMs?: Partial<Record<StorageCleanupCategory, number>>
+  rescueSnapshotMinAgeMs?: number
+}
+
+const DEFAULT_MIN_AGE_MS = 7 * 24 * 60 * 60 * 1000
+const DEFAULT_RESCUE_SNAPSHOT_MIN_AGE_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Decide whether a candidate may be deleted. This function is pure and never
+ * resolves or removes a path; the deletion service must perform its own path
+ * and race checks after this policy decision.
+ */
+export function evaluateStorageCleanupCandidate(
+  candidate: StorageCleanupCandidate,
+  options: StorageCleanupPolicyOptions = {}
+): StorageCleanupDecision {
+  if (!isValidCandidate(candidate)) return { safeToDelete: false, reason: 'invalid-candidate' }
+  if (candidate.activeThread) return { safeToDelete: false, reason: 'protected-active-thread' }
+  if (candidate.unmergedWorktree) return { safeToDelete: false, reason: 'protected-unmerged-worktree' }
+  if (candidate.pinnedCheckpoint) return { safeToDelete: false, reason: 'protected-pinned-checkpoint' }
+
+  const now = options.now?.getTime() ?? Date.now()
+  const lastUsed = Date.parse(candidate.lastUsedAt)
+  if (!Number.isFinite(lastUsed) || lastUsed > now) return { safeToDelete: false, reason: 'invalid-candidate' }
+
+  const age = now - lastUsed
+  if (candidate.rescueSnapshot && age < normalizeAge(options.rescueSnapshotMinAgeMs, DEFAULT_RESCUE_SNAPSHOT_MIN_AGE_MS)) {
+    return { safeToDelete: false, reason: 'protected-recent-rescue-snapshot' }
+  }
+
+  const minAge = normalizeAge(options.minAgeMs?.[candidate.category], DEFAULT_MIN_AGE_MS)
+  return age >= minAge
+    ? { safeToDelete: true, reason: 'eligible' }
+    : { safeToDelete: false, reason: 'not-old-enough' }
+}
+
+function isValidCandidate(candidate: StorageCleanupCandidate): boolean {
+  const allowedKeys = new Set([
+    'category',
+    'id',
+    'bytes',
+    'lastUsedAt',
+    'activeThread',
+    'unmergedWorktree',
+    'pinnedCheckpoint',
+    'rescueSnapshot'
+  ])
+  return Boolean(
+    candidate &&
+      Object.keys(candidate).every((key) => allowedKeys.has(key)) &&
+      typeof candidate.id === 'string' &&
+      candidate.id.trim().length > 0 &&
+      STORAGE_CLEANUP_CATEGORIES.includes(candidate.category) &&
+      Number.isSafeInteger(candidate.bytes) &&
+      candidate.bytes >= 0 &&
+      isUtcTimestamp(candidate.lastUsedAt) &&
+      isOptionalBoolean(candidate.activeThread) &&
+      isOptionalBoolean(candidate.unmergedWorktree) &&
+      isOptionalBoolean(candidate.pinnedCheckpoint) &&
+      isOptionalBoolean(candidate.rescueSnapshot)
+  )
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === 'boolean'
+}
+
+function isUtcTimestamp(value: unknown): value is string {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value)) {
+    return false
+  }
+  const parsed = Date.parse(value)
+  const canonical = value.includes('.') ? value : value.replace('Z', '.000Z')
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === canonical
+}
+
+function normalizeAge(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isSafeInteger(value) && value >= 0 ? value : fallback
+}


### PR DESCRIPTION
## Problem
Storage cleanup needs an explicit fail-closed policy before any deletion service or UI can be added.

## Scope
This PR only defines and tests a pure candidate decision function. It does not scan the filesystem, delete files, add IPC, or add UI.

## Changes
- Protect active threads, unmerged worktrees, pinned checkpoints, and recent rescue snapshots.
- Apply a per-category minimum age with deterministic override support.
- Reject unknown fields, malformed values, future timestamps, invalid calendar dates, and non-UTC timestamps.
- Keep path resolution and race checks outside the policy so deletion remains a separate safety boundary.

## Validation
- 
pm.cmd exec vitest run src/main/services/storage-cleanup-policy.test.ts (3 passed)
- 
pm.cmd run typecheck (passed)
- 
pm.cmd --prefix kun run typecheck (passed)
- 
pm.cmd run lint (passed)
- 
pm.cmd run build (passed)
- git diff --check (passed)

## Review
Completed functional, lifecycle, data integrity, security, cross-platform, performance, compatibility, test quality, and scope review. The policy is pure and performs no filesystem operations.

## Follow-ups
A separate cleanup service must revalidate canonical paths and candidate state immediately before deletion.
