### PR TITLE
feat(events): consolidate IPC and SSE reliability

### DIFF
--- a/src/main/services/sse-resume-cursor-store.test.ts
+++ b/src/main/services/sse-resume-cursor-store.test.ts
@@ -1,0 +1,137 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import { SseResumeCursorStore } from './sse-resume-cursor-store'
+
+const cursor = (scopeId: string, lastSequence: number, updatedAt: string, runtimeGeneration = 'g1') => ({
+  scopeId,
+  streamId: 'stream-1',
+  lastSequence,
+  runtimeGeneration,
+  updatedAt
+})
+
+describe('SseResumeCursorStore', () => {
+  it('persists acknowledged cursors atomically and restores them', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    const path = join(root, 'nested', 'cursors.json')
+    try {
+      const store = new SseResumeCursorStore(path)
+      expect(await store.save(cursor('thread-1', 4, '2026-07-14T00:00:00.000Z'))).toBe(true)
+      expect(await store.get('thread-1')).toEqual(cursor('thread-1', 4, '2026-07-14T00:00:00.000Z'))
+      const restored = new SseResumeCursorStore(path)
+      expect(await restored.get('thread-1')).toEqual(cursor('thread-1', 4, '2026-07-14T00:00:00.000Z'))
+      expect(JSON.parse(await readFile(path, 'utf8')).version).toBe(1)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not move a cursor backwards within the same runtime generation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    try {
+      const store = new SseResumeCursorStore(join(root, 'cursors.json'))
+      expect(await store.save(cursor('thread-1', 10, '2026-07-14T00:00:01.000Z'))).toBe(true)
+      expect(await store.save(cursor('thread-1', 9, '2026-07-14T00:00:02.000Z'))).toBe(false)
+      expect(await store.get('thread-1')).toEqual(cursor('thread-1', 10, '2026-07-14T00:00:01.000Z'))
+      expect(await store.save(cursor('thread-1', 1, '2026-07-14T00:00:03.000Z', 'g2'))).toBe(true)
+      expect(await store.get('thread-1')).toEqual(cursor('thread-1', 1, '2026-07-14T00:00:03.000Z', 'g2'))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('serializes concurrent writes and trims oldest scopes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    try {
+      const store = new SseResumeCursorStore(join(root, 'cursors.json'), { maxEntries: 2 })
+      await Promise.all([
+        store.save(cursor('old', 1, '2026-07-14T00:00:00.000Z')),
+        store.save(cursor('newer', 2, '2026-07-14T00:00:02.000Z')),
+        store.save(cursor('newest', 3, '2026-07-14T00:00:03.000Z'))
+      ])
+      expect(await store.get('old')).toBeNull()
+      expect(await store.list()).toHaveLength(2)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('trims by timestamp when cursors use different UTC offsets', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    try {
+      const store = new SseResumeCursorStore(join(root, 'cursors.json'), { maxEntries: 2 })
+      await store.save(cursor('old', 1, '2026-07-14T02:00:00+02:00'))
+      await store.save(cursor('newer', 2, '2026-07-14T00:30:00Z'))
+      await store.save(cursor('newest', 3, '2026-07-14T01:00:00Z'))
+      expect(await store.get('old')).toBeNull()
+      expect(await store.list()).toEqual(expect.arrayContaining([
+        expect.objectContaining({ scopeId: 'newer' }),
+        expect.objectContaining({ scopeId: 'newest' })
+      ]))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails open on malformed data without overwriting the evidence', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    const path = join(root, 'cursors.json')
+    try {
+      await writeFile(path, '{not-json', 'utf8')
+      const store = new SseResumeCursorStore(path)
+      expect(await store.get('thread-1')).toBeNull()
+      expect(await readFile(path, 'utf8')).toBe('{not-json')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not permanently cache a transient read failure', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    const path = join(root, 'cursors.json')
+    try {
+      const store = new SseResumeCursorStore(path)
+      await mkdir(path)
+      await expect(store.get('thread-1')).rejects.toBeDefined()
+      await rm(path, { recursive: true, force: true })
+      await writeFile(path, JSON.stringify({ version: 1, cursors: {} }), 'utf8')
+      await expect(store.get('thread-1')).resolves.toBeNull()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails open for oversized cursor files without replacing evidence', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    const path = join(root, 'cursors.json')
+    try {
+      const oversized = '{' + 'x'.repeat(4 * 1024 * 1024) + '}'
+      await writeFile(path, oversized, 'utf8')
+      const store = new SseResumeCursorStore(path)
+      expect(await store.get('thread-1')).toBeNull()
+      expect((await readFile(path, 'utf8')).length).toBe(4 * 1024 * 1024 + 2)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores entries whose storage key does not match the cursor scope', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-sse-cursor-'))
+    const path = join(root, 'cursors.json')
+    try {
+      await writeFile(path, JSON.stringify({
+        version: 1,
+        cursors: {
+          'wrong-key': cursor('thread-1', 7, '2026-07-14T00:00:00.000Z')
+        }
+      }), 'utf8')
+      const store = new SseResumeCursorStore(path)
+      expect(await store.get('thread-1')).toBeNull()
+      expect(await store.list()).toEqual([])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/services/sse-resume-cursor-store.ts
+++ b/src/main/services/sse-resume-cursor-store.ts
@@ -1,0 +1,157 @@
+import { mkdir, readFile, stat } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { atomicWriteFile } from '../../../kun/src/adapters/file/atomic-write.js'
+import {
+  SSE_RESUME_CURSOR_SCHEMA_VERSION,
+  SseResumeCursorFileSchema,
+  SseResumeCursorSchema,
+  type SseResumeCursor
+} from '../../shared/sse-cursor'
+
+const DEFAULT_MAX_ENTRIES = 256
+const MAX_CURSOR_FILE_BYTES = 4 * 1024 * 1024
+
+function sameGeneration(left: SseResumeCursor, right: SseResumeCursor): boolean {
+  return !left.runtimeGeneration || !right.runtimeGeneration || left.runtimeGeneration === right.runtimeGeneration
+}
+
+/**
+ * Small, bounded, single-writer store for renderer resume cursors.
+ *
+ * It deliberately does not delete a malformed file: a corrupt cursor file is
+ * evidence for diagnostics, while a fresh in-memory state lets the app recover
+ * without losing the authoritative thread history.
+ */
+export class SseResumeCursorStore {
+  private readonly maxEntries: number
+  private loaded = false
+  private entries = new Map<string, SseResumeCursor>()
+  private operationTail: Promise<void> = Promise.resolve()
+
+  constructor(
+    private readonly filePath: string,
+    options: { maxEntries?: number } = {}
+  ) {
+    const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
+    if (!Number.isSafeInteger(maxEntries) || maxEntries < 1 || maxEntries > 10_000) {
+      throw new Error('maxEntries must be a safe integer between 1 and 10000')
+    }
+    this.maxEntries = maxEntries
+  }
+
+  async get(scopeId: string): Promise<SseResumeCursor | null> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded()
+      const cursor = this.entries.get(scopeId)
+      return cursor ? { ...cursor } : null
+    })
+  }
+
+  async list(): Promise<SseResumeCursor[]> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded()
+      return [...this.entries.values()]
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+        .map((cursor) => ({ ...cursor }))
+    })
+  }
+
+  async save(cursor: SseResumeCursor): Promise<boolean> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded()
+      const normalized = SseResumeCursorSchema.parse(cursor)
+      const previous = this.entries.get(normalized.scopeId)
+      if (
+        previous &&
+        sameGeneration(previous, normalized) &&
+        normalized.lastSequence < previous.lastSequence
+      ) {
+        return false
+      }
+      this.entries.set(normalized.scopeId, normalized)
+      this.trim()
+      await this.persist()
+      return true
+    })
+  }
+
+  async clear(scopeId: string): Promise<boolean> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded()
+      const removed = this.entries.delete(scopeId)
+      if (removed) await this.persist()
+      return removed
+    })
+  }
+
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const next = this.operationTail.then(task, task)
+    this.operationTail = next.then(() => undefined, () => undefined)
+    return next
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return
+    let fileSize: number
+    try {
+      fileSize = (await stat(this.filePath)).size
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.loaded = true
+        return
+      }
+      throw error
+    }
+    if (!Number.isSafeInteger(fileSize) || fileSize > MAX_CURSOR_FILE_BYTES) {
+      // Keep oversized evidence untouched and fail open with an empty in-memory
+      // cursor set. Future saves can replace it through the normal atomic path.
+      this.entries = new Map()
+      this.loaded = true
+      return
+    }
+    let raw: string
+    try {
+      raw = await readFile(this.filePath, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.loaded = true
+        return
+      }
+      throw error
+    }
+    if (Buffer.byteLength(raw, 'utf8') > MAX_CURSOR_FILE_BYTES) {
+      this.entries = new Map()
+      this.loaded = true
+      return
+    }
+    try {
+      const parsed = SseResumeCursorFileSchema.parse(JSON.parse(raw))
+      this.entries = new Map(
+        Object.entries(parsed.cursors)
+          .filter(([scopeId, cursor]) => scopeId === cursor.scopeId)
+      )
+      this.trim()
+    } catch {
+      // Keep the malformed file untouched and start from a recoverable cursor set.
+      this.entries = new Map()
+    }
+    this.loaded = true
+  }
+
+  private trim(): void {
+    if (this.entries.size <= this.maxEntries) return
+    const sorted = [...this.entries.values()]
+      .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
+      .slice(0, this.maxEntries)
+    this.entries = new Map(sorted.map((cursor) => [cursor.scopeId, cursor]))
+  }
+
+  private async persist(): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true })
+    const cursors = Object.fromEntries(this.entries)
+    await atomicWriteFile(this.filePath, JSON.stringify({
+      version: SSE_RESUME_CURSOR_SCHEMA_VERSION,
+      cursors
+    }, null, 2))
+  }
+}

