### PR TITLE
fix(tools): keep glob question marks within paths

### DIFF
--- a/kun/src/adapters/tool/builtin-tool-utils.test.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 import {
   createShellCommandRunner,
+  globToRegExp,
   makeListEntry,
   normalizeToolPath,
   resolveExecutable,
@@ -440,5 +441,29 @@ describe('tool path normalization', () => {
     const entry = makeListEntry('/workspace/src/index.ts', '/workspace', fileStat)
 
     expect(entry.relative_path).toBe('src/index.ts')
+  })
+})
+
+describe('globToRegExp', () => {
+  it('matches ? as exactly one non-separator character', () => {
+    const matcher = globToRegExp('src/?.ts')
+
+    expect(matcher.test('src/a.ts')).toBe(true)
+    expect(matcher.test('src/A.ts')).toBe(true)
+    expect(matcher.test('src/😀.ts')).toBe(true)
+    expect(matcher.test('src/ab.ts')).toBe(false)
+    expect(matcher.test('src/😀😀.ts')).toBe(false)
+    expect(matcher.test('src/.ts')).toBe(false)
+    expect(matcher.test('src/a/b.ts')).toBe(false)
+  })
+
+  it('keeps the optional **/ prefix without allowing ? to cross directories', () => {
+    const matcher = globToRegExp('**/a?.tsx')
+
+    expect(matcher.test('ab.tsx')).toBe(true)
+    expect(matcher.test('src/ab.tsx')).toBe(true)
+    expect(matcher.test('src/nested/ab.tsx')).toBe(true)
+    expect(matcher.test('src/nested/abc.tsx')).toBe(false)
+    expect(matcher.test('src/nested/a/b.tsx')).toBe(false)
   })
 })

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -1022,9 +1022,9 @@ export function globToRegExp(pattern: string): RegExp {
   const withWildcards = escaped
     .replace(/\*\*/g, '::DOUBLE_STAR::')
     .replace(/\*/g, '[^/]*')
-    .replace(/\?/g, '.')
+    .replace(/\?/g, '[^/]')
     .replace(/::DOUBLE_STAR::/g, '.*')
-  return new RegExp(`^${optionalPrefix ? '(?:.*/)?' : ''}${withWildcards}$`, 'i')
+  return new RegExp(`^${optionalPrefix ? '(?:.*/)?' : ''}${withWildcards}$`, 'iu')
 }
 
 export function normalizeToolPath(value: string): string {


### PR DESCRIPTION
## Summary

- Splits the valuable glob fix out of mixed PR #961 and rebuilds it on the current `develop` branch.

## Changes

- Makes `?` match exactly one Unicode code point within a path segment.
- Prevents `?` from matching `/` and preserves optional `**/` behavior.

## Tests

- Focused builtin-tool utility suite (29 passed), including ASCII, separators, optional `**/`, and emoji cases.
- Full Kun suite (2142 passed, 1 skipped).
- Kun typecheck/build, targeted ESLint, and `git diff --check`.

Original contribution: @fix2015 in #961.

Replaces the glob portion of #961.
