### PR TITLE
feat(notifications): define notification center contract

### DIFF
--- a/src/shared/notification-center.test.ts
+++ b/src/shared/notification-center.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { isNotificationExpired, parseNotificationCenterRecord } from './notification-center'
+
+const valid = {
+  id: 'notice-1',
+  kind: 'background-task',
+  severity: 'success',
+  title: 'Task complete',
+  body: 'The background task finished.',
+  occurredAt: '2026-07-14T00:00:00.000Z',
+  dedupeKey: 'task:123',
+  threadId: 'thread-1',
+  expiresAt: '2026-07-15T00:00:00.000Z',
+  action: { id: 'open-thread', label: 'Open thread', command: 'thread.open' }
+}
+
+describe('parseNotificationCenterRecord', () => {
+  it('parses and normalizes a bounded notification record', () => {
+    const result = parseNotificationCenterRecord(valid)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.occurredAt).toBe('2026-07-14T00:00:00.000Z')
+      expect(result.data.action?.command).toBe('thread.open')
+    }
+  })
+
+  it('rejects unknown kinds and severities', () => {
+    expect(parseNotificationCenterRecord({ ...valid, kind: 'unknown' }).success).toBe(false)
+    expect(parseNotificationCenterRecord({ ...valid, severity: 'critical' }).success).toBe(false)
+  })
+
+  it('rejects invalid lifecycle timestamps', () => {
+    expect(parseNotificationCenterRecord({ ...valid, expiresAt: valid.occurredAt }).success).toBe(false)
+    expect(parseNotificationCenterRecord({ ...valid, readAt: '2026-07-13T00:00:00.000Z' }).success).toBe(false)
+    expect(parseNotificationCenterRecord({ ...valid, occurredAt: '2026-07-14' }).success).toBe(false)
+  })
+
+  it('bounds text and rejects control characters while allowing body newlines', () => {
+    expect(parseNotificationCenterRecord({ ...valid, title: ' x' }).success).toBe(false)
+    expect(parseNotificationCenterRecord({ ...valid, body: 'line 1\nline 2' }).success).toBe(true)
+    expect(parseNotificationCenterRecord({ ...valid, body: `bad\u0000` }).success).toBe(false)
+    expect(parseNotificationCenterRecord({ ...valid, body: 'x'.repeat(2_001) }).success).toBe(false)
+  })
+
+  it('rejects malformed actions and unsafe command text', () => {
+    expect(parseNotificationCenterRecord({ ...valid, action: [] }).success).toBe(false)
+    expect(parseNotificationCenterRecord({ ...valid, action: { id: 'open', label: 'Open\n' } }).success).toBe(false)
+    expect(parseNotificationCenterRecord({ ...valid, action: { id: 'open', label: 'Open', command: 'javascript:alert(1)' } }).success).toBe(false)
+    expect(parseNotificationCenterRecord({ ...valid, action: { id: 'open', label: 'Open', command: 'thread.open' } }).success).toBe(true)
+  })
+})
+
+describe('isNotificationExpired', () => {
+  it('handles expiring and non-expiring notifications fail-closed', () => {
+    const parsed = parseNotificationCenterRecord(valid)
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(isNotificationExpired(parsed.data, Date.parse('2026-07-14T12:00:00.000Z'))).toBe(false)
+      expect(isNotificationExpired(parsed.data, Date.parse('2026-07-15T00:00:00.000Z'))).toBe(true)
+      expect(isNotificationExpired({ ...parsed.data, expiresAt: undefined }, Date.now())).toBe(false)
+      expect(isNotificationExpired(parsed.data, Number.NaN)).toBe(false)
+    }
+  })
+})