--- a/src/renderer/src/store/chat-projection-reducer.fuzz.test.ts
+++ b/src/renderer/src/store/chat-projection-reducer.fuzz.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import type { RuntimeProjectionAction } from '../agent/runtime-projection-actions'
+import type { ChatState } from './chat-store-types'
+import { reduceChatProjection } from './chat-projection-reducer'
+
+const NOW = Date.parse('2026-07-11T00:00:00.000Z')
+const context = {
+  now: NOW,
+  clearRecoveringError: (error: string | null) => error === 'recovering' ? null : error,
+  goalTimelineText: (goal: ChatState['activeThreadGoal'], cleared?: boolean) =>
+    cleared || !goal ? 'Goal cleared' : `Goal ${goal.status}: ${goal.objective}`,
+  runtimeStatusText: () => 'Runtime status',
+  runtimeErrorView: (event: { message: string; code?: string }) => ({
+    summary: event.message,
+    ...(event.code ? { code: event.code } : {})
+  }),
+  upsertRuntimeError: (blocks: ChatState['blocks'], block: ChatState['blocks'][number]) => {
+    const index = blocks.findIndex((candidate) => candidate.id === block.id)
+    if (index < 0) return [...blocks, block]
+    const next = [...blocks]
+    next[index] = block
+    return next
+  },
+  formatRuntimeError: (error: unknown) => error instanceof Error ? error.message : String(error),
+  runtimeErrorDetail: () => '',
+  isInterruptSettledError: () => false,
+  settlePendingRuntimeWork: (blocks: ChatState['blocks']) => blocks,
+  threadSnapshotLooksRunning: () => false,
+  hasAssistantTextForCompletedTurn: () => false
+}
+
+function state(): ChatState {
+  return {
+    activeThreadId: 'thread_1',
+    blocks: [],
+    liveReasoning: '',
+    liveAssistant: '',
+    threads: [{
+      id: 'thread_1', title: 'Thread', updatedAt: '2026-07-10T00:00:00.000Z', model: 'model', mode: 'agent'
+    }],
+    usageRefreshKey: 0,
+    error: 'recovering'
+  } as unknown as ChatState
+}
+
+function nextRandom(seed: number): number {
+  return (seed * 1664525 + 1013904223) >>> 0
+}
+
+function makeActions(seed: number): RuntimeProjectionAction[] {
+  const actions: RuntimeProjectionAction[] = []
+  let random = seed >>> 0
+  for (let index = 0; index < 80; index += 1) {
+    random = nextRandom(random)
+    const id = `item_${random % 5}`
+    const choice = random % 10
+    if (choice === 0) {
+      actions.push({ type: 'seq_observed', seq: random % 20 })
+    } else if (choice === 1) {
+      actions.push({
+        type: 'deltas_received',
+        deltas: [{ kind: random % 2 === 0 ? 'agent_message' : 'agent_reasoning', text: `delta-${index}`, seq: random % 20 }]
+      })
+    } else if (choice === 2) {
+      actions.push({ type: 'approval_received', payload: { approvalId: id, summary: 'Run test' } })
+    } else if (choice === 3) {
+      actions.push({ type: 'approval_status_changed', payload: { approvalId: id, status: random % 2 === 0 ? 'allowed' : 'expired' } })
+    } else if (choice === 4) {
+      actions.push({ type: 'user_input_requested', payload: { itemId: id, requestId: `request_${id}`, questions: [] } })
+    } else if (choice === 5) {
+      actions.push({ type: 'user_input_status_changed', payload: { itemId: id, status: random % 2 === 0 ? 'submitted' : 'cancelled' } })
+    } else if (choice === 6) {
+      actions.push({ type: 'runtime_status_received', payload: { kind: 'model_request_retry', itemId: id, attempt: random % 4 } })
+    } else if (choice === 7) {
+      actions.push({ type: 'runtime_error_received', payload: { itemId: id, message: `error-${index}`, code: random % 2 ? 'E_REPLAY' : undefined } })
+    } else if (choice === 8) {
+      actions.push({
+        type: 'thread_snapshot_reconciled',
+        payload: { threadId: random % 2 ? 'thread_1' : 'other-thread', blocks: [], latestSeq: random % 20 }
+      })
+    } else {
+      actions.push({ type: random % 2 === 0 ? 'turn_completed' : 'turn_failed', ...(random % 2 === 0 ? {} : { error: new Error(`failure-${index}`), options: { terminal: true } }) } as RuntimeProjectionAction)
+    }
+    if (random % 7 === 0) actions.push(actions.at(-1)!)
+  }
+  return actions
+}
+
+function project(actions: RuntimeProjectionAction[]): ChatState {
+  return actions.reduce(
+    (current, action) => ({ ...current, ...reduceChatProjection(current, action, context) }),
+    state()
+  )
+}
+
+describe('chat projection reducer fuzz invariants', () => {
+  it.each([0x1a2b3c4d, 0x55667788, 0xdeadbeef])('is deterministic for generated replay sequence %i', (seed) => {
+    const actions = makeActions(seed)
+    expect(() => project(actions)).not.toThrow()
+    expect(project(actions)).toEqual(project(structuredClone(actions)))
+  })
+
+  it('does not project snapshots from a different thread into the active timeline', () => {
+    const projected = project([{
+      type: 'thread_snapshot_reconciled',
+      payload: {
+        threadId: 'other-thread',
+        blocks: [{ kind: 'assistant', id: 'foreign', createdAt: '2026-07-11T00:00:00.000Z', text: 'foreign' }],
+        latestSeq: 100
+      }
+    }])
+    expect(projected.blocks).toEqual([])
+    expect(projected.lastSeq).not.toBe(100)
+  })
+})

