### PR TITLE
feat(im): define inbound message identity

### DIFF
--- a/src/main/claw-message-identity.test.ts
+++ b/src/main/claw-message-identity.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { inboundMessageDedupeKey, normalizeInboundMessageIdentity } from './claw-message-identity'
+
+describe('inbound message identity', () => {
+  it('normalizes the channel and requires all identity dimensions', () => {
+    expect(normalizeInboundMessageIdentity({
+      channel: ' Feishu ',
+      accountId: 'bot-a',
+      conversationId: 'chat-1',
+      platformMessageId: ' msg-1 '
+    })).toEqual({
+      channel: 'feishu',
+      accountId: 'bot-a',
+      conversationId: 'chat-1',
+      platformMessageId: 'msg-1'
+    })
+    expect(normalizeInboundMessageIdentity({ channel: 'telegram', accountId: 'bot-a' })).toBeNull()
+  })
+
+  it('does not collide for equal message ids from different channels or accounts', () => {
+    const first = normalizeInboundMessageIdentity({
+      channel: 'telegram', accountId: 'bot-a', conversationId: 'chat', platformMessageId: '42'
+    })!
+    const second = normalizeInboundMessageIdentity({
+      channel: 'feishu', accountId: 'bot-a', conversationId: 'chat', platformMessageId: '42'
+    })!
+    const third = normalizeInboundMessageIdentity({
+      channel: 'telegram', accountId: 'bot-b', conversationId: 'chat', platformMessageId: '42'
+    })!
+    expect(new Set([inboundMessageDedupeKey(first), inboundMessageDedupeKey(second), inboundMessageDedupeKey(third)]).size).toBe(3)
+  })
+
+  it('keeps punctuation unambiguous and rejects unsafe values', () => {
+    const identity = normalizeInboundMessageIdentity({
+      channel: 'webhook', accountId: 'account', conversationId: 'a|b', platformMessageId: 'c|d'
+    })!
+    expect(inboundMessageDedupeKey(identity)).toBe('im:["webhook","account","a|b","c|d"]')
+    expect(normalizeInboundMessageIdentity({
+      channel: 'webhook', accountId: 'account\n', conversationId: 'chat', platformMessageId: 'id'
+    })).toBeNull()
+    expect(normalizeInboundMessageIdentity({
+      channel: 'webhook', accountId: 'x'.repeat(257), conversationId: 'chat', platformMessageId: 'id'
+    })).toBeNull()
+  })
+})

--- a/src/main/claw-message-identity.ts
+++ b/src/main/claw-message-identity.ts
@@ -1,0 +1,54 @@
+export type InboundMessageIdentity = {
+  channel: string
+  accountId: string
+  conversationId: string
+  platformMessageId: string
+}
+
+export type InboundMessageIdentityInput = Partial<InboundMessageIdentity> & {
+  channel?: unknown
+  accountId?: unknown
+  conversationId?: unknown
+  platformMessageId?: unknown
+}
+
+const MAX_IDENTITY_PART_LENGTH = 256
+
+/**
+ * Normalize the provider-owned identity used for inbound webhook idempotency.
+ * All four parts are required: a platform message id is not globally unique
+ * across channels or bot accounts.
+ */
+export function normalizeInboundMessageIdentity(input: unknown): InboundMessageIdentity | null {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null
+  const value = input as InboundMessageIdentityInput
+  const channel = normalizePart(value.channel, true)
+  const accountId = normalizePart(value.accountId)
+  const conversationId = normalizePart(value.conversationId)
+  const platformMessageId = normalizePart(value.platformMessageId)
+  if (!channel || !accountId || !conversationId || !platformMessageId) return null
+  return { channel, accountId, conversationId, platformMessageId }
+}
+
+/**
+ * JSON encoding keeps the dedupe key unambiguous even when an id contains
+ * punctuation that would collide with a delimiter-based key.
+ */
+export function inboundMessageDedupeKey(identity: InboundMessageIdentity): string {
+  const normalized = normalizeInboundMessageIdentity(identity)
+  if (!normalized) throw new Error('invalid inbound message identity')
+  return `im:${JSON.stringify([
+    normalized.channel,
+    normalized.accountId,
+    normalized.conversationId,
+    normalized.platformMessageId
+  ])}`
+}
+
+function normalizePart(value: unknown, lowerCase = false): string | null {
+  if (typeof value !== 'string') return null
+  if ([...value].some((character) => character.charCodeAt(0) < 0x20 || character.charCodeAt(0) === 0x7f)) return null
+  const normalized = value.trim()
+  if (normalized.length === 0 || normalized.length > MAX_IDENTITY_PART_LENGTH) return null
+  return lowerCase ? normalized.toLowerCase() : normalized
+}


### PR DESCRIPTION
## Problem\nClaw channels currently pass provider message ids through several paths without one shared identity or collision-safe dedupe key. The same platform id can be reused by different channels, bot accounts, or conversations.\n\n## Scope\nThis PR defines the identity contract only. It does not change webhook handling or add persistence; the idempotency store is a separate follow-up.\n\n## Changes\n- Require channel, account, conversation, and platform message id.\n- Normalize channel names and reject blank, control-character, or oversized identity parts.\n- Build a JSON-encoded dedupe key so delimiter characters cannot collide.\n- Add coverage for cross-channel/account uniqueness and unsafe input.\n\n## Validation\n- npm.cmd exec vitest run src/main/claw-message-identity.test.ts (3 passed)\n- npm.cmd run typecheck\n- npm.cmd --prefix kun run typecheck\n- npm.cmd run lint\n- npm.cmd run build\n- git diff --check\n\nNo package smoke required: pure main-process contract only.\n\nPart of #885