### PR TITLE
feat(workflow): add node migration registry

### DIFF
--- a/src/shared/workflow-node-migration.test.ts
+++ b/src/shared/workflow-node-migration.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { WorkflowNodeMigrationRegistry, type WorkflowNodeMigration } from './workflow-node-migration'
+
+const migration = (fromVersion: number, toVersion: number, nodeType = 'http-request'): WorkflowNodeMigration => ({
+  nodeType,
+  fromVersion,
+  toVersion,
+  migrate: (config) => config
+})
+
+describe('WorkflowNodeMigrationRegistry', () => {
+  it('registers a migration and resolves a direct path', () => {
+    const registry = new WorkflowNodeMigrationRegistry()
+    const step = migration(1, 2)
+    registry.register(step)
+
+    expect(registry.findPath('http-request', 1, 2)).toEqual([step])
+  })
+
+  it('resolves the shortest deterministic forward chain', () => {
+    const registry = new WorkflowNodeMigrationRegistry()
+    const direct = migration(1, 3)
+    const first = migration(1, 2)
+    const second = migration(2, 3)
+    registry.register(second)
+    registry.register(first)
+    registry.register(direct)
+
+    expect(registry.findPath('http-request', 1, 3)).toEqual([direct])
+  })
+
+  it('returns a chained path when no direct migration exists', () => {
+    const registry = new WorkflowNodeMigrationRegistry()
+    const first = migration(1, 2)
+    const second = migration(2, 3)
+    registry.register(second)
+    registry.register(first)
+
+    expect(registry.findPath('http-request', 1, 3)).toEqual([first, second])
+  })
+
+  it('returns an empty path for an already current version and null when unreachable', () => {
+    const registry = new WorkflowNodeMigrationRegistry()
+    expect(registry.findPath('http-request', 2, 2)).toEqual([])
+    expect(registry.findPath('http-request', 1, 3)).toBeNull()
+    expect(registry.findPath('http-request', 3, 1)).toBeNull()
+    expect(registry.findPath('condition', 1, 2)).toBeNull()
+  })
+
+  it('rejects duplicate and backward migrations', () => {
+    const registry = new WorkflowNodeMigrationRegistry()
+    registry.register(migration(1, 2))
+    expect(() => registry.register(migration(1, 2))).toThrow('already registered')
+    expect(() => registry.register(migration(2, 1))).toThrow('move forward')
+  })
+
+  it.each([
+    migration(0, 1, ''),
+    migration(0, 1, 'node\n'),
+    { nodeType: 'custom', fromVersion: -1, toVersion: 1, migrate: () => ({}) },
+    { nodeType: 'custom', fromVersion: 1, toVersion: Number.POSITIVE_INFINITY, migrate: () => ({}) },
+    { nodeType: 'custom', fromVersion: 1, toVersion: 2, migrate: undefined }
+  ])('rejects malformed migration definitions: %j', (value) => {
+    const registry = new WorkflowNodeMigrationRegistry()
+    expect(() => registry.register(value as WorkflowNodeMigration)).toThrow()
+  })
+
+  it('normalizes node type whitespace without mutating the input', () => {
+    const registry = new WorkflowNodeMigrationRegistry()
+    const input = migration(1, 2, '  custom  ')
+    registry.register(input)
+    expect(registry.findPath('custom', 1, 2)).toHaveLength(1)
+    expect(input.nodeType).toBe('  custom  ')
+  })
+})