--- a/src/shared/ipc-cancellation.test.ts
+++ b/src/shared/ipc-cancellation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IpcCancellationAckSchema,
+  IpcCancellationRequestSchema,
+  IpcOperationRequestSchema,
+  IpcOperationTerminalSchema
+} from './ipc-cancellation'
+
+const timestamp = '2026-07-14T00:00:00.000Z'
+
+describe('IPC cancellation contract', () => {
+  it('uses one bounded request identity across the lifecycle', () => {
+    const request = IpcOperationRequestSchema.parse({
+      requestId: 'transfer_1',
+      operation: 'project-export'
+    })
+    const cancel = IpcCancellationRequestSchema.parse({
+      requestId: request.requestId,
+      reason: 'user-requested',
+      requestedAt: timestamp
+    })
+    const ack = IpcCancellationAckSchema.parse({
+      requestId: cancel.requestId,
+      status: 'accepted',
+      acknowledgedAt: timestamp
+    })
+    expect(ack.requestId).toBe(request.requestId)
+  })
+
+  it('allows an idempotent acknowledgement for an already terminal request', () => {
+    expect(IpcCancellationAckSchema.parse({
+      requestId: 'probe_1',
+      status: 'already-terminal',
+      acknowledgedAt: timestamp
+    }).status).toBe('already-terminal')
+  })
+
+  it('represents cancellation as a terminal outcome, not as an error-only response', () => {
+    expect(IpcOperationTerminalSchema.parse({
+      requestId: 'index_1',
+      status: 'cancelled',
+      finishedAt: timestamp
+    }).status).toBe('cancelled')
+  })
+
+  it('rejects invalid timestamps, empty identities, and unbounded extra fields', () => {
+    expect(() => IpcOperationRequestSchema.parse({ requestId: '', operation: 'probe' })).toThrow()
+    expect(() => IpcCancellationRequestSchema.parse({
+      requestId: 'probe_1',
+      requestedAt: 'now'
+    })).toThrow()
+    expect(() => IpcOperationTerminalSchema.parse({
+      requestId: 'probe_1',
+      status: 'cancelled',
+      finishedAt: timestamp,
+      stack: 'secret'
+    })).toThrow()
+  })
+})

