### PR TITLE
release: Kun v0.2.27-1

### DIFF
--- a/kun/src/services/extension-media-archive-service.ts
+++ b/kun/src/services/extension-media-archive-service.ts
@@ -14,6 +14,9 @@ import type { ExtensionPrincipal } from './extension-agent-service.js'
 import {
   ExtensionMediaHandleError,
   ExtensionMediaHandleService,
+  fileIdentityFromStat,
+  identifiesSameFile,
+  matchesFileIdentity,
   type CompletedMediaOutputRecovery,
   type MediaHandleProjection,
   type MediaOutputCompletionTransaction,
@@ -595,8 +598,7 @@ function assertNoAlias(inputs: ResolvedMediaHandle[], output: ResolvedMediaHandl
   for (const input of inputs) {
     if (input.absolutePath === output.absolutePath ||
       Boolean(input.identity && output.identity &&
-        input.identity.device === output.identity.device &&
-        input.identity.inode === output.identity.inode)) {
+        identifiesSameFile(input.identity, output.identity))) {
       throw new ExtensionMediaArchiveError(
         'output_alias',
         'Project package output cannot alias an input'
@@ -609,18 +611,14 @@ function sameIdentity(
   info: Awaited<ReturnType<typeof lstat>>,
   identity: NonNullable<ResolvedMediaHandle['identity']>
 ): boolean {
-  return info.size === identity.size && info.mtimeMs === identity.mtimeMs &&
-    Math.max(0, Number(info.dev)) === identity.device &&
-    Math.max(0, Number(info.ino)) === identity.inode
+  return matchesFileIdentity(identity, fileIdentityFromStat(info))
 }
 
 function sameStatIdentity(
   info: Awaited<ReturnType<typeof lstat>>,
   identity: NonNullable<PendingMediaOutputTransaction['originalIdentity']>
 ): boolean {
-  return info.size === identity.size && info.mtimeMs === identity.mtimeMs &&
-    Math.max(0, Number(info.dev)) === identity.device &&
-    Math.max(0, Number(info.ino)) === identity.inode
+  return matchesFileIdentity(identity, fileIdentityFromStat(info))
 }
 
 async function lstatIfPresent(path: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {

--- a/kun/src/services/extension-media-ffmpeg-service.ts
+++ b/kun/src/services/extension-media-ffmpeg-service.ts
@@ -4,6 +4,9 @@ import { basename, dirname, extname, isAbsolute, join, sep } from 'node:path'
 import type { ExtensionPrincipal } from './extension-agent-service.js'
 import {
   ExtensionMediaHandleService,
+  fileIdentityFromStat,
+  identifiesSameFile,
+  matchesFileIdentity,
   ExtensionMediaHandleError,
   type CompletedMediaOutputRecovery,
   type MediaOutputCompletionTransaction,
@@ -1151,9 +1154,7 @@ function sameStatIdentity(
   info: Awaited<ReturnType<typeof lstat>>,
   identity: NonNullable<PendingMediaOutputTransaction['originalIdentity']>
 ): boolean {
-  return info.size === identity.size && info.mtimeMs === identity.mtimeMs &&
-    Math.max(0, Number(info.dev)) === identity.device &&
-    Math.max(0, Number(info.ino)) === identity.inode
+  return matchesFileIdentity(identity, fileIdentityFromStat(info))
 }
 
 function safeStagingExtension(path: string): string {
@@ -1182,7 +1183,7 @@ function assertNoAliases(inputs: ResolvedMediaHandle[], outputs: ResolvedMediaHa
 
 function sameFile(left: ResolvedMediaHandle, right: ResolvedMediaHandle): boolean {
   return left.absolutePath === right.absolutePath ||
-    Boolean(left.identity && right.identity && sameIdentity(left.identity, right.identity))
+    Boolean(left.identity && right.identity && identifiesSameFile(left.identity, right.identity))
 }
 
 function sameIdentity(
@@ -1190,8 +1191,7 @@ function sameIdentity(
   right: ResolvedMediaHandle['identity']
 ): boolean {
   if (!left || !right) return left === right
-  return left.device === right.device && left.inode === right.inode &&
-    left.size === right.size && left.mtimeMs === right.mtimeMs
+  return matchesFileIdentity(left, right)
 }
 
 function outputTransaction(input: {
@@ -1271,12 +1271,10 @@ async function promoteAll(outputs: PreparedOutput[]): Promise<PromotedOutput[]> 
         if (!target.isFile() || target.isSymbolicLink()) {
           throw new ExtensionMediaFfmpegError('invalid_output', 'Media export target is no longer a regular file')
         }
-        if (!output.target.identity || !sameIdentity(output.target.identity, {
-          device: Math.max(0, target.dev),
-          inode: Math.max(0, target.ino),
-          size: target.size,
-          mtimeMs: target.mtimeMs
-        })) {
+        if (!output.target.identity || !sameIdentity(
+          output.target.identity,
+          fileIdentityFromStat(target)
+        )) {
           throw new ExtensionMediaFfmpegError('invalid_output', 'Media export target changed before promotion')
         }
         await rename(output.target.absolutePath, output.backupPath)

--- a/kun/src/services/extension-media-handle-service.test.ts
+++ b/kun/src/services/extension-media-handle-service.test.ts
@@ -5,7 +5,10 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { ExtensionPrincipal } from './extension-agent-service.js'
 import {
   ExtensionMediaHandleError,
-  ExtensionMediaHandleService
+  ExtensionMediaHandleService,
+  fileIdentityFromStat,
+  identifiesSameFile,
+  matchesFileIdentity
 } from './extension-media-handle-service.js'
 import { extensionWorkspaceKey } from '../extensions/paths.js'
 
@@ -33,6 +36,24 @@ async function fixture() {
 }
 
 describe('ExtensionMediaHandleService', () => {
+  it('omits filesystem identifiers that cannot be safely persisted in JSON', () => {
+    const identity = fileIdentityFromStat({
+      size: 128,
+      mtimeMs: 1_700_000_000_000,
+      dev: Number.MAX_SAFE_INTEGER + 2,
+      ino: Number.MAX_SAFE_INTEGER + 4
+    })
+
+    expect(identity).toEqual({ size: 128, mtimeMs: 1_700_000_000_000 })
+    expect(matchesFileIdentity(identity, {
+      size: 128,
+      mtimeMs: 1_700_000_000_000,
+      device: 42,
+      inode: 99
+    })).toBe(true)
+    expect(identifiesSameFile(identity, identity)).toBe(false)
+  })
+
   it('registers workspace media without projecting an absolute path', async () => {
     const { workspace, dataDir, principal } = await fixture()
     const service = new ExtensionMediaHandleService({ dataDir })

--- a/kun/src/services/extension-media-handle-service.ts
+++ b/kun/src/services/extension-media-handle-service.ts
@@ -13,8 +13,11 @@ const MediaHandleLifecycleSchema = z.enum(['persistent', 'cache'])
 const FileIdentitySchema = z.strictObject({
   size: z.number().int().nonnegative(),
   mtimeMs: z.number().nonnegative(),
-  device: z.number().int().nonnegative(),
-  inode: z.number().int().nonnegative()
+  // Windows can report NTFS identifiers above Number.MAX_SAFE_INTEGER. They
+  // are useful hardening signals, but must not make a valid media handle
+  // impossible to persist in JSON.
+  device: z.number().int().nonnegative().optional(),
+  inode: z.number().int().nonnegative().optional()
 })
 const StoredMediaHandleSchema = z.strictObject({
   id: z.string().min(1),
@@ -45,7 +48,7 @@ type StoredMediaHandle = z.infer<typeof StoredMediaHandleSchema>
 type MediaHandleMode = z.infer<typeof MediaHandleModeSchema>
 type MediaHandleSource = z.infer<typeof MediaHandleSourceSchema>
 type MediaHandleLifecycle = z.infer<typeof MediaHandleLifecycleSchema>
-type FileIdentity = z.infer<typeof FileIdentitySchema>
+export type FileIdentity = z.infer<typeof FileIdentitySchema>
 
 export type MediaHandleProjection = {
   id: string
@@ -658,7 +661,7 @@ export class ExtensionMediaHandleService {
           candidate.mode === 'read' &&
           candidate.reservationId === reservationId &&
           candidate.absolutePath === record.absolutePath &&
-          candidate.identity !== undefined && sameIdentity(candidate.identity, record.identity!)
+          candidate.identity !== undefined && matchesFileIdentity(candidate.identity, record.identity!)
         )
         if (generated.length !== 1) {
           throw new ExtensionMediaHandleError(
@@ -1005,15 +1008,37 @@ async function canonicalOutput(path: string): Promise<string> {
   }
 }
 
+export function fileIdentityFromStat(info: {
+  size: number | bigint
+  mtimeMs: number | bigint
+  dev: number | bigint
+  ino: number | bigint
+}): FileIdentity {
+  const device = serializableFileSystemIdentifier(info.dev)
+  const inode = serializableFileSystemIdentifier(info.ino)
+  return {
+    size: statNumber(info.size),
+    mtimeMs: statNumber(info.mtimeMs),
+    ...(device === undefined ? {} : { device }),
+    ...(inode === undefined ? {} : { inode })
+  }
+}
+
+function serializableFileSystemIdentifier(value: number | bigint): number | undefined {
+  if (typeof value === 'bigint') {
+    return value >= 0n && value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : undefined
+  }
+  return Number.isSafeInteger(value) && value >= 0 ? value : undefined
+}
+
+function statNumber(value: number | bigint): number {
+  return typeof value === 'bigint' ? Number(value) : value
+}
+
 async function readIdentity(path: string): Promise<FileIdentity> {
   const info = await stat(path)
   if (!info.isFile()) throw new ExtensionMediaHandleError('not_regular_file', 'Media input is not a regular file')
-  return {
-    size: info.size,
-    mtimeMs: info.mtimeMs,
-    device: Math.max(0, info.dev),
-    inode: Math.max(0, info.ino)
-  }
+  return fileIdentityFromStat(info)
 }
 
 async function refreshIdentity(record: StoredMediaHandle): Promise<StoredMediaHandle> {
@@ -1027,7 +1052,7 @@ async function refreshIdentity(record: StoredMediaHandle): Promise<StoredMediaHa
     }
   }
   const current = await readIdentity(record.absolutePath)
-  if (record.identity && !sameIdentity(record.identity, current)) {
+  if (record.identity && !matchesFileIdentity(record.identity, current)) {
     throw new ExtensionMediaHandleError('file_changed', 'Media file identity changed')
   }
   return { ...record, identity: current }
@@ -1065,8 +1090,15 @@ function assertOwnedRecordIncludingRevoked(
   }
 }
 
-function sameIdentity(left: FileIdentity, right: FileIdentity): boolean {
+export function matchesFileIdentity(left: FileIdentity, right: FileIdentity): boolean {
   return left.size === right.size && left.mtimeMs === right.mtimeMs &&
+    (left.device === undefined || right.device === undefined || left.device === right.device) &&
+    (left.inode === undefined || right.inode === undefined || left.inode === right.inode)
+}
+
+export function identifiesSameFile(left: FileIdentity, right: FileIdentity): boolean {
+  return left.device !== undefined && right.device !== undefined &&
+    left.inode !== undefined && right.inode !== undefined &&
     left.device === right.device && left.inode === right.inode
 }
 
@@ -1109,7 +1141,7 @@ function completionIdentity(record: StoredMediaHandle): string {
   const identity = record.identity
   if (!identity) return ''
   return createHash('sha256')
-    .update(`${record.id}\0${identity.device}\0${identity.inode}\0${identity.size}\0${identity.mtimeMs}`)
+    .update(`${record.id}\0${identity.device ?? ''}\0${identity.inode ?? ''}\0${identity.size}\0${identity.mtimeMs}`)
     .digest('base64url')
 }
 

--- a/kun/src/services/extension-media-process-service.ts
+++ b/kun/src/services/extension-media-process-service.ts
@@ -1016,7 +1016,7 @@ function sourceEvidence(input: ResolvedMediaHandle): ExtensionAudioSourceEvidenc
     handleId: input.id,
     fingerprint: createHash('sha256')
       .update(
-        `${input.identity.device}\0${input.identity.inode}\0${input.identity.size}\0${input.identity.mtimeMs}`
+        `${input.identity.device ?? ''}\0${input.identity.inode ?? ''}\0${input.identity.size}\0${input.identity.mtimeMs}`
       )
       .digest('hex'),
     fingerprintAlgorithm: 'sha256-file-identity-v1'

--- a/scripts/smoke-packaged-extension-desktop.cjs
+++ b/scripts/smoke-packaged-extension-desktop.cjs
@@ -185,13 +185,9 @@ async function main() {
       () => processState(desktopProcess)
     )
     const workbenchSession = await attachToTarget(cdp, workbenchTarget.targetId)
-    await synchronizeWorkbenchContributionDiscovery({
+    await replayWorkbenchContributionDiscovery({
       cdp,
       sessionId: workbenchSession,
-      workspaceRoot,
-      contributionId: CONTRIBUTION_ID,
-      timeoutMs,
-      processState: () => processState(desktopProcess)
     })
     await waitForContributionAndClick({
       cdp,
@@ -805,59 +801,19 @@ async function attachToTarget(cdp, targetId) {
   return attached.sessionId
 }
 
-function hasWorkbenchContribution(response, contributionId) {
-  if (!response || response.ok !== true || typeof response.body !== 'string') return false
-  try {
-    const snapshot = JSON.parse(response.body)
-    return Array.isArray(snapshot?.extensions) && snapshot.extensions.some((extension) =>
-      extension?.id === EXTENSION_ID &&
-      Array.isArray(extension?.contributes?.['views.rightSidebar']) &&
-      extension.contributes['views.rightSidebar'].some(
-        (view) => `extension:${extension.id}/${view?.id}` === contributionId
-      )
-    )
-  } catch {
-    return false
-  }
-}
+const WORKBENCH_DISCOVERY_RETRY_DELAYS_MS = [0, 250, 1_000, 3_000, 10_000]
 
-async function synchronizeWorkbenchContributionDiscovery({
-  cdp,
-  sessionId,
-  workspaceRoot,
-  contributionId,
-  timeoutMs,
-  processState: readProcessState
-}) {
-  // The renderer starts contribution discovery asynchronously after its first
-  // committed Workbench render. Confirm that the trusted bridge can already
-  // see the installed, workspace-granted extension, then replay the normal
-  // extension-change signal a few times so the committed listener cannot miss
-  // it during a cold packaged launch.
-  await pollUntil(async () => {
-    assertDesktopProcessRunning(readProcessState())
-    const evaluated = await cdp.send('Runtime.evaluate', {
-      expression: `(async () => {
-        const bridge = globalThis.kunGui
-        if (!bridge || typeof bridge.extensionGetWorkbench !== 'function') return null
-        return bridge.extensionGetWorkbench({ workspaceRoot: ${JSON.stringify(workspaceRoot)} })
-      })()`,
-      awaitPromise: true,
-      returnByValue: true
-    }, sessionId)
-    const response = evaluationValue(evaluated, 'reading the packaged workbench contribution snapshot')
-    return hasWorkbenchContribution(response, contributionId) ? response : undefined
-  }, { timeoutMs, description: `packaged workbench discovery for ${contributionId}` })
-
+async function replayWorkbenchContributionDiscovery({ cdp, sessionId }) {
+  // Workbench contribution discovery starts after the first committed render.
+  // Queue retries up front so a cold packaged renderer cannot miss the one
+  // signal that asks it to retry after the local runtime becomes ready.
   await cdp.send('Runtime.evaluate', {
-    expression: `(async () => {
-      for (const delayMs of [0, 250, 1_000]) {
-        if (delayMs > 0) await new Promise((resolvePromise) => setTimeout(resolvePromise, delayMs))
-        window.dispatchEvent(new Event('kun:extensions-changed'))
+    expression: `(() => {
+      for (const delayMs of ${JSON.stringify(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS)}) {
+        window.setTimeout(() => window.dispatchEvent(new Event('kun:extensions-changed')), delayMs)
       }
       return true
     })()`,
-    awaitPromise: true,
     returnByValue: true
   }, sessionId)
 }
@@ -1908,7 +1864,8 @@ module.exports = {
   resolvedDesktopResourceCandidates,
   desktopUserDataCandidates,
   findUnexpectedPopupTargets,
-  hasWorkbenchContribution,
+  WORKBENCH_DISCOVERY_RETRY_DELAYS_MS,
+  replayWorkbenchContributionDiscovery,
   isExtensionGuestTarget,
   isWorkbenchTarget,
   platformDesktopArguments,

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -31,7 +31,8 @@ const {
   desktopSmokeWorkspaceParent,
   desktopUserDataCandidates,
   findUnexpectedPopupTargets,
-  hasWorkbenchContribution,
+  WORKBENCH_DISCOVERY_RETRY_DELAYS_MS,
+  replayWorkbenchContributionDiscovery,
   isExtensionGuestTarget,
   isWorkbenchTarget,
   platformDesktopArguments,
@@ -425,27 +426,24 @@ test('recognizes the workbench and kun-extension guest CDP targets', () => {
   )
 })
 
-test('recognizes the installed smoke view in a trusted workbench bridge snapshot', () => {
-  const snapshot = {
-    schemaVersion: 1,
-    revision: 7,
-    extensions: [{
-      id: EXTENSION_ID,
-      contributes: {
-        'views.rightSidebar': [{ id: 'smoke' }]
-      }
-    }]
-  }
-  assert.equal(
-    hasWorkbenchContribution({ ok: true, status: 200, body: JSON.stringify(snapshot) }, CONTRIBUTION_ID),
-    true
-  )
-  assert.equal(
-    hasWorkbenchContribution({ ok: true, status: 200, body: JSON.stringify(snapshot) }, 'extension:other.example/smoke'),
-    false
-  )
-  assert.equal(hasWorkbenchContribution({ ok: false, status: 503, body: '' }, CONTRIBUTION_ID), false)
-  assert.equal(hasWorkbenchContribution({ ok: true, status: 200, body: 'not-json' }, CONTRIBUTION_ID), false)
+test('replays extension discovery through and beyond the cold renderer startup window', async () => {
+  assert.deepEqual(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS, [0, 250, 1_000, 3_000, 10_000])
+  const calls = []
+  await replayWorkbenchContributionDiscovery({
+    cdp: { send: async (...args) => calls.push(args) },
+    sessionId: 'workbench-session'
+  })
+  assert.deepEqual(calls.map(([method, params, sessionId]) => ({ method, sessionId, params: {
+    awaitPromise: params.awaitPromise,
+    returnByValue: params.returnByValue
+  } })), [{
+    method: 'Runtime.evaluate',
+    sessionId: 'workbench-session',
+    params: { awaitPromise: undefined, returnByValue: true }
+  }])
+  const expression = calls[0][1].expression
+  assert.match(expression, /window\.setTimeout/)
+  assert.doesNotMatch(expression, /extensionGetWorkbench/)
 })
 
 test('routes flattened CDP commands and rejects protocol errors', async () => {


### PR DESCRIPTION
## Summary

Prepare the `0.2.27-1` release retry after the previous merged release workflow failed before producing Windows and Linux artifacts.

## Changes

- Prevent media-handle persistence from serializing Windows filesystem identifiers that exceed JavaScript's safe integer range, while retaining available identity checks.
- Replay extension-discovery notifications through the packaged renderer cold-start window instead of blocking the desktop smoke on a precondition that can never become true.

## Root cause

- Windows failed in the Extension public release gate because a large NTFS inode was rejected by Zod during atomic JSON validation.
- Linux successfully built its AppImage, then the packaged Chromium smoke timed out waiting for a workbench contribution before it had replayed the event that starts the renderer retry path.

## Validation

- `npm run build:kun`
- `npm run typecheck`
- `npm --prefix kun run test -- src/services/extension-media-handle-service.test.ts src/services/extension-media-ffmpeg-service.test.ts src/services/extension-media-archive-service.test.ts src/services/extension-media-process-service.test.ts`
- `node --test scripts/smoke-packaged-extension-desktop.test.cjs`
- `npm run check:extension-release-gate`
