### PR TITLE
feat(storage): add bounded atomic backups

### DIFF
--- a/src/main/services/atomic-backup-service.test.ts
+++ b/src/main/services/atomic-backup-service.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createAtomicBackup, restoreAtomicBackup } from './atomic-backup-service'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function tempRoot() {
+  const root = await mkdtemp(join(tmpdir(), 'kun-backup-'))
+  roots.push(root)
+  return root
+}
+
+describe('atomic backup service', () => {
+  it('writes atomically and restores a checksum-validated backup', async () => {
+    const directory = await tempRoot()
+    const record = await createAtomicBackup(
+      { contents: '{"ok":true}\n' },
+      { directory, id: 'settings', now: () => new Date('2026-07-14T00:00:00.000Z') }
+    )
+
+    expect(record.bytes).toBe(12)
+    expect(await restoreAtomicBackup(record, { directory })).toBe('{"ok":true}\n')
+    expect(await readdir(directory)).toEqual([expect.stringMatching(/^settings-.*\.backup$/)])
+  })
+
+  it('rotates only its own backups within count and byte limits', async () => {
+    const directory = await tempRoot()
+    for (let index = 0; index < 3; index += 1) {
+      await createAtomicBackup(
+        { contents: `v${index}` },
+        {
+          directory,
+          id: 'migration',
+          maxBackups: 2,
+          maxTotalBytes: 4,
+          now: () => new Date(`2026-07-${String(10 + index).padStart(2, '0')}T00:00:00.000Z`)
+        }
+      )
+    }
+    const files = await readdir(directory)
+    expect(files).toHaveLength(2)
+    expect(files.every((file) => file.startsWith('migration-'))).toBe(true)
+    expect(await readFile(join(directory, files[1]), 'utf8')).toMatch(/^v[12]$/)
+  })
+
+  it('rejects sensitive or oversized payloads and detects tampering', async () => {
+    const directory = await tempRoot()
+    await expect(createAtomicBackup(
+      { contents: 'token=secret', sensitivity: 'sensitive' as never },
+      { directory, id: 'secrets' }
+    )).rejects.toThrow(/sensitive/)
+    await expect(createAtomicBackup(
+      { contents: '12345' },
+      { directory, id: 'small', maxBytesPerBackup: 4 }
+    )).rejects.toThrow(/size limit/)
+
+    const record = await createAtomicBackup({ contents: 'stable' }, { directory, id: 'config' })
+    await writeFile(record.path, 'stablx')
+    await expect(restoreAtomicBackup(record, { directory })).rejects.toThrow(/checksum/)
+    const bounded = await createAtomicBackup({ contents: '1234' }, { directory, id: 'bounded' })
+    await expect(restoreAtomicBackup(bounded, { directory, maxBytes: 3 })).rejects.toThrow(/size/)
+    await expect(restoreAtomicBackup(record, { directory: join(directory, 'other') })).rejects.toThrow(/outside/)
+  })
+})

