### PR TITLE
feat(workflow): define persisted version contract

### DIFF
--- a/src/shared/workflow-version.test.ts
+++ b/src/shared/workflow-version.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CURRENT_WORKFLOW_SCHEMA_VERSION,
+  createWorkflowVersionMetadata,
+  inspectWorkflowVersion
+} from './workflow-version'
+
+describe('workflow version contract', () => {
+  it('creates current metadata with the originating app version', () => {
+    expect(createWorkflowVersionMetadata('0.2.21')).toEqual({
+      schemaVersion: CURRENT_WORKFLOW_SCHEMA_VERSION,
+      createdAppVersion: '0.2.21',
+      lastMigratedVersion: CURRENT_WORKFLOW_SCHEMA_VERSION
+    })
+  })
+
+  it('accepts legacy documents without mutating them', () => {
+    const document = { id: 'workflow-1', nodes: [] }
+    expect(inspectWorkflowVersion(document)).toMatchObject({ kind: 'missing' })
+    expect(document).toEqual({ id: 'workflow-1', nodes: [] })
+  })
+
+  it('accepts the current version and rejects future versions', () => {
+    expect(inspectWorkflowVersion({
+      schemaVersion: 1,
+      createdAppVersion: '0.2.21',
+      lastMigratedVersion: 1
+    })).toEqual({
+      kind: 'supported',
+      metadata: { schemaVersion: 1, createdAppVersion: '0.2.21', lastMigratedVersion: 1 }
+    })
+    expect(inspectWorkflowVersion({ schemaVersion: 2 })).toEqual({ kind: 'future', schemaVersion: 2 })
+  })
+
+  it('rejects malformed or unsafe metadata', () => {
+    expect(inspectWorkflowVersion(null)).toEqual({ kind: 'invalid' })
+    expect(inspectWorkflowVersion({ schemaVersion: 0 })).toEqual({ kind: 'invalid' })
+    expect(inspectWorkflowVersion({ schemaVersion: 1, createdAppVersion: '0.2.21', lastMigratedVersion: 0 })).toEqual({ kind: 'invalid' })
+    expect(inspectWorkflowVersion({ schemaVersion: 1, createdAppVersion: '\u0000' })).toEqual({ kind: 'invalid' })
+    expect(() => createWorkflowVersionMetadata('')).toThrow('invalid workflow app version')
+  })
+})

--- a/src/shared/workflow-version.ts
+++ b/src/shared/workflow-version.ts
@@ -1,0 +1,92 @@
+/**
+ * Version metadata for persisted workflow documents.
+ *
+ * This contract is intentionally independent from the editor/runtime so callers
+ * can reject future documents before attempting a lossy normalization.
+ */
+export const CURRENT_WORKFLOW_SCHEMA_VERSION = 1 as const
+
+export type WorkflowVersionMetadata = {
+  schemaVersion: number
+  createdAppVersion: string
+  lastMigratedVersion: number
+}
+
+export type WorkflowVersionInspection =
+  | { kind: 'supported'; metadata: WorkflowVersionMetadata }
+  | { kind: 'missing'; metadata: WorkflowVersionMetadata }
+  | { kind: 'future'; schemaVersion: number }
+  | { kind: 'invalid' }
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function boundedVersion(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 1000 ? value : null
+}
+
+function appVersion(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  const hasControlCharacter = [...normalized].some((character) => {
+    const code = character.charCodeAt(0)
+    return code < 0x20 || code === 0x7f
+  })
+  return normalized.length > 0 && normalized.length <= 64 && !hasControlCharacter
+    ? normalized
+    : null
+}
+
+/**
+ * Inspect version metadata without mutating the supplied workflow document.
+ * Missing metadata is accepted for legacy documents and receives a current
+ * in-memory default; future versions are rejected so unknown fields are not
+ * silently discarded by the legacy normalizer.
+ */
+export function inspectWorkflowVersion(value: unknown): WorkflowVersionInspection {
+  const input = record(value)
+  if (!input) return { kind: 'invalid' }
+  if (input.schemaVersion === undefined) {
+    return {
+      kind: 'missing',
+      metadata: {
+        schemaVersion: CURRENT_WORKFLOW_SCHEMA_VERSION,
+        createdAppVersion: 'legacy',
+        lastMigratedVersion: CURRENT_WORKFLOW_SCHEMA_VERSION
+      }
+    }
+  }
+
+  const schemaVersion = boundedVersion(input.schemaVersion)
+  if (schemaVersion === null) return { kind: 'invalid' }
+  if (schemaVersion > CURRENT_WORKFLOW_SCHEMA_VERSION) return { kind: 'future', schemaVersion }
+
+  const createdAppVersion = appVersion(input.createdAppVersion)
+  const lastMigratedVersion = boundedVersion(input.lastMigratedVersion)
+  if (
+    !createdAppVersion ||
+    lastMigratedVersion === null ||
+    lastMigratedVersion < schemaVersion ||
+    lastMigratedVersion > CURRENT_WORKFLOW_SCHEMA_VERSION
+  ) {
+    return { kind: 'invalid' }
+  }
+
+  return {
+    kind: 'supported',
+    metadata: { schemaVersion, createdAppVersion, lastMigratedVersion }
+  }
+}
+
+export function createWorkflowVersionMetadata(appVersionValue: string): WorkflowVersionMetadata {
+  const createdAppVersion = appVersion(appVersionValue)
+  if (!createdAppVersion) throw new Error('invalid workflow app version')
+  return {
+    schemaVersion: CURRENT_WORKFLOW_SCHEMA_VERSION,
+    createdAppVersion,
+    lastMigratedVersion: CURRENT_WORKFLOW_SCHEMA_VERSION
+  }
+}


### PR DESCRIPTION
## Problem\nPersisted workflows are named V1 but do not have a small, reusable contract for schema metadata or future-version handling. A legacy normalizer could otherwise silently discard fields from a newer document.\n\n## Scope\nThis PR defines and tests the version contract only. It does not change workflow persistence, migration, editor behavior, or execution.\n\n## Changes\n- Add bounded schema/app/migration version metadata.\n- Accept legacy documents in memory without mutating them.\n- Classify current, malformed, and future versions so callers can enter read-only handling instead of lossy normalization.\n- Add unit coverage for all classifications and unsafe values.\n\n## Validation\n- npm.cmd exec vitest run src/shared/workflow-version.test.ts (4 passed)\n- npm.cmd run typecheck\n- npm.cmd --prefix kun run typecheck\n- npm.cmd run lint\n- npm.cmd run build\n- git diff --check\n\nNo package smoke required: shared pure contract only.\n\nPart of #885