### PR TITLE
feat(extensions): bind package signature payload

### DIFF
--- a/src/shared/extension-signature.test.ts
+++ b/src/shared/extension-signature.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildExtensionSignaturePayload,
+  isExtensionSignatureCurrent,
+  parseExtensionPackageSignature,
+  type ExtensionPackageSignature
+} from './extension-signature'
+
+const valid: ExtensionPackageSignature = {
+  payloadVersion: 1,
+  algorithm: 'ed25519',
+  publisherId: 'acme',
+  keyId: 'release-2026.07',
+  extensionId: 'acme.demo',
+  extensionVersion: '1.2.3',
+  packageSha256: 'a'.repeat(64),
+  signedAt: '2026-07-01T00:00:00.000Z',
+  expiresAt: '2026-08-01T00:00:00.000Z',
+  signatureBase64: `${'A'.repeat(86)}==`
+}
+
+describe('extension package signature contract', () => {
+  it('accepts the exact bounded payload version 1 envelope', () => {
+    expect(parseExtensionPackageSignature(valid)).toEqual({ success: true, data: valid })
+  })
+
+  it('rejects unknown, missing, and self-asserted key material fields', () => {
+    const { keyId: _keyId, ...missingKeyId } = valid
+    expect(parseExtensionPackageSignature({ ...valid, unexpected: true }).success).toBe(false)
+    expect(parseExtensionPackageSignature(missingKeyId).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, publicKeyBase64: 'attacker-key' }).success).toBe(false)
+  })
+
+  it('rejects unsupported algorithms, versions, and non-canonical cryptographic values', () => {
+    expect(parseExtensionPackageSignature({ ...valid, payloadVersion: 2 }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, algorithm: 'rsa-pss' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, packageSha256: 'A'.repeat(64) }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, signatureBase64: `${'A'.repeat(85)}B==` }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, signatureBase64: 'not-base64' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({
+      ...valid,
+      extensionVersion: `${'1'.repeat(125)}.0.0`
+    }).success).toBe(false)
+  })
+
+  it('binds the publisher identity and canonical validity window', () => {
+    expect(parseExtensionPackageSignature({ ...valid, publisherId: 'other' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, signedAt: '2026-07-01T00:00:00Z' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, signedAt: '2026-02-30T00:00:00.000Z' }).success).toBe(false)
+    expect(parseExtensionPackageSignature({ ...valid, expiresAt: valid.signedAt }).success).toBe(false)
+  })
+})
+
+describe('buildExtensionSignaturePayload', () => {
+  it('emits a deterministic golden payload with every security identity field', () => {
+    const { signatureBase64: _signatureBase64, ...payload } = valid
+    expect(buildExtensionSignaturePayload(payload)).toBe(
+      `{"payloadVersion":1,"algorithm":"ed25519","publisherId":"acme","keyId":"release-2026.07",` +
+      `"extensionId":"acme.demo","extensionVersion":"1.2.3","packageSha256":"${'a'.repeat(64)}",` +
+      `"signedAt":"2026-07-01T00:00:00.000Z","expiresAt":"2026-08-01T00:00:00.000Z"}`
+    )
+  })
+
+  it.each([
+    ['publisherId', 'other'],
+    ['keyId', 'release-2026.08'],
+    ['extensionId', 'acme.other'],
+    ['extensionVersion', '1.2.4'],
+    ['packageSha256', 'b'.repeat(64)],
+    ['signedAt', '2026-07-02T00:00:00.000Z'],
+    ['expiresAt', '2026-08-02T00:00:00.000Z']
+  ] as const)('changes the signed bytes when %s changes', (field, value) => {
+    const { signatureBase64: _signatureBase64, ...payload } = valid
+    const baseline = buildExtensionSignaturePayload(payload)
+    const changed = { ...payload, [field]: value }
+    if (field === 'publisherId') changed.extensionId = `${value}.demo`
+
+    expect(buildExtensionSignaturePayload(changed)).not.toBe(baseline)
+  })
+})
+
+describe('isExtensionSignatureCurrent', () => {
+  it('uses a half-open deterministic validity window and fails closed for invalid clocks', () => {
+    expect(isExtensionSignatureCurrent(valid, Date.parse(valid.signedAt))).toBe(true)
+    expect(isExtensionSignatureCurrent(valid, Date.parse(valid.expiresAt) - 1)).toBe(true)
+    expect(isExtensionSignatureCurrent(valid, Date.parse(valid.expiresAt))).toBe(false)
+    expect(isExtensionSignatureCurrent(valid, Date.parse(valid.signedAt) - 1)).toBe(false)
+    expect(isExtensionSignatureCurrent(valid, Number.NaN)).toBe(false)
+  })
+})

