### PR TITLE
fix(model): enforce pending stream accounting invariants

### DIFF
--- a/kun/src/adapters/model/compat-model-client.streaming-tool-calls.test.ts
+++ b/kun/src/adapters/model/compat-model-client.streaming-tool-calls.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { CompatModelClient, type ModelStreamLimits } from './compat-model-client.js'
 import {
   ModelStreamResourceBudget,
+  ModelStreamResourceStateError,
   TOOL_ARGUMENT_PART_COMPACTION_WINDOW,
   type PendingToolCall
 } from './model-stream-resource-budget.js'
@@ -530,14 +531,61 @@ describe('CompatModelClient streaming resource limits', () => {
       maxCompletedToolCalls: 32,
       maxCompletedToolArgumentBytes: 1_000_000
     })
-    const pending: PendingToolCall = {
-      name: 'edit', argumentParts: [], argumentBytes: 0, argumentFragments: 0
-    }
+    const pendingCalls = new Map<string, PendingToolCall>()
+    const pending = budget.pendingCall(pendingCalls, 'call-1', 0)
+    pending.name = 'edit'
     for (let index = 0; index < 5_000; index += 1) budget.appendArguments(pending, 'x')
     expect(pending.argumentFragments).toBe(5_000)
     expect(pending.argumentParts.length).toBeLessThanOrEqual(TOOL_ARGUMENT_PART_COMPACTION_WINDOW)
     expect(pending.argumentBlocks?.length).toBeGreaterThan(1)
     expect(budget.pendingArguments(pending)).toBe('x'.repeat(5_000))
