### PR TITLE
feat(budget): define model budget contract

### DIFF
--- a/kun/src/contracts/model-budget.ts
+++ b/kun/src/contracts/model-budget.ts
@@ -1,0 +1,110 @@
+export const MODEL_BUDGET_SCOPES = ['turn', 'thread', 'provider', 'agent', 'workflow'] as const
+export type ModelBudgetScope = typeof MODEL_BUDGET_SCOPES[number]
+
+export type ModelBudgetPolicy = {
+  scope: ModelBudgetScope
+  limitUsd: number
+  warningRatio: number
+}
+
+export type ModelBudgetUsage = {
+  usedUsd: number
+}
+
+export type ModelBudgetDecision = {
+  scope: ModelBudgetScope
+  status: 'allow' | 'warn' | 'deny'
+  limitUsd: number
+  usedUsd: number
+  remainingUsd: number
+  warningAtUsd: number
+}
+
+export type ModelBudgetValidationError =
+  | 'not-an-object'
+  | 'unknown-field'
+  | 'invalid-scope'
+  | 'invalid-limit'
+  | 'invalid-warning-ratio'
+  | 'invalid-usage'
+
+export type ModelBudgetEvaluation =
+  | { ok: true; policy: ModelBudgetPolicy; decision: ModelBudgetDecision }
+  | { ok: false; error: ModelBudgetValidationError }
+
+const DEFAULT_WARNING_RATIO = 0.8
+
+export function evaluateModelBudget(policyInput: unknown, usageInput: unknown): ModelBudgetEvaluation {
+  const policy = normalizeModelBudgetPolicy(policyInput)
+  if (!policy.ok) return policy
+  if (!isRecord(usageInput) || !hasOnlyKeys(usageInput, ['usedUsd']) ||
+      !isFiniteNonNegativeNumber(usageInput.usedUsd)) {
+    return { ok: false, error: 'invalid-usage' }
+  }
+
+  const usedUsd = usageInput.usedUsd
+  const warningAtUsd = policy.value.limitUsd * policy.value.warningRatio
+  const status = usedUsd >= policy.value.limitUsd
+    ? 'deny'
+    : usedUsd >= warningAtUsd
+      ? 'warn'
+      : 'allow'
+  return {
+    ok: true,
+    policy: policy.value,
+    decision: {
+      scope: policy.value.scope,
+      status,
+      limitUsd: policy.value.limitUsd,
+      usedUsd,
+      remainingUsd: Math.max(0, policy.value.limitUsd - usedUsd),
+      warningAtUsd
+    }
+  }
+}
+
+export function normalizeModelBudgetPolicy(input: unknown):
+  | { ok: true; value: ModelBudgetPolicy }
+  | { ok: false; error: ModelBudgetValidationError } {
+  if (!isRecord(input)) return { ok: false, error: 'not-an-object' }
+  if (!hasOnlyKeys(input, ['scope', 'limitUsd', 'warningRatio'])) {
+    return { ok: false, error: 'unknown-field' }
+  }
+  if (!MODEL_BUDGET_SCOPES.includes(input.scope as ModelBudgetScope)) {
+    return { ok: false, error: 'invalid-scope' }
+  }
+  if (!isFinitePositiveNumber(input.limitUsd)) return { ok: false, error: 'invalid-limit' }
+  const warningRatio = input.warningRatio === undefined ? DEFAULT_WARNING_RATIO : input.warningRatio
+  if (!isFiniteNumber(warningRatio) || warningRatio < 0 || warningRatio > 1) {
+    return { ok: false, error: 'invalid-warning-ratio' }
+  }
+  return {
+    ok: true,
+    value: {
+      scope: input.scope as ModelBudgetScope,
+      limitUsd: input.limitUsd,
+      warningRatio
+    }
+  }
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null && !Array.isArray(input)
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const allowed = new Set(keys)
+  return Object.keys(value).every((key) => allowed.has(key))
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function isFinitePositiveNumber(value: unknown): value is number {
+  return isFiniteNumber(value) && value > 0
+}
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 0
+}

