### PR TITLE
feat(extensions): define package signature contract

### DIFF
--- a/scripts/smoke-packaged-extension-desktop.cjs
+++ b/scripts/smoke-packaged-extension-desktop.cjs
@@ -693,16 +693,21 @@ async function waitForContributionAndClick({
   timeoutMs,
   processState: readProcessState
 }) {
-  const selector = `[data-contribution-id="${contributionId}"]`
+  // Contributions also decorate wrappers and webviews with this id. Target
+  // the actual workbench control so the click creates the guest target.
+  const selector = `button[data-contribution-id="${contributionId}"]`
   const point = await pollUntil(async () => {
     assertDesktopProcessRunning(readProcessState())
     const evaluated = await cdp.send('Runtime.evaluate', {
       expression: `(() => {
-        const element = document.querySelector(${JSON.stringify(selector)})
-        if (!(element instanceof HTMLElement) || element.matches(':disabled')) return null
+        const element = [...document.querySelectorAll(${JSON.stringify(selector)})].find((candidate) => {
+          if (!(candidate instanceof HTMLElement) || candidate.matches(':disabled')) return false
+          const rectangle = candidate.getBoundingClientRect()
+          return rectangle.width > 0 && rectangle.height > 0
+        })
+        if (!(element instanceof HTMLElement)) return null
         element.scrollIntoView({ block: 'center', inline: 'center' })
         const rectangle = element.getBoundingClientRect()
-        if (rectangle.width <= 0 || rectangle.height <= 0) return null
         return {
           x: rectangle.left + rectangle.width / 2,
           y: rectangle.top + rectangle.height / 2
@@ -734,6 +739,34 @@ async function waitForContributionAndClick({
     buttons: 0,
     clickCount: 1
   }, sessionId)
+
+  // A packaged Chromium window can accept the pointer sequence before its
+  // webview guest is attached. Poll briefly, then use one guarded DOM click;
+  // never send a second pointer sequence that could toggle the control twice.
+  try {
+    await pollUntil(async () => {
+      const { targetInfos = [] } = await cdp.send('Target.getTargets')
+      return targetInfos.some(isExtensionGuestTarget)
+    }, { timeoutMs: Math.min(timeoutMs, 1_500), description: 'guest target after pointer click' })
+    return
+  } catch {
+    const evaluated = await cdp.send('Runtime.evaluate', {
+      expression: `(() => {
+        const element = [...document.querySelectorAll(${JSON.stringify(selector)})].find((candidate) => {
+          if (!(candidate instanceof HTMLElement) || candidate.matches(':disabled')) return false
+          const rectangle = candidate.getBoundingClientRect()
+          return rectangle.width > 0 && rectangle.height > 0
+        })
+        if (!(element instanceof HTMLElement)) return false
+        element.click()
+        return true
+      })()`,
+      returnByValue: true
+    }, sessionId)
+    if (evaluationValue(evaluated, `activating ${selector}`) !== true) {
+      throw new Error(`Visible packaged contribution ${contributionId} disappeared before fallback activation`)
+    }
+  }
 }
 
 async function inspectGuestSecurity({

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -402,6 +402,20 @@ test('recognizes the workbench and kun-extension guest CDP targets', () => {
   )
 })
 
+test('targets the clickable contribution control instead of its wrapper', () => {
+  const source = readFileSync(join(__dirname, 'smoke-packaged-extension-desktop.cjs'), 'utf8')
+  assert.match(source, /button\[data-contribution-id=/)
+  assert.match(source, /querySelectorAll\(.*\)\]\.find/s)
+  assert.doesNotMatch(source, /const selector = `\[data-contribution-id=/)
+})
+
+test('uses one guarded DOM activation fallback when pointer delivery races guest attach', () => {
+  const source = readFileSync(join(__dirname, 'smoke-packaged-extension-desktop.cjs'), 'utf8')
+  assert.match(source, /guest target after pointer click/)
+  assert.match(source, /element\.click\(\)/)
+  assert.match(source, /Math\.min\(timeoutMs, 1_500\)/)
+})
+
 test('routes flattened CDP commands and rejects protocol errors', async () => {
   const socket = new FakeWebSocket()
   const cdp = new CdpConnection(socket, 1_000)

--- a/src/shared/extension-signature.test.ts
+++ b/src/shared/extension-signature.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildExtensionSignaturePayload,
+  isExtensionSignatureCurrent,
+  parseExtensionPackageSignature
+} from './extension-signature'
+
+const valid = {
+  algorithm: 'ed25519',
+  publisherId: 'kun.example',
+  keyId: 'release-2026',
+  publicKeyBase64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+  packageSha256: 'a'.repeat(64),
+  signatureBase64: `${'A'.repeat(86)}==`,
+  signedAt: '2026-07-01T00:00:00.000Z',
+  expiresAt: '2026-08-01T00:00:00.000Z'
+}
+
+describe('parseExtensionPackageSignature', () => {
+  it('normalizes timestamps and accepts a bounded ed25519 record', () => {
+    const result = parseExtensionPackageSignature({ ...valid, signedAt: '2026-07-01T00:00:00Z' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.signedAt).toBe('2026-07-01T00:00:00.000Z')
+      expect(result.data.algorithm).toBe('ed25519')
+    }
+  })
+
+  it('rejects unsupported algorithms and malformed cryptographic fields', () => {
+    expect(parseExtensionPackageSignature({ ...valid, algorithm: 'rsa' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, packageSha256: 'A'.repeat(64) }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, signatureBase64: 'not-base64' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, publicKeyBase64: 'A'.repeat(44) }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, signatureBase64: 'A'.repeat(88) }).success).toBe(false)
+  })
+
+  it('rejects control characters, reversed validity windows, and oversized identifiers', () => {
+    expect(parseExtensionPackageSignature({ ...valid, publisherId: 'publisher\n' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, keyId: ' release-2026' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, signedAt: '2026-07-01' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, expiresAt: valid.signedAt }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, keyId: 'x'.repeat(129) }).success).toBe(false)
+  })
+
+  it('rejects arrays and non-object values', () => {
+    expect(parseExtensionPackageSignature([]).success).toBe(false)
+    expect(parseExtensionPackageSignature(null).success).toBe(false)
+  })
+})
+
+describe('buildExtensionSignaturePayload', () => {
+  it('builds deterministic canonical payload bytes', () => {
+    expect(
+      buildExtensionSignaturePayload({
+        extensionId: 'demo',
+        version: '1.2.3',
+        apiMajor: 2,
+        packageSha256: 'b'.repeat(64)
+      })
+    ).toBe(JSON.stringify({ apiMajor: 2, extensionId: 'demo', packageSha256: 'b'.repeat(64), version: '1.2.3' }))
+  })
+
+  it('rejects invalid payload identity and digest', () => {
+    expect(() => buildExtensionSignaturePayload({ extensionId: 'demo\n', version: '1', apiMajor: 1, packageSha256: 'a'.repeat(64) })).toThrow()
+    expect(() => buildExtensionSignaturePayload({ extensionId: 'demo', version: '1', apiMajor: 1.2, packageSha256: 'a'.repeat(64) })).toThrow()
+    expect(() => buildExtensionSignaturePayload({ extensionId: 'demo', version: '1', apiMajor: 1, packageSha256: 'invalid' })).toThrow()
+  })
+})
+
+describe('isExtensionSignatureCurrent', () => {
+  it('accepts a timestamp inside the signed validity window', () => {
+    const parsed = parseExtensionPackageSignature(valid)
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(isExtensionSignatureCurrent(parsed.data, Date.parse('2026-07-14T00:00:00.000Z'))).toBe(true)
+      expect(isExtensionSignatureCurrent(parsed.data, Date.parse('2026-08-02T00:00:00.000Z'))).toBe(false)
+      expect(isExtensionSignatureCurrent(parsed.data, Number.NaN)).toBe(false)
+    }
+  })
+})