--- a/src/shared/ipc-cancellation.ts
+++ b/src/shared/ipc-cancellation.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+const RequestId = z.string().trim().min(1).max(128)
+const Timestamp = z.string().datetime({ offset: true })
+
+/** A bounded request identity shared by the start, cancel, and terminal events. */
+export const IpcOperationRequestSchema = z.object({
+  requestId: RequestId,
+  operation: z.string().trim().min(1).max(128)
+}).strict()
+export type IpcOperationRequest = z.infer<typeof IpcOperationRequestSchema>
+
+/** Cancellation is a separate message so every long-running operation can acknowledge it. */
+export const IpcCancellationRequestSchema = z.object({
+  requestId: RequestId,
+  reason: z.string().trim().min(1).max(256).optional(),
+  requestedAt: Timestamp
+}).strict()
+export type IpcCancellationRequest = z.infer<typeof IpcCancellationRequestSchema>
+
+export const IpcCancellationAckStatus = z.enum([
+  'accepted',
+  'already-terminal',
+  'unknown-request'
+])
+export type IpcCancellationAckStatus = z.infer<typeof IpcCancellationAckStatus>
+
+/** Acknowledgement confirms that the cancellation message was observed, not that work stopped. */
+export const IpcCancellationAckSchema = z.object({
+  requestId: RequestId,
+  status: IpcCancellationAckStatus,
+  acknowledgedAt: Timestamp
+}).strict()
+export type IpcCancellationAck = z.infer<typeof IpcCancellationAckSchema>
+
+export const IpcOperationTerminalStatus = z.enum(['completed', 'failed', 'cancelled'])
+export type IpcOperationTerminalStatus = z.infer<typeof IpcOperationTerminalStatus>
+
+/** Exactly one terminal event is expected for a request; consumers must treat it as idempotent. */
+export const IpcOperationTerminalSchema = z.object({
+  requestId: RequestId,
+  status: IpcOperationTerminalStatus,
+  finishedAt: Timestamp,
+  errorCode: z.string().trim().min(1).max(128).optional()
+}).strict()
+export type IpcOperationTerminal = z.infer<typeof IpcOperationTerminalSchema>

