### PR TITLE
feat(provider): define circuit breaker policy

### DIFF
--- a/kun/src/services/provider-circuit-breaker.test.ts
+++ b/kun/src/services/provider-circuit-breaker.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decideProviderRequest,
+  initialProviderCircuit,
+  recordProviderFailure,
+  recordProviderSuccess
+} from './provider-circuit-breaker.js'
+
+describe('provider circuit breaker policy', () => {
+  it('opens after retryable failures and allows one half-open probe', () => {
+    const policy = { failureThreshold: 2, openDurationMs: 100 }
+    let state = initialProviderCircuit()
+    state = recordProviderFailure(state, 'server', 10, policy)
+    state = recordProviderFailure(state, 'timeout', 20, policy)
+    expect(decideProviderRequest(state, 50, policy).reason).toBe('open')
+    const probe = decideProviderRequest(state, 121, policy)
+    expect(probe).toMatchObject({ allowed: true, probe: true, reason: 'half-open-probe' })
+    expect(decideProviderRequest({ ...probe.snapshot, probeInFlight: true }, 122, policy).reason)
+      .toBe('half-open-busy')
+  })
+
+  it('closes and resets on success', () => {
+    const open = recordProviderFailure(
+      recordProviderFailure(initialProviderCircuit(), 'rate-limit', 1, { failureThreshold: 2, openDurationMs: 10 }),
+      'network',
+      2,
+      { failureThreshold: 2, openDurationMs: 10 }
+    )
+    expect(recordProviderSuccess(open)).toEqual(initialProviderCircuit())
+  })
+
+  it('does not trip or retry automatically for authentication and client failures', () => {
+    const state = recordProviderFailure(
+      recordProviderFailure(initialProviderCircuit(), 'authentication', 1),
+      'client',
+      2
+    )
+    expect(state).toEqual(initialProviderCircuit())
+  })
+
+  it('fails closed for invalid snapshots while keeping a safe default policy', () => {
+    const decision = decideProviderRequest({ state: 'invalid' as never, consecutiveFailures: -1, openedAt: null, probeInFlight: false }, 0)
+    expect(decision).toMatchObject({ allowed: true, reason: 'closed' })
+    expect(recordProviderFailure(initialProviderCircuit(), 'server', 0, { failureThreshold: 0, openDurationMs: 0 }).consecutiveFailures)
+      .toBe(1)
+  })
+
+  it('rejects unknown failure kinds and invalid timestamps without opening the circuit', () => {
+    const state = recordProviderFailure(
+      { ...initialProviderCircuit(), probeInFlight: true },
+      'unknown' as never,
+      Number.NaN
+    )
+    expect(state).toEqual(initialProviderCircuit())
+    expect(decideProviderRequest(initialProviderCircuit(), Number.NaN).allowed).toBe(false)
+  })
+
+  it('does not preserve unknown fields from untrusted state or policy objects', () => {
+    const decision = decideProviderRequest(
+      { ...initialProviderCircuit(), injected: true } as never,
+      0,
+      { failureThreshold: 1, openDurationMs: 1, injected: true } as never
+    )
+    expect(decision.snapshot).toEqual(initialProviderCircuit())
+  })
+})