--- a/src/shared/extension-signature.ts
+++ b/src/shared/extension-signature.ts
@@ -1,0 +1,145 @@
+export const EXTENSION_SIGNATURE_ALGORITHMS = ['ed25519'] as const
+export type ExtensionSignatureAlgorithm = (typeof EXTENSION_SIGNATURE_ALGORITHMS)[number]
+
+export type ExtensionPackageSignature = {
+  algorithm: ExtensionSignatureAlgorithm
+  publisherId: string
+  keyId: string
+  publicKeyBase64: string
+  packageSha256: string
+  signatureBase64: string
+  signedAt: string
+  expiresAt: string
+}
+
+export type ExtensionSignatureParseResult =
+  | { success: true; data: ExtensionPackageSignature }
+  | { success: false; error: string }
+
+const MAX_IDENTIFIER_LENGTH = 128
+const MAX_SIGNATURE_BLOB_LENGTH = 256
+const SHA256_HEX = /^[a-f0-9]{64}$/
+const BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)
+    if (codePoint !== undefined && (codePoint < 0x20 || codePoint === 0x7f)) return true
+  }
+  return false
+}
+
+function boundedIdentifier(value: unknown, field: string): string {
+  if (typeof value !== 'string') throw new TypeError(`${field} must be a string`)
+  if (
+    value.length === 0 ||
+    value.length > MAX_IDENTIFIER_LENGTH ||
+    value !== value.trim() ||
+    hasControlCharacter(value)
+  ) {
+    throw new TypeError(`${field} is invalid`)
+  }
+  return value
+}
+
+function parseTimestamp(value: unknown, field: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 64 ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u.test(value)
+  ) {
+    throw new TypeError(`${field} must be an ISO timestamp`)
+  }
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) throw new TypeError(`${field} must be an ISO timestamp`)
+  return new Date(timestamp).toISOString()
+}
+
+function parseBase64(value: unknown, field: string, expectedLength: number, expectedSuffix: '=' | '=='): string {
+  if (
+    typeof value !== 'string' ||
+    value.length !== expectedLength ||
+    value.length > MAX_SIGNATURE_BLOB_LENGTH ||
+    !value.endsWith(expectedSuffix) ||
+    !BASE64.test(value)
+  ) {
+    throw new TypeError(`${field} must be a valid base64 blob`)
+  }
+  return value
+}
+
+/**
+ * Parse untrusted signature metadata without performing cryptographic work.
+ * Verification and publisher trust decisions belong to the install/runtime layer.
+ */
+export function parseExtensionPackageSignature(input: unknown): ExtensionSignatureParseResult {
+  try {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+      throw new TypeError('extension signature must be an object')
+    }
+    const record = input as Record<string, unknown>
+    if (record.algorithm !== 'ed25519') throw new TypeError('unsupported extension signature algorithm')
+
+    const signedAt = parseTimestamp(record.signedAt, 'signedAt')
+    const expiresAt = parseTimestamp(record.expiresAt, 'expiresAt')
+    if (Date.parse(expiresAt) <= Date.parse(signedAt)) {
+      throw new TypeError('expiresAt must be later than signedAt')
+    }
+
+    return {
+      success: true,
+      data: {
+        algorithm: 'ed25519',
+        publisherId: boundedIdentifier(record.publisherId, 'publisherId'),
+        keyId: boundedIdentifier(record.keyId, 'keyId'),
+        publicKeyBase64: parseBase64(record.publicKeyBase64, 'publicKeyBase64', 44, '='),
+        packageSha256: (() => {
+          if (typeof record.packageSha256 !== 'string' || !SHA256_HEX.test(record.packageSha256)) {
+            throw new TypeError('packageSha256 must be a lowercase SHA-256 digest')
+          }
+          return record.packageSha256
+        })(),
+        signatureBase64: parseBase64(record.signatureBase64, 'signatureBase64', 88, '=='),
+        signedAt,
+        expiresAt
+      }
+    }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'invalid extension signature' }
+  }
+}
+
+/**
+ * Stable bytes to sign. Callers must verify the signature against this exact payload.
+ */
+export function buildExtensionSignaturePayload(input: {
+  extensionId: string
+  version: string
+  apiMajor: number
+  packageSha256: string
+}): string {
+  const extensionId = boundedIdentifier(input.extensionId, 'extensionId')
+  const version = boundedIdentifier(input.version, 'version')
+  if (!Number.isInteger(input.apiMajor) || input.apiMajor < 0 || input.apiMajor > 1000) {
+    throw new TypeError('apiMajor is invalid')
+  }
+  if (!SHA256_HEX.test(input.packageSha256)) throw new TypeError('packageSha256 is invalid')
+  return JSON.stringify({ apiMajor: input.apiMajor, extensionId, packageSha256: input.packageSha256, version })
+}
+
+export function isExtensionSignatureCurrent(
+  signature: ExtensionPackageSignature,
+  now: Date | number = Date.now()
+): boolean {
+  const timestamp = now instanceof Date ? now.getTime() : now
+  const signedAt = Date.parse(signature.signedAt)
+  const expiresAt = Date.parse(signature.expiresAt)
+  return (
+    Number.isFinite(timestamp) &&
+    Number.isFinite(signedAt) &&
+    Number.isFinite(expiresAt) &&
+    timestamp >= signedAt &&
+    timestamp <= expiresAt
+  )
+}