--- a/src/shared/ipc-error.test.ts
+++ b/src/shared/ipc-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { AppIpcErrorSchema } from './ipc-error'
+
+describe('AppIpcErrorSchema', () => {
+  it('accepts a bounded retryable error with primitive details', () => {
+    const error = {
+      code: 'provider_unavailable',
+      message: 'The provider is temporarily unavailable.',
+      retryable: true,
+      incidentId: 'inc_123',
+      details: { status: 503, provider: 'deepseek', retryAfterMs: 1000 }
+    }
+
+    expect(AppIpcErrorSchema.parse(error)).toEqual(error)
+  })
+
+  it('rejects stacks, nested objects, and unknown fields', () => {
+    expect(() => AppIpcErrorSchema.parse({
+      code: 'internal_error',
+      message: 'failed',
+      retryable: false,
+      stack: 'secret stack'
+    })).toThrow()
+    expect(() => AppIpcErrorSchema.parse({
+      code: 'internal_error',
+      message: 'failed',
+      retryable: false,
+      details: { nested: { secret: true } }
+    })).toThrow()
+  })
+
+  it('bounds messages, identifiers, and detail field counts', () => {
+    const details = Object.fromEntries(
+      Array.from({ length: 33 }, (_, index) => [`field${index}`, true])
+    )
+
+    expect(() => AppIpcErrorSchema.parse({
+      code: 'internal_error',
+      message: 'failed',
+      retryable: false,
+      details
+    })).toThrow()
+    expect(() => AppIpcErrorSchema.parse({
+      code: 'x'.repeat(129),
+      message: 'failed',
+      retryable: false
+    })).toThrow()
+  })
+})

--- a/src/shared/ipc-error.ts
+++ b/src/shared/ipc-error.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+const IpcErrorDetailValue = z.union([z.string().max(2048), z.number().finite(), z.boolean()])
+
+/**
+ * Cross-process error payload. The envelope intentionally excludes stacks and
+ * arbitrary objects so main-process internals cannot leak through IPC.
+ */
+export const AppIpcErrorSchema = z.object({
+  code: z.string().min(1).max(128),
+  message: z.string().min(1).max(2048),
+  retryable: z.boolean(),
+  incidentId: z.string().min(1).max(128).optional(),
+  details: z.record(z.string().min(1).max(128), IpcErrorDetailValue)
+    .refine((value) => Object.keys(value).length <= 32, 'Too many error detail fields.')
+    .optional()
+}).strict()
+
+export type AppIpcError = z.infer<typeof AppIpcErrorSchema>

--- a/src/shared/sse-cursor.ts
+++ b/src/shared/sse-cursor.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+/** A renderer-owned acknowledgement cursor persisted across process restarts. */
+export const SseResumeCursorSchema = z.object({
+  scopeId: z.string().trim().min(1).max(128),
+  streamId: z.string().trim().min(1).max(128),
+  lastSequence: z.number().int().nonnegative().safe(),
+  runtimeGeneration: z.string().trim().min(1).max(128).optional(),
+  updatedAt: z.string().datetime({ offset: true })
+}).strict()
+
+export type SseResumeCursor = z.infer<typeof SseResumeCursorSchema>
+
+export const SSE_RESUME_CURSOR_SCHEMA_VERSION = 1 as const
+
+export const SseResumeCursorFileSchema = z.object({
+  version: z.literal(SSE_RESUME_CURSOR_SCHEMA_VERSION),
+  cursors: z.record(z.string().min(1).max(128), SseResumeCursorSchema)
+}).strict()
+
+export type SseResumeCursorFile = z.infer<typeof SseResumeCursorFileSchema>

