### PR TITLE
fix: correct glob ? wildcard and guard pending counters

### DIFF
--- a/kun/src/adapters/model/model-stream-resource-budget.ts
+++ b/kun/src/adapters/model/model-stream-resource-budget.ts
@@ -164,8 +164,8 @@ export class ModelStreamResourceBudget {
     if (!value) return undefined
     pending.delete(callId)
     this.pendingToolCalls = Math.max(0, this.pendingToolCalls - 1)
-    this.pendingArgumentBytes -= value.argumentBytes
-    this.pendingArgumentFragments -= value.argumentFragments
+    this.pendingArgumentBytes = Math.max(0, this.pendingArgumentBytes - value.argumentBytes)
+    this.pendingArgumentFragments = Math.max(0, this.pendingArgumentFragments - value.argumentFragments)
     return value
   }
 

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -784,7 +784,7 @@ export function globToRegExp(pattern: string): RegExp {
   const withWildcards = escaped
     .replace(/\*\*/g, '::DOUBLE_STAR::')
     .replace(/\*/g, '[^/]*')
-    .replace(/\?/g, '.')
+    .replace(/\?/g, '[^/]')
     .replace(/::DOUBLE_STAR::/g, '.*')
   return new RegExp(`^${optionalPrefix ? '(?:.*/)?' : ''}${withWildcards}$`, 'i')
 }


### PR DESCRIPTION
## Summary

- **`globToRegExp`: fix `?` wildcard** — The `?` glob character was converted to `.` (matches any character including `/`). Changed to `[^/]` so it correctly matches any single character *except* the path separator, consistent with standard glob semantics.
- **`removePendingCall`: guard negative counters** — `pendingToolCalls` was already wrapped with `Math.max(0, ...)` but `pendingArgumentBytes` and `pendingArgumentFragments` were not. Applied the same guard to prevent counters from going negative due to race conditions or duplicate removals.

## Test plan

- Verify `globToRegExp('src/?.ts')` does not match `src/a/b.ts` (the `/` should not be matched by `?`)
- Verify pending argument counters never go below zero after concurrent `removePendingCall` invocations