### PR TITLE
fix(permissions): scope external path approval per call

### DIFF
--- a/kun/src/adapters/tool/builtin-file-tools.ts
+++ b/kun/src/adapters/tool/builtin-file-tools.ts
@@ -1,3 +1,5 @@
+import { constants } from 'node:fs'
+import { open, stat, type FileHandle } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { LocalToolHost, type LocalTool } from './local-tool-host.js'
 import {
@@ -12,9 +14,83 @@ import {
 } from './edit-diff.js'
 import { withFileMutationQueue } from './file-mutation-queue.js'
 import type { EditLocalToolOptions, WriteLocalToolOptions } from './builtin-tool-types.js'
+import type { ApprovedExternalWriteTarget, ToolHostContext } from '../../ports/tool-host.js'
 import { defaultEditLocalToolOperations, defaultWriteLocalToolOperations } from './builtin-tool-operations.js'
 import { parseEditInstructions, resolveWorkspacePath, withToolBoundary } from './builtin-tool-utils.js'
 import { assertCanWritePath } from './sandbox-policy.js'
+import { resolvePathThroughSymlinks, sameFilesystemPath } from './workspace-path.js'
+
+function approvedExternalTarget(
+  absolutePath: string,
+  context: Pick<ToolHostContext, 'approvedExternalWriteTargets'>
+): ApprovedExternalWriteTarget | undefined {
+  return context.approvedExternalWriteTargets?.find((target) =>
+    sameFilesystemPath(target.path, absolutePath)
+  )
+}
+
+async function openVerifiedExternalTarget(
+  target: ApprovedExternalWriteTarget,
+  access: 'write' | 'edit',
+  openFile: (path: string, flags: number) => Promise<FileHandle> = open
+): Promise<FileHandle> {
+  const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
+  const flags = (access === 'edit' ? constants.O_RDWR : constants.O_WRONLY) | noFollow
+  const handle = await openFile(target.path, flags)
+  try {
+    const current = await handle.stat({ bigint: true })
+    if (
+      !current.isFile() ||
+      current.ino === 0n ||
+      current.dev !== target.device ||
+      current.ino !== target.inode
+    ) {
+      throw new Error(`approved external file changed before execution: ${target.path}`)
+    }
+    if (current.nlink !== 1n) {
+      throw new Error(`approved external file must have exactly one hard link: ${target.path}`)
+    }
+    const currentParent = await stat(dirname(target.path), { bigint: true })
+    const currentPhysicalPath = await resolvePathThroughSymlinks(target.path)
+    if (
+      !currentParent.isDirectory() ||
+      currentParent.ino === 0n ||
+      currentParent.dev !== target.parentDevice ||
+      currentParent.ino !== target.parentInode ||
+      !sameFilesystemPath(currentPhysicalPath, target.path)
+    ) {
+      throw new Error(`approved external file parent changed before execution: ${target.path}`)
+    }
+    return handle
+  } catch (error) {
+    await handle.close().catch(() => undefined)
+    throw error
+  }
+}
+
+async function writeTextToHandle(
+  handle: FileHandle,
+  content: string,
+  target: ApprovedExternalWriteTarget
+): Promise<void> {
+  const current = await handle.stat({ bigint: true })
+  if (current.nlink !== 1n) {
+    throw new Error(`approved external file must have exactly one hard link: ${target.path}`)
+  }
+  const buffer = Buffer.from(content, 'utf8')
+  let offset = 0
+  while (offset < buffer.length) {
+    const { bytesWritten } = await handle.write(
+      buffer,
+      offset,
+      buffer.length - offset,
+      offset
+    )
+    if (bytesWritten <= 0) throw new Error('external file write made no progress')
+    offset += bytesWritten
+  }
+  await handle.truncate(buffer.length)
+}
 
 /**
  * Arguments that failed JSON parsing arrive as `{ __raw: "<partial json>" }`
@@ -38,6 +114,7 @@ function truncatedArgumentsError(raw: unknown): { output: { error: string }; isE
 export function createWriteLocalTool(_options: WriteLocalToolOptions = {}): LocalTool {
   const mkdirOp = _options.operations?.mkdir ?? defaultWriteLocalToolOperations.mkdir!
   const writeFileOp = _options.operations?.writeFile ?? defaultWriteLocalToolOperations.writeFile!
+  const openExternalOp = _options.operations?.openExternal ?? open
   return LocalToolHost.defineTool({
     name: 'write',
     description: 'Create or overwrite a workspace file with the provided content.',
@@ -52,6 +129,7 @@ export function createWriteLocalTool(_options: WriteLocalToolOptions = {}): Loca
     },
     policy: 'on-request',
     toolKind: 'file_change',
+    externalWritePathArguments: ['path'],
     execute: async (args, context) => withToolBoundary(async () => {
       const truncated = truncatedArgumentsError(args.__raw)
       if (truncated) return truncated
@@ -63,8 +141,18 @@ export function createWriteLocalTool(_options: WriteLocalToolOptions = {}): Loca
       const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       assertCanWritePath(absolutePath, context)
       return withFileMutationQueue(absolutePath, async () => {
-        await mkdirOp(dirname(absolutePath))
-        await writeFileOp(absolutePath, content)
+        const externalTarget = approvedExternalTarget(absolutePath, context)
+        if (externalTarget) {
+          const handle = await openVerifiedExternalTarget(externalTarget, 'write', openExternalOp)
+          try {
+            await writeTextToHandle(handle, content, externalTarget)
+          } finally {
+            await handle.close()
+          }
+        } else {
+          await mkdirOp(dirname(absolutePath))
+          await writeFileOp(absolutePath, content)
+        }
         return {
           output: {
             path: absolutePath,
@@ -83,6 +171,7 @@ export const createWriteToolDefinition = createWriteLocalTool
 export function createEditLocalTool(_options: EditLocalToolOptions = {}): LocalTool {
   const readFileOp = _options.operations?.readFile ?? defaultEditLocalToolOperations.readFile!
   const writeFileOp = _options.operations?.writeFile ?? defaultEditLocalToolOperations.writeFile!
+  const openExternalOp = _options.operations?.openExternal ?? open
   return LocalToolHost.defineTool({
     name: 'edit',
     description: 'Edit a workspace file using exact text replacement. Supports multiple disjoint edits in one call.',
@@ -110,6 +199,7 @@ export function createEditLocalTool(_options: EditLocalToolOptions = {}): LocalT
     },
     policy: 'on-request',
     toolKind: 'file_change',
+    externalWritePathArguments: ['path'],
     execute: async (args, context) => withToolBoundary(async () => {
       const truncated = truncatedArgumentsError(args.__raw)
       if (truncated) return truncated
@@ -121,25 +211,40 @@ export function createEditLocalTool(_options: EditLocalToolOptions = {}): LocalT
       const { absolutePath, relativePath } = await resolveWorkspacePath(rawPath, context)
       assertCanWritePath(absolutePath, context)
       return withFileMutationQueue(absolutePath, async () => {
-        const rawSource = await readFileOp(absolutePath)
-        const { bom, text: source } = stripBom(rawSource)
-        const lineEnding = detectLineEnding(source)
-        const normalizedSource = normalizeToLF(source)
-        const { baseContent, newContent } = applyEditsToNormalizedContent(normalizedSource, edits, relativePath)
-        const next = bom + restoreLineEndings(newContent, lineEnding)
-        await writeFileOp(absolutePath, next)
-        const diff = generateDisplayDiff(baseContent, newContent)
-        const patch = generateUnifiedPatch(relativePath, baseContent, newContent)
-        return {
-          output: {
-            path: absolutePath,
-            relative_path: relativePath,
-            replacements: edits.length,
-            bytes_written: Buffer.byteLength(next, 'utf8'),
-            diff,
-            patch,
-            first_changed_line: firstChangedLine(baseContent, newContent)
+        const externalTarget = approvedExternalTarget(absolutePath, context)
+        const handle = externalTarget
+          ? await openVerifiedExternalTarget(externalTarget, 'edit', openExternalOp)
+          : undefined
+        try {
+          const rawSource = handle
+            ? await handle.readFile({ encoding: 'utf8' })
+            : await readFileOp(absolutePath)
+          const { bom, text: source } = stripBom(rawSource)
+          const lineEnding = detectLineEnding(source)
+          const normalizedSource = normalizeToLF(source)
+          const { baseContent, newContent } = applyEditsToNormalizedContent(normalizedSource, edits, relativePath)
+          const next = bom + restoreLineEndings(newContent, lineEnding)
+          if (handle) {
+            if (!externalTarget) throw new Error('external edit handle is missing its approved target')
+            await writeTextToHandle(handle, next, externalTarget)
+          } else {
+            await writeFileOp(absolutePath, next)
           }
+          const diff = generateDisplayDiff(baseContent, newContent)
+          const patch = generateUnifiedPatch(relativePath, baseContent, newContent)
+          return {
+            output: {
+              path: absolutePath,
+              relative_path: relativePath,
+              replacements: edits.length,
+              bytes_written: Buffer.byteLength(next, 'utf8'),
+              diff,
+              patch,
+              first_changed_line: firstChangedLine(baseContent, newContent)
+            }
+          }
+        } finally {
+          await handle?.close()
         }
       })
     })

--- a/kun/src/adapters/tool/builtin-tool-types.ts
+++ b/kun/src/adapters/tool/builtin-tool-types.ts
@@ -1,4 +1,5 @@
 import { stat } from 'node:fs/promises'
+import type { FileHandle } from 'node:fs/promises'
 import type { LocalTool } from './local-tool-host.js'
 
 export type FsStats = NonNullable<Awaited<ReturnType<typeof stat>>>
@@ -235,11 +236,15 @@ export interface BashLocalToolOperations {
 export interface WriteLocalToolOperations {
   mkdir?: (path: string) => Promise<void>
   writeFile?: (path: string, content: string) => Promise<void>
+  /** Test/composition seam; the returned handle is always identity-verified before use. */
+  openExternal?: (path: string, flags: number) => Promise<FileHandle>
 }
 
 export interface EditLocalToolOperations {
   readFile?: (path: string) => Promise<string>
   writeFile?: (path: string, content: string) => Promise<void>
+  /** Test/composition seam; the returned handle is always identity-verified before use. */
+  openExternal?: (path: string, flags: number) => Promise<FileHandle>
 }
 
 export interface GrepLocalToolOperations {

--- a/kun/src/adapters/tool/builtin-tool-utils.ts
+++ b/kun/src/adapters/tool/builtin-tool-utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { lstat, readFile, readdir, readlink, realpath, stat } from 'node:fs/promises'
+import { readFile, readdir, stat } from 'node:fs/promises'
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path'
 import type { ToolHostContext } from '../../ports/tool-host.js'
@@ -16,6 +16,15 @@ import type {
   TruncateMode
 } from './builtin-tool-types.js'
 import { COMPACT_RESOURCE_FILE_NAMES } from './builtin-tool-types.js'
+import {
+  isPathInsideOrEqual,
+  resolveExistingWorkspaceRoot,
+  resolvePathThroughSymlinks,
+  sameFilesystemPath,
+  workspaceRoot
+} from './workspace-path.js'
+
+export { workspaceRoot } from './workspace-path.js'
 
 type SpawnSyncLike = typeof spawnSync
 type SpawnLike = typeof spawn
@@ -65,11 +74,6 @@ export async function withToolBoundary(
   }
 }
 