--- a/src/shared/sse-gap.test.ts
+++ b/src/shared/sse-gap.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { inspectSseSequence, SseSequenceDecision, type SseSequenceCursor } from './sse-gap'
+
+const event = (sequence: number, streamId = 'stream_1') => ({
+  streamId,
+  sequence,
+  eventId: `event_${sequence}`,
+  occurredAt: '2026-07-14T00:00:00.000Z'
+})
+
+describe('inspectSseSequence', () => {
+  it('accepts the first event and creates a cursor', () => {
+    const result = inspectSseSequence(null, event(0))
+    expect(result.decision).toBe(SseSequenceDecision.Accepted)
+    expect(result.nextCursor).toEqual({ streamId: 'stream_1', lastSequence: 0 })
+  })
+
+  it('accepts the next contiguous event and advances only the returned cursor', () => {
+    const cursor: SseSequenceCursor = { streamId: 'stream_1', lastSequence: 0 }
+    const result = inspectSseSequence(cursor, event(1))
+    expect(result.decision).toBe(SseSequenceDecision.Accepted)
+    expect(result.nextCursor?.lastSequence).toBe(1)
+    expect(cursor.lastSequence).toBe(0)
+  })
+
+  it('classifies duplicate and out-of-order events without moving the cursor', () => {
+    const cursor = { streamId: 'stream_1', lastSequence: 4 }
+    expect(inspectSseSequence(cursor, event(4)).decision).toBe(SseSequenceDecision.Duplicate)
+    expect(inspectSseSequence(cursor, event(2)).decision).toBe(SseSequenceDecision.OutOfOrder)
+    expect(inspectSseSequence(cursor, event(4)).nextCursor).toEqual(cursor)
+  })
+
+  it('reports a gap and leaves projection at the last confirmed sequence', () => {
+    const cursor = { streamId: 'stream_1', lastSequence: 4 }
+    const result = inspectSseSequence(cursor, event(7))
+    expect(result.decision).toBe(SseSequenceDecision.Gap)
+    expect(result.expectedSequence).toBe(5)
+    expect(result.nextCursor).toEqual(cursor)
+  })
+
+  it('rejects events from an old or replaced stream', () => {
+    const cursor = { streamId: 'stream_2', lastSequence: 4 }
+    const result = inspectSseSequence(cursor, event(5, 'stream_1'))
+    expect(result.decision).toBe(SseSequenceDecision.OldStream)
+    expect(result.nextCursor).toEqual(cursor)
+  })
+
+  it('validates event metadata before making a projection decision', () => {
+    expect(() => inspectSseSequence(null, { ...event(0), eventId: '' })).toThrow()
+  })
+})

--- a/src/shared/sse-gap.ts
+++ b/src/shared/sse-gap.ts
@@ -1,0 +1,90 @@
+import {
+  SequencedRuntimeEventSchema,
+  type SequencedRuntimeEvent
+} from './sse-sequence'
+
+export type SseSequenceCursor = {
+  streamId: string
+  lastSequence: number
+}
+
+export const SseSequenceDecision = {
+  Accepted: 'accepted',
+  Duplicate: 'duplicate',
+  Gap: 'gap',
+  OutOfOrder: 'out-of-order',
+  OldStream: 'old-stream'
+} as const
+export type SseSequenceDecision = typeof SseSequenceDecision[keyof typeof SseSequenceDecision]
+
+export type SseSequenceInspection = {
+  decision: SseSequenceDecision
+  streamId: string
+  receivedSequence: number
+  expectedSequence: number | null
+  nextCursor: SseSequenceCursor | null
+}
+
+/**
+ * Compares one validated event with a renderer cursor without mutating it.
+ * A gap must stop projection until a bounded replay or authoritative reload runs.
+ */
+export function inspectSseSequence(
+  cursor: SseSequenceCursor | null,
+  rawEvent: SequencedRuntimeEvent
+): SseSequenceInspection {
+  const event = SequencedRuntimeEventSchema.parse(rawEvent)
+  if (!cursor) {
+    return {
+      decision: SseSequenceDecision.Accepted,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence: event.sequence,
+      nextCursor: { streamId: event.streamId, lastSequence: event.sequence }
+    }
+  }
+  if (event.streamId !== cursor.streamId) {
+    return {
+      decision: SseSequenceDecision.OldStream,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence: null,
+      nextCursor: cursor
+    }
+  }
+  const expectedSequence = cursor.lastSequence + 1
+  if (event.sequence === expectedSequence) {
+    return {
+      decision: SseSequenceDecision.Accepted,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: { streamId: cursor.streamId, lastSequence: event.sequence }
+    }
+  }
+  if (event.sequence === cursor.lastSequence) {
+    return {
+      decision: SseSequenceDecision.Duplicate,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: cursor
+    }
+  }
+  if (event.sequence > expectedSequence) {
+    return {
+      decision: SseSequenceDecision.Gap,
+      streamId: event.streamId,
+      receivedSequence: event.sequence,
+      expectedSequence,
+      nextCursor: cursor
+    }
+  }
+  return {
+    decision: SseSequenceDecision.OutOfOrder,
+    streamId: event.streamId,
+    receivedSequence: event.sequence,
+    expectedSequence,
+    nextCursor: cursor
+  }
+}

