### PR TITLE
test(a11y): add static accessibility harness

### DIFF
--- a/src/renderer/src/testing/accessibility-harness.test.ts
+++ b/src/renderer/src/testing/accessibility-harness.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { auditStaticMarkup } from './accessibility-harness'
+
+describe('static accessibility harness', () => {
+  it('accepts named controls, labelled fields, and modal dialogs', () => {
+    const issues = auditStaticMarkup(`
+      <button aria-label="Save"></button>
+      <label for="email">Email</label><input id="email" />
+      <div role="dialog" aria-modal="true" aria-labelledby="dialog-title"><h2 id="dialog-title">Settings</h2></div>
+    `)
+    expect(issues).toEqual([])
+  })
+
+  it('reports unnamed interactive elements, fields, and dialogs', () => {
+    const issues = auditStaticMarkup('<button></button><input /><div role="dialog"></div>')
+    expect(issues.map((issue) => issue.rule)).toEqual([
+      'interactive-name',
+      'form-label',
+      'dialog-semantics'
+    ])
+  })
+
+  it('detects duplicate ids and broken labelledby references', () => {
+    const issues = auditStaticMarkup(
+      '<span id="same"></span><span id="same"></span><button aria-labelledby="missing"></button>'
+    )
+    expect(issues.map((issue) => issue.rule)).toEqual(['duplicate-id', 'interactive-name'])
+  })
+
+  it('ignores aria-hidden and type=hidden implementation details', () => {
+    expect(auditStaticMarkup('<button aria-hidden="true"></button><input type="hidden" />')).toEqual([])
+  })
+
+  it('does not treat text inside aria-hidden icons as a control name', () => {
+    const issues = auditStaticMarkup('<button><span aria-hidden="true">x</span></button>')
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.rule).toBe('interactive-name')
+  })
+})

--- a/src/renderer/src/testing/accessibility-harness.ts
+++ b/src/renderer/src/testing/accessibility-harness.ts
@@ -1,0 +1,96 @@
+export type AccessibilityIssue = {
+  rule: 'interactive-name' | 'form-label' | 'dialog-semantics' | 'duplicate-id'
+  element: string
+  message: string
+}
+
+export function auditStaticMarkup(markup: string): AccessibilityIssue[] {
+  const issues: AccessibilityIssue[] = []
+  const ids = collectIds(markup, issues)
+
+  for (const match of markup.matchAll(/<(button|a)\b([^>]*)>([\s\S]*?)<\/\1>/gi)) {
+    const [, tag, attributes, contents] = match
+    if (isHidden(attributes)) continue
+    const name = firstAttribute(attributes, 'aria-label') ??
+      firstAttribute(attributes, 'title') ??
+      textContent(contents)
+    const labelledBy = firstAttribute(attributes, 'aria-labelledby')
+    if ((!name || !name.trim()) && (!labelledBy || !hasReferencedIds(labelledBy, ids))) {
+      issues.push({
+        rule: 'interactive-name',
+        element: tag.toLowerCase(),
+        message: `${tag.toLowerCase()} must have visible text, an aria-label, or a valid aria-labelledby reference`
+      })
+    }
+  }
+
+  for (const match of markup.matchAll(/<(input|select|textarea)\b([^>]*)>/gi)) {
+    const [, tag, attributes] = match
+    if (isHidden(attributes) || firstAttribute(attributes, 'type')?.toLowerCase() === 'hidden') continue
+    const hasName = firstAttribute(attributes, 'aria-label') || firstAttribute(attributes, 'aria-labelledby')
+    const id = firstAttribute(attributes, 'id')
+    const hasLabel = id !== undefined && new RegExp(`<label\\b[^>]*\\bfor=["']${escapeRegExp(id)}["']`, 'i').test(markup)
+    if (!hasName && !hasLabel) {
+      issues.push({
+        rule: 'form-label',
+        element: tag.toLowerCase(),
+        message: `${tag.toLowerCase()} must have an aria label or an associated label element`
+      })
+    }
+  }
+
+  for (const match of markup.matchAll(/<([a-z][\w-]*)\b([^>]*)>/gi)) {
+    const [, tag, attributes] = match
+    if (firstAttribute(attributes, 'role')?.toLowerCase() !== 'dialog' || isHidden(attributes)) continue
+    const hasModal = firstAttribute(attributes, 'aria-modal')?.toLowerCase() === 'true'
+    const label = firstAttribute(attributes, 'aria-label')
+    const labelledBy = firstAttribute(attributes, 'aria-labelledby')
+    if (!hasModal || (!label && (!labelledBy || !hasReferencedIds(labelledBy, ids)))) {
+      issues.push({
+        rule: 'dialog-semantics',
+        element: tag.toLowerCase(),
+        message: 'dialog must declare aria-modal="true" and an accessible name'
+      })
+    }
+  }
+
+  return issues
+}
+
+function collectIds(markup: string, issues: AccessibilityIssue[]): Set<string> {
+  const ids = new Set<string>()
+  for (const match of markup.matchAll(/\bid=["']([^"']+)["']/gi)) {
+    const id = match[1]
+    if (!id) continue
+    if (ids.has(id)) {
+      issues.push({ rule: 'duplicate-id', element: '*', message: `duplicate id: ${id}` })
+    }
+    ids.add(id)
+  }
+  return ids
+}
+
+function firstAttribute(attributes: string, name: string): string | undefined {
+  return attributes.match(new RegExp(`\\b${name}\\s*=\\s*["']([^"']*)["']`, 'i'))?.[1]
+}
+
+function hasReferencedIds(value: string, ids: Set<string>): boolean {
+  const references = value.split(/\s+/).filter(Boolean)
+  return references.length > 0 && references.every((id) => ids.has(id))
+}
+
+function isHidden(attributes: string): boolean {
+  return firstAttribute(attributes, 'aria-hidden')?.toLowerCase() === 'true'
+}
+
+function textContent(value: string): string {
+  return value
+    .replace(/<([a-z][\w-]*)\b[^>]*\baria-hidden=["']true["'][^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}


### PR DESCRIPTION
## Problem
The accessibility roadmap needs repeatable checks for high-risk markup, but the repository has no lightweight harness and no DOM test dependency.

## Scope
Adds a test-only static markup auditor covering interactive names, form labels, dialog semantics, duplicate IDs, valid aria-labelledby references, and aria-hidden/type-hidden exemptions. It has no runtime or renderer behavior change and adds no dependency.

## Non-goals
This is the shared harness only; Workbench, Settings, Write, Connect, and Workflow component remediation remain separate PRs.

## Tests
- npm.cmd exec vitest run src/renderer/src/testing/accessibility-harness.test.ts (5 passed)
- npm.cmd run typecheck
- npm.cmd --prefix kun run typecheck
- npm.cmd run lint
- npm.cmd run build
- git diff --check

## Review
Completed functional, lifecycle, data integrity, security, cross-platform, compatibility, and scope review. No package smoke is claimed because this is a test-only utility.

## Issue
Part of #885