### PR TITLE
feat(settings): add configurable turn duration

### DIFF
--- a/src/main/ipc/app-ipc-schemas.test.ts
+++ b/src/main/ipc/app-ipc-schemas.test.ts
@@ -693,6 +693,28 @@ describe('app-ipc-schemas', () => {
     expect(payload.agents?.kun?.runtimeTuning?.streamIdleTimeoutMs).toBe(300000)
   })
 
+  it('accepts a configurable maximum turn duration in runtime tuning patches', () => {
+    const payload = settingsPatchSchema.parse({
+      agents: {
+        kun: {
+          runtimeTuning: {
+            maxWallTimeMs: 7_200_000
+          }
+        }
+      }
+    })
+
+    expect(payload.agents?.kun?.runtimeTuning?.maxWallTimeMs).toBe(7_200_000)
+  })
+
+  it('rejects an out-of-range maximum turn duration', () => {
+    expect(() =>
+      settingsPatchSchema.parse({
+        agents: { kun: { runtimeTuning: { maxWallTimeMs: 86_400_001 } } }
+      })
+    ).toThrow()
+  })
+
   it('rejects an out-of-range stream idle timeout', () => {
     expect(() =>
       settingsPatchSchema.parse({

--- a/src/main/ipc/app-ipc-schemas/settings.ts
+++ b/src/main/ipc/app-ipc-schemas/settings.ts
@@ -272,6 +272,7 @@ const kunRuntimePatchSchema = z.object({
     summaryProviderId: z.string().trim().max(64).optional()
   }).strict().optional(),
   runtimeTuning: z.object({
+    maxWallTimeMs: z.number().int().positive().max(86_400_000).optional(),
     streamIdleTimeoutMs: z.number().int().min(0).max(3_600_000).optional(),
     toolStorm: z.object({
       enabled: z.boolean().optional(),

--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -566,6 +566,7 @@ describe('syncGuiManagedKunConfig', () => {
       }
     })
     expect(parsed.runtime.streamIdleTimeoutMs).toBe(450000)
+    expect(parsed.runtime.turnLimits).toMatchObject({ maxWallTimeMs: 86400000 })
     expect(parsed.runtime.toolStorm).toMatchObject({ enabled: true, windowSize: 8, threshold: 3 })
     expect(parsed.runtime.toolArgumentRepair).toMatchObject({ maxStringBytes: 524288 })
     expect(parsed.capabilities.attachments).toMatchObject({ enabled: true })
@@ -1205,6 +1206,7 @@ describe('syncGuiManagedKunConfig', () => {
           summaryInputMaxBytes: 131072
         },
         runtimeTuning: {
+          maxWallTimeMs: 7_200_000,
           streamIdleTimeoutMs: 120000,
           toolStorm: {
             enabled: false,
@@ -1306,6 +1308,7 @@ describe('syncGuiManagedKunConfig', () => {
     expect(parsed.runtime.toolStorm.customStormFlag).toBeUndefined()
     expect(parsed.runtime.customRuntimeFlag).toBeUndefined()
     expect(parsed.runtime.toolArgumentRepair).toMatchObject({ maxStringBytes: 262144 })
+    expect(parsed.runtime.turnLimits).toMatchObject({ maxWallTimeMs: 7_200_000 })
     expect(parsed.runtime.streamIdleTimeoutMs).toBe(120000)
     expect(parsed.capabilities.attachments).toMatchObject({ enabled: true })
     expect(parsed.capabilities.mcp.servers.github.command).toBe('github-mcp')

--- a/src/main/runtime/kun-runtime-capability-config.ts
+++ b/src/main/runtime/kun-runtime-capability-config.ts
@@ -104,6 +104,10 @@ export function runtimeTuningConfigForRuntime(
 ): Record<string, unknown> {
   return {
     ...existing,
+    turnLimits: {
+      ...objectValue(existing.turnLimits),
+      maxWallTimeMs: value.maxWallTimeMs
+    },
     streamIdleTimeoutMs: value.streamIdleTimeoutMs,
     toolStorm: {
       ...objectValue(existing.toolStorm),

--- a/src/renderer/src/components/settings-section-agents.test.ts
+++ b/src/renderer/src/components/settings-section-agents.test.ts
@@ -150,6 +150,10 @@ const labels: Record<string, string> = {
   kunCompactionSummaryTimeout: 'Summary timeout',
   kunCompactionSummaryMaxTokens: 'Summary max tokens',
   kunCompactionSummaryInputBytes: 'Summary input bytes',
+  kunMaxWallTime: 'Maximum turn duration',
+  kunMaxWallTimeDesc: 'Maximum turn duration description',
+  kunStreamIdleTimeout: 'Stream idle timeout',
+  kunStreamIdleTimeoutDesc: 'Stream idle timeout description',
   kunToolStorm: 'Tool storm',
   kunToolStormDesc: 'Tool storm description',
   kunToolStormLimits: 'Tool storm limits',
@@ -667,6 +671,8 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
 
     expect(html).toContain('Assistant advanced settings')
     expect(html).toContain('Storage, model context, and tool guards')
+    expect(html).toContain('Maximum turn duration')
+    expect(html).toContain('value="86400000"')
     expect(html).toContain('MCP advanced settings')
     expect(html).not.toContain('<details open')
   })

--- a/src/renderer/src/components/settings-section-agents.tsx
+++ b/src/renderer/src/components/settings-section-agents.tsx
@@ -288,6 +288,7 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
     fallbackHardThreshold: contextCompaction.defaultHardThreshold
   })
   const runtimeTuning = kun.runtimeTuning ?? {
+    maxWallTimeMs: 86400000,
     streamIdleTimeoutMs: 45000,
     toolStorm: {
       enabled: true,
@@ -1625,6 +1626,23 @@ export function AgentsSettingsSection({ ctx }: { ctx: Record<string, any> }): Re
                           />
                         </label>
                       </div>
+                    }
+                  />
+                  <SettingRow
+                    title={t('kunMaxWallTime')}
+                    description={t('kunMaxWallTimeDesc')}
+                    control={
+                      <input
+                        type="number"
+                        min={1000}
+                        max={86400000}
+                        step={60000}
+                        className="w-40 rounded-xl border border-ds-border bg-ds-card px-3 py-2 text-[14px] text-ds-ink shadow-sm focus:border-accent/40 focus:outline-none focus:ring-1 focus:ring-accent/30"
+                        value={runtimeTuning.maxWallTimeMs}
+                        onChange={(e) =>
+                          updateRuntimeTuning({ maxWallTimeMs: Number(e.target.value) })
+                        }
+                      />
                     }
                   />
                   <SettingRow

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -808,6 +808,8 @@
   "kunCompactionSummaryTimeout": "Summary timeout ms",
   "kunCompactionSummaryMaxTokens": "Summary max tokens",
   "kunCompactionSummaryInputBytes": "Summary input bytes",
+  "kunMaxWallTime": "Maximum turn duration (ms)",
+  "kunMaxWallTimeDesc": "Hard wall-clock limit for one turn, including model responses and tool work. Default and maximum: 86400000 (24 hours).",
   "kunStreamIdleTimeout": "Stream idle timeout (ms)",
   "kunStreamIdleTimeoutDesc": "Fail the turn if the model sends no data for this many milliseconds. Raise it for local LLM servers that stay silent while prefilling a large prompt; set 0 to disable the limit. Default 45000.",
   "kunToolStorm": "Repeated tool-call protection",

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -808,6 +808,8 @@
   "kunCompactionSummaryTimeout": "摘要超时 ms",
   "kunCompactionSummaryMaxTokens": "摘要最大 token",
   "kunCompactionSummaryInputBytes": "摘要输入字节",
+  "kunMaxWallTime": "单轮最大运行时长（毫秒）",
+  "kunMaxWallTimeDesc": "单轮对话的总运行时长上限，包含模型响应和工具执行。默认值和最大值均为 86400000（24 小时）。",
   "kunStreamIdleTimeout": "流式空闲超时（毫秒）",
   "kunStreamIdleTimeoutDesc": "当模型在这么多毫秒内没有返回任何数据时，判定为卡死并结束本轮。本地模型在预处理超大输入时会长时间静默，可适当调大此值；填 0 表示不限制。默认 45000。",
   "kunToolStorm": "重复工具调用保护",

--- a/src/shared/app-settings-kun.ts
+++ b/src/shared/app-settings-kun.ts
@@ -351,6 +351,7 @@ export function defaultKunContextCompactionSettings(): KunContextCompactionSetti
 
 export function defaultKunRuntimeTuningSettings(): KunRuntimeTuningSettingsV1 {
   return {
+    maxWallTimeMs: 86_400_000,
     streamIdleTimeoutMs: 450_000,
     toolStorm: {
       enabled: true,
@@ -483,6 +484,9 @@ export function mergeKunRuntimeSettings(
     ...currentRuntimeTuning,
     ...(patch?.runtimeTuning
       ? {
+          ...(patch.runtimeTuning.maxWallTimeMs !== undefined
+            ? { maxWallTimeMs: patch.runtimeTuning.maxWallTimeMs }
+            : {}),
           ...(patch.runtimeTuning.streamIdleTimeoutMs !== undefined
             ? { streamIdleTimeoutMs: patch.runtimeTuning.streamIdleTimeoutMs }
             : {}),
@@ -953,6 +957,11 @@ function normalizeKunRuntimeTuningSettings(
 ): KunRuntimeTuningSettingsV1 {
   const defaults = defaultKunRuntimeTuningSettings()
   return {
+    maxWallTimeMs: boundedPositiveInt(
+      input?.maxWallTimeMs,
+      defaults.maxWallTimeMs,
+      86_400_000
+    ),
     streamIdleTimeoutMs: boundedNonNegativeInt(
       input?.streamIdleTimeoutMs,
       defaults.streamIdleTimeoutMs,

--- a/src/shared/app-settings-types.ts
+++ b/src/shared/app-settings-types.ts
@@ -674,6 +674,10 @@ export type KunToolArgumentRepairSettingsV1 = {
 
 export type KunRuntimeTuningSettingsV1 = {
   /**
+   * 单轮代理任务的总运行时长上限（毫秒），包含模型响应和工具执行。
+   */
+  maxWallTimeMs: number
+  /**
    * Max idle gap (ms) between streaming chunks before a turn fails with
    * `stream_idle_timeout`. `0` disables the guard — useful for local LLM
    * servers that stay silent while prefilling a very large prompt.
@@ -696,6 +700,7 @@ export type KunSettingsEnvelopeV1 = {
 export type AgentRuntimeSettingsMapV1 = KunSettingsEnvelopeV1
 
 export type KunRuntimeTuningSettingsPatchV1 = {
+  maxWallTimeMs?: number
   streamIdleTimeoutMs?: number
   toolStorm?: Partial<KunToolStormSettingsV1>
   toolArgumentRepair?: Partial<KunToolArgumentRepairSettingsV1>

--- a/src/shared/app-settings.test.ts
+++ b/src/shared/app-settings.test.ts
@@ -311,6 +311,7 @@ describe('kun defaults', () => {
         summaryInputMaxBytes: 98304
       },
       runtimeTuning: {
+        maxWallTimeMs: 86400000,
         streamIdleTimeoutMs: 450000,
         toolStorm: {
           enabled: true,
@@ -879,7 +880,28 @@ describe('mergeKunRuntimeSettings', () => {
     expect(next.runtimeTuning.toolStorm.windowSize).toBe(current.runtimeTuning.toolStorm.windowSize)
     expect(next.runtimeTuning.toolStorm.threshold).toBe(5)
     expect(next.runtimeTuning.toolArgumentRepair).toEqual(current.runtimeTuning.toolArgumentRepair)
+    expect(next.runtimeTuning.maxWallTimeMs).toBe(current.runtimeTuning.maxWallTimeMs)
     expect(next.runtimeTuning.streamIdleTimeoutMs).toBe(current.runtimeTuning.streamIdleTimeoutMs)
+  })
+
+  it('normalizes the maximum turn duration', () => {
+    const current = defaultKunRuntimeSettings()
+    expect(current.runtimeTuning.maxWallTimeMs).toBe(86_400_000)
+
+    const set = mergeKunRuntimeSettings(current, {
+      runtimeTuning: { maxWallTimeMs: 7_200_000 }
+    })
+    expect(set.runtimeTuning.maxWallTimeMs).toBe(7_200_000)
+    expect(set.runtimeTuning.toolStorm).toEqual(current.runtimeTuning.toolStorm)
+
+    expect(
+      mergeKunRuntimeSettings(current, { runtimeTuning: { maxWallTimeMs: 0 } })
+        .runtimeTuning.maxWallTimeMs
+    ).toBe(86_400_000)
+    expect(
+      mergeKunRuntimeSettings(current, { runtimeTuning: { maxWallTimeMs: 999_999_999 } })
+        .runtimeTuning.maxWallTimeMs
+    ).toBe(86_400_000)
   })
 
   it('normalizes the stream idle timeout (0 disables, out-of-range clamps)', () => {


### PR DESCRIPTION
## Summary

- expose the per-turn wall-clock limit in Kun advanced settings
- raise the GUI-managed default from 15 minutes to the supported maximum of 24 hours
- fix the missing GUI configuration reported in [KunAgent/Kun#982](https://github.com/KunAgent/Kun/issues/982)

## Changes

- persist `maxWallTimeMs` under `agents.kun.runtimeTuning`
- map the setting to `runtime.turnLimits.maxWallTimeMs`
- default to `86400000` milliseconds while still allowing users to configure a lower value
- validate values up to 24 hours and add Chinese/English UI copy
- cover defaults, normalization, IPC validation, runtime config generation, and settings rendering

## Tests

- `npx vitest run src/shared/app-settings.test.ts src/main/ipc/app-ipc-schemas.test.ts src/main/kun-process.test.ts src/renderer/src/components/settings-section-agents.test.ts`
- `npm run typecheck`
- `npm run build`

Fixes KunAgent/Kun#982