--- a/src/shared/extension-signature.ts
+++ b/src/shared/extension-signature.ts
@@ -1,0 +1,168 @@
+export const EXTENSION_SIGNATURE_PAYLOAD_VERSION = 1 as const
+export const EXTENSION_SIGNATURE_ALGORITHM = 'ed25519' as const
+
+export type ExtensionSignaturePayload = {
+  payloadVersion: typeof EXTENSION_SIGNATURE_PAYLOAD_VERSION
+  algorithm: typeof EXTENSION_SIGNATURE_ALGORITHM
+  publisherId: string
+  keyId: string
+  extensionId: string
+  extensionVersion: string
+  packageSha256: string
+  signedAt: string
+  expiresAt: string
+}
+
+export type ExtensionPackageSignature = ExtensionSignaturePayload & {
+  signatureBase64: string
+}
+
+export type ExtensionSignatureParseResult =
+  | { success: true; data: ExtensionPackageSignature }
+  | { success: false; error: string }
+
+const SIGNATURE_FIELDS = new Set([
+  'payloadVersion',
+  'algorithm',
+  'publisherId',
+  'keyId',
+  'extensionId',
+  'extensionVersion',
+  'packageSha256',
+  'signedAt',
+  'expiresAt',
+  'signatureBase64'
+])
+const PUBLISHER_ID = /^[a-z0-9][a-z0-9-]{0,63}$/
+const KEY_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/
+const EXTENSION_ID = /^[a-z0-9][a-z0-9-]{0,63}\.[a-z][a-z0-9-]{0,63}$/
+const MAX_EXTENSION_VERSION_LENGTH = 128
+const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+const SHA256_HEX = /^[a-f0-9]{64}$/
+const CANONICAL_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+// Ed25519 signatures are exactly 64 bytes. The last Base64 character is
+// restricted to canonical zero pad bits rather than accepting aliases.
+const ED25519_SIGNATURE_BASE64 = /^(?:[A-Za-z0-9+/]{4}){21}[A-Za-z0-9+/][AQgw]==$/
+
+/**
+ * Parses untrusted signature metadata. Trust lookup and cryptographic
+ * verification remain responsibilities of the extension installation layer.
+ */
+export function parseExtensionPackageSignature(input: unknown): ExtensionSignatureParseResult {
+  try {
+    if (!isRecord(input)) throw new TypeError('extension signature must be an object')
+    const unknownFields = Object.keys(input).filter((field) => !SIGNATURE_FIELDS.has(field))
+    if (unknownFields.length > 0 || Object.keys(input).length !== SIGNATURE_FIELDS.size) {
+      throw new TypeError('extension signature fields do not match payload version 1')
+    }
+
+    const payload = parsePayload(input)
+    const signatureBase64 = stringMatching(
+      input.signatureBase64,
+      ED25519_SIGNATURE_BASE64,
+      'signatureBase64 must be a canonical 64-byte Ed25519 signature'
+    )
+
+    return { success: true, data: { ...payload, signatureBase64 } }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'invalid extension package signature'
+    }
+  }
+}
+
+/**
+ * Returns the exact UTF-8 JSON text covered by the Ed25519 signature. Field
+ * order is part of payload version 1 and must not be changed in place.
+ */
+export function buildExtensionSignaturePayload(input: ExtensionSignaturePayload): string {
+  const payload = parsePayload(input as unknown as Record<string, unknown>)
+  return JSON.stringify({
+    payloadVersion: payload.payloadVersion,
+    algorithm: payload.algorithm,
+    publisherId: payload.publisherId,
+    keyId: payload.keyId,
+    extensionId: payload.extensionId,
+    extensionVersion: payload.extensionVersion,
+    packageSha256: payload.packageSha256,
+    signedAt: payload.signedAt,
+    expiresAt: payload.expiresAt
+  })
+}
+
+export function isExtensionSignatureCurrent(
+  signature: ExtensionSignaturePayload,
+  now: Date | number = Date.now()
+): boolean {
+  const timestamp = now instanceof Date ? now.getTime() : now
+  const signedAt = Date.parse(signature.signedAt)
+  const expiresAt = Date.parse(signature.expiresAt)
+  return Number.isFinite(timestamp) &&
+    Number.isFinite(signedAt) &&
+    Number.isFinite(expiresAt) &&
+    timestamp >= signedAt &&
+    timestamp < expiresAt
+}
+
+function parsePayload(record: Record<string, unknown>): ExtensionSignaturePayload {
+  if (record.payloadVersion !== EXTENSION_SIGNATURE_PAYLOAD_VERSION) {
+    throw new TypeError('unsupported extension signature payload version')
+  }
+  if (record.algorithm !== EXTENSION_SIGNATURE_ALGORITHM) {
+    throw new TypeError('unsupported extension signature algorithm')
+  }
+
+  const publisherId = stringMatching(record.publisherId, PUBLISHER_ID, 'publisherId is invalid')
+  const keyId = stringMatching(record.keyId, KEY_ID, 'keyId is invalid')
+  const extensionId = stringMatching(record.extensionId, EXTENSION_ID, 'extensionId is invalid')
+  if (!extensionId.startsWith(`${publisherId}.`)) {
+    throw new TypeError('extensionId publisher does not match publisherId')
+  }
+  const extensionVersion = stringMatching(
+    record.extensionVersion,
+    SEMVER,
+    'extensionVersion must be valid SemVer',
+    MAX_EXTENSION_VERSION_LENGTH
+  )
+  const packageSha256 = stringMatching(
+    record.packageSha256,
+    SHA256_HEX,
+    'packageSha256 must be a lowercase SHA-256 digest'
+  )
+  const signedAt = parseCanonicalTimestamp(record.signedAt, 'signedAt')
+  const expiresAt = parseCanonicalTimestamp(record.expiresAt, 'expiresAt')
+  if (Date.parse(expiresAt) <= Date.parse(signedAt)) {
+    throw new TypeError('expiresAt must be later than signedAt')
+  }
+
+  return {
+    payloadVersion: EXTENSION_SIGNATURE_PAYLOAD_VERSION,
+    algorithm: EXTENSION_SIGNATURE_ALGORITHM,
+    publisherId,
+    keyId,
+    extensionId,
+    extensionVersion,
+    packageSha256,
+    signedAt,
+    expiresAt
+  }
+}
+
+function parseCanonicalTimestamp(value: unknown, field: string): string {
+  const timestamp = stringMatching(value, CANONICAL_TIMESTAMP, `${field} must be a canonical UTC timestamp`)
+  const milliseconds = Date.parse(timestamp)
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== timestamp) {
+    throw new TypeError(`${field} must be a canonical UTC timestamp`)
+  }
+  return timestamp
+}
+
+function stringMatching(value: unknown, pattern: RegExp, error: string, maxLength = Number.POSITIVE_INFINITY): string {
+  if (typeof value !== 'string' || value.length > maxLength || !pattern.test(value)) throw new TypeError(error)
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}


### PR DESCRIPTION
## Summary

- Rebuilds the extension-signature contract from #938 on the current `develop` branch.
- Defines the canonical bytes a future trust-store/verification layer must verify; this PR intentionally does not claim to implement trust or cryptographic verification.

## Changes

- Binds payload version, algorithm, publisher/key identity, extension identity/version, package SHA-256, and validity timestamps.
- Rejects unknown/missing fields, self-asserted public keys, non-canonical Base64, timestamps, hashes, publisher mismatches, and oversized/non-SemVer versions.
- Emits a deterministic versioned JSON payload with fixed field order.
- Provides deterministic validity-window checks.

## Tests

- `npx vitest run src/shared/extension-signature.test.ts` (13 passed).
- Full root app suite (4496 passed) plus all extension-package suites (58 passed).
- Root typecheck, targeted ESLint, and `git diff --check`.

Original contribution and contract direction: @luoye520ww in #938.

Replaces #938.
