### PR TITLE
feat(storage): define data retention contract

### DIFF
--- a/src/shared/data-retention.test.ts
+++ b/src/shared/data-retention.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_RETENTION_DAYS, normalizeDataRetentionPolicy, shouldRetainByAge } from './data-retention'
+
+describe('data retention contract', () => {
+  it('normalizes per-category days and supports null as keep forever', () => {
+    expect(normalizeDataRetentionPolicy({ logs: 7, attachments: null })).toEqual({
+      ok: true,
+      value: { logs: 7, attachments: null }
+    })
+  })
+
+  it('retains recent data and removes only data older than its category policy', () => {
+    const day = 24 * 60 * 60 * 1_000
+    const policy = { logs: 7, attachments: null }
+    expect(shouldRetainByAge(policy, 'logs', 10 * day, 16 * day)).toBe(true)
+    expect(shouldRetainByAge(policy, 'logs', 1 * day, 16 * day)).toBe(false)
+    expect(shouldRetainByAge(policy, 'attachments', 0, 100 * day)).toBe(true)
+  })
+
+  it('keeps future or invalid timestamps rather than deleting conservatively', () => {
+    expect(shouldRetainByAge({ logs: 1 }, 'logs', 2_000, 1_000)).toBe(true)
+    expect(shouldRetainByAge({ logs: 1 }, 'logs', Number.NaN, 1_000)).toBe(true)
+  })
+
+  it.each([
+    [{ unknown: 7 }, 'unknown-category'],
+    [{ logs: 0 }, 'invalid-days'],
+    [{ logs: MAX_RETENTION_DAYS + 1 }, 'invalid-days'],
+    [{ logs: 1.5 }, 'invalid-days'],
+    [{}, 'empty-policy']
+  ])('rejects unsafe policies %#', (input, error) => {
+    expect(normalizeDataRetentionPolicy(input)).toEqual({ ok: false, error })
+  })
+
+  it('rejects arrays and keeps unknown categories out of age checks', () => {
+    expect(normalizeDataRetentionPolicy([])).toEqual({ ok: false, error: 'not-an-object' })
+    expect(shouldRetainByAge({ logs: 1 }, 'diagnostics', 0, 100 * 24 * 60 * 60 * 1_000)).toBe(true)
+    expect(shouldRetainByAge({ logs: -1 }, 'logs', 0, 100 * 24 * 60 * 60 * 1_000)).toBe(true)
+    expect(shouldRetainByAge(null, 'logs', 0, 100 * 24 * 60 * 60 * 1_000)).toBe(true)
+  })
+})

--- a/src/shared/data-retention.ts
+++ b/src/shared/data-retention.ts
@@ -1,0 +1,61 @@
+export const DATA_RETENTION_CATEGORIES = [
+  'threads',
+  'attachments',
+  'checkpoints',
+  'worktrees',
+  'logs',
+  'diagnostics',
+  'extensionLogs',
+  'models'
+] as const
+export type DataRetentionCategory = typeof DATA_RETENTION_CATEGORIES[number]
+
+export type DataRetentionPolicy = Partial<Record<DataRetentionCategory, number | null>>
+
+export type DataRetentionValidationError =
+  | 'not-an-object'
+  | 'unknown-category'
+  | 'invalid-days'
+  | 'empty-policy'
+
+export type DataRetentionValidation =
+  | { ok: true; value: DataRetentionPolicy }
+  | { ok: false; error: DataRetentionValidationError }
+
+export const MAX_RETENTION_DAYS = 3_650
+
+export function normalizeDataRetentionPolicy(input: unknown): DataRetentionValidation {
+  if (!isRecord(input)) return { ok: false, error: 'not-an-object' }
+  const entries = Object.entries(input)
+  if (entries.length === 0) return { ok: false, error: 'empty-policy' }
+  const result: DataRetentionPolicy = {}
+  for (const [category, days] of entries) {
+    if (!DATA_RETENTION_CATEGORIES.includes(category as DataRetentionCategory)) {
+      return { ok: false, error: 'unknown-category' }
+    }
+    if (days !== null && (typeof days !== 'number' || !Number.isSafeInteger(days) || days < 1 || days > MAX_RETENTION_DAYS)) {
+      return { ok: false, error: 'invalid-days' }
+    }
+    result[category as DataRetentionCategory] = days
+  }
+  return { ok: true, value: result }
+}
+
+export function shouldRetainByAge(
+  policy: unknown,
+  category: unknown,
+  createdAtMs: number,
+  nowMs: number
+): boolean {
+  const normalized = normalizeDataRetentionPolicy(policy)
+  if (!normalized.ok || !DATA_RETENTION_CATEGORIES.includes(category as DataRetentionCategory)) return true
+  const days = normalized.value[category as DataRetentionCategory]
+  if (days === null || days === undefined) return true
+  if (!Number.isSafeInteger(createdAtMs) || !Number.isSafeInteger(nowMs) || createdAtMs < 0 || nowMs < 0) return true
+  if (createdAtMs > nowMs) return true
+  return nowMs - createdAtMs < days * 24 * 60 * 60 * 1_000
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null && !Array.isArray(input)
+}


### PR DESCRIPTION
## Problem
Kun has log-only retention settings, but storage cleanup also needs a consistent policy for threads, attachments, checkpoints, worktrees, diagnostics, extension logs, and model caches.

## Scope
Adds a shared category allowlist and strict retention policy normalizer. Categories accept bounded day counts or null for keep-forever. Age checks revalidate untrusted policies and retain data on invalid/future timestamps.

## Non-goals
No automatic deletion, disk scanner, backup integration, quota UI, or settings migration is included; those are separate PRs.

## Tests
- npm.cmd exec vitest run src/shared/data-retention.test.ts (9 passed)
- npm.cmd run typecheck
- npm.cmd --prefix kun run typecheck
- npm.cmd run lint
- npm.cmd run build
- git diff --check

## Review
Completed functional, data integrity, security, cross-platform, compatibility, and scope review. No package smoke is claimed because this PR is a shared contract-only change.

## Issue
Part of #885