### PR TITLE
release: Kun v0.2.27-2

### DIFF
--- a/kun/src/services/extension-media-ffmpeg-service.test.ts
+++ b/kun/src/services/extension-media-ffmpeg-service.test.ts
@@ -7,7 +7,8 @@ import { ExtensionMediaHandleService } from './extension-media-handle-service.js
 import {
   EXTENSION_MEDIA_INPUT_FORMAT_WHITELIST,
   EXTENSION_MEDIA_INPUT_PROTOCOL_WHITELIST,
-  ExtensionMediaProcessService
+  ExtensionMediaProcessService,
+  runBoundedProcess
 } from './extension-media-process-service.js'
 import {
   ExtensionMediaFfmpegService,
@@ -26,7 +27,7 @@ async function fixture() {
   roots.push(root)
   const workspace = join(root, 'workspace')
   const dataDir = join(root, 'data')
-  const bin = join(root, 'ffmpeg')
+  const bin = join(root, process.platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg')
   await mkdir(join(workspace, 'exports'), { recursive: true })
   await writeFile(join(workspace, 'clip.mp4'), Buffer.from('source-video'))
   await writeFile(bin, `#!/usr/bin/env node
@@ -39,7 +40,7 @@ const target = process.argv.at(-1)
 fs.writeFileSync(target, Buffer.from('rendered-video'))
 process.stdout.write('frame=12\\nout_time_us=1250000\\ntotal_size=14\\nspeed=2.5x\\nprogress=end\\n')
 `)
-  await chmod(bin, 0o755)
+  if (process.platform !== 'win32') await chmod(bin, 0o755)
   const principal: ExtensionPrincipal = {
     extensionId: 'acme.video',
     extensionVersion: '1.0.0',
@@ -69,10 +70,24 @@ process.stdout.write('frame=12\\nout_time_us=1250000\\ntotal_size=14\\nspeed=2.5
   const processes = new ExtensionMediaProcessService({
     handleService: handles,
     ffmpegPath: bin,
-    pathEnv: process.env.PATH
+    pathEnv: process.env.PATH,
+    processRunner: (_executable, args, options) =>
+      runBoundedProcess(process.execPath, [bin, ...args], options)
   })
   const ffmpeg = new ExtensionMediaFfmpegService({ handleService: handles, processService: processes })
-  return { root, workspace, dataDir, bin, principal, handles, input, output, ffmpeg }
+  return {
+    root,
+    workspace,
+    dataDir,
+    bin,
+    principal,
+    handles,
+    input,
+    output,
+    ffmpeg,
+    processRunner: (_executable: string, args: string[], options: Parameters<typeof runBoundedProcess>[2]) =>
+      runBoundedProcess(process.execPath, [bin, ...args], options)
+  }
 }
 
 describe('validateAndSubstituteFfmpegArguments', () => {
@@ -468,7 +483,8 @@ describe('ExtensionMediaFfmpegService', { timeout: MEDIA_PROCESS_TEST_TIMEOUT_MS
       processService: new ExtensionMediaProcessService({
         handleService: recoveredHandles,
         ffmpegPath: test.bin,
-        pathEnv: process.env.PATH
+        pathEnv: process.env.PATH,
+        processRunner: test.processRunner
       })
     })
     await recoveredFfmpeg.rollbackInterruptedTransaction(
@@ -512,7 +528,8 @@ describe('ExtensionMediaFfmpegService', { timeout: MEDIA_PROCESS_TEST_TIMEOUT_MS
       processService: new ExtensionMediaProcessService({
         handleService: recoveredHandles,
         ffmpegPath: test.bin,
-        pathEnv: process.env.PATH
+        pathEnv: process.env.PATH,
+        processRunner: test.processRunner
       })
     })
     await recoveredFfmpeg.commitRecoveredTransaction(
@@ -588,7 +605,8 @@ fs.writeFileSync(process.argv.at(-1), Buffer.alloc(2048))
     const oversizedProcesses = new ExtensionMediaProcessService({
       handleService: oversized.handles,
       ffmpegPath: oversized.bin,
-      pathEnv: process.env.PATH
+      pathEnv: process.env.PATH,
+      processRunner: oversized.processRunner
     })
     const bounded = new ExtensionMediaFfmpegService({
       handleService: oversized.handles,
@@ -606,7 +624,8 @@ fs.writeFileSync(process.argv.at(-1), Buffer.alloc(2048))
     const missingProcesses = new ExtensionMediaProcessService({
       handleService: missing.handles,
       ffmpegPath: missing.bin,
-      pathEnv: process.env.PATH
+      pathEnv: process.env.PATH,
+      processRunner: missing.processRunner
     })
     const invalid = new ExtensionMediaFfmpegService({
       handleService: missing.handles,

--- a/kun/src/services/extension-media-process-service.test.ts
+++ b/kun/src/services/extension-media-process-service.test.ts
@@ -10,7 +10,8 @@ import {
   ExtensionMediaProcessError,
   ExtensionMediaProcessService,
   detectBeatGridFromPcm,
-  defaultMediaDiscoveryDirectories
+  defaultMediaDiscoveryDirectories,
+  runBoundedProcess
 } from './extension-media-process-service.js'
 
 const roots: string[] = []
@@ -25,11 +26,11 @@ async function fixture(scriptBody: string) {
   roots.push(root)
   const workspace = join(root, 'workspace')
   const dataDir = join(root, 'data')
-  const bin = join(root, 'ffprobe')
+  const bin = join(root, process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe')
   await mkdir(workspace, { recursive: true })
   await writeFile(join(workspace, 'clip.mp4'), Buffer.from('video-fixture'))
   await writeFile(bin, `#!/usr/bin/env node\n${scriptBody}\n`)
-  await chmod(bin, 0o755)
+  if (process.platform !== 'win32') await chmod(bin, 0o755)
   const principal: ExtensionPrincipal = {
     extensionId: 'acme.video',
     extensionVersion: '1.0.0',
@@ -44,14 +45,35 @@ async function fixture(scriptBody: string) {
     mode: 'read',
     source: 'workspace'
   })
-  return { root, workspace, dataDir, bin: await realpath(bin), principal, handles, handle }
+  const resolvedBin = await realpath(bin)
+  return {
+    root,
+    workspace,
+    dataDir,
+    bin: resolvedBin,
+    principal,
+    handles,
+    handle,
+    processRunner: (_executable: string, args: string[], options: Parameters<typeof runBoundedProcess>[2]) =>
+      runBoundedProcess(process.execPath, [resolvedBin, ...args], options)
+  }
+}
+
+function createMediaProcessService(
+  test: Awaited<ReturnType<typeof fixture>>,
+  options: Omit<ConstructorParameters<typeof ExtensionMediaProcessService>[0], 'handleService' | 'processRunner'> = {}
+): ExtensionMediaProcessService {
+  return new ExtensionMediaProcessService({
+    handleService: test.handles,
+    processRunner: test.processRunner,
+    ...options
+  })
 }
 
 describe('ExtensionMediaProcessService', { timeout: MEDIA_PROCESS_TEST_TIMEOUT_MS }, () => {
   it('discovers a configured binary without returning its path', async () => {
     const test = await fixture(`process.stdout.write('ffprobe version 7.1-test\\n')`)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       pathEnv: process.env.PATH
     })
@@ -67,8 +89,7 @@ describe('ExtensionMediaProcessService', { timeout: MEDIA_PROCESS_TEST_TIMEOUT_M
 
   it('discovers reviewed desktop prefixes before an inherited shell PATH', async () => {
     const test = await fixture(`process.stdout.write('ffprobe version 7.1-reviewed\\n')`)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       pathEnv: process.env.PATH,
       discoveryDirectories: [test.root]
     })
@@ -94,8 +115,7 @@ describe('ExtensionMediaProcessService', { timeout: MEDIA_PROCESS_TEST_TIMEOUT_M
       else if (args.includes('-filters')) process.stdout.write(' T.. drawtext V->V\\n ..S subtitles V->V\\n T.. eq V->V\\n T.. colorbalance V->V\\n T.. boxblur V->V\\n T.. unsharp V->V\\n T.. vignette V->V\\n ... arbitrary ignored\\n')
       else if (args.includes('-muxers')) process.stdout.write('  E mp4 MP4\\n  E mov MOV\\n  E matroska Matroska\\n  E dangerous ignored\\n')
     `)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffmpegPath: test.bin,
       pathEnv: process.env.PATH
     })
@@ -127,16 +147,15 @@ describe('ExtensionMediaProcessService', { timeout: MEDIA_PROCESS_TEST_TIMEOUT_M
     })
   })
 
-  it('reads a successful FFmpeg filter inventory from stderr', async () => {
+  it('reads a successful FFmpeg filter inventory with variable display flags from stderr', async () => {
     const test = await fixture(`
       const args = process.argv.slice(2)
       if (args.includes('-version')) process.stdout.write('ffmpeg version 8.0-stderr-inventory\\n')
       else if (args.includes('-encoders')) process.stdout.write(' V..... libx264 H.264\\n A..... aac AAC\\n')
-      else if (args.includes('-filters')) process.stderr.write(' T.C drawtext V->V Draw text\\n')
+      else if (args.includes('-filters')) process.stderr.write(' TSC. drawtext V->V Draw text\\n')
       else if (args.includes('-muxers')) process.stdout.write('  E mp4 MP4\\n')
     `)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffmpegPath: test.bin,
       pathEnv: process.env.PATH
     })
@@ -189,8 +208,7 @@ const expected = [
 if (expected.some((value, index) => args[index] !== value) || args.length !== expected.length + 1) process.exit(22)
 process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
     const test = await fixture(script)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       pathEnv: process.env.PATH
     })
@@ -248,8 +266,7 @@ process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
       }
       const script = `process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
       const test = await fixture(script)
-      const service = new ExtensionMediaProcessService({
-        handleService: test.handles,
+      const service = createMediaProcessService(test, {
         ffprobePath: test.bin,
         pathEnv: process.env.PATH
       })
@@ -273,8 +290,7 @@ process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
 
   it('checks permission before attempting executable discovery', async () => {
     const test = await fixture(`process.exit(99)`)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: join(test.root, 'missing')
     })
     await expect(service.probe({ ...test.principal, permissions: [] }, test.handle.id))
@@ -290,8 +306,7 @@ process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
       mode: 'read',
       source: 'workspace'
     })
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       pathEnv: process.env.PATH
     })
@@ -301,8 +316,7 @@ process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
 
   it('bounds output and cancellation without exposing local paths', async () => {
     const test = await fixture(`process.stdout.write('x'.repeat(8192)); setTimeout(() => {}, 30_000)`)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       pathEnv: process.env.PATH,
       maxProbeOutputBytes: 1024
@@ -320,8 +334,7 @@ process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
 
   it('reports invalid JSON with a stable redacted error', async () => {
     const test = await fixture(`process.stdout.write('{invalid')`)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       pathEnv: process.env.PATH
     })
@@ -331,16 +344,14 @@ process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
 
   it('reports missing executables and aborts a running probe', async () => {
     const test = await fixture(`setTimeout(() => process.stdout.write('{}'), 30_000)`)
-    const missing = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const missing = createMediaProcessService(test, {
       ffprobePath: join(test.root, 'missing-ffprobe'),
       pathEnv: ''
     })
     await expect(missing.probe(test.principal, test.handle.id))
       .rejects.toMatchObject({ code: 'executable_unavailable' })
 
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       pathEnv: process.env.PATH
     })
@@ -358,8 +369,7 @@ process.stdout.write(${JSON.stringify(JSON.stringify(payload))})`
       else if (args.includes('-filters')) process.stdout.write(' ... silencedetect A->A\\n')
       else if (args.includes('-muxers')) process.stdout.write('  E s16le raw PCM\\n')
     `)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       ffmpegPath: test.bin,
       pathEnv: process.env.PATH
@@ -418,8 +428,7 @@ else if (args.some((value) => value.startsWith('silencedetect='))) {
 } else process.exit(23)
 `
     const test = await fixture(script)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       ffmpegPath: test.bin,
       pathEnv: process.env.PATH
@@ -498,8 +507,7 @@ const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)']
 fs.writeFileSync(process.argv.at(-1) + '.descendant-pid', String(descendant.pid))
 setInterval(() => {}, 1000)
 `)
-    const service = new ExtensionMediaProcessService({
-      handleService: test.handles,
+    const service = createMediaProcessService(test, {
       ffprobePath: test.bin,
       pathEnv: process.env.PATH
     })

--- a/kun/src/services/extension-media-process-service.ts
+++ b/kun/src/services/extension-media-process-service.ts
@@ -255,6 +255,9 @@ type MediaProcessOptions = {
   ffmpegTimeoutMs?: number
   maxFfmpegProgressBytes?: number
   maxFfmpegLogBytes?: number
+  // Test fixtures are JavaScript files, which Windows cannot execute directly
+  // with the production shell-free process boundary.
+  processRunner?: typeof runBoundedProcess
 }
 
 /**
@@ -273,6 +276,7 @@ export class ExtensionMediaProcessService {
   private readonly configuredPaths: Partial<Record<MediaExecutableName, string>>
   private readonly pathEnv: string
   private readonly discoveryDirectories: string[]
+  private readonly processRunner: typeof runBoundedProcess
 
   constructor(private readonly options: MediaProcessOptions) {
     this.now = options.now ?? (() => new Date())
@@ -289,6 +293,7 @@ export class ExtensionMediaProcessService {
     }
     this.pathEnv = options.pathEnv ?? process.env.PATH ?? ''
     this.discoveryDirectories = options.discoveryDirectories ?? defaultMediaDiscoveryDirectories()
+    this.processRunner = options.processRunner ?? runBoundedProcess
   }
 
   async capabilities(principal: ExtensionPrincipal): Promise<MediaCapabilities> {
@@ -340,7 +345,7 @@ export class ExtensionMediaProcessService {
       )
     }
     const executable = await this.requireExecutable('ffprobe')
-    const result = await runBoundedProcess(executable.path, [
+    const result = await this.processRunner(executable.path, [
       '-v', 'error',
       '-hide_banner',
       '-protocol_whitelist', EXTENSION_MEDIA_INPUT_PROTOCOL_WHITELIST,
@@ -389,7 +394,7 @@ export class ExtensionMediaProcessService {
       )
     }
     const executable = await this.requireExecutable('ffmpeg')
-    const result = await runBoundedProcess(executable.path, [
+    const result = await this.processRunner(executable.path, [
       '-v', 'info',
       '-hide_banner',
       '-nostdin',
@@ -458,7 +463,7 @@ export class ExtensionMediaProcessService {
       input.samplePeriodMicros * input.maxFeaturePoints
     )
     const executable = await this.requireExecutable('ffmpeg')
-    const result = await runBoundedProcess(executable.path, [
+    const result = await this.processRunner(executable.path, [
       '-v', 'error',
       '-hide_banner',
       '-nostdin',
@@ -535,7 +540,7 @@ export class ExtensionMediaProcessService {
     }
     const maximumDurationMicros = Math.min(durationMicros, BEAT_MAX_ANALYSIS_MICROS)
     const executable = await this.requireExecutable('ffmpeg')
-    const result = await runBoundedProcess(executable.path, [
+    const result = await this.processRunner(executable.path, [
       '-v', 'error',
       '-hide_banner',
       '-nostdin',
@@ -631,7 +636,7 @@ export class ExtensionMediaProcessService {
     const embeddings: ExtensionVisualFrameAnalysis['embeddings'] = []
     for (const sample of samples) {
       options.signal?.throwIfAborted()
-      const result = await runBoundedProcess(executable.path, [
+      const result = await this.processRunner(executable.path, [
         '-v', 'error',
         '-hide_banner',
         '-nostdin',
@@ -687,7 +692,7 @@ export class ExtensionMediaProcessService {
   ): Promise<{ exitCode: number }> {
     requireProcessPermission(principal)
     const executable = await this.requireExecutable('ffmpeg')
-    const result = await runBoundedProcess(executable.path, args, {
+    const result = await this.processRunner(executable.path, args, {
       env: scrubbedEnvironment(this.pathEnv),
       timeoutMs: this.ffmpegTimeoutMs,
       maxStdoutBytes: this.maxFfmpegProgressBytes,
@@ -707,7 +712,7 @@ export class ExtensionMediaProcessService {
     )
     if (!executable) return { name, available: false }
     try {
-      const result = await runBoundedProcess(executable.path, ['-version'], {
+      const result = await this.processRunner(executable.path, ['-version'], {
         env: scrubbedEnvironment(this.pathEnv),
         timeoutMs: this.discoveryTimeoutMs,
         maxStdoutBytes: this.maxDiagnosticBytes,
@@ -717,7 +722,8 @@ export class ExtensionMediaProcessService {
       const firstLine = result.stdout.toString('utf8').split(/\r?\n/u, 1)[0]?.trim() ?? ''
       const version = boundedVersion(firstLine, name)
       const features = name === 'ffmpeg'
-        ? await inspectFfmpegFeatures(
+          ? await inspectFfmpegFeatures(
+            this.processRunner,
             executable.path,
             scrubbedEnvironment(this.pathEnv),
             this.discoveryTimeoutMs,
@@ -755,6 +761,7 @@ export class ExtensionMediaProcessService {
 }
 
 async function inspectFfmpegFeatures(
+  processRunner: typeof runBoundedProcess,
   executable: string,
   env: NodeJS.ProcessEnv,
   timeoutMs: number,
@@ -762,19 +769,19 @@ async function inspectFfmpegFeatures(
 ): Promise<NonNullable<MediaCapability['features']>> {
   try {
     const [encoders, filters, muxers] = await Promise.all([
-      runBoundedProcess(executable, ['-hide_banner', '-encoders'], {
+      processRunner(executable, ['-hide_banner', '-encoders'], {
         env,
         timeoutMs,
         maxStdoutBytes: maxBytes,
         maxStderrBytes: maxBytes
       }),
-      runBoundedProcess(executable, ['-hide_banner', '-filters'], {
+      processRunner(executable, ['-hide_banner', '-filters'], {
         env,
         timeoutMs,
         maxStdoutBytes: maxBytes,
         maxStderrBytes: maxBytes
       }),
-      runBoundedProcess(executable, ['-hide_banner', '-muxers'], {
+      processRunner(executable, ['-hide_banner', '-muxers'], {
         env,
         timeoutMs,
         maxStdoutBytes: maxBytes,
@@ -799,14 +806,14 @@ async function inspectFfmpegFeatures(
     if (/^\s*[A-Z.]{6}\s+flac\s/mu.test(encoderText)) features.push('flac-encoder')
     if (/^\s*[A-Z.]{6}\s+pcm_s24le\s/mu.test(encoderText)) features.push('pcm-s24-encoder')
     if (/^\s*[A-Z.]{6}\s+pcm_s16le\s/mu.test(encoderText)) features.push('pcm-s16-encoder')
-    if (/^\s*[A-Z.]{3}\s+drawtext\s/mu.test(filterText)) features.push('drawtext-filter')
-    if (/^\s*[A-Z.]{3}\s+subtitles\s/mu.test(filterText)) features.push('subtitles-filter')
-    if (/^\s*[A-Z.]{3}\s+eq\s/mu.test(filterText)) features.push('eq-filter')
-    if (/^\s*[A-Z.]{3}\s+colorbalance\s/mu.test(filterText)) features.push('colorbalance-filter')
-    if (/^\s*[A-Z.]{3}\s+boxblur\s/mu.test(filterText)) features.push('boxblur-filter')
-    if (/^\s*[A-Z.]{3}\s+unsharp\s/mu.test(filterText)) features.push('unsharp-filter')
-    if (/^\s*[A-Z.]{3}\s+vignette\s/mu.test(filterText)) features.push('vignette-filter')
-    if (/^\s*[A-Z.]{3}\s+silencedetect\s/mu.test(filterText)) features.push('silencedetect-filter')
+    if (hasFfmpegFilter(filterText, 'drawtext')) features.push('drawtext-filter')
+    if (hasFfmpegFilter(filterText, 'subtitles')) features.push('subtitles-filter')
+    if (hasFfmpegFilter(filterText, 'eq')) features.push('eq-filter')
+    if (hasFfmpegFilter(filterText, 'colorbalance')) features.push('colorbalance-filter')
+    if (hasFfmpegFilter(filterText, 'boxblur')) features.push('boxblur-filter')
+    if (hasFfmpegFilter(filterText, 'unsharp')) features.push('unsharp-filter')
+    if (hasFfmpegFilter(filterText, 'vignette')) features.push('vignette-filter')
+    if (hasFfmpegFilter(filterText, 'silencedetect')) features.push('silencedetect-filter')
     if (/^\s*[E.]\s+mp4(?:\s|,)/mu.test(muxerText)) features.push('mp4-muxer')
     if (/^\s*[E.]\s+mov(?:\s|,)/mu.test(muxerText)) features.push('mov-muxer')
     if (/^\s*[E.]\s+matroska(?:\s|,)/mu.test(muxerText)) features.push('matroska-muxer')
@@ -819,6 +826,12 @@ async function inspectFfmpegFeatures(
 
 function capabilityInventoryText(result: RunResult): string {
   return Buffer.concat([result.stdout, Buffer.from('\n'), result.stderr]).toString('utf8')
+}
+
+function hasFfmpegFilter(inventory: string, name: string): boolean {
+  // Filter flags are presentation metadata. Their width differs between
+  // FFmpeg builds, so use the stable filter-name column instead.
+  return new RegExp(`^\\s*(?:[A-Z.]+\\s+)?${name}(?:\\s|$)`, 'mu').test(inventory)
 }
 
 type DiscoveredExecutable = { path: string; source: 'configured' | 'path' }
@@ -893,7 +906,7 @@ function scrubbedEnvironment(pathEnv: string): NodeJS.ProcessEnv {
   }
 }
 
-async function runBoundedProcess(
+export async function runBoundedProcess(
   executable: string,
   args: string[],
   options: {

--- a/kun/src/services/extension-visual-analysis-service.test.ts
+++ b/kun/src/services/extension-visual-analysis-service.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { MediaVisualAdapterBinding } from '@kun/extension-api'
 import type { ExtensionPrincipal } from './extension-agent-service.js'
 import { ExtensionMediaHandleService } from './extension-media-handle-service.js'
-import { ExtensionMediaProcessService } from './extension-media-process-service.js'
+import { ExtensionMediaProcessService, runBoundedProcess } from './extension-media-process-service.js'
 import {
   ExtensionVisualAnalysisService,
   KUN_LOCAL_VISUAL_MODEL_DESCRIPTOR,
@@ -199,11 +199,11 @@ async function createFixture(scriptBody: string) {
   roots.push(root)
   const workspace = join(root, 'workspace')
   const dataDir = join(root, 'data')
-  const binary = join(root, 'media-tool')
+  const binary = join(root, process.platform === 'win32' ? 'media-tool.exe' : 'media-tool')
   await mkdir(workspace, { recursive: true })
   await writeFile(join(workspace, 'clip.mp4'), Buffer.from('authorized-video-fixture'))
   await writeFile(binary, `#!/usr/bin/env node\n${scriptBody}\n`)
-  await chmod(binary, 0o755)
+  if (process.platform !== 'win32') await chmod(binary, 0o755)
   const principal: ExtensionPrincipal = {
     extensionId: 'kun-examples.kun-video-editor',
     extensionVersion: '0.3.0',
@@ -222,7 +222,9 @@ async function createFixture(scriptBody: string) {
     handleService: handles,
     ffprobePath: binary,
     ffmpegPath: binary,
-    pathEnv: process.env.PATH
+    pathEnv: process.env.PATH,
+    processRunner: (_executable, args, options) =>
+      runBoundedProcess(process.execPath, [binary, ...args], options)
   })
   return {
     root,

--- a/scripts/smoke-development-ui-plugin-layout.cjs
+++ b/scripts/smoke-development-ui-plugin-layout.cjs
@@ -117,7 +117,7 @@ async function main() {
     }))
 
     const settings = {
-      ...desktopSmokeSettings(runtimePort, workspaceRoot),
+      ...desktopSmokeSettings(runtimePort, workspaceRoot, profile),
       locale: 'zh',
       theme: 'light'
     }

--- a/scripts/smoke-development-video-editor-layout.cjs
+++ b/scripts/smoke-development-video-editor-layout.cjs
@@ -103,6 +103,7 @@ async function main() {
     const settings = desktopVideoEditorSettings({
       runtimePort,
       workspaceRoot,
+      dataDir: profile,
       modelBaseUrl: 'http://127.0.0.1:9/v1'
     })
     const serializedSettings = `${JSON.stringify(settings, null, 2)}\n`

--- a/scripts/smoke-packaged-extension-desktop.cjs
+++ b/scripts/smoke-packaged-extension-desktop.cjs
@@ -8,7 +8,7 @@ const { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } = require('nod
 const { createServer: createHttpServer } = require('node:http')
 const { createConnection, createServer } = require('node:net')
 const { tmpdir } = require('node:os')
-const { join, resolve } = require('node:path')
+const { isAbsolute, join, resolve } = require('node:path')
 const { pathToFileURL } = require('node:url')
 const {
   EXTENSION_ID,
@@ -21,6 +21,8 @@ const {
 const CONTRIBUTION_ID = `extension:${EXTENSION_ID}/smoke`
 const WEBVIEW_MARKER = 'Packaged Webview smoke'
 const DEFAULT_TIMEOUT_MS = 120_000
+const DEFAULT_CDP_COMMAND_TIMEOUT_MS = 30_000
+const GUEST_MEDIA_READY_TIMEOUT_MS = 20_000
 const PROCESS_OUTPUT_LIMIT = 128 * 1024
 const POPUP_SETTLE_MS = 500
 const MAX_CLEANUP_TIMEOUT_MS = 15_000
@@ -70,7 +72,7 @@ async function main() {
   ])
   const runtimePort = await availablePort()
   const desktopSettings = `${JSON.stringify(
-    desktopSmokeSettings(runtimePort, workspaceRoot),
+    desktopSmokeSettings(runtimePort, workspaceRoot, profile),
     null,
     2
   )}\n`
@@ -174,7 +176,11 @@ async function main() {
       timeoutMs,
       processState: () => processState(desktopProcess)
     })
-    cdp = await CdpConnection.connect(endpoint.webSocketDebuggerUrl)
+    cdp = await CdpConnection.connect(
+      endpoint.webSocketDebuggerUrl,
+      globalThis.WebSocket,
+      Math.min(timeoutMs, DEFAULT_CDP_COMMAND_TIMEOUT_MS)
+    )
     await cdp.send('Target.setDiscoverTargets', { discover: true })
 
     const workbenchTarget = await waitForTarget(
@@ -184,14 +190,21 @@ async function main() {
       timeoutMs,
       () => processState(desktopProcess)
     )
-    const workbenchSession = await attachToTarget(cdp, workbenchTarget.targetId)
-    await replayWorkbenchContributionDiscovery({
+    const workbenchSession = {
+      targetId: workbenchTarget.targetId,
+      sessionId: undefined
+    }
+    await synchronizeWorkbenchContributionDiscovery({
       cdp,
-      sessionId: workbenchSession,
+      session: workbenchSession,
+      workspaceRoot,
+      contributionId: CONTRIBUTION_ID,
+      timeoutMs,
+      processState: () => processState(desktopProcess)
     })
     await waitForContributionAndClick({
       cdp,
-      sessionId: workbenchSession,
+      session: workbenchSession,
       contributionId: CONTRIBUTION_ID,
       timeoutMs,
       processState: () => processState(desktopProcess)
@@ -204,12 +217,15 @@ async function main() {
       timeoutMs,
       () => processState(desktopProcess)
     )
-    const guestSession = await attachToTarget(cdp, guestTarget.targetId)
+    const guestSession = {
+      targetId: guestTarget.targetId,
+      sessionId: undefined
+    }
     const guestResult = await inspectGuestSecurity({
       cdp,
-      sessionId: guestSession,
+      session: guestSession,
       targetId: guestTarget.targetId,
-      workbenchSessionId: workbenchSession,
+      workbenchSession,
       localFileUrl: pathToFileURL(join(workspaceRoot, 'packaged-playback.wav')).href,
       fetchUrl: networkCanary.url,
       popupUrl: networkCanary.popupUrl,
@@ -220,9 +236,9 @@ async function main() {
 
     await assertStaleViewSessionMediaBlocked({
       cdp,
-      guestSessionId: guestSession,
+      guestSession,
       guestTargetId: guestTarget.targetId,
-      workbenchSessionId: workbenchSession,
+      workbenchSession,
       timeoutMs,
       processState: () => processState(desktopProcess)
     })
@@ -288,7 +304,10 @@ function desktopSmokeWorkspaceParent(sourceRoot = resolve(__dirname, '..')) {
   return join(sourceRoot, 'dist', '.kun-desktop-smoke')
 }
 
-function desktopSmokeSettings(runtimePort, workspaceRoot) {
+function desktopSmokeSettings(runtimePort, workspaceRoot, dataDir) {
+  if (!isAbsolute(dataDir)) {
+    throw new TypeError('Packaged desktop smoke dataDir must be absolute')
+  }
   return {
     version: 1,
     workspaceRoot,
@@ -298,7 +317,7 @@ function desktopSmokeSettings(runtimePort, workspaceRoot) {
         baseUrl: 'https://invalid.example',
         providerId: 'deepseek',
         model: 'deepseek-chat',
-        dataDir: '~/.kun/data',
+        dataDir,
         port: runtimePort
       }
     }
@@ -322,8 +341,10 @@ async function grantSmokeWorkspaceTrust(unpackedRoot, profile, workspaceRoot) {
       ? entry.versions[entry.selectedVersion]
       : undefined
   if (!active) throw new Error('Desktop smoke extension has no selected registry version')
-  const canonicalWorkspace = await realpath(workspaceRoot)
-  const workspaceKey = paths.workspaceKey(canonicalWorkspace)
+  // Extension workspace identity is deliberately lexical. Using realpath here
+  // can grant a different key from the absolute path sent by the renderer when
+  // a CI workspace or one of its parents is a symlink.
+  const workspaceKey = paths.workspaceKey(workspaceRoot)
   await registry.setWorkspaceEnabled(EXTENSION_ID, workspaceKey, true)
   await registry.setWorkspacePermissionGrant(
     EXTENSION_ID,
@@ -527,6 +548,7 @@ function createIsolatedEnvironment(environment, paths) {
     TEMP: paths.temporaryDirectory,
     KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE: '1',
     KUN_DISABLE_OS_CREDENTIAL_STORE: '1',
+    NO_AT_BRIDGE: '1',
     ELECTRON_ENABLE_LOGGING: '1',
     NODE_ENV: 'production'
   })
@@ -547,7 +569,9 @@ function scrubDesktopEnvironment(environment) {
   for (const key of Object.keys(result)) {
     if (
       exactOverrides.has(key) ||
-      (key.startsWith('KUN_') && key !== 'KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE') ||
+      (key.startsWith('KUN_') &&
+        key !== 'KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE' &&
+        key !== 'KUN_DISABLE_OS_CREDENTIAL_STORE') ||
       key.startsWith('DEEPSEEK_')
     ) {
       delete result[key]
@@ -608,7 +632,7 @@ function runPackagedKun(executable, runtimeEntry, args, environment, timeoutMs =
 }
 
 class CdpConnection {
-  constructor(socket, commandTimeoutMs = 15_000) {
+  constructor(socket, commandTimeoutMs = DEFAULT_CDP_COMMAND_TIMEOUT_MS) {
     this.socket = socket
     this.commandTimeoutMs = commandTimeoutMs
     this.sequence = 0
@@ -619,7 +643,11 @@ class CdpConnection {
     socket.addEventListener('error', () => this.rejectPending(new Error('CDP WebSocket failed')))
   }
 
-  static async connect(url, WebSocketClass = globalThis.WebSocket) {
+  static async connect(
+    url,
+    WebSocketClass = globalThis.WebSocket,
+    commandTimeoutMs = DEFAULT_CDP_COMMAND_TIMEOUT_MS
+  ) {
     if (typeof WebSocketClass !== 'function') {
       throw new Error('The desktop smoke requires the WebSocket global from Node.js 22 or newer')
     }
@@ -635,7 +663,7 @@ class CdpConnection {
         once: true
       })
     })
-    return new CdpConnection(socket)
+    return new CdpConnection(socket, commandTimeoutMs)
   }
 
   send(method, params = {}, sessionId) {
@@ -801,26 +829,172 @@ async function attachToTarget(cdp, targetId) {
   return attached.sessionId
 }
 
-const WORKBENCH_DISCOVERY_RETRY_DELAYS_MS = [0, 250, 1_000, 3_000, 10_000]
+function isRecoverableCdpSessionError(error) {
+  return error instanceof Error &&
+    /(?:Session with given id not found|No session with given id|Target (?:closed|is detached)|Execution context was destroyed|Cannot find context with specified id)/iu.test(error.message)
+}
 
-async function replayWorkbenchContributionDiscovery({ cdp, sessionId }) {
-  // Workbench contribution discovery starts after the first committed render.
-  // Queue retries up front so a cold packaged renderer cannot miss the one
-  // signal that asks it to retry after the local runtime becomes ready.
-  await cdp.send('Runtime.evaluate', {
-    expression: `(() => {
-      for (const delayMs of ${JSON.stringify(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS)}) {
-        window.setTimeout(() => window.dispatchEvent(new Event('kun:extensions-changed')), delayMs)
+function isCdpCommandTimeout(error) {
+  return error instanceof Error && /CDP command timed out:/u.test(error.message)
+}
+
+async function sendToRecoverableTargetSession({
+  cdp,
+  session,
+  targetMatches,
+  targetDescription,
+  method,
+  params,
+  timeoutMs,
+  processState: readProcessState,
+  operation
+}) {
+  const deadline = Date.now() + timeoutMs
+  let lastSessionError
+  while (Date.now() < deadline) {
+    assertDesktopProcessRunning(readProcessState())
+    if (!session.sessionId) {
+      const { targetInfos = [] } = await cdp.send('Target.getTargets')
+      const target = targetInfos.find((candidate) =>
+        candidate.targetId === session.targetId && targetMatches(candidate)) ??
+        targetInfos.find(targetMatches)
+      if (!target) {
+        await delay(100)
+        continue
       }
-      return true
-    })()`,
-    returnByValue: true
-  }, sessionId)
+      try {
+        session.targetId = target.targetId
+        session.sessionId = await attachToTarget(cdp, target.targetId)
+      } catch (error) {
+        if (!isRecoverableCdpSessionError(error) && !isCdpCommandTimeout(error)) throw error
+        lastSessionError = error
+        session.sessionId = undefined
+        await delay(100)
+        continue
+      }
+    }
+    try {
+      return await cdp.send(method, params, session.sessionId)
+    } catch (error) {
+      if (
+        !isRecoverableCdpSessionError(error) &&
+        !(method === 'Runtime.evaluate' && isCdpCommandTimeout(error))
+      ) throw error
+      lastSessionError = error
+      session.sessionId = undefined
+      await delay(100)
+    }
+  }
+  throw new Error(
+    `Timed out while ${operation} after the packaged ${targetDescription} CDP session was replaced; ` +
+    `last error: ${lastSessionError instanceof Error ? lastSessionError.message : 'session unavailable'}`
+  )
+}
+
+function sendToWorkbenchSession(options) {
+  return sendToRecoverableTargetSession({
+    ...options,
+    targetMatches: isWorkbenchTarget,
+    targetDescription: 'workbench'
+  })
+}
+
+function sendToGuestSession(options) {
+  return sendToRecoverableTargetSession({
+    ...options,
+    targetMatches: isExtensionGuestTarget,
+    targetDescription: 'Extension guest'
+  })
+}
+
+const WORKBENCH_DISCOVERY_RETRY_DELAYS_MS = [0, 250, 1_000]
+
+function hasWorkbenchContribution(response, contributionId) {
+  if (!response || response.ok !== true || typeof response.body !== 'string') return false
+  try {
+    const snapshot = JSON.parse(response.body)
+    return Array.isArray(snapshot?.extensions) && snapshot.extensions.some((extension) =>
+      extension?.id === EXTENSION_ID &&
+      Array.isArray(extension?.contributes?.['views.rightSidebar']) &&
+      extension.contributes['views.rightSidebar'].some(
+        (view) => `extension:${extension.id}/${view?.id}` === contributionId
+      )
+    )
+  } catch {
+    return false
+  }
+}
+
+async function synchronizeWorkbenchContributionDiscovery({
+  cdp,
+  session,
+  workspaceRoot,
+  contributionId,
+  timeoutMs,
+  processState: readProcessState
+}) {
+  let lastResponse
+  try {
+    await pollUntil(async () => {
+      assertDesktopProcessRunning(readProcessState())
+      const evaluated = await sendToWorkbenchSession({
+        cdp,
+        session,
+        method: 'Runtime.evaluate',
+        params: {
+          expression: `(async () => {
+            const root = document.getElementById('root')
+            const bridge = globalThis.kunGui
+            if (!root?.hasChildNodes() || !bridge || typeof bridge.extensionGetWorkbench !== 'function') {
+              return null
+            }
+            return bridge.extensionGetWorkbench({ workspaceRoot: ${JSON.stringify(workspaceRoot)} })
+          })()`,
+          awaitPromise: true,
+          returnByValue: true
+        },
+        timeoutMs,
+        processState: readProcessState,
+        operation: 'reading the packaged workbench contribution snapshot'
+      })
+      lastResponse = evaluationValue(
+        evaluated,
+        'reading the packaged workbench contribution snapshot'
+      )
+      return hasWorkbenchContribution(lastResponse, contributionId) ? lastResponse : undefined
+    }, { timeoutMs, description: `packaged workbench discovery for ${contributionId}` })
+  } catch (error) {
+    const diagnostic = lastResponse === undefined
+      ? 'no bridge response'
+      : JSON.stringify(lastResponse).slice(0, 2_000)
+    throw new Error(`${error instanceof Error ? error.message : String(error)}; last bridge response: ${diagnostic}`)
+  }
+
+  // The bridge response proves that the runtime, registry, workspace grant,
+  // and renderer preload are ready. Notify the committed layout effect only
+  // after that point, with short retries for the final React commit boundary.
+  await sendToWorkbenchSession({
+    cdp,
+    session,
+    method: 'Runtime.evaluate',
+    params: {
+      expression: `(() => {
+        for (const delayMs of ${JSON.stringify(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS)}) {
+          window.setTimeout(() => window.dispatchEvent(new Event('kun:extensions-changed')), delayMs)
+        }
+        return true
+      })()`,
+      returnByValue: true
+    },
+    timeoutMs,
+    processState: readProcessState,
+    operation: 'notifying the packaged workbench contribution listener'
+  })
 }
 
 async function waitForContributionAndClick({
   cdp,
-  sessionId,
+  session,
   contributionId,
   timeoutMs,
   processState: readProcessState
@@ -831,49 +1005,77 @@ async function waitForContributionAndClick({
   const selector = `button[data-contribution-id="${contributionId}"]`
   const point = await pollUntil(async () => {
     assertDesktopProcessRunning(readProcessState())
-    const evaluated = await cdp.send('Runtime.evaluate', {
-      expression: `(() => {
-        const element = document.querySelector(${JSON.stringify(selector)})
-        if (!(element instanceof HTMLElement) || element.matches(':disabled')) return null
-        element.scrollIntoView({ block: 'center', inline: 'center' })
-        const rectangle = element.getBoundingClientRect()
-        if (rectangle.width <= 0 || rectangle.height <= 0) return null
-        return {
-          x: rectangle.left + rectangle.width / 2,
-          y: rectangle.top + rectangle.height / 2
-        }
-      })()`,
-      returnByValue: true
-    }, sessionId)
+    const evaluated = await sendToWorkbenchSession({
+      cdp,
+      session,
+      method: 'Runtime.evaluate',
+      params: {
+        expression: `(() => {
+          const element = document.querySelector(${JSON.stringify(selector)})
+          if (!(element instanceof HTMLElement) || element.matches(':disabled')) return null
+          element.scrollIntoView({ block: 'center', inline: 'center' })
+          const rectangle = element.getBoundingClientRect()
+          if (rectangle.width <= 0 || rectangle.height <= 0) return null
+          return {
+            x: rectangle.left + rectangle.width / 2,
+            y: rectangle.top + rectangle.height / 2
+          }
+        })()`,
+        returnByValue: true
+      },
+      timeoutMs,
+      processState: readProcessState,
+      operation: `locating ${selector}`
+    })
     return evaluationValue(evaluated, `locating ${selector}`)
   }, { timeoutMs, description: `workbench contribution ${contributionId}` })
 
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mouseMoved',
-    x: point.x,
-    y: point.y
-  }, sessionId)
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mousePressed',
-    x: point.x,
-    y: point.y,
-    button: 'left',
-    buttons: 1,
-    clickCount: 1
-  }, sessionId)
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mouseReleased',
-    x: point.x,
-    y: point.y,
-    button: 'left',
-    buttons: 0,
-    clickCount: 1
-  }, sessionId)
+  await sendToWorkbenchSession({
+    cdp,
+    session,
+    method: 'Input.dispatchMouseEvent',
+    params: { type: 'mouseMoved', x: point.x, y: point.y },
+    timeoutMs,
+    processState: readProcessState,
+    operation: `moving to ${selector}`
+  })
+  await sendToWorkbenchSession({
+    cdp,
+    session,
+    method: 'Input.dispatchMouseEvent',
+    params: {
+      type: 'mousePressed',
+      x: point.x,
+      y: point.y,
+      button: 'left',
+      buttons: 1,
+      clickCount: 1
+    },
+    timeoutMs,
+    processState: readProcessState,
+    operation: `pressing ${selector}`
+  })
+  await sendToWorkbenchSession({
+    cdp,
+    session,
+    method: 'Input.dispatchMouseEvent',
+    params: {
+      type: 'mouseReleased',
+      x: point.x,
+      y: point.y,
+      button: 'left',
+      buttons: 0,
+      clickCount: 1
+    },
+    timeoutMs,
+    processState: readProcessState,
+    operation: `releasing ${selector}`
+  })
 }
 
 async function waitForContributionTabCloseAndClick({
   cdp,
-  sessionId,
+  session,
   contributionId,
   timeoutMs,
   processState: readProcessState
@@ -881,100 +1083,194 @@ async function waitForContributionTabCloseAndClick({
   const selector = `.ds-extension-view[data-contribution-id="${contributionId}"]`
   const point = await pollUntil(async () => {
     assertDesktopProcessRunning(readProcessState())
-    const evaluated = await cdp.send('Runtime.evaluate', {
-      expression: `(() => {
-        const view = document.querySelector(${JSON.stringify(selector)})
-        const panel = view?.closest('[role="tabpanel"]')
-        const tabId = panel?.getAttribute('aria-labelledby')
-        const tab = tabId ? document.getElementById(tabId) : null
-        const closeButton = tab?.parentElement?.querySelector('button:not([role="tab"])')
-        if (!(closeButton instanceof HTMLElement) || closeButton.matches(':disabled')) return null
-        closeButton.scrollIntoView({ block: 'center', inline: 'center' })
-        const rectangle = closeButton.getBoundingClientRect()
-        if (rectangle.width <= 0 || rectangle.height <= 0) return null
-        return {
-          x: rectangle.left + rectangle.width / 2,
-          y: rectangle.top + rectangle.height / 2
-        }
-      })()`,
-      returnByValue: true
-    }, sessionId)
+    const evaluated = await sendToWorkbenchSession({
+      cdp,
+      session,
+      method: 'Runtime.evaluate',
+      params: {
+        expression: `(() => {
+          const view = document.querySelector(${JSON.stringify(selector)})
+          const panel = view?.closest('[role="tabpanel"]')
+          const tabId = panel?.getAttribute('aria-labelledby')
+          const tab = tabId ? document.getElementById(tabId) : null
+          const closeButton = tab?.parentElement?.querySelector('button:not([role="tab"])')
+          if (!(closeButton instanceof HTMLElement) || closeButton.matches(':disabled')) return null
+          closeButton.scrollIntoView({ block: 'center', inline: 'center' })
+          const rectangle = closeButton.getBoundingClientRect()
+          if (rectangle.width <= 0 || rectangle.height <= 0) return null
+          return {
+            x: rectangle.left + rectangle.width / 2,
+            y: rectangle.top + rectangle.height / 2
+          }
+        })()`,
+        returnByValue: true
+      },
+      timeoutMs,
+      processState: readProcessState,
+      operation: `locating the close control for ${selector}`
+    })
     return evaluationValue(evaluated, `locating the close control for ${selector}`)
   }, { timeoutMs, description: `workbench contribution tab close ${contributionId}` })
 
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mouseMoved',
-    x: point.x,
-    y: point.y
-  }, sessionId)
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mousePressed',
-    x: point.x,
-    y: point.y,
-    button: 'left',
-    buttons: 1,
-    clickCount: 1
-  }, sessionId)
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mouseReleased',
-    x: point.x,
-    y: point.y,
-    button: 'left',
-    buttons: 0,
-    clickCount: 1
-  }, sessionId)
+  await sendToWorkbenchSession({
+    cdp,
+    session,
+    method: 'Input.dispatchMouseEvent',
+    params: { type: 'mouseMoved', x: point.x, y: point.y },
+    timeoutMs,
+    processState: readProcessState,
+    operation: `moving to the close control for ${selector}`
+  })
+  await sendToWorkbenchSession({
+    cdp,
+    session,
+    method: 'Input.dispatchMouseEvent',
+    params: {
+      type: 'mousePressed',
+      x: point.x,
+      y: point.y,
+      button: 'left',
+      buttons: 1,
+      clickCount: 1
+    },
+    timeoutMs,
+    processState: readProcessState,
+    operation: `pressing the close control for ${selector}`
+  })
+  await sendToWorkbenchSession({
+    cdp,
+    session,
+    method: 'Input.dispatchMouseEvent',
+    params: {
+      type: 'mouseReleased',
+      x: point.x,
+      y: point.y,
+      button: 'left',
+      buttons: 0,
+      clickCount: 1
+    },
+    timeoutMs,
+    processState: readProcessState,
+    operation: `releasing the close control for ${selector}`
+  })
 }
 
 async function inspectGuestSecurity({
   cdp,
-  sessionId,
+  session,
   targetId,
-  workbenchSessionId,
+  workbenchSession,
   localFileUrl,
   fetchUrl,
   popupUrl,
   timeoutMs,
   processState: readProcessState
 }) {
-  await waitForGuestReady(cdp, sessionId, timeoutMs, readProcessState)
+  const sendGuest = (method, params, operation) => sendToGuestSession({
+    cdp,
+    session,
+    method,
+    params,
+    timeoutMs,
+    processState: readProcessState,
+    operation
+  })
+  await waitForGuestReady(
+    cdp,
+    session.sessionId,
+    timeoutMs,
+    readProcessState,
+    (method, params) => sendGuest(method, params, 'waiting for the extension guest')
+  )
 
-  await cdp.send('Page.enable', {}, sessionId)
+  await sendGuest('Page.enable', {}, 'enabling the Extension guest page domain')
   // Prove sender-bound kun-media loading and seeking under the production CSP
   // before the separate Host network-filter test intentionally bypasses CSP.
-  const mediaPlaybackResult = await inspectGuestMediaPlayback(cdp, sessionId)
-  const imagePlaybackResult = await inspectGuestImagePlayback(cdp, sessionId)
+  const mediaPlaybackResult = await waitForSuccessfulGuestInspection({
+    inspect: () => inspectGuestMediaPlayback(
+      cdp,
+      session.sessionId,
+      (method, params) => sendGuest(method, params, 'loading sender-bound kun-media playback')
+    ),
+    isSuccessful: (result) => result?.mediaPlaybackMode === 'ok',
+    timeoutMs,
+    description: 'sender-bound kun-media playback readiness'
+  })
+  const imagePlaybackResult = await waitForSuccessfulGuestInspection({
+    inspect: () => inspectGuestImagePlayback(
+      cdp,
+      session.sessionId,
+      (method, params) => sendGuest(method, params, 'loading a sender-bound kun-media image')
+    ),
+    isSuccessful: (result) => result?.imagePlaybackMode === 'ok',
+    timeoutMs,
+    description: 'sender-bound kun-media image readiness'
+  })
 
   // The protocol response carries the production `connect-src 'none'` baseline in
   // addition to the fixture's explicit loopback source. Bypass CSP only after
   // media playback so the Host webRequest filter is the fetch control under test.
-  await cdp.send('Page.setBypassCSP', { enabled: true }, sessionId)
-  await cdp.send('Page.enable', {}, workbenchSessionId)
-  await cdp.send('Page.setBypassCSP', { enabled: true }, workbenchSessionId)
+  await sendGuest(
+    'Page.setBypassCSP',
+    { enabled: true },
+    'enabling Extension guest CSP bypass for network-filter validation'
+  )
+  const sendWorkbench = (method, params, operation) => sendToWorkbenchSession({
+    cdp,
+    session: workbenchSession,
+    method,
+    params,
+    timeoutMs,
+    processState: readProcessState,
+    operation
+  })
+  await sendWorkbench('Page.enable', {}, 'enabling the packaged workbench page domain')
+  await sendWorkbench(
+    'Page.setBypassCSP',
+    { enabled: true },
+    'enabling workbench CSP bypass for sender-isolation validation'
+  )
 
   let mediaIsolationResult
   try {
     const copiedMediaUrlMode = await inspectMediaUrlFetch(
       cdp,
-      workbenchSessionId,
+      workbenchSession.sessionId,
       mediaPlaybackResult.mediaLeaseUrl,
-      'checking a copied kun-media URL from the workbench sender'
+      'checking a copied kun-media URL from the workbench sender',
+      (method, params) => sendWorkbench(
+        method,
+        params,
+        'checking a copied kun-media URL from the workbench sender'
+      )
     )
     const arbitraryLocalPathMode = await inspectMediaUrlFetch(
       cdp,
-      sessionId,
+      session.sessionId,
       localFileUrl,
-      'checking an arbitrary file URL from the extension guest'
+      'checking an arbitrary file URL from the extension guest',
+      (method, params) => sendGuest(
+        method,
+        params,
+        'checking an arbitrary file URL from the extension guest'
+      )
     )
     const releaseMode = await releaseGuestMediaLease(
       cdp,
-      sessionId,
-      mediaPlaybackResult.mediaPlayback?.leaseId
+      session.sessionId,
+      mediaPlaybackResult.mediaPlayback?.leaseId,
+      (method, params) => sendGuest(method, params, 'releasing the packaged media lease')
     )
     const postReleaseMediaUrlMode = await inspectMediaUrlFetch(
       cdp,
-      sessionId,
+      session.sessionId,
       mediaPlaybackResult.mediaLeaseUrl,
-      'checking a released kun-media URL from its original guest'
+      'checking a released kun-media URL from its original guest',
+      (method, params) => sendGuest(
+        method,
+        params,
+        'checking a released kun-media URL from its original guest'
+      )
     )
     mediaIsolationResult = {
       copiedMediaUrlMode,
@@ -985,8 +1281,9 @@ async function inspectGuestSecurity({
   } finally {
     await releaseGuestMediaLease(
       cdp,
-      sessionId,
-      mediaPlaybackResult.mediaPlayback?.leaseId
+      session.sessionId,
+      mediaPlaybackResult.mediaPlayback?.leaseId,
+      (method, params) => sendGuest(method, params, 'cleaning up the packaged media lease')
     ).catch(() => undefined)
   }
 
@@ -999,7 +1296,7 @@ async function inspectGuestSecurity({
   let value
   let targetsAfter = []
   try {
-    const evaluated = await cdp.send('Runtime.evaluate', {
+    const evaluated = await sendGuest('Runtime.evaluate', {
       expression: `(async () => {
         const bridgeMethods = ['request', 'notify', 'onNotification', 'registerHandler', 'dispose']
           .filter((name) => typeof globalThis.kunExtension?.[name] === 'function')
@@ -1101,7 +1398,7 @@ async function inspectGuestSecurity({
       awaitPromise: true,
       returnByValue: true,
       userGesture: true
-    }, sessionId)
+    }, 'inspecting extension guest security')
     value = evaluationValue(evaluated, 'inspecting extension guest security')
     await delay(POPUP_SETTLE_MS)
     ;({ targetInfos: targetsAfter = [] } = await cdp.send('Target.getTargets'))
@@ -1123,8 +1420,96 @@ async function inspectGuestSecurity({
   }
 }
 
-async function inspectGuestImagePlayback(cdp, sessionId) {
-  const evaluated = await cdp.send('Runtime.evaluate', {
+async function waitForSuccessfulGuestInspection({
+  inspect,
+  isSuccessful,
+  timeoutMs,
+  description
+}) {
+  let lastResult
+  try {
+    return await pollUntil(async () => {
+      lastResult = await inspect()
+      return isSuccessful(lastResult) ? lastResult : undefined
+    }, {
+      timeoutMs: Math.min(timeoutMs, GUEST_MEDIA_READY_TIMEOUT_MS),
+      description
+    })
+  } catch (error) {
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}; ` +
+      `last guest inspection: ${JSON.stringify(lastResult ?? null)}`
+    )
+  }
+}
+
+let guestAsyncInspectionSequence = 0
+
+async function runGuestAsyncInspection({
+  cdp,
+  sessionId,
+  sendCommand,
+  expression,
+  userGesture = false,
+  timeoutMs,
+  description
+}) {
+  guestAsyncInspectionSequence += 1
+  const resultKey = `__kunPackagedGuestInspection${guestAsyncInspectionSequence}`
+  const serializedKey = JSON.stringify(resultKey)
+  const send = (method, params) => sendCommand
+    ? sendCommand(method, params)
+    : cdp.send(method, params, sessionId)
+  const start = () => send('Runtime.evaluate', {
+      expression: `(() => {
+        const key = ${serializedKey}
+        globalThis[key] = { state: 'pending' }
+        Promise.resolve(${expression}).then(
+          (value) => { globalThis[key] = { state: 'fulfilled', value } },
+          (error) => {
+            globalThis[key] = {
+              state: 'rejected',
+              error: error instanceof Error ? error.message : String(error)
+            }
+          }
+        )
+        return key
+      })()`,
+      returnByValue: true,
+      userGesture
+    })
+  await start()
+  try {
+    const completed = await pollUntil(async () => {
+      const evaluated = await send('Runtime.evaluate', {
+        expression: `globalThis[${serializedKey}] ?? null`,
+        returnByValue: true
+      })
+      const state = evaluationValue(evaluated, description)
+      if (state === null || state === undefined) {
+        // A guest main-frame navigation replaces the execution context without
+        // necessarily invalidating the flattened target session. Restart the
+        // inspection in the current context instead of waiting on the orphaned
+        // promise from the previous document.
+        await start()
+        return undefined
+      }
+      if (state?.state === 'rejected') {
+        throw new Error(`${description} rejected: ${String(state.error ?? 'unknown error')}`)
+      }
+      return state?.state === 'fulfilled' ? { value: state.value } : undefined
+    }, { timeoutMs, description })
+    return completed.value
+  } finally {
+    await send('Runtime.evaluate', {
+      expression: `delete globalThis[${serializedKey}]`,
+      returnByValue: true
+    }).catch(() => undefined)
+  }
+}
+
+async function inspectGuestImagePlayback(cdp, sessionId, sendCommand) {
+  const params = {
     expression: `(async () => {
       if (typeof globalThis.kunExtension?.request !== 'function') {
         return { imagePlaybackMode: 'unavailable', imagePlayback: null }
@@ -1192,12 +1577,20 @@ async function inspectGuestImagePlayback(cdp, sessionId) {
     awaitPromise: true,
     returnByValue: true,
     userGesture: true
-  }, sessionId)
-  return evaluationValue(evaluated, 'loading a sender-bound kun-media image under production CSP')
+  }
+  return runGuestAsyncInspection({
+    cdp,
+    sessionId,
+    sendCommand,
+    expression: params.expression,
+    userGesture: true,
+    timeoutMs: GUEST_MEDIA_READY_TIMEOUT_MS,
+    description: 'loading a sender-bound kun-media image under production CSP'
+  })
 }
 
-async function inspectGuestMediaPlayback(cdp, sessionId) {
-  const evaluated = await cdp.send('Runtime.evaluate', {
+async function inspectGuestMediaPlayback(cdp, sessionId, sendCommand) {
+  const params = {
     expression: `(async () => {
       if (typeof globalThis.kunExtension?.request !== 'function') {
         return { mediaPlaybackMode: 'unavailable', mediaPlayback: null }
@@ -1284,16 +1677,24 @@ async function inspectGuestMediaPlayback(cdp, sessionId) {
     awaitPromise: true,
     returnByValue: true,
     userGesture: true
-  }, sessionId)
-  return evaluationValue(evaluated, 'loading sender-bound kun-media playback under production CSP')
+  }
+  return runGuestAsyncInspection({
+    cdp,
+    sessionId,
+    sendCommand,
+    expression: params.expression,
+    userGesture: true,
+    timeoutMs: GUEST_MEDIA_READY_TIMEOUT_MS,
+    description: 'loading sender-bound kun-media playback under production CSP'
+  })
 }
 
-async function waitForGuestReady(cdp, sessionId, timeoutMs, readProcessState) {
+async function waitForGuestReady(cdp, sessionId, timeoutMs, readProcessState, sendCommand) {
   let lastGuestState
   try {
     await pollUntil(async () => {
       assertDesktopProcessRunning(readProcessState())
-      const evaluated = await cdp.send('Runtime.evaluate', {
+      const params = {
         expression: `(() => ({
           readyState: document.readyState,
           location: location.href,
@@ -1303,7 +1704,10 @@ async function waitForGuestReady(cdp, sessionId, timeoutMs, readProcessState) {
           bridge: typeof globalThis.kunExtension === 'object'
         }))()`,
         returnByValue: true
-      }, sessionId)
+      }
+      const evaluated = sendCommand
+        ? await sendCommand('Runtime.evaluate', params)
+        : await cdp.send('Runtime.evaluate', params, sessionId)
       const value = evaluationValue(evaluated, 'waiting for the extension guest')
       lastGuestState = value
       return value?.readyState === 'complete' && value.marker === WEBVIEW_MARKER && value.bridge
@@ -1316,9 +1720,9 @@ async function waitForGuestReady(cdp, sessionId, timeoutMs, readProcessState) {
   }
 }
 
-async function inspectMediaUrlFetch(cdp, sessionId, url, description) {
+async function inspectMediaUrlFetch(cdp, sessionId, url, description, sendCommand) {
   if (typeof url !== 'string' || url.length === 0) return 'invalid-url'
-  const evaluated = await cdp.send('Runtime.evaluate', {
+  const params = {
     expression: `(async () => {
       try {
         const response = await Promise.race([
@@ -1337,13 +1741,16 @@ async function inspectMediaUrlFetch(cdp, sessionId, url, description) {
     })()`,
     awaitPromise: true,
     returnByValue: true
-  }, sessionId)
+  }
+  const evaluated = sendCommand
+    ? await sendCommand('Runtime.evaluate', params)
+    : await cdp.send('Runtime.evaluate', params, sessionId)
   return evaluationValue(evaluated, description)
 }
 
-async function releaseGuestMediaLease(cdp, sessionId, leaseId) {
+async function releaseGuestMediaLease(cdp, sessionId, leaseId, sendCommand) {
   if (typeof leaseId !== 'string' || leaseId.length === 0) return 'invalid-lease'
-  const evaluated = await cdp.send('Runtime.evaluate', {
+  const params = {
     expression: `(async () => {
       try {
         await globalThis.kunExtension.request(
@@ -1358,12 +1765,15 @@ async function releaseGuestMediaLease(cdp, sessionId, leaseId) {
     })()`,
     awaitPromise: true,
     returnByValue: true
-  }, sessionId)
+  }
+  const evaluated = sendCommand
+    ? await sendCommand('Runtime.evaluate', params)
+    : await cdp.send('Runtime.evaluate', params, sessionId)
   return evaluationValue(evaluated, 'releasing the packaged media lease')
 }
 
-async function createGuestMediaLease(cdp, sessionId) {
-  const evaluated = await cdp.send('Runtime.evaluate', {
+async function createGuestMediaLease(cdp, sessionId, sendCommand) {
+  const params = {
     expression: `(async () => globalThis.kunExtension.request(
       'media.openViewResource',
       { handleId: ${JSON.stringify(MEDIA_PLAYBACK_HANDLE_ID)} },
@@ -1372,19 +1782,39 @@ async function createGuestMediaLease(cdp, sessionId) {
     awaitPromise: true,
     returnByValue: true,
     userGesture: true
-  }, sessionId)
+  }
+  const evaluated = sendCommand
+    ? await sendCommand('Runtime.evaluate', params)
+    : await cdp.send('Runtime.evaluate', params, sessionId)
   return evaluationValue(evaluated, 'minting a media lease for stale View Session validation')
 }
 
 async function assertStaleViewSessionMediaBlocked({
   cdp,
-  guestSessionId,
+  guestSession,
   guestTargetId,
-  workbenchSessionId,
+  workbenchSession,
   timeoutMs,
   processState: readProcessState
 }) {
-  const staleLease = await createGuestMediaLease(cdp, guestSessionId)
+  const sendGuest = (method, params, operation) => sendToGuestSession({
+    cdp,
+    session: guestSession,
+    method,
+    params,
+    timeoutMs,
+    processState: readProcessState,
+    operation
+  })
+  const staleLease = await createGuestMediaLease(
+    cdp,
+    guestSession.sessionId,
+    (method, params) => sendGuest(
+      method,
+      params,
+      'minting a media lease for stale View Session validation'
+    )
+  )
   if (
     !staleLease ||
     typeof staleLease.url !== 'string' ||
@@ -1399,40 +1829,76 @@ async function assertStaleViewSessionMediaBlocked({
   // request to unmount its owning surface.
   await waitForContributionTabCloseAndClick({
     cdp,
-    sessionId: workbenchSessionId,
+    session: workbenchSession,
     contributionId: CONTRIBUTION_ID,
     timeoutMs,
     processState: readProcessState
   })
+  const closedGuestTargetId = guestSession.targetId ?? guestTargetId
   await pollUntil(async () => {
     assertDesktopProcessRunning(readProcessState())
     const { targetInfos = [] } = await cdp.send('Target.getTargets')
-    return targetInfos.every((target) => target.targetId !== guestTargetId)
+    return targetInfos.every((target) => target.targetId !== closedGuestTargetId)
   }, { timeoutMs, description: 'disposed packaged Extension View Session' })
 
   await waitForContributionAndClick({
     cdp,
-    sessionId: workbenchSessionId,
+    session: workbenchSession,
     contributionId: CONTRIBUTION_ID,
     timeoutMs,
     processState: readProcessState
   })
   const replacementTarget = await waitForTarget(
     cdp,
-    (target) => isExtensionGuestTarget(target) && target.targetId !== guestTargetId,
+    (target) => isExtensionGuestTarget(target) && target.targetId !== closedGuestTargetId,
     'replacement kun-extension guest for stale View Session validation',
     timeoutMs,
     readProcessState
   )
-  const replacementSessionId = await attachToTarget(cdp, replacementTarget.targetId)
-  await waitForGuestReady(cdp, replacementSessionId, timeoutMs, readProcessState)
-  await cdp.send('Page.enable', {}, replacementSessionId)
-  await cdp.send('Page.setBypassCSP', { enabled: true }, replacementSessionId)
+  const replacementSession = {
+    targetId: replacementTarget.targetId,
+    sessionId: undefined
+  }
+  const sendReplacementGuest = (method, params, operation) => sendToGuestSession({
+    cdp,
+    session: replacementSession,
+    method,
+    params,
+    timeoutMs,
+    processState: readProcessState,
+    operation
+  })
+  await waitForGuestReady(
+    cdp,
+    replacementSession.sessionId,
+    timeoutMs,
+    readProcessState,
+    (method, params) => sendReplacementGuest(
+      method,
+      params,
+      'waiting for the replacement Extension guest'
+    )
+  )
+  await sendReplacementGuest(
+    'Page.enable',
+    {},
+    'enabling the replacement Extension guest page domain'
+  )
+  await sendReplacementGuest(
+    'Page.setBypassCSP',
+    { enabled: true },
+    'enabling replacement Extension guest CSP bypass'
+  )
   const staleViewSessionMode = await inspectMediaUrlFetch(
     cdp,
-    replacementSessionId,
+    replacementSession.sessionId,
     staleLease.url,
-    'checking a stale View Session media URL from its replacement guest'
+    'checking a stale View Session media URL from its replacement guest',
+    (method, params) => sendReplacementGuest(
+      method,
+      params,
+      'checking a stale View Session media URL from its replacement guest'
+    )
   )
   if (staleViewSessionMode !== 'blocked') {
     throw new Error(
@@ -1864,8 +2330,12 @@ module.exports = {
   resolvedDesktopResourceCandidates,
   desktopUserDataCandidates,
   findUnexpectedPopupTargets,
+  hasWorkbenchContribution,
   WORKBENCH_DISCOVERY_RETRY_DELAYS_MS,
-  replayWorkbenchContributionDiscovery,
+  runGuestAsyncInspection,
+  sendToGuestSession,
+  synchronizeWorkbenchContributionDiscovery,
+  waitForSuccessfulGuestInspection,
   isExtensionGuestTarget,
   isWorkbenchTarget,
   platformDesktopArguments,

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -31,8 +31,12 @@ const {
   desktopSmokeWorkspaceParent,
   desktopUserDataCandidates,
   findUnexpectedPopupTargets,
+  hasWorkbenchContribution,
   WORKBENCH_DISCOVERY_RETRY_DELAYS_MS,
-  replayWorkbenchContributionDiscovery,
+  runGuestAsyncInspection,
+  sendToGuestSession,
+  synchronizeWorkbenchContributionDiscovery,
+  waitForSuccessfulGuestInspection,
   isExtensionGuestTarget,
   isWorkbenchTarget,
   platformDesktopArguments,
@@ -96,9 +100,16 @@ test('selects host-native packaged resources and never launches desktop Electron
     desktopApplicationEntry('/packaged/Resources', '/host/Electron', '/packaged/Kun'),
     join('/packaged/Resources', 'app.asar')
   )
-  assert.equal(
-    desktopSmokeSettings(43123, '/isolated-home/.kun/default_workspace').workspaceRoot,
-    '/isolated-home/.kun/default_workspace'
+  const smokeSettings = desktopSmokeSettings(
+    43123,
+    '/isolated-home/.kun/default_workspace',
+    '/isolated-home/.kun/data'
+  )
+  assert.equal(smokeSettings.workspaceRoot, '/isolated-home/.kun/default_workspace')
+  assert.equal(smokeSettings.agents.kun.dataDir, '/isolated-home/.kun/data')
+  assert.throws(
+    () => desktopSmokeSettings(43123, '/workspace', '~/.kun/data'),
+    /dataDir must be absolute/
   )
   assert.equal(
     desktopSmokeWorkspaceParent('/source-checkout'),
@@ -134,7 +145,10 @@ test('selects host-native packaged resources and never launches desktop Electron
   const linux = createDesktopLaunchPlan({
     executable: '/packaged/kun',
     applicationArguments: ['--remote-debugging-port=12345'],
-    environment: { ELECTRON_RUN_AS_NODE: '1' },
+    environment: {
+      ELECTRON_RUN_AS_NODE: '1',
+      KUN_DISABLE_OS_CREDENTIAL_STORE: '1'
+    },
     platform: 'linux',
     hasDisplay: false,
     xvfbExecutable: '/usr/bin/xvfb-run'
@@ -142,6 +156,7 @@ test('selects host-native packaged resources and never launches desktop Electron
   assert.equal(linux.command, '/usr/bin/xvfb-run')
   assert.deepEqual(linux.args, ['-a', '-s', '-screen 0 1280x900x24', '/packaged/kun', '--remote-debugging-port=12345'])
   assert.equal(linux.env.ELECTRON_RUN_AS_NODE, undefined)
+  assert.equal(linux.env.KUN_DISABLE_OS_CREDENTIAL_STORE, '1')
   assert.equal(linux.wrappedByXvfb, true)
 
   const isolated = createIsolatedEnvironment(
@@ -169,6 +184,7 @@ test('selects host-native packaged resources and never launches desktop Electron
   assert.equal(isolated.NODE_ENV, 'production')
   assert.equal(isolated.KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE, '1')
   assert.equal(isolated.KUN_DISABLE_OS_CREDENTIAL_STORE, '1')
+  assert.equal(isolated.NO_AT_BRIDGE, '1')
   for (const key of [
     'ELECTRON_RENDERER_URL',
     'ELECTRON_RUN_AS_NODE',
@@ -426,24 +442,312 @@ test('recognizes the workbench and kun-extension guest CDP targets', () => {
   )
 })
 
-test('replays extension discovery through and beyond the cold renderer startup window', async () => {
-  assert.deepEqual(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS, [0, 250, 1_000, 3_000, 10_000])
+test('synchronizes renderer discovery after the trusted bridge sees the installed smoke view', async () => {
+  assert.deepEqual(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS, [0, 250, 1_000])
+  const response = {
+    ok: true,
+    status: 200,
+    body: JSON.stringify({
+      schemaVersion: 1,
+      revision: 7,
+      extensions: [{
+        id: EXTENSION_ID,
+        contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
+      }]
+    })
+  }
+  assert.equal(hasWorkbenchContribution(response, CONTRIBUTION_ID), true)
+  assert.equal(hasWorkbenchContribution(response, 'extension:other.example/smoke'), false)
   const calls = []
-  await replayWorkbenchContributionDiscovery({
-    cdp: { send: async (...args) => calls.push(args) },
-    sessionId: 'workbench-session'
+  const session = { targetId: 'workbench-target', sessionId: 'workbench-session' }
+  await synchronizeWorkbenchContributionDiscovery({
+    cdp: {
+      send: async (...args) => {
+        calls.push(args)
+        return args[1].expression.includes('extensionGetWorkbench')
+          ? { result: { value: response } }
+          : { result: { value: true } }
+      }
+    },
+    session,
+    workspaceRoot: '/workspace',
+    contributionId: CONTRIBUTION_ID,
+    timeoutMs: 1_000,
+    processState: () => ({ exitCode: null, signalCode: null })
   })
   assert.deepEqual(calls.map(([method, params, sessionId]) => ({ method, sessionId, params: {
     awaitPromise: params.awaitPromise,
     returnByValue: params.returnByValue
-  } })), [{
+  } })), [
+    {
+      method: 'Runtime.evaluate',
+      sessionId: 'workbench-session',
+      params: { awaitPromise: true, returnByValue: true }
+    },
+    {
+      method: 'Runtime.evaluate',
+      sessionId: 'workbench-session',
+      params: { awaitPromise: undefined, returnByValue: true }
+    }
+  ])
+  assert.match(calls[0][1].expression, /extensionGetWorkbench/)
+  assert.match(calls[1][1].expression, /window\.setTimeout/)
+})
+
+test('reattaches renderer discovery when the packaged workbench CDP session is replaced', async () => {
+  const response = {
+    ok: true,
+    status: 200,
+    body: JSON.stringify({
+      extensions: [{
+        id: EXTENSION_ID,
+        contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
+      }]
+    })
+  }
+  const calls = []
+  let rejectedOldSession = false
+  const session = { targetId: 'old-target', sessionId: 'old-session' }
+  await synchronizeWorkbenchContributionDiscovery({
+    cdp: {
+      send: async (method, params, sessionId) => {
+        calls.push([method, params, sessionId])
+        if (method === 'Runtime.evaluate' && sessionId === 'old-session' && !rejectedOldSession) {
+          rejectedOldSession = true
+          throw new Error('CDP Runtime.evaluate failed (-32001): Session with given id not found.')
+        }
+        if (method === 'Target.getTargets') {
+          return {
+            targetInfos: [{
+              targetId: 'replacement-target',
+              type: 'page',
+              url: 'file:///opt/Kun/resources/app.asar/out/renderer/index.html'
+            }]
+          }
+        }
+        if (method === 'Target.attachToTarget') return { sessionId: 'replacement-session' }
+        if (method === 'Runtime.enable') return {}
+        return params.expression.includes('extensionGetWorkbench')
+          ? { result: { value: response } }
+          : { result: { value: true } }
+      }
+    },
+    session,
+    workspaceRoot: '/workspace',
+    contributionId: CONTRIBUTION_ID,
+    timeoutMs: 1_000,
+    processState: () => ({ exitCode: null, signalCode: null })
+  })
+  assert.deepEqual(session, {
+    targetId: 'replacement-target',
+    sessionId: 'replacement-session'
+  })
+  assert.equal(calls.some(([method]) => method === 'Target.getTargets'), true)
+  assert.equal(calls.some(([method]) => method === 'Target.attachToTarget'), true)
+  assert.equal(
+    calls.filter(([method, , sessionId]) =>
+      method === 'Runtime.evaluate' && sessionId === 'replacement-session').length,
+    2
+  )
+})
+
+test('retries renderer discovery when the initial packaged workbench target is replaced before attach', async () => {
+  const response = {
+    ok: true,
+    status: 200,
+    body: JSON.stringify({
+      extensions: [{
+        id: EXTENSION_ID,
+        contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
+      }]
+    })
+  }
+  const calls = []
+  let targetLookupCount = 0
+  const session = { targetId: 'initial-target', sessionId: undefined }
+  await synchronizeWorkbenchContributionDiscovery({
+    cdp: {
+      send: async (method, params, sessionId) => {
+        calls.push([method, params, sessionId])
+        if (method === 'Target.getTargets') {
+          targetLookupCount += 1
+          return {
+            targetInfos: [{
+              targetId: targetLookupCount === 1 ? 'initial-target' : 'replacement-target',
+              type: 'page',
+              url: 'file:///opt/Kun/resources/app.asar/out/renderer/index.html'
+            }]
+          }
+        }
+        if (method === 'Target.attachToTarget') {
+          return {
+            sessionId: params.targetId === 'initial-target'
+              ? 'initial-session'
+              : 'replacement-session'
+          }
+        }
+        if (method === 'Runtime.enable' && sessionId === 'initial-session') {
+          throw new Error('CDP Runtime.enable failed (-32001): Session with given id not found.')
+        }
+        if (method === 'Runtime.enable') return {}
+        return params.expression.includes('extensionGetWorkbench')
+          ? { result: { value: response } }
+          : { result: { value: true } }
+      }
+    },
+    session,
+    workspaceRoot: '/workspace',
+    contributionId: CONTRIBUTION_ID,
+    timeoutMs: 1_000,
+    processState: () => ({ exitCode: null, signalCode: null })
+  })
+  assert.deepEqual(session, {
+    targetId: 'replacement-target',
+    sessionId: 'replacement-session'
+  })
+  assert.equal(targetLookupCount, 2)
+  assert.equal(calls.some(([method, params]) =>
+    method === 'Target.attachToTarget' && params.targetId === 'replacement-target'), true)
+  assert.equal(
+    calls.filter(([method, , sessionId]) =>
+      method === 'Runtime.evaluate' && sessionId === 'replacement-session').length,
+    2
+  )
+})
+
+test('reattaches a replaced packaged Extension guest before replaying its CDP command', async () => {
+  const calls = []
+  let rejectedOldSession = false
+  const session = { targetId: 'old-guest', sessionId: 'old-guest-session' }
+  const response = await sendToGuestSession({
+    cdp: {
+      send: async (method, params, sessionId) => {
+        calls.push([method, params, sessionId])
+        if (method === 'Runtime.evaluate' && sessionId === 'old-guest-session' && !rejectedOldSession) {
+          rejectedOldSession = true
+          throw new Error('CDP Runtime.evaluate failed (-32001): Session with given id not found.')
+        }
+        if (method === 'Target.getTargets') {
+          return {
+            targetInfos: [{
+              targetId: 'replacement-guest',
+              type: 'webview',
+              url: `kun-extension://${EXTENSION_ID}/dist/webview/index.html?kunViewSession=replacement`
+            }]
+          }
+        }
+        if (method === 'Target.attachToTarget') return { sessionId: 'replacement-guest-session' }
+        if (method === 'Runtime.enable') return {}
+        return { result: { value: 'replayed' } }
+      }
+    },
+    session,
     method: 'Runtime.evaluate',
-    sessionId: 'workbench-session',
-    params: { awaitPromise: undefined, returnByValue: true }
-  }])
-  const expression = calls[0][1].expression
-  assert.match(expression, /window\.setTimeout/)
-  assert.doesNotMatch(expression, /extensionGetWorkbench/)
+    params: { expression: 'location.href', returnByValue: true },
+    timeoutMs: 1_000,
+    processState: () => ({ exitCode: null, signalCode: null }),
+    operation: 'testing guest recovery'
+  })
+  assert.deepEqual(response, { result: { value: 'replayed' } })
+  assert.deepEqual(session, {
+    targetId: 'replacement-guest',
+    sessionId: 'replacement-guest-session'
+  })
+  assert.equal(calls.some(([method, params]) =>
+    method === 'Target.attachToTarget' && params.targetId === 'replacement-guest'), true)
+  assert.equal(calls.at(-1)?.[2], 'replacement-guest-session')
+})
+
+test('reattaches and replays a guest Runtime evaluation after a silent CDP timeout', async () => {
+  let timedOut = false
+  const session = { targetId: 'guest-target', sessionId: 'timed-out-session' }
+  const response = await sendToGuestSession({
+    cdp: {
+      send: async (method, params, sessionId) => {
+        if (method === 'Runtime.evaluate' && !timedOut) {
+          timedOut = true
+          throw new Error('CDP command timed out: Runtime.evaluate')
+        }
+        if (method === 'Target.getTargets') {
+          return {
+            targetInfos: [{
+              targetId: 'guest-target',
+              type: 'webview',
+              url: `kun-extension://${EXTENSION_ID}/dist/webview/index.html?kunViewSession=current`
+            }]
+          }
+        }
+        if (method === 'Target.attachToTarget') return { sessionId: 'reattached-session' }
+        if (method === 'Runtime.enable') return {}
+        return { result: { value: params.expression } }
+      }
+    },
+    session,
+    method: 'Runtime.evaluate',
+    params: { expression: 'document.readyState', returnByValue: true },
+    timeoutMs: 1_000,
+    processState: () => ({ exitCode: null, signalCode: null }),
+    operation: 'testing silent guest timeout recovery'
+  })
+  assert.deepEqual(response, { result: { value: 'document.readyState' } })
+  assert.equal(session.sessionId, 'reattached-session')
+})
+
+test('runs long guest inspections as a started task with short result polls', async () => {
+  const expressions = []
+  let polls = 0
+  let starts = 0
+  const result = await runGuestAsyncInspection({
+    cdp: {},
+    sessionId: 'guest-session',
+    sendCommand: async (_method, params) => {
+      expressions.push(params.expression)
+      if (params.expression.includes('Promise.resolve')) {
+        starts += 1
+        return { result: { value: '__kunPackagedGuestInspectionTest' } }
+      }
+      if (params.expression.startsWith('delete ')) return { result: { value: true } }
+      polls += 1
+      if (polls === 1) return { result: { value: null } }
+      if (polls === 2) return { result: { value: { state: 'pending' } } }
+      return { result: { value: { state: 'fulfilled', value: { mode: 'ok' } } } }
+    },
+    expression: '(async () => ({ mode: \'ok\' }))()',
+    userGesture: true,
+    timeoutMs: 1_000,
+    description: 'test asynchronous guest inspection'
+  })
+  assert.deepEqual(result, { mode: 'ok' })
+  assert.equal(polls, 3)
+  assert.equal(starts, 2)
+  assert.equal(expressions.some((expression) => expression.includes('Promise.resolve')), true)
+  assert.equal(expressions.at(-1)?.startsWith('delete '), true)
+})
+
+test('waits for the packaged Extension guest main-frame media binding to become current', async () => {
+  let attempts = 0
+  const result = await waitForSuccessfulGuestInspection({
+    inspect: async () => {
+      attempts += 1
+      return attempts === 1
+        ? { mediaPlaybackMode: 'rejected', mediaPlaybackError: { message: 'binding pending' } }
+        : { mediaPlaybackMode: 'ok', mediaPlayback: { leaseId: 'lease-1' } }
+    },
+    isSuccessful: (value) => value.mediaPlaybackMode === 'ok',
+    timeoutMs: 1_000,
+    description: 'test guest media binding'
+  })
+  assert.equal(attempts, 2)
+  assert.deepEqual(result, {
+    mediaPlaybackMode: 'ok',
+    mediaPlayback: { leaseId: 'lease-1' }
+  })
+})
+
+test('uses a command budget that covers bounded packaged guest security checks', () => {
+  const cdp = new CdpConnection(new FakeWebSocket())
+  assert.equal(cdp.commandTimeoutMs, 30_000)
+  cdp.close()
 })
 
 test('routes flattened CDP commands and rejects protocol errors', async () => {

--- a/scripts/smoke-packaged-video-editor-desktop.cjs
+++ b/scripts/smoke-packaged-video-editor-desktop.cjs
@@ -151,6 +151,7 @@ async function main() {
     const settings = desktopVideoEditorSettings({
       runtimePort,
       workspaceRoot,
+      dataDir: profile,
       modelBaseUrl: modelFixture.baseUrl
     })
     const serializedSettings = `${JSON.stringify(settings, null, 2)}\n`
@@ -434,8 +435,8 @@ async function main() {
   }
 }
 
-function desktopVideoEditorSettings({ runtimePort, workspaceRoot, modelBaseUrl }) {
-  const base = desktopSmokeSettings(runtimePort, workspaceRoot)
+function desktopVideoEditorSettings({ runtimePort, workspaceRoot, dataDir, modelBaseUrl }) {
+  const base = desktopSmokeSettings(runtimePort, workspaceRoot, dataDir)
   return {
     ...base,
     locale: 'zh',

--- a/scripts/smoke-packaged-video-editor-desktop.test.cjs
+++ b/scripts/smoke-packaged-video-editor-desktop.test.cjs
@@ -48,11 +48,13 @@ test('seeds a Chinese light desktop profile against an offline OpenAI-compatible
   const settings = desktopVideoEditorSettings({
     runtimePort: 43123,
     workspaceRoot: '/isolated/workspace',
+    dataDir: '/isolated/home/.kun/data',
     modelBaseUrl: 'http://127.0.0.1:43124/v1'
   })
   assert.equal(settings.locale, 'zh')
   assert.equal(settings.theme, 'light')
   assert.equal(settings.workspaceRoot, '/isolated/workspace')
+  assert.equal(settings.agents.kun.dataDir, '/isolated/home/.kun/data')
   assert.equal(settings.agents.kun.port, 43123)
   assert.equal(settings.agents.kun.baseUrl, 'http://127.0.0.1:43124/v1')
   assert.equal(settings.agents.kun.model, MODEL_NAME)

--- a/scripts/smoke-packaged-video-editor-layout.cjs
+++ b/scripts/smoke-packaged-video-editor-layout.cjs
@@ -94,6 +94,7 @@ async function main() {
     const settings = desktopVideoEditorSettings({
       runtimePort,
       workspaceRoot,
+      dataDir: profile,
       modelBaseUrl: 'http://127.0.0.1:9/v1'
     })
     const serializedSettings = `${JSON.stringify(settings, null, 2)}\n`


### PR DESCRIPTION
## Summary

Retry the Kun 0.2.27 release after the previous release workflow exposed cross-platform Extension native media and packaged desktop smoke failures.

## Changes

- Run Windows supervised-process fixtures through the Node executable so cancellation semantics are tested instead of failing on extensionless fixture startup.
- Accept current FFmpeg filter capability flags on macOS.
- Make packaged desktop Chromium validation recover from Electron target/session replacement and execution-context navigation.
- Isolate Linux desktop smoke state and disable accessibility/credential-store interference in CI without changing production behavior.

## Tests

- PR Checks typecheck and test: passed
- Linux AppImage packaged validation: passed
- macOS x64/arm64 ad-hoc packaged validation: passed
- Windows NSIS packaged validation: passed
- CodeQL: passed

Validation run: https://github.com/KunAgent/Kun/actions/runs/29607589931