--- a/src/main/services/atomic-backup-service.ts
+++ b/src/main/services/atomic-backup-service.ts
@@ -1,0 +1,206 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { lstat, mkdir, opendir, open, rm } from 'node:fs/promises'
+import { basename, isAbsolute, join, relative, resolve } from 'node:path'
+import { atomicWriteFile } from '../../../kun/src/adapters/file/atomic-write'
+
+export type BackupPayload = {
+  contents: string
+  sensitivity?: 'non-sensitive'
+}
+
+export type AtomicBackupOptions = {
+  directory: string
+  id: string
+  maxBackups?: number
+  maxTotalBytes?: number
+  maxBytesPerBackup?: number
+  now?: () => Date
+}
+
+export type AtomicBackupRecord = {
+  schemaVersion: 1
+  id: string
+  path: string
+  bytes: number
+  sha256: string
+  createdAt: string
+}
+
+export type RestoreBackupOptions = {
+  directory: string
+  maxBytes?: number
+}
+
+const DEFAULT_MAX_BACKUPS = 5
+const DEFAULT_MAX_TOTAL_BYTES = 50 * 1024 * 1024
+const DEFAULT_MAX_BYTES_PER_BACKUP = 10 * 1024 * 1024
+const MAX_ID_LENGTH = 64
+const MAX_ROTATION_SCAN_ENTRIES = 4096
+
+/** Create a bounded text backup using the existing atomic file writer. */
+export async function createAtomicBackup(
+  payload: BackupPayload,
+  options: AtomicBackupOptions
+): Promise<AtomicBackupRecord> {
+  validatePayload(payload)
+  const limits = normalizeLimits(options)
+  const contentsBytes = Buffer.byteLength(payload.contents, 'utf8')
+  if (contentsBytes > limits.maxBytesPerBackup || contentsBytes > limits.maxTotalBytes) {
+    throw new Error('backup contents exceed configured size limit')
+  }
+  const createdAt = options.now?.() ?? new Date()
+  if (!Number.isFinite(createdAt.getTime())) throw new Error('backup timestamp is invalid')
+
+  const id = sanitizeId(options.id)
+  const directory = resolve(options.directory)
+  await mkdir(directory, { recursive: true })
+  const path = join(directory, `${id}-${formatTimestamp(createdAt)}-${randomUUID()}.backup`)
+  const record: AtomicBackupRecord = {
+    schemaVersion: 1,
+    id,
+    path,
+    bytes: contentsBytes,
+    sha256: sha256(payload.contents),
+    createdAt: createdAt.toISOString()
+  }
+  await atomicWriteFile(path, payload.contents)
+  await rotateBackups(directory, id, path, limits)
+  return record
+}
+
+/** Read and checksum-validate a backup within its configured directory. */
+export async function restoreAtomicBackup(
+  record: AtomicBackupRecord,
+  options: RestoreBackupOptions
+): Promise<string> {
+  validateRecord(record)
+  const directory = resolve(options.directory)
+  const path = resolve(record.path)
+  if (!isWithin(directory, path) || basename(path) !== basename(record.path)) {
+    throw new Error('backup path is outside the configured directory')
+  }
+  const maxBytes = normalizeLimit(options.maxBytes ?? DEFAULT_MAX_BYTES_PER_BACKUP, 'maxBytes')
+  const before = await lstat(path)
+  if (!before.isFile()) throw new Error('backup path is not a regular file')
+  if (before.size > maxBytes || before.size !== record.bytes) throw new Error('backup size is invalid')
+  const contents = await readBoundedText(path, maxBytes)
+  if (Buffer.byteLength(contents, 'utf8') !== record.bytes || sha256(contents) !== record.sha256) {
+    throw new Error('backup checksum validation failed')
+  }
+  const after = await lstat(path)
+  if (!after.isFile()) throw new Error('backup path changed to a non-file')
+  if (after.size !== before.size || after.mtimeMs !== before.mtimeMs) {
+    throw new Error('backup changed during restore')
+  }
+  return contents
+}
+
+function validatePayload(payload: BackupPayload): void {
+  if (!payload || Object.keys(payload).some((key) => key !== 'contents' && key !== 'sensitivity')) {
+    throw new Error('backup payload contains unknown fields')
+  }
+  if (typeof payload.contents !== 'string') throw new Error('backup contents must be text')
+  if (payload.sensitivity !== undefined && payload.sensitivity !== 'non-sensitive') {
+    throw new Error('sensitive backup contents are not allowed')
+  }
+}
+
+function validateRecord(record: AtomicBackupRecord): void {
+  if (!record || record.schemaVersion !== 1 || typeof record.id !== 'string' || !record.id ||
+      typeof record.path !== 'string' || !isAbsolute(record.path) ||
+      !Number.isSafeInteger(record.bytes) || record.bytes < 0 ||
+      !/^[a-f0-9]{64}$/.test(record.sha256) ||
+      !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(record.createdAt)) {
+    throw new Error('backup record is invalid')
+  }
+}
+
+function normalizeLimits(options: AtomicBackupOptions): {
+  maxBackups: number
+  maxTotalBytes: number
+  maxBytesPerBackup: number
+} {
+  return {
+    maxBackups: normalizeLimit(options.maxBackups ?? DEFAULT_MAX_BACKUPS, 'maxBackups'),
+    maxTotalBytes: normalizeLimit(options.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES, 'maxTotalBytes'),
+    maxBytesPerBackup: normalizeLimit(options.maxBytesPerBackup ?? DEFAULT_MAX_BYTES_PER_BACKUP, 'maxBytesPerBackup')
+  }
+}
+
+function normalizeLimit(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`${name} must be a positive safe integer`)
+  return value
+}
+
+function sanitizeId(raw: string): string {
+  if (typeof raw !== 'string') throw new Error('backup id must be text')
+  const value = raw.trim().replace(/[^A-Za-z0-9._-]+/g, '-')
+  if (!value || value === '.' || value === '..') throw new Error('backup id is invalid')
+  return value.slice(0, MAX_ID_LENGTH)
+}
+
+async function rotateBackups(
+  directory: string,
+  id: string,
+  keepPath: string,
+  limits: { maxBackups: number; maxTotalBytes: number }
+): Promise<void> {
+  const prefix = `${id}-`
+  const backups: Array<{ path: string; bytes: number; mtimeMs: number }> = []
+  const directoryHandle = await opendir(directory)
+  try {
+    for await (const entry of directoryHandle) {
+      if (backups.length >= MAX_ROTATION_SCAN_ENTRIES) {
+        throw new Error('backup directory contains too many entries')
+      }
+      if (!entry.isFile() || !entry.name.startsWith(prefix) || !entry.name.endsWith('.backup')) continue
+      const path = join(directory, entry.name)
+      const metadata = await lstat(path)
+      if (!metadata.isFile()) continue
+      backups.push({ path, bytes: metadata.size, mtimeMs: metadata.mtimeMs })
+    }
+  } finally {
+    await directoryHandle.close().catch(() => undefined)
+  }
+  backups.sort((a, b) => a.mtimeMs - b.mtimeMs || a.path.localeCompare(b.path))
+  let total = backups.reduce((sum, backup) => sum + backup.bytes, 0)
+  while (backups.length > limits.maxBackups || total > limits.maxTotalBytes) {
+    const index = backups.findIndex((backup) => backup.path !== keepPath)
+    if (index < 0) break
+    const [oldest] = backups.splice(index, 1)
+    await rm(oldest.path, { force: true })
+    total -= oldest.bytes
+  }
+}
+
+async function readBoundedText(path: string, maxBytes: number): Promise<string> {
+  const handle = await open(path, 'r')
+  const chunks: Buffer[] = []
+  let total = 0
+  try {
+    while (total <= maxBytes) {
+      const chunk = Buffer.alloc(Math.min(64 * 1024, maxBytes + 1 - total))
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, total)
+      if (bytesRead === 0) break
+      chunks.push(chunk.subarray(0, bytesRead))
+      total += bytesRead
+      if (total > maxBytes) throw new Error('backup exceeds restore size limit')
+    }
+    return Buffer.concat(chunks).toString('utf8')
+  } finally {
+    await handle.close().catch(() => undefined)
+  }
+}
+
+function isWithin(root: string, target: string): boolean {
+  const rel = relative(root, target)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+function formatTimestamp(value: Date): string {
+  return value.toISOString().replace(/[:.]/g, '-')
+}
+
+function sha256(contents: string): string {
+  return createHash('sha256').update(contents, 'utf8').digest('hex')
+}


### PR DESCRIPTION
## Problem
Data migrations and imports need a bounded backup primitive with atomic writes and validated restore before callers can safely integrate it.

## Scope
This PR adds only the backup core and real temporary-directory tests. It does not hook migration, import/export, upgrades, UI, or automatic retention into callers.

## Changes
- Write non-sensitive text backups through the existing atomic writer.
- Enforce per-backup, total-byte, and per-id count limits with bounded rotation.
- Reject sensitive payloads, unsafe IDs, malformed records, symlink paths, path traversal, and checksum changes.
- Restore with bounded chunked reads and before/after file validation.

## Validation
- 
pm.cmd exec vitest run src/main/services/atomic-backup-service.test.ts (3 passed)
- 
pm.cmd run typecheck (passed)
- 
pm.cmd --prefix kun run typecheck (passed)
- 
pm.cmd run lint (passed)
- 
pm.cmd run build (passed)
- git diff --check (passed)

## Review
Completed functional, lifecycle, data integrity, security, cross-platform, performance, compatibility, test quality, and scope review. The service is isolated from callers and only rotates files it created for the same backup id.

## Follow-ups
Separate PRs should wire this service before config migration, project import, database migration, and app upgrade.
