### PR TITLE
feat(workflow): add secret reference contract

### DIFF
--- a/src/shared/workflow-secret-reference.test.ts
+++ b/src/shared/workflow-secret-reference.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { parseWorkflowSecretReference } from './workflow-secret-reference'
+
+describe('parseWorkflowSecretReference', () => {
+  it('normalizes a reference and keeps only non-secret identifiers', () => {
+    expect(
+      parseWorkflowSecretReference({
+        credentialSourceId: '  cred_google  ',
+        accountId: ' account-1 ',
+        secretName: ' access-token '
+      })
+    ).toEqual({
+      credentialSourceId: 'cred_google',
+      accountId: 'account-1',
+      secretName: 'access-token'
+    })
+  })
+
+  it.each([
+    undefined,
+    null,
+    [],
+    {},
+    { credentialSourceId: '' },
+    { credentialSourceId: 'cred', value: 'plain-secret' },
+    { credentialSourceId: 'cred', token: 'oauth-token' },
+    { credentialSourceId: 'cred', apiKey: 'api-key' },
+    { credentialSourceId: 'cred', secret: 'secret' }
+  ])('rejects malformed or secret-bearing input: %j', (value) => {
+    expect(parseWorkflowSecretReference(value)).toBeNull()
+  })
+
+  it('rejects control characters and oversized identifiers', () => {
+    expect(parseWorkflowSecretReference({ credentialSourceId: 'cred\nsource' })).toBeNull()
+    expect(parseWorkflowSecretReference({ credentialSourceId: 'cred\n' })).toBeNull()
+    expect(parseWorkflowSecretReference({ credentialSourceId: '\tcred' })).toBeNull()
+    expect(parseWorkflowSecretReference({ credentialSourceId: 'x'.repeat(257) })).toBeNull()
+    expect(parseWorkflowSecretReference({ credentialSourceId: 'cred', accountId: 42 })).toBeNull()
+  })
+
+  it('does not mutate or retain the input object', () => {
+    const input = { credentialSourceId: 'cred', accountId: 'account' }
+    const parsed = parseWorkflowSecretReference(input)
+    expect(parsed).toEqual(input)
+    expect(parsed).not.toBe(input)
+    input.accountId = 'changed'
+    expect(parsed?.accountId).toBe('account')
+  })
+})

--- a/src/shared/workflow-secret-reference.ts
+++ b/src/shared/workflow-secret-reference.ts
@@ -1,0 +1,59 @@
+/**
+ * A workflow may refer to a credential without persisting the credential
+ * material itself. This contract is deliberately small so runtime resolution
+ * can be added independently without changing the persisted workflow shape.
+ */
+export type WorkflowSecretReference = {
+  credentialSourceId: string
+  accountId?: string
+  secretName?: string
+}
+
+const MAX_REFERENCE_PART_LENGTH = 256
+const ALLOWED_KEYS = new Set(['credentialSourceId', 'accountId', 'secretName'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)
+    if (codePoint !== undefined && (codePoint < 0x20 || codePoint === 0x7f)) return true
+  }
+  return false
+}
+
+function normalizePart(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  if (containsControlCharacter(value)) return undefined
+  const normalized = value.trim()
+  if (!normalized || normalized.length > MAX_REFERENCE_PART_LENGTH) return undefined
+  return normalized
+}
+
+/**
+ * Parses an untrusted value into a reference-only shape.
+ *
+ * Unknown keys are rejected intentionally: accepting a future `value` or
+ * `token` field here would make it too easy to persist a secret accidentally.
+ */
+export function parseWorkflowSecretReference(value: unknown): WorkflowSecretReference | null {
+  if (!isRecord(value)) return null
+  if (Object.keys(value).some((key) => !ALLOWED_KEYS.has(key))) return null
+
+  const credentialSourceId = normalizePart(value.credentialSourceId)
+  if (!credentialSourceId) return null
+
+  const accountId = value.accountId === undefined ? undefined : normalizePart(value.accountId)
+  if (value.accountId !== undefined && !accountId) return null
+
+  const secretName = value.secretName === undefined ? undefined : normalizePart(value.secretName)
+  if (value.secretName !== undefined && !secretName) return null
+
+  return {
+    credentialSourceId,
+    ...(accountId ? { accountId } : {}),
+    ...(secretName ? { secretName } : {})
+  }
+}


### PR DESCRIPTION
## Problem
Workflow secret variables currently model credentials as plain `value` fields. Export sanitizes them, but there is no shared contract that prevents future persistence paths from accepting secret material.

## Root cause
Workflow configuration has no reference-only type or parser for credential-backed values, so runtime wiring would otherwise have to define its own validation and could accidentally persist tokens.

## Scope
This PR adds the small, reference-only contract and tests. It does not change the existing WorkflowEnvVarV1 shape, runtime resolution, migrations, or UI; those changes will be reviewed separately.

## Changes
- Add `WorkflowSecretReference` with `credentialSourceId`, optional `accountId`, and optional `secretName`.
- Add strict parsing that normalizes bounded identifiers and rejects control characters, unknown keys, and secret-bearing fields such as `value`, `token`, and `apiKey`.
- Add regression tests for malformed input, secret material, immutability, and boundary values.

## Safety
- The parser returns a new object containing identifiers only.
- Unknown fields are rejected to fail closed if a caller tries to pass plaintext credential fields.
- No secrets are logged, serialized, or sent to the renderer.

## Validation
- `npm.cmd exec vitest run src/shared/workflow-secret-reference.test.ts` — 1 file, 12 tests passed.
- `npm.cmd run typecheck` — passed.
- `npm.cmd --prefix kun run typecheck` — passed.
- `npm.cmd run lint` — passed.
- `npm.cmd run build` — passed.
- `git diff --check` — passed.

## Review performed
Functional correctness, architecture, concurrency/lifecycle, data integrity, security, cross-platform behavior, compatibility, test quality, and PR scope were reviewed. A control-character edge case found during final review was fixed and re-tested.

## PR size
- Production files: 1
- Test files: 1
- Production LOC: 59
- Total diff: 108 additions

## Follow-ups
Runtime credential resolution and migration of existing workflow secret variables should be separate PRs so this contract remains independently reviewable and reversible.