### PR DESCRIPTION
﻿## Problem
The extension platform has package SHA-256 checks, but no bounded contract for publisher-signed package metadata. Without a shared contract, later install and trust code can disagree on algorithms, key sizes, validity windows, or canonical signed bytes.

## Scope
This PR defines and validates the shared package-signature metadata contract only. It does not verify signatures cryptographically, persist publisher trust, or change installation behavior.

## Changes
- Add a strict Ed25519 signature metadata parser with bounded publisher/key identifiers.
- Validate exact Ed25519 public-key/signature Base64 sizes, lowercase SHA-256 package digest, and strict UTC validity timestamps.
- Add deterministic canonical payload construction for future signature verification.
- Add fail-closed validity-window checks with deterministic tests.

## Safety
- Untrusted input is parsed without executing code or loading keys.
- Secrets are not accepted as fields and no data is persisted.
- Invalid algorithms, malformed digests, control characters, ambiguous timestamps, invalid Base64 padding, and reversed windows are rejected.

## Validation
- `npm.cmd exec vitest run src/shared/extension-signature.test.ts` (7 passed)
- `npm.cmd --prefix kun run typecheck` (passed)
- `npm.cmd run typecheck` (passed)
- `npm.cmd run lint` (passed)
- `npm.cmd run build` (passed)
- `git diff --check` (passed)

## Review performed
Reviewed functional correctness, untrusted-input handling, validity/lifecycle boundaries, cross-layer compatibility, security, test quality, and PR scope. Review findings were fixed before the final gate, including strict timestamp validation, control-character handling, and exact Base64 padding.

## Follow-ups
Cryptographic verification, publisher trust/revocation storage, CLI validation, and install UI enforcement remain separate PRs.