--- a/src/shared/notification-center.ts
+++ b/src/shared/notification-center.ts
@@ -1,0 +1,141 @@
+export const NOTIFICATION_KINDS = [
+  'approval-required',
+  'background-task',
+  'runtime-recovered',
+  'provider-failure',
+  'extension-failure',
+  'transfer-complete',
+  'system'
+] as const
+export type NotificationKind = (typeof NOTIFICATION_KINDS)[number]
+
+export const NOTIFICATION_SEVERITIES = ['info', 'success', 'warning', 'error'] as const
+export type NotificationSeverity = (typeof NOTIFICATION_SEVERITIES)[number]
+
+export type NotificationAction = {
+  id: string
+  label: string
+  command?: string
+}
+
+export type NotificationCenterRecord = {
+  id: string
+  kind: NotificationKind
+  severity: NotificationSeverity
+  title: string
+  body: string
+  occurredAt: string
+  dedupeKey: string
+  threadId?: string
+  readAt?: string
+  expiresAt?: string
+  action?: NotificationAction
+}
+
+export type NotificationParseResult =
+  | { success: true; data: NotificationCenterRecord }
+  | { success: false; error: string }
+
+const IDENTIFIER_LIMIT = 160
+const TITLE_LIMIT = 160
+const BODY_LIMIT = 2_000
+const COMMAND_LIMIT = 160
+const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u
+const COMMAND_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u
+
+function hasForbiddenControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)
+    if (codePoint !== undefined && (codePoint < 0x20 || codePoint === 0x7f) && !'\r\n\t'.includes(character)) {
+      return true
+    }
+  }
+  return false
+}
+
+function boundedText(value: unknown, field: string, maxLength: number, allowNewlines = false): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > maxLength || value !== value.trim()) {
+    throw new TypeError(`${field} is invalid`)
+  }
+  if (hasForbiddenControlCharacter(value) || (!allowNewlines && /[\r\n\t]/u.test(value))) {
+    throw new TypeError(`${field} contains unsupported characters`)
+  }
+  return value
+}
+
+function optionalText(value: unknown, field: string, maxLength: number): string | undefined {
+  return value === undefined ? undefined : boundedText(value, field, maxLength)
+}
+
+function timestamp(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length > 64 || !ISO_UTC.test(value)) {
+    throw new TypeError(`${field} must be a UTC ISO timestamp`)
+  }
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) throw new TypeError(`${field} must be a UTC ISO timestamp`)
+  return new Date(parsed).toISOString()
+}
+
+function isNotificationKind(value: unknown): value is NotificationKind {
+  return typeof value === 'string' && (NOTIFICATION_KINDS as readonly string[]).includes(value)
+}
+
+function isNotificationSeverity(value: unknown): value is NotificationSeverity {
+  return typeof value === 'string' && (NOTIFICATION_SEVERITIES as readonly string[]).includes(value)
+}
+
+function parseAction(value: unknown): NotificationAction | undefined {
+  if (value === undefined) return undefined
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new TypeError('action is invalid')
+  const record = value as Record<string, unknown>
+  const command = optionalText(record.command, 'action.command', COMMAND_LIMIT)
+  if (command && !COMMAND_ID.test(command)) throw new TypeError('action.command is invalid')
+  return {
+    id: boundedText(record.id, 'action.id', IDENTIFIER_LIMIT),
+    label: boundedText(record.label, 'action.label', TITLE_LIMIT),
+    command
+  }
+}
+
+export function parseNotificationCenterRecord(input: unknown): NotificationParseResult {
+  try {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) throw new TypeError('notification must be an object')
+    const record = input as Record<string, unknown>
+    if (!isNotificationKind(record.kind)) throw new TypeError('notification kind is invalid')
+    if (!isNotificationSeverity(record.severity)) throw new TypeError('notification severity is invalid')
+    const occurredAt = timestamp(record.occurredAt, 'occurredAt')
+    const readAt = record.readAt === undefined ? undefined : timestamp(record.readAt, 'readAt')
+    const expiresAt = record.expiresAt === undefined ? undefined : timestamp(record.expiresAt, 'expiresAt')
+    if (expiresAt && Date.parse(expiresAt) <= Date.parse(occurredAt)) {
+      throw new TypeError('expiresAt must be later than occurredAt')
+    }
+    if (readAt && Date.parse(readAt) < Date.parse(occurredAt)) {
+      throw new TypeError('readAt cannot precede occurredAt')
+    }
+    return {
+      success: true,
+      data: {
+        id: boundedText(record.id, 'id', IDENTIFIER_LIMIT),
+        kind: record.kind,
+        severity: record.severity,
+        title: boundedText(record.title, 'title', TITLE_LIMIT),
+        body: boundedText(record.body, 'body', BODY_LIMIT, true),
+        occurredAt,
+        dedupeKey: boundedText(record.dedupeKey, 'dedupeKey', IDENTIFIER_LIMIT),
+        threadId: optionalText(record.threadId, 'threadId', IDENTIFIER_LIMIT),
+        readAt,
+        expiresAt,
+        action: parseAction(record.action)
+      }
+    }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'invalid notification' }
+  }
+}
+
+export function isNotificationExpired(record: NotificationCenterRecord, now: Date | number = Date.now()): boolean {
+  if (!record.expiresAt) return false
+  const timestampValue = now instanceof Date ? now.getTime() : now
+  const expiresAt = Date.parse(record.expiresAt)
+  return Number.isFinite(timestampValue) && Number.isFinite(expiresAt) && timestampValue >= expiresAt
+}


### PR DESCRIPTION
﻿## Problem
Notifications are currently emitted through separate completion and toast paths without a shared model for severity, deduplication, thread association, actions, read state, or expiry.

## Scope
This PR defines the shared notification-center contract and safe parser only. It does not add persistence, UI, or replace the existing completion notification path.

## Changes
- Define bounded notification kinds and severities for approvals, background work, runtime recovery, provider/extension failures, transfers, and system events.
- Parse and normalize UTC timestamps with lifecycle checks for read and expiry state.
- Bound user-facing text and internal identifiers; allow body line breaks but reject control characters.
- Restrict optional actions to internal command identifiers rather than URLs or paths.
- Add expiry evaluation for validated records.

## Safety
- All external records are treated as untrusted and parsed without execution.
- Text, identifiers, action commands, and timestamps are bounded.
- No secrets, URLs, or arbitrary executable payloads are part of the contract.

## Validation
- `npm.cmd exec vitest run src/shared/notification-center.test.ts` (6 passed)
- `npm.cmd --prefix kun run typecheck` (passed)
- `npm.cmd run typecheck` (passed)
- `npm.cmd run lint` (passed)
- `npm.cmd run build` (passed)
- `git diff --check` (passed)

## Review performed
Reviewed functional correctness, lifecycle ordering, untrusted input handling, command safety, compatibility, test quality, and PR scope. No blocker or high-severity findings remain.

## Follow-ups
A persistent notification store, runtime event adapters, deduplication policy, and notification-center UI should be separate PRs.