--- a/kun/tests/model-budget.test.ts
+++ b/kun/tests/model-budget.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateModelBudget, normalizeModelBudgetPolicy } from '../src/contracts/model-budget.js'
+
+describe('model budget contract', () => {
+  it('allows usage below the warning threshold', () => {
+    expect(evaluateModelBudget({ scope: 'thread', limitUsd: 10 }, { usedUsd: 7 })).toMatchObject({
+      ok: true,
+      decision: { status: 'allow', remainingUsd: 3, warningAtUsd: 8 }
+    })
+  })
+
+  it('warns at the threshold and denies at or above the limit', () => {
+    const warning = evaluateModelBudget({ scope: 'provider', limitUsd: 10, warningRatio: 0.5 }, { usedUsd: 5 })
+    const denied = evaluateModelBudget({ scope: 'provider', limitUsd: 10, warningRatio: 0.5 }, { usedUsd: 11 })
+    expect(warning.ok).toBe(true)
+    expect(denied.ok).toBe(true)
+    if (warning.ok && denied.ok) {
+      expect(warning.decision).toMatchObject({ status: 'warn', remainingUsd: 5 })
+      expect(denied.decision).toMatchObject({ status: 'deny', remainingUsd: 0 })
+    }
+  })
+
+  it('supports all defined scopes and normalizes the default warning ratio', () => {
+    for (const scope of ['turn', 'thread', 'provider', 'agent', 'workflow'] as const) {
+      expect(normalizeModelBudgetPolicy({ scope, limitUsd: 1 })).toEqual({
+        ok: true,
+        value: { scope, limitUsd: 1, warningRatio: 0.8 }
+      })
+    }
+  })
+
+  it.each([
+    [{ scope: 'session', limitUsd: 1 }, 'invalid-scope'],
+    [{ scope: 'thread', limitUsd: 0 }, 'invalid-limit'],
+    [{ scope: 'thread', limitUsd: 1, warningRatio: 2 }, 'invalid-warning-ratio'],
+    [{ scope: 'thread', limitUsd: 1, extra: true }, 'unknown-field']
+  ])('rejects invalid policies %#', (input, error) => {
+    expect(normalizeModelBudgetPolicy(input)).toEqual({ ok: false, error })
+  })
+
+  it('rejects negative, infinite, and extra usage fields', () => {
+    expect(evaluateModelBudget({ scope: 'turn', limitUsd: 1 }, { usedUsd: -1 })).toEqual({ ok: false, error: 'invalid-usage' })
+    expect(evaluateModelBudget({ scope: 'turn', limitUsd: 1 }, { usedUsd: Infinity })).toEqual({ ok: false, error: 'invalid-usage' })
+    expect(evaluateModelBudget({ scope: 'turn', limitUsd: 1 }, { usedUsd: 0, tokenCount: 1 })).toEqual({ ok: false, error: 'invalid-usage' })
+  })
+})


### PR DESCRIPTION
## Problem
Kun already enforces a thread cost limit, but there is no shared contract for turn, thread, provider, agent, and workflow budgets. Different integrations could otherwise implement warning and denial semantics inconsistently.

## Scope
Adds a pure model-budget contract and evaluator for the five budget scopes. It validates finite positive limits, bounded warning ratios, non-negative usage, rejects unknown fields, and returns deterministic allow/warn/deny decisions with remaining budget.

## Non-goals
This PR does not change existing thread persistence, UI, model routing, provider queues, or automatic model switching. Those integrations remain separate follow-up PRs.

## Tests
- npm.cmd --prefix kun test -- tests/model-budget.test.ts (8 passed)
- npm.cmd run typecheck
- npm.cmd --prefix kun run typecheck
- npm.cmd run lint
- npm.cmd run build
- git diff --check

## Review
Completed functional, concurrency/lifecycle, data integrity, security, compatibility, and scope review. No package smoke is claimed because this PR is a pure contract module.

## Issue
Part of #885