--- a/src/shared/workflow-node-migration.ts
+++ b/src/shared/workflow-node-migration.ts
@@ -1,0 +1,88 @@
+/** A single, forward-only migration for one workflow node type. */
+export interface WorkflowNodeMigration {
+  nodeType: string
+  fromVersion: number
+  toVersion: number
+  migrate(config: unknown): unknown
+}
+
+const MAX_NODE_TYPE_LENGTH = 256
+const MAX_VERSION = 10_000
+
+function isValidNodeType(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)
+    if (codePoint !== undefined && (codePoint < 0x20 || codePoint === 0x7f)) return false
+  }
+  const normalized = value.trim()
+  if (!normalized || normalized.length > MAX_NODE_TYPE_LENGTH) return false
+  return true
+}
+
+function isValidVersion(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= MAX_VERSION
+}
+
+function migrationKey(migration: Pick<WorkflowNodeMigration, 'nodeType' | 'fromVersion' | 'toVersion'>): string {
+  return `${migration.nodeType}\u0000${migration.fromVersion}\u0000${migration.toVersion}`
+}
+
+function assertMigration(migration: WorkflowNodeMigration): WorkflowNodeMigration {
+  if (!migration || typeof migration !== 'object') throw new TypeError('workflow migration must be an object')
+  if (!isValidNodeType(migration.nodeType)) throw new TypeError('workflow migration nodeType is invalid')
+  if (!isValidVersion(migration.fromVersion) || !isValidVersion(migration.toVersion)) {
+    throw new TypeError('workflow migration versions are invalid')
+  }
+  if (migration.toVersion <= migration.fromVersion) {
+    throw new TypeError('workflow migration must move forward')
+  }
+  if (typeof migration.migrate !== 'function') throw new TypeError('workflow migration callback is required')
+
+  return {
+    ...migration,
+    nodeType: migration.nodeType.trim()
+  }
+}
+
+/**
+ * In-memory registry used by a future workflow loader. It deliberately does
+ * not run callbacks; callers can review and execute a resolved chain in the
+ * persistence boundary that owns backups and rollback.
+ */
+export class WorkflowNodeMigrationRegistry {
+  private readonly migrations = new Map<string, WorkflowNodeMigration>()
+
+  register(migration: WorkflowNodeMigration): void {
+    const normalized = assertMigration(migration)
+    const key = migrationKey(normalized)
+    if (this.migrations.has(key)) throw new Error(`workflow migration already registered: ${key}`)
+    this.migrations.set(key, normalized)
+  }
+
+  findPath(nodeType: string, fromVersion: number, toVersion: number): readonly WorkflowNodeMigration[] | null {
+    if (!isValidNodeType(nodeType) || !isValidVersion(fromVersion) || !isValidVersion(toVersion)) return null
+    const normalizedNodeType = nodeType.trim()
+    if (fromVersion > toVersion) return null
+    if (fromVersion === toVersion) return []
+
+    const paths: WorkflowNodeMigration[][] = [[]]
+    const visited = new Set<number>([fromVersion])
+    while (paths.length > 0) {
+      const path = paths.shift()!
+      const currentVersion = path.length === 0 ? fromVersion : path[path.length - 1]!.toVersion
+      const next = [...this.migrations.values()]
+        .filter((migration) => migration.nodeType === normalizedNodeType && migration.fromVersion === currentVersion)
+        .sort((left, right) => left.toVersion - right.toVersion)
+
+      for (const migration of next) {
+        if (migration.toVersion > toVersion || visited.has(migration.toVersion)) continue
+        const candidate = [...path, migration]
+        if (migration.toVersion === toVersion) return candidate
+        visited.add(migration.toVersion)
+        paths.push(candidate)
+      }
+    }
+    return null
+  }
+}


### PR DESCRIPTION
## Problem
Workflow node configurations need a versioned migration boundary, but there is no shared registry for declaring or resolving node migrations. Implementations would otherwise duplicate lookup rules and risk applying backward or ambiguous migrations.

## Root cause
The workflow model has node kinds and persisted configs but no forward-only migration contract that can be reviewed independently from storage and UI behavior.

## Scope
This PR adds the in-memory migration registry contract only. It does not migrate existing workflows, execute callbacks, change persistence, or add UI.

## Changes
- Define `WorkflowNodeMigration` with a node type, forward version range, and migration callback.
- Validate bounded node types, finite non-negative versions, forward-only ranges, and callbacks.
- Reject duplicate registrations and resolve deterministic shortest forward paths.
- Add tests for direct/chained paths, unreachable and reverse paths, malformed definitions, normalization, and duplicate registration.

## Safety
- Registry resolution does not execute migration callbacks or mutate persisted data.
- Invalid and backward definitions fail closed.
- Node types are checked for control characters and bounded length.

## Validation
- `npm.cmd exec vitest run src/shared/workflow-node-migration.test.ts` — 1 file, 11 tests passed.
- `npm.cmd run typecheck` — passed.
- `npm.cmd --prefix kun run typecheck` — passed.
- `npm.cmd run lint` — passed.
- `npm.cmd run build` — passed.
- `git diff --check` — passed.

## Review performed
Reviewed functional correctness, architecture, lifecycle/concurrency boundaries, data integrity, security, cross-platform behavior, compatibility, test quality, and PR scope. A trailing control-character acceptance bug found by the targeted test was fixed before submission.

## PR size
- Production files: 1
- Test files: 1
- Production LOC: 88
- Total diff: 163 additions

## Follow-ups
Workflow loader integration and per-node migration implementations should be submitted separately, with backup/rollback behavior owned by the persistence layer.