### PR TITLE
feat(network): define custom CA bundle contract

### DIFF
--- a/src/main/services/skill-service.ts
+++ b/src/main/services/skill-service.ts
@@ -8,7 +8,10 @@ import {
   COMMON_WORKSPACE_SKILL_DIRS,
   type CommonSkillDir
 } from '../../shared/skill-dirs'
-import { expandHomePath } from './workspace-service'
+// Keep the skill catalog usable from Node-only migration/config tests. The
+// workspace barrel also exports Electron-backed editors and files, which
+// unnecessarily requires the Electron binary during CI.
+import { expandHomePath } from './workspace-paths'
 
 export type GuiSkillScope = 'project' | 'global'
 

--- a/src/shared/custom-ca.test.ts
+++ b/src/shared/custom-ca.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeCustomCaBundleConfig } from './custom-ca'
+
+describe('custom CA bundle contract', () => {
+  it('normalizes an absolute bundle path and lowercases its fingerprint', () => {
+    expect(normalizeCustomCaBundleConfig({
+      enabled: true,
+      bundlePath: 'C:\\certs\\corp.pem',
+      expectedSha256: 'A'.repeat(64)
+    })).toEqual({
+      ok: true,
+      value: {
+        enabled: true,
+        bundlePath: 'C:\\certs\\corp.pem',
+        expectedSha256: 'a'.repeat(64)
+      }
+    })
+  })
+
+  it('supports disabled configuration only without retained certificate data', () => {
+    expect(normalizeCustomCaBundleConfig({ enabled: false, bundlePath: '' })).toEqual({
+      ok: true,
+      value: { enabled: false, bundlePath: '' }
+    })
+    expect(normalizeCustomCaBundleConfig({ enabled: false, bundlePath: '/tmp/old.pem' }).ok).toBe(false)
+  })
+
+  it.each([
+    [{ enabled: true, bundlePath: 'relative.pem' }, 'path-not-absolute'],
+    [{ enabled: true, bundlePath: '/tmp/ca.pem', expectedSha256: 'not-a-hash' }, 'invalid-sha256'],
+    [{ enabled: true, bundlePath: '/tmp/ca\u0000.pem' }, 'path-control-character'],
+    [{ enabled: true, bundlePath: '/tmp/ca.pem', insecureSkipVerify: true }, 'unknown-field']
+  ])('rejects unsafe configuration %#', (input, error) => {
+    expect(normalizeCustomCaBundleConfig(input)).toEqual({ ok: false, error })
+  })
+
+  it('accepts POSIX and UNC absolute paths but rejects arrays and missing enabled', () => {
+    expect(normalizeCustomCaBundleConfig({ enabled: true, bundlePath: '/etc/ssl/corp.pem' }).ok).toBe(true)
+    expect(normalizeCustomCaBundleConfig({ enabled: true, bundlePath: '\\\\server\\share\\corp.pem' }).ok).toBe(true)
+    expect(normalizeCustomCaBundleConfig([])).toEqual({ ok: false, error: 'not-an-object' })
+    expect(normalizeCustomCaBundleConfig({ bundlePath: '/tmp/ca.pem' })).toEqual({ ok: false, error: 'invalid-enabled' })
+  })
+})

--- a/src/shared/custom-ca.ts
+++ b/src/shared/custom-ca.ts
@@ -1,0 +1,66 @@
+export type CustomCaBundleConfig = {
+  enabled: boolean
+  bundlePath: string
+  expectedSha256?: string
+}
+
+export type CustomCaValidationError =
+  | 'not-an-object'
+  | 'unknown-field'
+  | 'invalid-enabled'
+  | 'path-required'
+  | 'path-not-absolute'
+  | 'path-too-long'
+  | 'path-control-character'
+  | 'invalid-sha256'
+
+export type CustomCaValidationResult =
+  | { ok: true; value: CustomCaBundleConfig }
+  | { ok: false; error: CustomCaValidationError }
+
+const MAX_BUNDLE_PATH_LENGTH = 4096
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i
+
+export function normalizeCustomCaBundleConfig(input: unknown): CustomCaValidationResult {
+  if (!isRecord(input)) return { ok: false, error: 'not-an-object' }
+  const keys = Object.keys(input).sort()
+  if (keys.some((key) => !['bundlePath', 'enabled', 'expectedSha256'].includes(key))) {
+    return { ok: false, error: 'unknown-field' }
+  }
+  if (typeof input.enabled !== 'boolean') return { ok: false, error: 'invalid-enabled' }
+
+  const bundlePath = typeof input.bundlePath === 'string' ? input.bundlePath : ''
+  const expectedSha256 = input.expectedSha256
+  if (!input.enabled) {
+    if (bundlePath || expectedSha256 !== undefined) return { ok: false, error: 'path-required' }
+    return { ok: true, value: { enabled: false, bundlePath: '' } }
+  }
+
+  if (!bundlePath) return { ok: false, error: 'path-required' }
+  if (bundlePath.length > MAX_BUNDLE_PATH_LENGTH) return { ok: false, error: 'path-too-long' }
+  if (/\p{Cc}/u.test(bundlePath)) return { ok: false, error: 'path-control-character' }
+  if (!isAbsolutePath(bundlePath)) return { ok: false, error: 'path-not-absolute' }
+  if (expectedSha256 !== undefined &&
+      (typeof expectedSha256 !== 'string' || !SHA256_PATTERN.test(expectedSha256))) {
+    return { ok: false, error: 'invalid-sha256' }
+  }
+
+  return {
+    ok: true,
+    value: {
+      enabled: true,
+      bundlePath,
+      ...(expectedSha256 === undefined ? {} : { expectedSha256: expectedSha256.toLowerCase() })
+    }
+  }
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null && !Array.isArray(input)
+}
+
+function isAbsolutePath(value: string): boolean {
+  return value.startsWith('/') ||
+    value.startsWith('\\\\') ||
+    /^[a-z]:[\\/]/i.test(value)
+}


### PR DESCRIPTION
## Problem
Enterprise networks may require a user-selected CA bundle, but the project has no shared validation contract. This PR establishes the safe boundary before runtime wiring.

## Scope
Adds a strict shared Custom CA bundle contract with absolute cross-platform path validation, optional SHA-256 fingerprint normalization, bounded path length, and control-character rejection. Disabled settings cannot retain certificate metadata.

## Non-goals
No TLS agent wiring, proxy changes, settings UI, or certificate file reads are included; those will be separate PRs.

## Safety
The contract intentionally does not expose PEM contents and rejects unknown fields including insecureSkipVerify.

## Tests
- npm.cmd exec vitest run src/shared/custom-ca.test.ts (7 passed)
- npm.cmd run typecheck
- npm.cmd --prefix kun run typecheck
- npm.cmd run lint
- npm.cmd run build
- git diff --check

## Review
Completed functional, data integrity, security, cross-platform, compatibility, and scope review. No package smoke is claimed because this is a shared contract-only change.

## Issue
Part of #885