--- a/src/shared/sse-recovery.test.ts
+++ b/src/shared/sse-recovery.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { inspectSseSequence } from './sse-gap'
+import { planSseRecovery } from './sse-recovery'
+
+const event = (sequence: number, streamId = 'stream_1') => ({
+  streamId,
+  sequence,
+  eventId: `event_${sequence}`,
+  occurredAt: '2026-07-14T00:00:00.000Z'
+})
+
+describe('planSseRecovery', () => {
+  it('does nothing for accepted, duplicate, and out-of-order events', () => {
+    const accepted = inspectSseSequence({ streamId: 'stream_1', lastSequence: 0 }, event(1))
+    const duplicate = inspectSseSequence({ streamId: 'stream_1', lastSequence: 1 }, event(1))
+    const stale = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(0))
+    expect(planSseRecovery(accepted).action).toBe('none')
+    expect(planSseRecovery(duplicate).action).toBe('none')
+    expect(planSseRecovery(stale).action).toBe('none')
+  })
+
+  it('plans a bounded replay for a small gap', () => {
+    const inspection = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(5))
+    expect(planSseRecovery(inspection, { maxReplayEvents: 8 })).toEqual({
+      action: 'replay',
+      streamId: 'stream_1',
+      fromSequence: 3,
+      toSequence: 4,
+      maxEvents: 8
+    })
+  })
+
+  it('reloads when a gap exceeds the replay budget or replay failed', () => {
+    const inspection = inspectSseSequence({ streamId: 'stream_1', lastSequence: 2 }, event(10))
+    expect(planSseRecovery(inspection, { maxReplayEvents: 3 })).toMatchObject({
+      action: 'reload',
+      reason: 'gap-too-large'
+    })
+    expect(planSseRecovery(inspection, { replayFailed: true })).toMatchObject({
+      action: 'reload',
+      reason: 'replay-failed'
+    })
+  })
+
+  it('reloads for an old stream and caps unsafe replay budgets', () => {
+    const oldStream = inspectSseSequence({ streamId: 'stream_2', lastSequence: 2 }, event(3, 'stream_1'))
+    expect(planSseRecovery(oldStream)).toEqual({
+      action: 'reload',
+      streamId: 'stream_1',
+      reason: 'old-stream'
+    })
+    const gap = inspectSseSequence({ streamId: 'stream_1', lastSequence: 0 }, event(2))
+    expect(planSseRecovery(gap, { maxReplayEvents: 99999 })).toMatchObject({ maxEvents: 1000 })
+  })
+})

--- a/src/shared/sse-recovery.ts
+++ b/src/shared/sse-recovery.ts
@@ -1,0 +1,51 @@
+import {
+  SseSequenceDecision,
+  type SseSequenceInspection
+} from './sse-gap'
+
+export type SseRecoveryPlan =
+  | { action: 'none'; reason: 'accepted' | 'duplicate' | 'out-of-order'; streamId: string }
+  | { action: 'replay'; streamId: string; fromSequence: number; toSequence: number; maxEvents: number }
+  | { action: 'reload'; streamId: string; reason: 'old-stream' | 'gap-too-large' | 'replay-failed' }
+
+export type SseRecoveryOptions = {
+  maxReplayEvents?: number
+  replayFailed?: boolean
+}
+
+/** Chooses a bounded recovery action; it never performs I/O or mutates the projection. */
+export function planSseRecovery(
+  inspection: SseSequenceInspection,
+  options: SseRecoveryOptions = {}
+): SseRecoveryPlan {
+  if (inspection.decision === SseSequenceDecision.OldStream) {
+    return { action: 'reload', streamId: inspection.streamId, reason: 'old-stream' }
+  }
+  if (inspection.decision !== SseSequenceDecision.Gap) {
+    return {
+      action: 'none',
+      reason: inspection.decision,
+      streamId: inspection.streamId
+    }
+  }
+  const maxEvents = Number.isSafeInteger(options.maxReplayEvents) && (options.maxReplayEvents ?? 0) > 0
+    ? Math.min(options.maxReplayEvents as number, 1000)
+    : 128
+  const fromSequence = inspection.expectedSequence
+  const toSequence = inspection.receivedSequence - 1
+  if (
+    options.replayFailed === true ||
+    fromSequence === null ||
+    toSequence < fromSequence ||
+    toSequence - fromSequence + 1 > maxEvents
+  ) {
+    return { action: 'reload', streamId: inspection.streamId, reason: options.replayFailed ? 'replay-failed' : 'gap-too-large' }
+  }
+  return {
+    action: 'replay',
+    streamId: inspection.streamId,
+    fromSequence,
+    toSequence,
+    maxEvents
+  }
+}