--- a/kun/src/services/provider-circuit-breaker.ts
+++ b/kun/src/services/provider-circuit-breaker.ts
@@ -1,0 +1,119 @@
+export type ProviderCircuitState = 'closed' | 'open' | 'half-open'
+export type ProviderFailureKind = 'rate-limit' | 'server' | 'network' | 'timeout' | 'authentication' | 'client'
+
+export type ProviderCircuitSnapshot = {
+  state: ProviderCircuitState
+  consecutiveFailures: number
+  openedAt: number | null
+  probeInFlight: boolean
+}
+
+export type ProviderCircuitPolicy = {
+  failureThreshold: number
+  openDurationMs: number
+}
+
+export type ProviderRequestDecision = {
+  allowed: boolean
+  probe: boolean
+  reason: 'closed' | 'open' | 'half-open-probe' | 'half-open-busy' | 'invalid-time'
+  snapshot: ProviderCircuitSnapshot
+}
+
+const DEFAULT_POLICY: ProviderCircuitPolicy = { failureThreshold: 3, openDurationMs: 30_000 }
+const FAILURE_KINDS: readonly ProviderFailureKind[] = [
+  'rate-limit',
+  'server',
+  'network',
+  'timeout',
+  'authentication',
+  'client'
+]
+
+export function initialProviderCircuit(): ProviderCircuitSnapshot {
+  return { state: 'closed', consecutiveFailures: 0, openedAt: null, probeInFlight: false }
+}
+
+export function decideProviderRequest(
+  snapshot: ProviderCircuitSnapshot,
+  now: number,
+  policy: ProviderCircuitPolicy = DEFAULT_POLICY
+): ProviderRequestDecision {
+  const normalized = normalizeSnapshot(snapshot)
+  const limits = normalizePolicy(policy)
+  if (!isValidTimestamp(now)) {
+    return {
+      allowed: false,
+      probe: false,
+      reason: 'invalid-time',
+      snapshot: normalized
+    }
+  }
+  if (normalized.state === 'open') {
+    if (now - (normalized.openedAt ?? now) < limits.openDurationMs) {
+      return { allowed: false, probe: false, reason: 'open', snapshot: normalized }
+    }
+    const next = { ...normalized, state: 'half-open' as const, probeInFlight: false }
+    return { allowed: true, probe: true, reason: 'half-open-probe', snapshot: next }
+  }
+  if (normalized.state === 'half-open') {
+    if (normalized.probeInFlight) return { allowed: false, probe: false, reason: 'half-open-busy', snapshot: normalized }
+    return { allowed: true, probe: true, reason: 'half-open-probe', snapshot: { ...normalized, probeInFlight: true } }
+  }
+  return { allowed: true, probe: false, reason: 'closed', snapshot: normalized }
+}
+
+export function recordProviderSuccess(snapshot: ProviderCircuitSnapshot): ProviderCircuitSnapshot {
+  return { state: 'closed', consecutiveFailures: 0, openedAt: null, probeInFlight: false }
+}
+
+export function recordProviderFailure(
+  snapshot: ProviderCircuitSnapshot,
+  kind: ProviderFailureKind,
+  now: number,
+  policy: ProviderCircuitPolicy = DEFAULT_POLICY
+): ProviderCircuitSnapshot {
+  const current = normalizeSnapshot(snapshot)
+  const limits = normalizePolicy(policy)
+  if (!FAILURE_KINDS.includes(kind) || !isValidTimestamp(now)) {
+    return { ...current, probeInFlight: false }
+  }
+  if (kind === 'authentication' || kind === 'client') return { ...current, probeInFlight: false }
+  const failures = current.consecutiveFailures + 1
+  if (current.state === 'half-open' || failures >= limits.failureThreshold) {
+    return { state: 'open', consecutiveFailures: failures, openedAt: now, probeInFlight: false }
+  }
+  return { ...current, consecutiveFailures: failures, probeInFlight: false }
+}
+
+function normalizeSnapshot(snapshot: ProviderCircuitSnapshot): ProviderCircuitSnapshot {
+  if (!snapshot || !hasExactKeys(snapshot, ['state', 'consecutiveFailures', 'openedAt', 'probeInFlight']) ||
+      !['closed', 'open', 'half-open'].includes(snapshot.state) ||
+      !Number.isSafeInteger(snapshot.consecutiveFailures) || snapshot.consecutiveFailures < 0 ||
+      (snapshot.openedAt !== null && !isValidTimestamp(snapshot.openedAt)) ||
+      typeof snapshot.probeInFlight !== 'boolean') {
+    return initialProviderCircuit()
+  }
+  return {
+    state: snapshot.state,
+    consecutiveFailures: snapshot.consecutiveFailures,
+    openedAt: snapshot.openedAt,
+    probeInFlight: snapshot.state === 'half-open' && snapshot.probeInFlight
+  }
+}
+
+function normalizePolicy(policy: ProviderCircuitPolicy): ProviderCircuitPolicy {
+  if (!policy || !hasExactKeys(policy, ['failureThreshold', 'openDurationMs']) ||
+      !Number.isSafeInteger(policy.failureThreshold) || policy.failureThreshold < 1 ||
+      !Number.isSafeInteger(policy.openDurationMs) || policy.openDurationMs < 1) return DEFAULT_POLICY
+  return { failureThreshold: policy.failureThreshold, openDurationMs: policy.openDurationMs }
+}
+
+function isValidTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}
+
+function hasExactKeys(value: object, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort()
+  return actual.length === keys.length && actual.every((key, index) => key === [...keys].sort()[index])
+}


### PR DESCRIPTION
## Problem
Provider failures currently lack a shared, deterministic circuit-breaker policy, so runtime integration cannot safely distinguish retryable outages from authentication and client errors.

## Scope
This PR adds the provider circuit-breaker state machine only. It handles closed/open/half-open transitions, one half-open probe, bounded failure thresholds, and fail-closed validation for untrusted state, policy, failure kinds, and timestamps.

## Non-goals
Provider queue, request execution, UI, and runtime wiring are intentionally separate follow-up PRs.

## Tests
- npm.cmd --prefix kun test -- src/services/provider-circuit-breaker.test.ts (6 passed)
- npm.cmd run typecheck
- npm.cmd --prefix kun run typecheck
- npm.cmd run lint
- npm.cmd run build
- git diff --check

## Review
Completed functional, concurrency/lifecycle, data integrity, security, compatibility, and scope review. No package smoke is claimed because this PR contains a pure runtime policy module without an entrypoint change.

## Issue
Part of #885