### PR TITLE
feat(storage): add schema downgrade guard

### DIFF
--- a/src/main/services/schema-downgrade-guard.test.ts
+++ b/src/main/services/schema-downgrade-guard.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { assessSchemaGuard } from './schema-downgrade-guard'
+
+describe('assessSchemaGuard', () => {
+  it('allows writes only when stored and supported versions match', () => {
+    expect(assessSchemaGuard({ storedVersion: 3, supportedVersion: 3 })).toEqual({
+      mode: 'read-write',
+      canWrite: true,
+      canExport: true,
+      reason: 'compatible'
+    })
+  })
+
+  it('opens newer data read-only and keeps export available', () => {
+    expect(assessSchemaGuard({ storedVersion: 4, supportedVersion: 3 })).toEqual({
+      mode: 'read-only',
+      canWrite: false,
+      canExport: true,
+      reason: 'newer-data-requires-upgrade'
+    })
+  })
+
+  it('requires migration for older data and fails closed for invalid versions', () => {
+    expect(assessSchemaGuard({ storedVersion: 2, supportedVersion: 3 })).toEqual({
+      mode: 'migration-required',
+      canWrite: false,
+      canExport: true,
+      reason: 'older-data-requires-migration'
+    })
+    expect(assessSchemaGuard({ storedVersion: -1, supportedVersion: 3 })).toEqual({
+      mode: 'read-only',
+      canWrite: false,
+      canExport: true,
+      reason: 'invalid-version'
+    })
+    expect(assessSchemaGuard({ storedVersion: 1.5, supportedVersion: 3 })).toEqual({
+      mode: 'read-only',
+      canWrite: false,
+      canExport: true,
+      reason: 'invalid-version'
+    })
+    expect(assessSchemaGuard(null as never)).toEqual({
+      mode: 'read-only',
+      canWrite: false,
+      canExport: true,
+      reason: 'invalid-version'
+    })
+    expect(assessSchemaGuard({ storedVersion: 3, supportedVersion: 3, extra: true } as never)).toEqual({
+      mode: 'read-only',
+      canWrite: false,
+      canExport: true,
+      reason: 'invalid-version'
+    })
+  })
+})

--- a/src/main/services/schema-downgrade-guard.ts
+++ b/src/main/services/schema-downgrade-guard.ts
@@ -1,0 +1,43 @@
+export type SchemaGuardInput = {
+  storedVersion: number
+  supportedVersion: number
+}
+
+export type SchemaGuardMode = 'read-write' | 'read-only' | 'migration-required'
+
+export type SchemaGuardDecision = {
+  mode: SchemaGuardMode
+  canWrite: boolean
+  canExport: true
+  reason: 'compatible' | 'newer-data-requires-upgrade' | 'older-data-requires-migration' | 'invalid-version'
+}
+
+/**
+ * Decide whether persisted data may be opened for writing. This contract does
+ * not migrate or mutate data; callers must honor `canWrite` before opening a
+ * write-capable store and always keep export available.
+ */
+export function assessSchemaGuard(input: SchemaGuardInput): SchemaGuardDecision {
+  if (!isValidInput(input) || !isVersion(input.storedVersion) || !isVersion(input.supportedVersion)) {
+    return { mode: 'read-only', canWrite: false, canExport: true, reason: 'invalid-version' }
+  }
+  if (input.storedVersion > input.supportedVersion) {
+    return { mode: 'read-only', canWrite: false, canExport: true, reason: 'newer-data-requires-upgrade' }
+  }
+  if (input.storedVersion < input.supportedVersion) {
+    return { mode: 'migration-required', canWrite: false, canExport: true, reason: 'older-data-requires-migration' }
+  }
+  return { mode: 'read-write', canWrite: true, canExport: true, reason: 'compatible' }
+}
+
+function isValidInput(input: SchemaGuardInput): boolean {
+  return Boolean(
+    input &&
+      typeof input === 'object' &&
+      Object.keys(input).every((key) => key === 'storedVersion' || key === 'supportedVersion')
+  )
+}
+
+function isVersion(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}


### PR DESCRIPTION
## Problem
Older application versions must not silently write data created by a newer schema, while users still need a safe read-only view and export path.

## Scope
This PR adds only a pure schema compatibility decision contract and tests. It does not change persisted formats, migrations, startup wiring, or UI.

## Changes
- Allow read/write only when stored and supported versions match.
- Force newer data into read-only mode with export available.
- Require migration before writing older data.
- Fail closed for invalid versions, null input, and unknown fields.

## Validation
- 
pm.cmd exec vitest run src/main/services/schema-downgrade-guard.test.ts (3 passed)
- 
pm.cmd run typecheck (passed)
- 
pm.cmd --prefix kun run typecheck (passed)
- 
pm.cmd run lint (passed)
- 
pm.cmd run build (passed)
- git diff --check (passed)

## Review
Completed functional, lifecycle, data integrity, security, cross-platform, compatibility, test quality, and scope review. The guard never mutates persisted data.

## Follow-ups
Startup read-only mode, export wiring, and migration execution belong in separate PRs.