--- a/src/shared/sse-sequence.test.ts
+++ b/src/shared/sse-sequence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { SequencedRuntimeEventSchema } from './sse-sequence'
+
+describe('SequencedRuntimeEventSchema', () => {
+  it('accepts a stable stream sequence envelope', () => {
+    const event = {
+      streamId: 'stream_123',
+      sequence: 42,
+      eventId: 'evt_42',
+      occurredAt: '2026-07-14T00:00:00.000Z'
+    }
+
+    expect(SequencedRuntimeEventSchema.parse(event)).toEqual(event)
+  })
+
+  it('accepts sequence zero for a newly-created stream', () => {
+    expect(SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 0,
+      eventId: 'evt_0',
+      occurredAt: '2026-07-14T00:00:00+00:00'
+    }).sequence).toBe(0)
+  })
+
+  it('rejects unsafe sequences, invalid timestamps, and unknown fields', () => {
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: Number.MAX_SAFE_INTEGER + 1,
+      eventId: 'evt',
+      occurredAt: '2026-07-14T00:00:00.000Z'
+    })).toThrow()
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 1,
+      eventId: 'evt',
+      occurredAt: 'yesterday'
+    })).toThrow()
+    expect(() => SequencedRuntimeEventSchema.parse({
+      streamId: 'stream_123',
+      sequence: 1,
+      eventId: 'evt',
+      occurredAt: '2026-07-14T00:00:00.000Z',
+      payload: {}
+    })).toThrow()
+  })
+})

--- a/src/shared/sse-sequence.ts
+++ b/src/shared/sse-sequence.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+/** Metadata required to detect duplicate, stale, and missing SSE events. */
+export const SequencedRuntimeEventSchema = z.object({
+  streamId: z.string().min(1).max(128),
+  sequence: z.number().int().nonnegative().safe(),
+  eventId: z.string().min(1).max(128),
+  occurredAt: z.string().datetime({ offset: true })
+}).strict()
+
+export type SequencedRuntimeEvent = z.infer<typeof SequencedRuntimeEventSchema>


### PR DESCRIPTION
## Problem

IPC and SSE reliability work had been split across several small PRs, making the contracts difficult to review and leaving cursor persistence, gap recovery, cancellation, and projection replay validation disconnected.

## Root cause

The renderer and main process had no single bounded contract for IPC errors/cancellation or sequenced runtime events. Resume cursors were not represented as a durable, validated, single-writer state, and event projection lacked deterministic replay/fuzz coverage.

## Scope

This PR consolidates the IPC/SSE reliability contracts into one independently testable change. It supersedes the overlapping implementation PRs listed below; it does not wire cancellation into every long-running operation or replace the existing runtime transport.

## Changes

- Add bounded `AppIpcError` and long-operation cancellation envelopes that exclude raw stacks and arbitrary objects.
- Add validated SSE sequence inspection, duplicate/out-of-order/gap classification, and bounded replay versus authoritative reload planning.
- Add a versioned, size-bounded, single-writer resume cursor store with runtime-generation and monotonic-sequence protection.
- Add deterministic chat projection replay/fuzz coverage and focused contract tests.

## Safety

- Error payloads are strict, bounded, and primitive-only; stacks are never part of the contract.
- Cursor files are capped at 4 MiB, malformed/oversized data is preserved for diagnostics, and writes use the existing atomic writer.
- Replay is bounded to at most 1,000 events and never mutates projection state directly.
- Runtime generation changes prevent stale cursors from blocking a new stream.

## Typecheck

```bash
npm.cmd run typecheck
npm.cmd --prefix kun run typecheck
```

Both passed.

## Tests

```bash
npm.cmd exec vitest run src/shared/ipc-cancellation.test.ts src/shared/ipc-error.test.ts src/shared/sse-sequence.test.ts src/shared/sse-gap.test.ts src/shared/sse-recovery.test.ts src/main/services/sse-resume-cursor-store.test.ts src/renderer/src/store/chat-projection-reducer.fuzz.test.ts
npm.cmd run lint
npm.cmd run build
git diff --check upstream/develop...HEAD
```

Results: 7 test files, 32/32 tests passed; lint, build, and diff check passed.

## Review performed

- Functional correctness
- Architecture and state ownership
- Concurrency/lifecycle and stale stream handling
- Data integrity and atomic cursor persistence
- Security and bounded error payloads
- Cross-platform TypeScript/build compatibility
- Scope and test quality

## PR size

```text
Production files: 7
Test files: 7
Production LOC: 401
Total diff: 907 additions
```

## Non-goals

- This PR does not add transport-specific SSE wiring or UI changes.
- Long-operation cancellation call-site integration remains separate.
- It does not change the runtime event schema already emitted by the Kun server.

## Supersedes

- #898
- #902
- #904
- #910
- #911
- #913
- #916

Part of the broader reliability work; no issue is auto-closed by this PR.