-export function workspaceRoot(workspace: string): string {
-  if (!workspace.trim()) return process.cwd()
-  return isAbsolute(workspace) ? resolve(workspace) : resolve(process.cwd(), workspace)
-}
-
 export async function resolveWorkspacePath(
   inputPath: string,
   context: ToolHostContext,
@@ -107,89 +111,24 @@ export async function resolveWorkspacePath(
       relativePath: normalizeToolPath(relative(root, lexicalAbsolutePath) || '.')
     }
   }
-  const resolvedRoot = await safeRealpath(root)
-  if (resolvedRoot === null) {
-    // Workspace root itself does not exist; nothing to anchor the escape
-    // check against. This is distinct from an actual escape (handled below).
-    throw new Error(`workspace root does not exist: ${root}`)
-  }
-  const resolvedAbsolute = await resolveSymlinkSafe(lexicalAbsolutePath)
-  const resolvedRelative = relative(resolvedRoot, resolvedAbsolute)
-  if (resolvedRelative === '..' || resolvedRelative.startsWith(`..${sep}`) || isAbsolute(resolvedRelative)) {
+  const { physicalRoot } = await resolveExistingWorkspaceRoot(root)
+  const resolvedAbsolute = await resolvePathThroughSymlinks(lexicalAbsolutePath)
+  const isInsideWorkspace = isPathInsideOrEqual(physicalRoot, resolvedAbsolute)
+  const isApprovedExternalPath = !options.enforceWorkspaceBoundary &&
+    context.approvedExternalWriteTargets?.some((target) =>
+      sameFilesystemPath(target.path, resolvedAbsolute)
+    ) === true
+  if (!isInsideWorkspace && !isApprovedExternalPath) {
     throw new Error(`path escapes the workspace root: ${inputPath}`)
   }
-  // Return LEXICAL paths to callers. The realpath-resolved pair is only used
-  // for the escape check above; downstream code (subprocess cwd, display
-  // paths, language-server init) expects the user-facing workspace path,
-  // which on symlinked roots (e.g. macOS `/tmp` -> `/private/tmp`) would
-  // otherwise diverge from what the user typed and break display layers.
+  // Workspace callers keep the lexical path expected by subprocess/display
+  // layers. External grants use the physical path that was checked so a
+  // symlink alias cannot be redirected after validation.
   return {
     workspaceRoot: root,
-    absolutePath: lexicalAbsolutePath,
+    absolutePath: isApprovedExternalPath ? resolvedAbsolute : lexicalAbsolutePath,
     relativePath: normalizeToolPath(relative(root, lexicalAbsolutePath) || '.')
   }
-}
-
-async function safeRealpath(target: string): Promise<string | null> {
-  try {
-    return await realpath(target)
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code
-    if (code === 'ENOENT') return null
-    if (code === 'EACCES' || code === 'ELOOP' || code === 'ENOTDIR') return null
-    throw error
-  }
-}
-
-// Whether `target` is itself a symbolic link, without following it. Returns
-// false when the entry is absent or cannot be stat-ed (treated as "not a link"
-// — the escape check still anchors against the nearest existing ancestor).
-async function isSymlink(target: string): Promise<boolean> {
-  try {
-    return (await lstat(target)).isSymbolicLink()
-  } catch {
-    return false
-  }
-}
-
-async function resolveSymlinkSafe(lexicalPath: string, depth = 0): Promise<string> {
-  // Guard against symlink loops (dangling link A -> B -> A never resolves).
-  if (depth > 40) {
-    throw new Error(`too many symbolic links resolving: ${lexicalPath}`)
-  }
-  const direct = await safeRealpath(lexicalPath)
-  if (direct !== null) return direct
-  // Target doesn't fully resolve — either a genuinely missing path (write/create
-  // case) or a *dangling* symlink whose target is absent. `realpath` reports
-  // both as ENOENT, so we must walk the components ourselves: anchor on the
-  // nearest existing ancestor, but if a non-resolving component is actually a
-  // symlink, follow it explicitly so the redirection is reflected in the escape
-  // check. Re-anchoring a dangling symlink lexically (the old behavior) let a
-  // planted link like `<ws>/evil -> /etc/passwd` (target absent) pass as an
-  // in-workspace path and escape on the subsequent write.
-  const segments: string[] = []
-  let current = lexicalPath
-  // Guard against pathological component counts.
-  for (let i = 0; i < 128 && current !== dirname(current); i += 1) {
-    const resolved = await safeRealpath(current)
-    if (resolved !== null) {
-      return segments.length > 0 ? resolve(resolved, ...segments) : resolved
-    }
-    if (await isSymlink(current)) {
-      // Dangling (or otherwise non-resolving) symlink: follow its target so the
-      // redirection is reflected, then re-resolve the target plus the suffix
-      // collected below this component.
-      const linkTarget = await readlink(current)
-      const resolvedParent = (await safeRealpath(dirname(current))) ?? dirname(current)
-      const followed = isAbsolute(linkTarget) ? resolve(linkTarget) : resolve(resolvedParent, linkTarget)
-      const rejoined = segments.length > 0 ? resolve(followed, ...segments) : followed
-      return resolveSymlinkSafe(rejoined, depth + 1)
-    }
-    segments.unshift(basename(current))
-    current = dirname(current)
-  }
-  // Nothing on the path exists; treat as escape.
-  throw new Error(`path escapes the workspace root: ${lexicalPath}`)
 }
 
 export function isBinaryBuffer(buffer: Buffer): boolean {

--- a/kun/src/adapters/tool/local-tool-host.test.ts
+++ b/kun/src/adapters/tool/local-tool-host.test.ts
@@ -1,7 +1,12 @@
+import { link, mkdtemp, mkdir, open, readFile, realpath, rename, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { LocalToolHost, echoTool, userInputTool } from './local-tool-host.js'
 import type { ToolHostContext } from '../../ports/tool-host.js'
 import { InMemoryArtifactStore } from '../../artifacts/artifact-store.js'
+import { createEditLocalTool, createWriteLocalTool } from './builtin-file-tools.js'
+import { resolveWorkspacePath, withToolBoundary } from './builtin-tool-utils.js'
 
 describe('LocalToolHost approval policy', () => {
   it('asks before auto tools when approval policy is always', async () => {
@@ -147,6 +152,616 @@ describe('LocalToolHost approval policy', () => {
       toolName: 'touch_workspace_file',
       output: { ok: true }
     })
+  })
+
+  it('writes one exact external target after a per-call approval without mutating the turn context', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-write-'))
+    const workspace = join(parent, 'workspace')
+    const externalDirectory = join(parent, 'external')
+    const target = join(externalDirectory, 'approved.txt')
+    try {
+      await Promise.all([mkdir(workspace), mkdir(externalDirectory)])
+      await writeFile(target, 'original')
+      const physicalTarget = await realpath(target)
+      const awaitApproval = vi.fn(async () => 'allow' as const)
+      const context = {
+        threadId: 'thread_external_write',
+        turnId: 'turn_external_write',
+        workspace,
+        approvalPolicy: 'auto',
+        sandboxMode: 'workspace-write',
+        abortSignal: new AbortController().signal,
+        awaitApproval
+      } satisfies ToolHostContext
+      const host = new LocalToolHost({ tools: [createWriteLocalTool()] })
+
+      const result = await host.execute(
+        {
+          callId: 'call_external_write',
+          toolName: 'write',
+          arguments: { path: target, content: 'approved' }
+        },
+        context
+      )
+
+      expect(awaitApproval).toHaveBeenCalledOnce()
+      expect(awaitApproval).toHaveBeenCalledWith(expect.objectContaining({
+        summary: expect.stringContaining(physicalTarget)
+      }))
+      expect(result.item).toMatchObject({ isError: false })
+      expect(context).not.toHaveProperty('approvedExternalWriteTargets')
+      await expect(readFile(target, 'utf8')).resolves.toBe('approved')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an existing external hard-link alias before approval', async (testContext) => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-hardlink-existing-'))
+    const workspace = join(parent, 'workspace')
+    const target = join(parent, 'target.txt')
+    const alias = join(parent, 'alias.txt')
+    const awaitApproval = vi.fn(async () => 'allow' as const)
+    try {
+      await mkdir(workspace)
+      await writeFile(target, 'original')
+      try {
+        await link(target, alias)
+      } catch {
+        testContext.skip()
+        return
+      }
+      const host = new LocalToolHost({ tools: [createWriteLocalTool()] })
+      const result = await host.execute(
+        {
+          callId: 'call_external_hardlink_existing',
+          toolName: 'write',
+          arguments: { path: target, content: 'must not be written' }
+        },
+        {
+          threadId: 'thread_external_hardlink_existing',
+          turnId: 'turn_external_hardlink_existing',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval
+        }
+      )
+
+      expect(awaitApproval).not.toHaveBeenCalled()
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { error: expect.stringContaining('exactly one hard link') }
+      })
+      await expect(readFile(target, 'utf8')).resolves.toBe('original')
+      await expect(readFile(alias, 'utf8')).resolves.toBe('original')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a hard-link alias added after approval but before open', async (testContext) => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-hardlink-race-'))
+    const workspace = join(parent, 'workspace')
+    const target = join(parent, 'target.txt')
+    const alias = join(parent, 'alias.txt')
+    let hardlinkError: unknown
+    try {
+      await mkdir(workspace)
+      await writeFile(target, 'original')
+      const openExternal = vi.fn(async (path: string, flags: number) => {
+        try {
+          await link(target, alias)
+        } catch (error) {
+          hardlinkError = error
+          throw error
+        }
+        return open(path, flags)
+      })
+      const host = new LocalToolHost({ tools: [createWriteLocalTool({
+        operations: { openExternal }
+      })] })
+      const result = await host.execute(
+        {
+          callId: 'call_external_hardlink_race',
+          toolName: 'write',
+          arguments: { path: target, content: 'must not be written' }
+        },
+        {
+          threadId: 'thread_external_hardlink_race',
+          turnId: 'turn_external_hardlink_race',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: vi.fn(async () => 'allow' as const)
+        }
+      )
+
+      if (hardlinkError) {
+        testContext.skip()
+        return
+      }
+      expect(openExternal).toHaveBeenCalledOnce()
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { error: expect.stringContaining('exactly one hard link') }
+      })
+      await expect(readFile(target, 'utf8')).resolves.toBe('original')
+      await expect(readFile(alias, 'utf8')).resolves.toBe('original')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('does not expand an external grant to a sibling or an enforced workspace boundary', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-exact-'))
+    const workspace = join(parent, 'workspace')
+    const approvedTarget = join(parent, 'approved.txt')
+    const siblingTarget = join(parent, 'sibling.txt')
+    try {
+      await mkdir(workspace)
+      await writeFile(approvedTarget, 'existing')
+      const physicalParent = await realpath(parent)
+      const physicalApprovedTarget = join(physicalParent, 'approved.txt')
+      const execute = vi.fn(async (_args: Record<string, unknown>, context: ToolHostContext) => {
+        await expect(resolveWorkspacePath(approvedTarget, context)).resolves.toMatchObject({
+          absolutePath: physicalApprovedTarget
+        })
+        await expect(resolveWorkspacePath(siblingTarget, context)).rejects.toThrow(/escapes the workspace root/)
+        await expect(resolveWorkspacePath(approvedTarget, context, {
+          enforceWorkspaceBoundary: true
+        })).rejects.toThrow(/escapes the workspace root/)
+        return { output: { ok: true } }
+      })
+      const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
+        name: 'exact_external_write',
+        description: 'exercise exact external grants',
+        inputSchema: { type: 'object' },
+        toolKind: 'file_change',
+        policy: 'auto',
+        externalWritePathArguments: ['path'],
+        execute
+      })] })
+
+      const result = await host.execute(
+        {
+          callId: 'call_exact_external_write',
+          toolName: 'exact_external_write',
+          arguments: { path: approvedTarget }
+        },
+        {
+          threadId: 'thread_exact_external_write',
+          turnId: 'turn_exact_external_write',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: vi.fn(async () => 'allow' as const)
+        }
+      )
+
+      expect(execute).toHaveBeenCalledOnce()
+      expect(result.item).toMatchObject({ output: { ok: true } })
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('does not request approval or write when the workspace root is missing', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-missing-workspace-'))
+    const target = join(parent, 'outside.txt')
+    const awaitApproval = vi.fn(async () => 'allow' as const)
+    try {
+      const host = new LocalToolHost({ tools: [createWriteLocalTool()] })
+      const result = await host.execute(
+        {
+          callId: 'call_missing_workspace',
+          toolName: 'write',
+          arguments: { path: target, content: 'must not be written' }
+        },
+        {
+          threadId: 'thread_missing_workspace',
+          turnId: 'turn_missing_workspace',
+          workspace: join(parent, 'missing-workspace'),
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval
+        }
+      )
+
+      expect(awaitApproval).not.toHaveBeenCalled()
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: {
+          code: 'sandbox_write_blocked',
+          error: expect.stringContaining('workspace root does not exist')
+        }
+      })
+      await expect(readFile(target, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('does not execute an external write when the per-call approval is denied', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-denied-'))
+    const workspace = join(parent, 'workspace')
+    const target = join(parent, 'denied.txt')
+    try {
+      await mkdir(workspace)
+      await writeFile(target, 'original')
+      const host = new LocalToolHost({ tools: [createWriteLocalTool()] })
+      const result = await host.execute(
+        {
+          callId: 'call_external_denied',
+          toolName: 'write',
+          arguments: { path: target, content: 'must not be written' }
+        },
+        {
+          threadId: 'thread_external_denied',
+          turnId: 'turn_external_denied',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: vi.fn(async () => ({ decision: 'deny' as const, reason: 'not this path' }))
+        }
+      )
+
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { code: 'approval_denied', reason: 'not this path' }
+      })
+      await expect(readFile(target, 'utf8')).resolves.toBe('original')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed without prompting when an external write would create a file', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-create-blocked-'))
+    const workspace = join(parent, 'workspace')
+    const target = join(parent, 'new-file.txt')
+    const awaitApproval = vi.fn(async () => 'allow' as const)
+    try {
+      await mkdir(workspace)
+      const host = new LocalToolHost({ tools: [createWriteLocalTool()] })
+      const result = await host.execute(
+        {
+          callId: 'call_external_create_blocked',
+          toolName: 'write',
+          arguments: { path: target, content: 'must not be created' }
+        },
+        {
+          threadId: 'thread_external_create_blocked',
+          turnId: 'turn_external_create_blocked',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval
+        }
+      )
+
+      expect(awaitApproval).not.toHaveBeenCalled()
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { error: expect.stringContaining('requires an existing regular file') }
+      })
+      await expect(readFile(target, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a parent-directory swap after write validation without touching the redirected file', async (testContext) => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-write-race-'))
+    const workspace = join(parent, 'workspace')
+    const approvedDirectory = join(parent, 'approved')
+    const displacedDirectory = join(parent, 'displaced')
+    const protectedDirectory = join(parent, 'protected')
+    const target = join(approvedDirectory, 'target.txt')
+    const protectedTarget = join(protectedDirectory, 'target.txt')
+    let symlinkError: unknown
+    try {
+      await Promise.all([mkdir(workspace), mkdir(approvedDirectory), mkdir(protectedDirectory)])
+      await Promise.all([writeFile(target, 'approved-original'), writeFile(protectedTarget, 'protected')])
+      const openExternal = vi.fn(async (path: string, flags: number) => {
+        await rename(approvedDirectory, displacedDirectory)
+        try {
+          await symlink(
+            protectedDirectory,
+            approvedDirectory,
+            process.platform === 'win32' ? 'junction' : 'dir'
+          )
+        } catch (error) {
+          symlinkError = error
+          throw error
+        }
+        return open(path, flags)
+      })
+      const host = new LocalToolHost({ tools: [createWriteLocalTool({
+        operations: { openExternal }
+      })] })
+
+      const result = await host.execute(
+        {
+          callId: 'call_external_write_race',
+          toolName: 'write',
+          arguments: { path: target, content: 'overwrite' }
+        },
+        {
+          threadId: 'thread_external_write_race',
+          turnId: 'turn_external_write_race',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: vi.fn(async () => 'allow' as const)
+        }
+      )
+
+      if (symlinkError) {
+        testContext.skip()
+        return
+      }
+      expect(openExternal).toHaveBeenCalledOnce()
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { error: expect.stringContaining('approved external file changed before execution') }
+      })
+      await expect(readFile(protectedTarget, 'utf8')).resolves.toBe('protected')
+      await expect(readFile(join(displacedDirectory, 'target.txt'), 'utf8')).resolves.toBe('approved-original')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects edit when the parent is swapped after open but before identity verification', async (testContext) => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-edit-race-'))
+    const workspace = join(parent, 'workspace')
+    const approvedDirectory = join(parent, 'approved')
+    const displacedDirectory = join(parent, 'displaced')
+    const protectedDirectory = join(parent, 'protected')
+    const target = join(approvedDirectory, 'target.txt')
+    const protectedTarget = join(protectedDirectory, 'target.txt')
+    let symlinkError: unknown
+    try {
+      await Promise.all([mkdir(workspace), mkdir(approvedDirectory), mkdir(protectedDirectory)])
+      await Promise.all([writeFile(target, 'alpha'), writeFile(protectedTarget, 'alpha')])
+      const openExternal = vi.fn(async (path: string, flags: number) => {
+        const handle = await open(path, flags)
+        await rename(approvedDirectory, displacedDirectory)
+        try {
+          await symlink(
+            protectedDirectory,
+            approvedDirectory,
+            process.platform === 'win32' ? 'junction' : 'dir'
+          )
+        } catch (error) {
+          symlinkError = error
+          await handle.close()
+          throw error
+        }
+        return handle
+      })
+      const host = new LocalToolHost({ tools: [createEditLocalTool({
+        operations: { openExternal }
+      })] })
+
+      const result = await host.execute(
+        {
+          callId: 'call_external_edit_race',
+          toolName: 'edit',
+          arguments: { path: target, oldText: 'alpha', newText: 'changed' }
+        },
+        {
+          threadId: 'thread_external_edit_race',
+          turnId: 'turn_external_edit_race',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: vi.fn(async () => 'allow' as const)
+        }
+      )
+
+      if (symlinkError) {
+        testContext.skip()
+        return
+      }
+      expect(openExternal).toHaveBeenCalledOnce()
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { error: expect.stringContaining('approved external file parent changed before execution') }
+      })
+      await expect(readFile(protectedTarget, 'utf8')).resolves.toBe('alpha')
+      await expect(readFile(join(displacedDirectory, 'target.txt'), 'utf8')).resolves.toBe('alpha')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves read-before-edit enforcement for approved external files', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-edit-read-guard-'))
+    const workspace = join(parent, 'workspace')
+    const target = join(parent, 'external.txt')
+    const awaitApproval = vi.fn(async () => 'allow' as const)
+    try {
+      await mkdir(workspace)
+      await writeFile(target, 'alpha')
+      const host = new LocalToolHost({ tools: [createEditLocalTool()], readTracker: true })
+      const result = await host.execute(
+        {
+          callId: 'call_external_edit_read_guard',
+          toolName: 'edit',
+          arguments: { path: target, oldText: 'alpha', newText: 'changed' }
+        },
+        {
+          threadId: 'thread_external_edit_read_guard',
+          turnId: 'turn_external_edit_read_guard',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval
+        }
+      )
+
+      expect(awaitApproval).not.toHaveBeenCalled()
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { code: 'read_before_edit_required' }
+      })
+      await expect(readFile(target, 'utf8')).resolves.toBe('alpha')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('edits an existing external file through the verified handle', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-edit-handle-'))
+    const workspace = join(parent, 'workspace')
+    const target = join(parent, 'external.txt')
+    try {
+      await mkdir(workspace)
+      await writeFile(target, 'alpha beta')
+      const host = new LocalToolHost({ tools: [createEditLocalTool()] })
+      const result = await host.execute(
+        {
+          callId: 'call_external_edit_handle',
+          toolName: 'edit',
+          arguments: { path: target, oldText: 'alpha', newText: 'changed' }
+        },
+        {
+          threadId: 'thread_external_edit_handle',
+          turnId: 'turn_external_edit_handle',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: vi.fn(async () => 'allow' as const)
+        }
+      )
+
+      expect(result.item).toMatchObject({ isError: false })
+      await expect(readFile(target, 'utf8')).resolves.toBe('changed beta')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an approved target redirected by a symlink before execution', async (testContext) => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-symlink-'))
+    const workspace = join(parent, 'workspace')
+    const approvedDirectory = join(parent, 'approved')
+    const protectedDirectory = join(parent, 'protected')
+    const target = join(approvedDirectory, 'target.txt')
+    const protectedTarget = join(protectedDirectory, 'target.txt')
+    let symlinkError: unknown
+    try {
+      await Promise.all([
+        mkdir(workspace),
+        mkdir(approvedDirectory),
+        mkdir(protectedDirectory)
+      ])
+      await Promise.all([
+        writeFile(target, 'original'),
+        writeFile(protectedTarget, 'must survive')
+      ])
+      const host = new LocalToolHost({ tools: [createWriteLocalTool()] })
+      const result = await host.execute(
+        {
+          callId: 'call_external_symlink_swap',
+          toolName: 'write',
+          arguments: { path: target, content: 'overwrite' }
+        },
+        {
+          threadId: 'thread_external_symlink_swap',
+          turnId: 'turn_external_symlink_swap',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          abortSignal: new AbortController().signal,
+          awaitApproval: async () => {
+            await rm(approvedDirectory, { recursive: true, force: true })
+            try {
+              await symlink(
+                protectedDirectory,
+                approvedDirectory,
+                process.platform === 'win32' ? 'junction' : 'dir'
+              )
+            } catch (error) {
+              symlinkError = error
+              return 'deny'
+            }
+            return 'allow'
+          }
+        }
+      )
+
+      if (symlinkError) {
+        testContext.skip()
+        return
+      }
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { error: expect.stringContaining('path escapes the workspace root') }
+      })
+      await expect(readFile(protectedTarget, 'utf8')).resolves.toBe('must survive')
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('strips caller-supplied external grants before tool execution', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-external-forged-'))
+    const workspace = join(parent, 'workspace')
+    const target = join(parent, 'forged.txt')
+    try {
+      await mkdir(workspace)
+      const host = new LocalToolHost({ tools: [LocalToolHost.defineTool({
+        name: 'ungranted_write',
+        description: 'must not inherit an external grant',
+        inputSchema: { type: 'object' },
+        toolKind: 'file_change',
+        policy: 'auto',
+        execute: async (_args, context) => withToolBoundary(async () => {
+          await resolveWorkspacePath(target, context)
+          return { output: { ok: true } }
+        })
+      })] })
+
+      const result = await host.execute(
+        { callId: 'call_forged_external_grant', toolName: 'ungranted_write', arguments: {} },
+        {
+          threadId: 'thread_forged_external_grant',
+          turnId: 'turn_forged_external_grant',
+          workspace,
+          approvalPolicy: 'auto',
+          sandboxMode: 'workspace-write',
+          approvedExternalWriteTargets: [{
+            path: target,
+            device: 1n,
+            inode: 1n,
+            parentDevice: 1n,
+            parentInode: 1n
+          }],
+          abortSignal: new AbortController().signal,
+          awaitApproval: vi.fn(async () => 'allow' as const)
+        }
+      )
+
+      expect(result.item).toMatchObject({
+        isError: true,
+        output: { error: expect.stringContaining('path escapes the workspace root') }
+      })
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
   })
 
   it('keeps user input tools advertised without a GUI gate but rejects execution', async () => {

--- a/kun/src/adapters/tool/local-tool-host.ts
+++ b/kun/src/adapters/tool/local-tool-host.ts
@@ -29,7 +29,11 @@ import {
   ReadTracker,
   type ReadTrackerOptions
 } from './read-tracker.js'
-import { sandboxBlockForTool, type SandboxBlock } from './sandbox-policy.js'
+import {
+  externalWriteTargetsForApproval,
+  sandboxBlockForTool,
+  type SandboxBlock
+} from './sandbox-policy.js'
 import {
   createToolOperationIdentity,
   ToolOperationJournal
@@ -56,6 +60,13 @@ export type LocalTool = {
    * such as sending workspace data to a third-party chat channel.
    */
   requiresExplicitApproval?: boolean
+  /**
+   * String argument names that are exact file mutation targets eligible for a
+   * one-call external workspace grant. Tools must opt in explicitly; merely
+   * being a `file_change` tool never grants inferred path arguments. Opted-in
+   * tools must still resolve and validate the target with `resolveWorkspacePath`.
+   */
+  externalWritePathArguments?: readonly string[]
   /**
    * Optional gating predicate. When present, the tool is only listed
    * and only executed when `shouldAdvertise` returns true for the
@@ -203,9 +214,25 @@ export class LocalToolHost implements ToolHost {
         approved: false
       }
     }
+    let externalWriteTargets: Awaited<ReturnType<typeof externalWriteTargetsForApproval>>
+    try {
+      externalWriteTargets = await externalWriteTargetsForApproval(tool, activeCall, context)
+    } catch (error) {
+      return {
+        item: this.errorToolResult(
+          context,
+          activeCall,
+          tool,
+          error instanceof Error ? error.message : String(error),
+          'sandbox_write_blocked'
+        ),
+        approved: false
+      }
+    }
+    const externalPathApproval = externalWriteTargets.length > 0
     // A configured hook may auto-approve ordinary tool calls, but it must not
     // bypass an explicit user decision for an external side effect.
-    const needsApproval = tool.requiresExplicitApproval ||
+    const needsApproval = externalPathApproval || tool.requiresExplicitApproval ||
       (!preHooks.autoApproved && this.requiresApproval(tool, activeCall, context))
     if (needsApproval) {
       const approvalId = `appr_${randomUUID().replaceAll('-', '')}`
@@ -214,7 +241,12 @@ export class LocalToolHost implements ToolHost {
         threadId: context.threadId,
         turnId: context.turnId,
         toolName: activeCall.toolName,
-        summary: this.buildApprovalSummary(activeCall)
+        summary: externalPathApproval
+          ? this.buildExternalPathApprovalSummary(
+              activeCall,
+              externalWriteTargets.map((target) => target.path)
+            )
+          : this.buildApprovalSummary(activeCall)
       })
       const resolution = await context.awaitApproval(approval)
       const decision = typeof resolution === 'string' ? resolution : resolution.decision
@@ -285,9 +317,19 @@ export class LocalToolHost implements ToolHost {
       }
     }
     this.operationJournal.begin(operationIdentity)
+    // Grants are minted by this host after an approval and must never be
+    // accepted from a reused/caller-supplied context.
+    const ungrantedContext = { ...context }
+    delete ungrantedContext.approvedExternalWriteTargets
+    const approvedExternalWriteTargets = Object.freeze(
+      externalWriteTargets.map((target) => Object.freeze({ ...target }))
+    )
+    const executionContext = externalPathApproval
+      ? { ...ungrantedContext, approvedExternalWriteTargets }
+      : ungrantedContext
     let result: Awaited<ReturnType<LocalTool['execute']>>
     try {
-      result = await tool.execute(activeCall.arguments, context, async (update) => {
+      result = await tool.execute(activeCall.arguments, executionContext, async (update) => {
         if (!onUpdate) return
         const partialItem = makeToolResultItem({
           id: `item_${activeCall.callId}`,
@@ -401,6 +443,11 @@ export class LocalToolHost implements ToolHost {
     return `Run ${call.toolName}(${args})`
   }
 
+  private buildExternalPathApprovalSummary(call: ToolCallLike, paths: readonly string[]): string {
+    const targets = paths.map((path) => JSON.stringify(path)).join(', ')
+    return `Allow ${call.toolName} to modify these exact paths outside the workspace for this call only: ${targets}`
+  }
+
   private completedToolResult(
     context: ToolHostContext,
     call: ToolCallLike,
@@ -454,7 +501,10 @@ export class LocalToolHost implements ToolHost {
       toolKind: tool.toolKind ?? 'tool_call',
       execute: tool.execute,
       ...(tool.shouldAdvertise ? { shouldAdvertise: tool.shouldAdvertise } : {}),
-      ...(tool.requiresExplicitApproval ? { requiresExplicitApproval: true } : {})
+      ...(tool.requiresExplicitApproval ? { requiresExplicitApproval: true } : {}),
+      ...(tool.externalWritePathArguments?.length
+        ? { externalWritePathArguments: [...tool.externalWritePathArguments] }
+        : {})
     }
   }
 }

--- a/kun/src/adapters/tool/sandbox-policy.test.ts
+++ b/kun/src/adapters/tool/sandbox-policy.test.ts
@@ -1,5 +1,13 @@
+import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { canWritePath, sandboxBlockForTool } from './sandbox-policy.js'
+import {
+  canWritePath,
+  externalWriteTargetsForApproval,
+  sandboxBlockForTool
+} from './sandbox-policy.js'
+import { sameFilesystemPath } from './workspace-path.js'
 
 describe('sandbox policy', () => {
   it('limits workspace-write file mutations to the workspace', () => {
@@ -15,6 +23,120 @@ describe('sandbox policy', () => {
         code: 'sandbox_write_blocked'
       }
     })
+  })
+
+  it('resolves only explicitly declared external write targets for approval', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-sandbox-policy-'))
+    const workspace = join(parent, 'workspace')
+    try {
+      await mkdir(workspace)
+      const tool = {
+        toolKind: 'file_change' as const,
+        externalWritePathArguments: ['path']
+      }
+      const physicalParent = await realpath(parent)
+      await writeFile(join(parent, 'outside.txt'), 'existing')
+      const targets = await externalWriteTargetsForApproval(
+        tool,
+        { arguments: { path: '../outside.txt' } },
+        { workspace, sandboxMode: 'workspace-write' }
+      )
+      expect(targets).toHaveLength(1)
+      expect(targets[0]).toMatchObject({
+        path: resolve(physicalParent, 'outside.txt')
+      })
+      expect(typeof targets[0]?.device).toBe('bigint')
+      expect(typeof targets[0]?.inode).toBe('bigint')
+      expect(typeof targets[0]?.parentDevice).toBe('bigint')
+      expect(typeof targets[0]?.parentInode).toBe('bigint')
+      await expect(externalWriteTargetsForApproval(
+        tool,
+        { arguments: { path: 'src/app.ts' } },
+        { workspace, sandboxMode: 'workspace-write' }
+      )).resolves.toEqual([])
+      await expect(externalWriteTargetsForApproval(
+        { toolKind: 'file_change' },
+        { arguments: { path: '../outside.txt' } },
+        { workspace, sandboxMode: 'workspace-write' }
+      )).resolves.toEqual([])
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed before approval when the workspace fixture does not exist', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-sandbox-missing-workspace-'))
+    try {
+      await expect(externalWriteTargetsForApproval(
+        {
+          toolKind: 'file_change',
+          externalWritePathArguments: ['path']
+        },
+        { arguments: { path: join(parent, 'outside.txt') } },
+        { workspace: join(parent, 'missing-workspace'), sandboxMode: 'workspace-write' }
+      )).rejects.toThrow(/workspace root does not exist/)
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed for a nonexistent external write target', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'kun-sandbox-missing-target-'))
+    const workspace = join(parent, 'workspace')
+    try {
+      await mkdir(workspace)
+      await expect(externalWriteTargetsForApproval(
+        {
+          toolKind: 'file_change',
+          externalWritePathArguments: ['path']
+        },
+        { arguments: { path: join(parent, 'new-external.txt') } },
+        { workspace, sandboxMode: 'workspace-write' }
+      )).rejects.toThrow(/requires an existing regular file/)
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
+  })
+
+  it('allows only the exact target carried by the active grant', () => {
+    expect(canWritePath('/repo/other/app.ts', {
+      workspace: '/repo/workspace',
+      sandboxMode: 'workspace-write',
+      approvedExternalWriteTargets: [{
+        path: '/repo/other/app.ts',
+        device: 1n,
+        inode: 2n,
+        parentDevice: 1n,
+        parentInode: 3n
+      }]
+    })).toEqual({ ok: true })
+    expect(canWritePath('/repo/other/sibling.ts', {
+      workspace: '/repo/workspace',
+      sandboxMode: 'workspace-write',
+      approvedExternalWriteTargets: [{
+        path: '/repo/other/app.ts',
+        device: 1n,
+        inode: 2n,
+        parentDevice: 1n,
+        parentInode: 3n
+      }]
+    })).toMatchObject({ ok: false })
+  })
+
+  it('uses case-insensitive exact matching only for Windows paths', () => {
+    expect(sameFilesystemPath(
+      'C:\\Users\\Example\\Target.txt',
+      'c:/users/example/TARGET.txt',
+      'win32'
+    )).toBe(true)
+    expect(sameFilesystemPath(
+      'C:\\Users\\Example\\Target.txt',
+      'C:\\Users\\Example\\Sibling.txt',
+      'win32'
+    )).toBe(false)
+    expect(sameFilesystemPath('/Users/Example/Target.txt', '/users/example/target.txt', 'linux')).toBe(false)
+    expect(sameFilesystemPath(`/repo/target${'/'.repeat(100_000)}`, '/repo/target', 'linux')).toBe(true)
+    expect(sameFilesystemPath('/repo/target\\', '/repo/target', 'linux')).toBe(false)
   })
 
   it('keeps command execution blocked in workspace-write mode', () => {

--- a/kun/src/adapters/tool/sandbox-policy.ts
+++ b/kun/src/adapters/tool/sandbox-policy.ts
@@ -1,16 +1,100 @@
-import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { dirname, isAbsolute, resolve } from 'node:path'
+import type { BigIntStats } from 'node:fs'
+import { stat } from 'node:fs/promises'
 import {
   DEFAULT_SANDBOX_MODE,
   SandboxModeSchema,
   type SandboxMode
 } from '../../contracts/policy.js'
-import type { ToolHostContext } from '../../ports/tool-host.js'
+import type {
+  ApprovedExternalWriteTarget,
+  ToolCallLike,
+  ToolHostContext
+} from '../../ports/tool-host.js'
 import type { LocalTool } from './local-tool-host.js'
-import { workspaceRoot } from './builtin-tool-utils.js'
+import {
+  isPathInsideOrEqual,
+  resolveExistingWorkspaceRoot,
+  resolvePathThroughSymlinks,
+  sameFilesystemPath,
+  workspaceRoot
+} from './workspace-path.js'
 
 export type SandboxBlock = {
   code: 'sandbox_read_only' | 'sandbox_command_blocked' | 'sandbox_write_blocked'
   message: string
+}
+
+/**
+ * Resolve exact external targets that an opted-in file tool wants to mutate.
+ * The physical targets captured here are compared again immediately before the
+ * tool writes, closing approval-prompt symlink/junction redirection.
+ */
+export async function externalWriteTargetsForApproval(
+  tool: Pick<LocalTool, 'toolKind' | 'externalWritePathArguments'>,
+  call: Pick<ToolCallLike, 'arguments'>,
+  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode'>
+): Promise<ApprovedExternalWriteTarget[]> {
+  if (
+    tool.toolKind !== 'file_change' ||
+    effectiveSandboxMode(context) !== 'workspace-write' ||
+    !tool.externalWritePathArguments?.length
+  ) {
+    return []
+  }
+
+  const { lexicalRoot, physicalRoot } = await resolveExistingWorkspaceRoot(context.workspace)
+  const externalTargets: ApprovedExternalWriteTarget[] = []
+  for (const argumentName of tool.externalWritePathArguments) {
+    const value = call.arguments[argumentName]
+    if (typeof value !== 'string' || !value.trim()) continue
+    const lexicalTarget = isAbsolute(value) ? resolve(value) : resolve(lexicalRoot, value)
+    const physicalTarget = await resolvePathThroughSymlinks(lexicalTarget)
+    if (
+      !isPathInsideOrEqual(physicalRoot, physicalTarget) &&
+      !externalTargets.some((target) => sameFilesystemPath(target.path, physicalTarget))
+    ) {
+      let targetStats: BigIntStats
+      try {
+        targetStats = await stat(physicalTarget, { bigint: true })
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(
+            `external write approval requires an existing regular file: ${physicalTarget}`
+          )
+        }
+        throw error
+      }
+      if (!targetStats.isFile() || targetStats.ino === 0n) {
+        throw new Error(
+          `external write approval requires a regular file with a stable identity: ${physicalTarget}`
+        )
+      }
+      if (targetStats.nlink !== 1n) {
+        throw new Error(
+          `external write approval requires a file with exactly one hard link: ${physicalTarget}`
+        )
+      }
+      const parentStats = await stat(dirname(physicalTarget), { bigint: true })
+      if (!parentStats.isDirectory() || parentStats.ino === 0n) {
+        throw new Error(
+          `external write approval requires a parent directory with a stable identity: ${physicalTarget}`
+        )
+      }
+      const confirmedTarget = await resolvePathThroughSymlinks(lexicalTarget)
+      if (!sameFilesystemPath(confirmedTarget, physicalTarget)) {
+        throw new Error(`external write target changed while preparing approval: ${physicalTarget}`)
+      }
+      externalTargets.push({
+        path: physicalTarget,
+        device: targetStats.dev,
+        inode: targetStats.ino,
+        parentDevice: parentStats.dev,
+        parentInode: parentStats.ino
+      })
+    }
+  }
+  return externalTargets
 }
 
 export function effectiveSandboxMode(
@@ -62,7 +146,7 @@ export function sandboxBlockForTool(
 
 export function canWritePath(
   absolutePath: string,
-  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode'>
+  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode' | 'approvedExternalWriteTargets'>
 ): { ok: true } | { ok: false; block: SandboxBlock } {
   const mode = effectiveSandboxMode(context)
   if (mode === 'danger-full-access') return { ok: true }
@@ -88,6 +172,11 @@ export function canWritePath(
   const root = workspaceRoot(context.workspace)
   const resolvedPath = isAbsolute(absolutePath) ? resolve(absolutePath) : resolve(root, absolutePath)
   if (isPathInsideOrEqual(root, resolvedPath)) return { ok: true }
+  if (context.approvedExternalWriteTargets?.some((target) =>
+    sameFilesystemPath(target.path, resolvedPath)
+  )) {
+    return { ok: true }
+  }
   return {
     ok: false,
     block: {
@@ -99,17 +188,10 @@ export function canWritePath(
 
 export function assertCanWritePath(
   absolutePath: string,
-  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode'>
+  context: Pick<ToolHostContext, 'workspace' | 'sandboxMode' | 'approvedExternalWriteTargets'>
 ): void {
   const decision = canWritePath(absolutePath, context)
   if (!decision.ok) throw new Error(decision.block.message)
-}
-
-function isPathInsideOrEqual(root: string, candidate: string): boolean {
-  const rootPath = resolve(root)
-  const candidatePath = resolve(candidate)
-  const rel = relative(rootPath, candidatePath)
-  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
 }
 
 function isInteractiveGuiGateTool(toolName: string): boolean {

--- a/kun/src/adapters/tool/workspace-path.ts
+++ b/kun/src/adapters/tool/workspace-path.ts
@@ -1,0 +1,129 @@
+import { lstat, readlink, realpath } from 'node:fs/promises'
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  posix,
+  resolve,
+  win32
+} from 'node:path'
+
+export function workspaceRoot(workspace: string): string {
+  if (!workspace.trim()) return process.cwd()
+  return isAbsolute(workspace) ? resolve(workspace) : resolve(process.cwd(), workspace)
+}
+
+export async function resolveExistingWorkspaceRoot(workspace: string): Promise<{
+  lexicalRoot: string
+  physicalRoot: string
+}> {
+  const lexicalRoot = workspaceRoot(workspace)
+  const physicalRoot = await safeRealpath(lexicalRoot)
+  if (physicalRoot === null) {
+    throw new Error(`workspace root does not exist: ${lexicalRoot}`)
+  }
+  return { lexicalRoot, physicalRoot }
+}
+
+/**
+ * Resolve a path through every existing symlink/junction while preserving a
+ * nonexistent suffix. A dangling symlink is followed explicitly so callers
+ * cannot treat its lexical location as the eventual write target.
+ */
+export async function resolvePathThroughSymlinks(inputPath: string): Promise<string> {
+  return resolveSymlinkSafe(resolve(inputPath))
+}
+
+export function sameFilesystemPath(
+  left: string,
+  right: string,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  const pathApi = platform === 'win32' ? win32 : posix
+  const normalize = (value: string): string => {
+    const normalized = pathApi.normalize(pathApi.resolve(value))
+    const root = pathApi.parse(normalized).root
+    const withoutTrailingSeparators = normalized.length > root.length
+      ? stripTrailingSeparators(normalized, root.length, platform)
+      : normalized
+    return platform === 'win32'
+      ? withoutTrailingSeparators.toLowerCase()
+      : withoutTrailingSeparators
+  }
+  return normalize(left) === normalize(right)
+}
+
+function stripTrailingSeparators(
+  value: string,
+  minimumLength: number,
+  platform: NodeJS.Platform
+): string {
+  let end = value.length
+  while (end > minimumLength) {
+    const code = value.charCodeAt(end - 1)
+    const isSeparator = code === 0x2f || (platform === 'win32' && code === 0x5c)
+    if (!isSeparator) break
+    end -= 1
+  }
+  return end === value.length ? value : value.slice(0, end)
+}
+
+export function isPathInsideOrEqual(
+  root: string,
+  candidate: string,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  const pathApi = platform === 'win32' ? win32 : posix
+  const rootPath = pathApi.resolve(root)
+  const candidatePath = pathApi.resolve(candidate)
+  if (sameFilesystemPath(rootPath, candidatePath, platform)) return true
+  const rel = pathApi.relative(rootPath, candidatePath)
+  return rel !== '..' &&
+    !rel.startsWith(`..${pathApi.sep}`) &&
+    !pathApi.isAbsolute(rel)
+}
+
+async function safeRealpath(target: string): Promise<string | null> {
+  try {
+    return await realpath(target)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return null
+    throw error
+  }
+}
+
+async function isSymlink(target: string): Promise<boolean> {
+  try {
+    return (await lstat(target)).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+async function resolveSymlinkSafe(lexicalPath: string, depth = 0): Promise<string> {
+  if (depth > 40) {
+    throw new Error(`too many symbolic links resolving: ${lexicalPath}`)
+  }
+  const direct = await safeRealpath(lexicalPath)
+  if (direct !== null) return direct
+
+  const segments: string[] = []
+  let current = lexicalPath
+  for (let i = 0; i < 128 && current !== dirname(current); i += 1) {
+    const resolved = await safeRealpath(current)
+    if (resolved !== null) {
+      return segments.length > 0 ? resolve(resolved, ...segments) : resolved
+    }
+    if (await isSymlink(current)) {
+      const linkTarget = await readlink(current)
+      const resolvedParent = (await safeRealpath(dirname(current))) ?? dirname(current)
+      const followed = isAbsolute(linkTarget) ? resolve(linkTarget) : resolve(resolvedParent, linkTarget)
+      const rejoined = segments.length > 0 ? resolve(followed, ...segments) : followed
+      return resolveSymlinkSafe(rejoined, depth + 1)
+    }
+    segments.unshift(basename(current))
+    current = dirname(current)
+  }
+  throw new Error(`path escapes the workspace root: ${lexicalPath}`)
+}

--- a/kun/src/ports/tool-host.ts
+++ b/kun/src/ports/tool-host.ts
@@ -60,6 +60,17 @@ export type GuiDesignArtifactContext = {
   relativePath: string
 }
 
+export type ApprovedExternalWriteTarget = {
+  /** Physical path shown in the approval prompt. */
+  path: string
+  /** Stable file identity captured before prompting. */
+  device: bigint
+  inode: bigint
+  /** Stable parent-directory identity captured before prompting. */
+  parentDevice: bigint
+  parentInode: bigint
+}
+
 export type ToolHostContext = {
   threadId: string
   turnId: string
@@ -112,6 +123,8 @@ export type ToolHostContext = {
   approvalPolicy: ApprovalPolicy
   /** Filesystem/command sandbox selected for this turn. Defaults at execution time for old callers. */
   sandboxMode?: SandboxMode
+  /** Existing physical files approved only for the active tool invocation. */
+  approvedExternalWriteTargets?: readonly ApprovedExternalWriteTarget[]
   /** Kun runtime data root; used to allow sandbox-safe reads of background shell output files. */
   runtimeDataDir?: string
   /** Store used to offload oversized tool results from model context. */


### PR DESCRIPTION
## Summary

- Rebuilds the valuable external-path approval behavior from #887 on the current `develop` branch.
- Keeps trusted-workspace mode efficient while making each external mutation explicit and single-use.
- Follow-up to #869.

## Changes

- Opts only the `write` and `edit` tools into exact per-call external-path approval.
- Resolves and records the approved physical file identity, strips caller-supplied grants, and mints the grant inside the host.
- Revalidates the approved single-link inode with a no-follow file handle and performs the mutation through that same handle.
- Fails closed for external file creation, where Node does not expose a portable parent-directory `openat` primitive.
- Rejects sibling-prefix, symlink, hard-link alias, casing, and approval-to-mutation path swaps.
- Normalizes trailing path separators with a linear scan, including adversarial repeated-separator coverage.

This protects the approval workflow from path redirection; it is not an OS-level lock against a hostile same-user process racing the final system call.

## Tests

- Focused permission/path tests (89 passed).
- Full Kun suite (2158 passed, 1 skipped).
- Kun and root typecheck/build, ESLint, and `git diff --check`.

Original contribution and problem analysis: @luoye520ww in #887.

Replaces #887.
