### PR TITLE
feat(security): sanitize tool process environments

### DIFF
--- a/kun/src/security/tool-environment.test.ts
+++ b/kun/src/security/tool-environment.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeToolEnvironment } from './tool-environment.js'
+
+describe('sanitizeToolEnvironment', () => {
+  it('removes credentials, credential paths, and runtime control variables', () => {
+    const result = sanitizeToolEnvironment({
+      PATH: 'bin',
+      OPENAI_API_KEY: 'secret',
+      KUN_RUNTIME_TOKEN: 'runtime-secret',
+      GOOGLE_APPLICATION_CREDENTIALS: 'C:/secret.json',
+      ELECTRON_RUN_AS_NODE: '1',
+      DEBUG_PORT: '9229',
+      LANG: 'en_US.UTF-8'
+    })
+
+    expect(result.env).toEqual({ PATH: 'bin', LANG: 'en_US.UTF-8' })
+    expect(result.removedKeys).toEqual([
+      'DEBUG_PORT',
+      'ELECTRON_RUN_AS_NODE',
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      'KUN_RUNTIME_TOKEN',
+      'OPENAI_API_KEY'
+    ])
+  })
+
+  it('removes proxy credentials but keeps a proxy without userinfo', () => {
+    const result = sanitizeToolEnvironment({
+      HTTP_PROXY: 'http://proxy.example:8080',
+      HTTPS_PROXY: 'https://user:password@proxy.example:8443',
+      NO_PROXY: 'localhost,127.0.0.1'
+    })
+
+    expect(result.env).toEqual({
+      HTTP_PROXY: 'http://proxy.example:8080',
+      NO_PROXY: 'localhost,127.0.0.1'
+    })
+    expect(result.removedKeys).toEqual(['HTTPS_PROXY'])
+  })
+
+  it('allows an explicitly approved key and does not expose values in audit output', () => {
+    const result = sanitizeToolEnvironment(
+      { provider_api_key: 'intentional', OTHER_SECRET: 'hidden' },
+      { allowKeys: ['PROVIDER_API_KEY'] }
+    )
+
+    expect(result.env).toEqual({ provider_api_key: 'intentional' })
+    expect(result.removedKeys).toEqual(['OTHER_SECRET'])
+    expect(JSON.stringify(result.removedKeys)).not.toContain('hidden')
+  })
+
+  it('ignores undefined values and keeps ordinary variables', () => {
+    expect(sanitizeToolEnvironment({ HOME: '/home/user', EMPTY: undefined })).toEqual({
+      env: { HOME: '/home/user' },
+      removedKeys: []
+    })
+  })
+})

--- a/kun/src/security/tool-environment.ts
+++ b/kun/src/security/tool-environment.ts
@@ -1,0 +1,104 @@
+const CREDENTIAL_PATH_KEYS = new Set([
+  'AWS_CONFIG_FILE',
+  'AWS_SHARED_CREDENTIALS_FILE',
+  'AZURE_CONFIG_DIR',
+  'CLAUDE_CONFIG_DIR',
+  'DOCKER_CONFIG',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'KUBECONFIG',
+  'NPM_CONFIG_USERCONFIG',
+  'SSH_AUTH_SOCK'
+])
+
+const INTERNAL_KEYS = new Set([
+  'DEEPSEEK_API_KEY',
+  'ELECTRON_NO_ATTACH_CONSOLE',
+  'ELECTRON_RUN_AS_NODE',
+  'KUN_RUNTIME_TOKEN',
+  'KUN_RUNTIME_URL',
+  'NODE_EXTRA_CA_CERTS',
+  'NODE_OPTIONS',
+  'V8_INSPECTOR'
+])
+
+const PROXY_KEYS = new Set([
+  'ALL_PROXY',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'NPM_CONFIG_PROXY',
+  'NPM_CONFIG_HTTPS_PROXY'
+])
+
+const SENSITIVE_KEY_PARTS = [
+  'ACCESS_TOKEN',
+  'API_KEY',
+  'AUTH_TOKEN',
+  'BEARER',
+  'CLIENT_SECRET',
+  'COOKIE',
+  'CREDENTIAL',
+  'PASSWORD',
+  'PASSWD',
+  'PRIVATE_KEY',
+  'REFRESH_TOKEN',
+  'SECRET',
+  'SESSION_TOKEN'
+] as const
+
+export type ToolEnvironmentSanitizationOptions = {
+  allowKeys?: readonly string[]
+}
+
+export type ToolEnvironmentSanitization = {
+  env: Record<string, string | undefined>
+  removedKeys: string[]
+}
+
+/**
+ * Remove credentials and host-process control variables before starting a tool.
+ * Values are never copied into the audit result; callers may log removedKeys
+ * without risking accidental credential disclosure.
+ */
+export function sanitizeToolEnvironment(
+  input: Record<string, string | undefined>,
+  options: ToolEnvironmentSanitizationOptions = {}
+): ToolEnvironmentSanitization {
+  const allowed = new Set((options.allowKeys ?? []).map((key) => key.trim().toUpperCase()).filter(Boolean))
+  const env: Record<string, string | undefined> = {}
+  const removedKeys: string[] = []
+
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined) continue
+    const normalizedKey = key.toUpperCase()
+    if (!allowed.has(normalizedKey) && shouldRemove(normalizedKey, value)) {
+      removedKeys.push(key)
+      continue
+    }
+    env[key] = value
+  }
+
+  removedKeys.sort((a, b) => a.localeCompare(b))
+  return { env, removedKeys }
+}
+
+function shouldRemove(key: string, value: string): boolean {
+  if (INTERNAL_KEYS.has(key) || CREDENTIAL_PATH_KEYS.has(key)) return true
+  if (key.startsWith('ELECTRON_') || key === 'DEBUG_PORT' || key === 'INSPECT_PORT') return true
+  if (SENSITIVE_KEY_PARTS.some((part) => key === part || key.includes(`_${part}`))) return true
+  if (PROXY_KEYS.has(key)) return proxyContainsCredentials(value)
+  return false
+}
+
+function proxyContainsCredentials(value: string): boolean {
+  const normalized = value.trim()
+  if (!normalized || !normalized.includes('://')) return false
+  try {
+    const parsed = new URL(normalized)
+    return Boolean(parsed.username || parsed.password)
+  } catch {
+    // An unparseable proxy is left alone here; URL validation belongs to the
+    // network policy layer, while this helper only removes known credentials.
+    return false
+  }
+}


### PR DESCRIPTION
## Problem\nTool child processes can inherit host credentials and Electron/runtime control variables when callers pass process.env directly.\n\n## Scope\nThis PR adds the reusable sanitizer only. It does not change shell, LSP, MCP, workflow, or extension process wiring; those integrations remain separate reviewable PRs.\n\n## Changes\n- Remove common API keys, OAuth tokens, secrets, cookies, passwords, credential-file paths, runtime tokens, and Electron/debug control variables by default.\n- Remove proxy URLs only when they contain userinfo, preserving ordinary proxy routing.\n- Support a case-insensitive exact allowlist for intentionally approved variables.\n- Return removed key names without values for safe audit logging.\n\n## Validation\n- npm.cmd --prefix kun test -- src/security/tool-environment.test.ts (4 passed)\n- npm.cmd --prefix kun run typecheck\n- npm.cmd run typecheck\n- npm.cmd run lint\n- npm.cmd run build\n- git diff --check\n\nNo package smoke required: utility contract only.\n\nPart of #869