+  })
+
+  it('releases pending argument capacity exactly once', () => {
+    const budget = new ModelStreamResourceBudget({
+      maxBufferBytes: 1_000,
+      maxFrameBytes: 1_000,
+      maxTotalBytes: 1_000,
+      maxFrames: 100,
+      maxOutputBytes: 1_000,
+      maxPendingToolCalls: 2,
+      maxPendingToolArgumentBytes: 4,
+      maxTotalPendingToolArgumentBytes: 4,
+      maxCompletedToolCalls: 2,
+      maxCompletedToolArgumentBytes: 8
+    })
+    const pendingCalls = new Map<string, PendingToolCall>()
+    const first = budget.pendingCall(pendingCalls, 'first', 0)
+    budget.appendArguments(first, '1234')
+
+    expect(budget.removePendingCall(pendingCalls, 'first')).toBe(first)
+    expect(budget.removePendingCall(pendingCalls, 'first')).toBeUndefined()
+
+    const second = budget.pendingCall(pendingCalls, 'second', 1)
+    expect(() => budget.appendArguments(second, '1234')).not.toThrow()
+  })
+
+  it('fails closed instead of hiding corrupted pending counters', () => {
+    const budget = new ModelStreamResourceBudget({
+      maxBufferBytes: 1_000,
+      maxFrameBytes: 1_000,
+      maxTotalBytes: 1_000,
+      maxFrames: 100,
+      maxOutputBytes: 1_000,
+      maxPendingToolCalls: 2,
+      maxPendingToolArgumentBytes: 8,
+      maxTotalPendingToolArgumentBytes: 8,
+      maxCompletedToolCalls: 2,
+      maxCompletedToolArgumentBytes: 8
+    })
+    const pendingCalls = new Map<string, PendingToolCall>()
+    const pending = budget.pendingCall(pendingCalls, 'call-1', 0)
+    budget.appendArguments(pending, '{}')
+    pending.argumentBytes += 1
+
+    expect(() => budget.removePendingCall(pendingCalls, 'call-1'))
+      .toThrow(ModelStreamResourceStateError)
+    expect(pendingCalls.has('call-1')).toBe(true)
   })
 
   it('bounds and sanitizes provider-controlled tool names in limit diagnostics', () => {
@@ -553,12 +601,9 @@ describe('CompatModelClient streaming resource limits', () => {
       maxCompletedToolCalls: 2,
       maxCompletedToolArgumentBytes: 2
     })
-    const pending: PendingToolCall = {
-      name: `edit\n${'x'.repeat(10_000)}SECRET_TAIL`,
-      argumentParts: [],
-      argumentBytes: 0,
-      argumentFragments: 0
-    }
+    const pendingCalls = new Map<string, PendingToolCall>()
+    const pending = budget.pendingCall(pendingCalls, 'call-1', 0)
+    pending.name = `edit\n${'x'.repeat(10_000)}SECRET_TAIL`
 
     let message = ''
     try {

--- a/kun/src/adapters/model/model-stream-resource-budget.ts
+++ b/kun/src/adapters/model/model-stream-resource-budget.ts
@@ -47,6 +47,13 @@ export class ModelStreamResourceLimitError extends Error {
   }
 }
 
+export class ModelStreamResourceStateError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ModelStreamResourceStateError'
+  }
+}
+
 export class ModelStreamResourceBudget {
   private totalBytes = 0
   private frames = 0
@@ -56,6 +63,10 @@ export class ModelStreamResourceBudget {
   private pendingToolCalls = 0
   private completedToolCalls = 0
   private completedToolArgumentBytes = 0
+  private readonly pendingAccounting = new WeakMap<PendingToolCall, {
+    argumentBytes: number
+    argumentFragments: number
+  }>()
 
   constructor(readonly limits: ModelStreamLimits) {}
 
@@ -79,6 +90,7 @@ export class ModelStreamResourceBudget {
   ): PendingToolCall {
     const existing = pending.get(callId)
     if (existing) {
+      this.assertTrackedPending(existing, pending)
       if (index !== undefined) existing.index = index
       return existing
     }
@@ -93,6 +105,7 @@ export class ModelStreamResourceBudget {
       argumentFragments: 0
     }
     pending.set(callId, created)
+    this.pendingAccounting.set(created, { argumentBytes: 0, argumentFragments: 0 })
     this.pendingToolCalls += 1
     return created
   }
@@ -106,6 +119,7 @@ export class ModelStreamResourceBudget {
 
   appendArguments(pending: PendingToolCall, value: string): void {
     if (!value) return
+    const accounting = this.assertTrackedPending(pending)
     const bytes = Buffer.byteLength(value, 'utf8')
     this.assertPendingCapacity(pending, bytes)
     pending.argumentParts.push(value)
@@ -113,6 +127,8 @@ export class ModelStreamResourceBudget {
     pending.argumentFragments += 1
     this.pendingArgumentBytes += bytes
     this.pendingArgumentFragments += 1
+    accounting.argumentBytes += bytes
+    accounting.argumentFragments += 1
     if (pending.argumentParts.length >= TOOL_ARGUMENT_PART_COMPACTION_WINDOW) {
       const blocks = pending.argumentBlocks ?? (pending.argumentBlocks = [])
       blocks.push(pending.argumentParts.join(''))
@@ -121,6 +137,7 @@ export class ModelStreamResourceBudget {
   }
 
   replaceArguments(pending: PendingToolCall, value: string): void {
+    const accounting = this.assertTrackedPending(pending)
     const bytes = value ? Buffer.byteLength(value, 'utf8') : 0
     const fragments = value ? 1 : 0
     this.assertPendingCapacity(
@@ -131,6 +148,8 @@ export class ModelStreamResourceBudget {
     )
     this.pendingArgumentBytes += bytes - pending.argumentBytes
     this.pendingArgumentFragments += fragments - pending.argumentFragments
+    accounting.argumentBytes = bytes
+    accounting.argumentFragments = fragments
     pending.argumentBlocks = []
     pending.argumentParts = value ? [value] : []
     pending.argumentBytes = bytes
@@ -162,10 +181,21 @@ export class ModelStreamResourceBudget {
   ): PendingToolCall | undefined {
     const value = pending.get(callId)
     if (!value) return undefined
+    const accounting = this.assertTrackedPending(value, pending)
+    if (
+      value.argumentBytes !== accounting.argumentBytes ||
+      value.argumentFragments !== accounting.argumentFragments ||
+      this.pendingToolCalls <= 0 ||
+      this.pendingArgumentBytes < accounting.argumentBytes ||
+      this.pendingArgumentFragments < accounting.argumentFragments
+    ) {
+      throw new ModelStreamResourceStateError('pending tool-call accounting is inconsistent')
+    }
     pending.delete(callId)
-    this.pendingToolCalls = Math.max(0, this.pendingToolCalls - 1)
-    this.pendingArgumentBytes -= value.argumentBytes
-    this.pendingArgumentFragments -= value.argumentFragments
+    this.pendingAccounting.delete(value)
+    this.pendingToolCalls -= 1
+    this.pendingArgumentBytes -= accounting.argumentBytes
+    this.pendingArgumentFragments -= accounting.argumentFragments
     return value
   }
 
@@ -206,6 +236,22 @@ export class ModelStreamResourceBudget {
         nextArgumentFragments: nextFragments
       })
     }
+  }
+
+  private assertTrackedPending(
+    pending: PendingToolCall,
+    collection?: Map<string, PendingToolCall>
+  ): { argumentBytes: number; argumentFragments: number } {
+    const accounting = this.pendingAccounting.get(pending)
+    if (
+      !accounting ||
+      pending.argumentBytes !== accounting.argumentBytes ||
+      pending.argumentFragments !== accounting.argumentFragments ||
+      (collection && this.pendingToolCalls !== collection.size)
+    ) {
+      throw new ModelStreamResourceStateError('pending tool-call accounting is inconsistent')
+    }
+    return accounting
   }
 
   exceeded(


### PR DESCRIPTION
## Summary

- Splits the valuable pending-stream accounting fix out of mixed PR #961 and rebuilds it on the current `develop` branch.

## Changes

- Tracks internal pending argument bytes/fragments separately from caller-visible mutable objects.
- Releases a pending call exactly once and returns `undefined` for duplicate removal.
- Fails closed with `ModelStreamResourceStateError` when pending objects, maps, or aggregate counters are inconsistent, instead of clamping corrupted counters.

## Tests

- Focused streaming/tool-call suite (26 passed), including duplicate removal and corrupted-state cases.
- Full Kun suite (2142 passed, 1 skipped).
- Kun typecheck/build, targeted ESLint, and `git diff --check`.

Original contribution: @fix2015 in #961.

Replaces the resource-accounting portion of #961.
