### PR TITLE
fix(runtime): exclude restart-only fields from hot config apply

### DIFF
--- a/src/main/runtime/kun-runtime-config-service.test.ts
+++ b/src/main/runtime/kun-runtime-config-service.test.ts
@@ -6,6 +6,12 @@ import {
   resolveKunRuntimeSettings
 } from '../../shared/app-settings'
 import { KunConfigSchema } from '../../../kun/src/config/kun-config.js'
+import {
+  RuntimeConfigApplyRequest,
+  type RuntimeConfigApplyRequest as RuntimeConfigApplyPayload
+} from '../../../kun/src/contracts/runtime-config.js'
+import { applyRuntimeConfig } from '../../../kun/src/server/routes/runtime-config.js'
+import type { ServerRuntime } from '../../../kun/src/server/routes/server-runtime.js'
 import type { AppSettingsV1 } from '../../shared/app-settings'
 import {
   buildManagedRuntimeHotApplyBody,
@@ -13,7 +19,7 @@ import {
 } from './kun-runtime-config-service'
 
 describe('Kun runtime config service', () => {
-  it('projects canonical runtime fields into a hot-apply body', () => {
+  it('projects canonical runtime fields into a hot-apply body without restart-only config', async () => {
     const runtime = {
       ...defaultKunRuntimeSettings(),
       apiKey: 'sk-test',
@@ -29,7 +35,15 @@ describe('Kun runtime config service', () => {
       agents: { kun: runtime }
     })
     const body = buildManagedRuntimeHotApplyBody(settings, KunConfigSchema.parse({
-      serve: { host: '127.0.0.1', port: 18899, providers: {} }
+      serve: {
+        host: '127.0.0.1',
+        port: 18899,
+        dataDir: '/tmp/kun-data',
+        runtimeToken: 'runtime-token',
+        insecure: false,
+        storage: { backend: 'hybrid' },
+        providers: {}
+      }
     }))
 
     expect(body.serve).toMatchObject({
@@ -40,6 +54,43 @@ describe('Kun runtime config service', () => {
       sandboxMode: 'read-only',
       providers: {}
     })
+    expect(body.serve).not.toHaveProperty('host')
+    expect(body.serve).not.toHaveProperty('port')
+    expect(body.serve).not.toHaveProperty('dataDir')
+    expect(body.serve).not.toHaveProperty('runtimeToken')
+    expect(body.serve).not.toHaveProperty('insecure')
+    expect(body.serve).not.toHaveProperty('storage')
+    expect(RuntimeConfigApplyRequest.safeParse(body).success).toBe(true)
+
+    const received: RuntimeConfigApplyPayload[] = []
+    const serverRuntime: Pick<ServerRuntime, 'applyConfig'> = {
+      applyConfig: async (request) => {
+        received.push(request)
+        return { ok: true as const }
+      }
+    }
+    const response = await applyRuntimeConfig(
+      serverRuntime as ServerRuntime,
+      new Request('http://127.0.0.1/v1/runtime/config/apply', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+    )
+
+    expect(response).not.toBeInstanceOf(Response)
+    if (response instanceof Response) throw new Error('expected JSON response')
+    expect(response.status).toBe(200)
+    expect(JSON.parse(response.body)).toEqual({ ok: true })
+    expect(received).toHaveLength(1)
+    const applied = received[0]!
+    expect(applied).toEqual(body)
+    expect(applied.serve).not.toHaveProperty('host')
+    expect(applied.serve).not.toHaveProperty('port')
+    expect(applied.serve).not.toHaveProperty('dataDir')
+    expect(applied.serve).not.toHaveProperty('runtimeToken')
+    expect(applied.serve).not.toHaveProperty('insecure')
+    expect(applied.serve).not.toHaveProperty('storage')
   })
 
   it('classifies compatibility fallback, success, restart, and failure responses', () => {

--- a/src/main/runtime/kun-runtime-config-service.ts
+++ b/src/main/runtime/kun-runtime-config-service.ts
@@ -10,6 +10,10 @@ import {
   RuntimeTuningConfigSchema,
   type KunConfig
 } from '../../../kun/src/config/kun-config.js'
+import {
+  RuntimeConfigApplyRequest,
+  type RuntimeConfigApplyRequest as RuntimeConfigApplyPayload
+} from '../../../kun/src/contracts/runtime-config.js'
 import { HooksConfigSchema } from '../../../kun/src/hooks/hook-config.js'
 import {
   AttachmentsCapabilityConfig,
@@ -220,14 +224,23 @@ type KunRuntimeConfigSettings = Pick<KunRuntimeSettingsV1,
 export function buildManagedRuntimeHotApplyBody(
   settings: AppSettingsV1,
   config: KunConfig
-): KunConfig {
+): RuntimeConfigApplyPayload {
   const runtime = resolveKunRuntimeSettings(settings)
   const serve = config.serve ?? {}
+  // Process-owned fields are valid in persisted config, but the hot-apply API
+  // deliberately rejects them because changing them requires a restart.
+  const hotServe = { ...serve }
+  delete hotServe.host
+  delete hotServe.port
+  delete hotServe.dataDir
+  delete hotServe.runtimeToken
+  delete hotServe.insecure
+  delete hotServe.storage
   const defaultClientApiKey = resolveCodexOAuthApiKey(runtime.apiKey).apiKey
-  return {
+  return RuntimeConfigApplyRequest.parse({
     ...config,
     serve: {
-      ...serve,
+      ...hotServe,
       apiKey: defaultClientApiKey || runtime.apiKey,
       baseUrl: runtime.baseUrl,
       modelProxyUrl: resolveModelProviderProxyUrl(settings),
@@ -240,7 +253,7 @@ export function buildManagedRuntimeHotApplyBody(
       toolOutputLimits: runtime.toolOutputLimits,
       providers: serve.providers ?? {}
     }
-  }
+  })
 }
 
 /** Pure response policy: callers own logging, retry, restart, and status effects. */


### PR DESCRIPTION
## Problem
Applying GUI-managed runtime settings could return HTTP 400 because the persisted `serve` object includes process-owned fields such as `storage` that the strict hot-apply route rejects.

## Root cause
The main-process projection reused the complete persisted `KunConfig` instead of the `RuntimeConfigApplyRequest` contract.

## Scope
This PR only makes the hot-apply request obey that existing contract. It does not introduce the broader versioned migration work tracked by #886.

## Changes
- Remove restart-only `serve` fields before hot apply.
- Parse the outbound body with the shared strict request schema.
- Add a route-level regression test for a persisted hybrid storage config.

## Safety
Persisted configuration is unchanged. The removed fields remain available to normal runtime startup and still require a restart when changed.

## Validation
- `npm.cmd exec vitest run src/main/runtime/kun-runtime-config-service.test.ts` (2 passed)
- `npm.cmd --prefix kun test -- tests/http-server.test.ts` (51 passed)
- `npm.cmd run typecheck`
- `npm.cmd --prefix kun run typecheck`
- `npm.cmd exec eslint -- src/main/runtime/kun-runtime-config-service.ts src/main/runtime/kun-runtime-config-service.test.ts`
- `npm.cmd run build`
- latest-source integration test: config projection -> `/v1/runtime/config/apply` -> `applyConfig` stub (200)

`npm.cmd run lint` was also attempted on a fresh latest-develop install but exceeded 15 minutes without output on this Windows machine; it is not claimed as passing. The canonical GitHub lint/typecheck/package checks remain required.

## Review performed
Functional correctness, request-contract ownership, runtime lifecycle, data integrity, secret handling, cross-platform behavior, test validity, and PR scope were reviewed. No blocker or high-severity finding remains.

## PR size
- Production files: 1
- Test files: 1
- Production LOC: +16/-2
- Total diff: +71/-6

## Issue
Part of #886