### PR TITLE
fix(checkpoint): degrade safely for unborn repositories

### DIFF
--- a/src/main/services/git-checkpoint-service.test.ts
+++ b/src/main/services/git-checkpoint-service.test.ts
@@ -39,6 +39,47 @@ afterEach(async () => {
 })
 
 describe('git checkpoint service', () => {
+  it('degrades an unborn repository before creating a checkpoint directory', async () => {
+    const unbornRepo = join(sandbox, 'unborn-repo')
+    const checkpointId = 'gcp_unborn_head'
+    execFileSync('git', ['init', '-b', 'main', unbornRepo], { stdio: 'pipe' })
+    await writeFile(join(unbornRepo, 'untracked.txt'), 'untracked\n')
+
+    const checkpoint = await createGitCheckpoint({
+      dataDir,
+      workspaceRoot: unbornRepo,
+      threadId: 'thr_unborn',
+      checkpointId
+    })
+
+    expect(checkpoint).toEqual({
+      ok: false,
+      reason: 'unborn_head',
+      message: 'Git repository has no initial commit yet.'
+    })
+    const checkpointDir = join(dataDir, 'git-checkpoints', checkpointId)
+    await expect(stat(checkpointDir)).rejects.toThrow()
+    await expect(stat(join(checkpointDir, 'metadata.json'))).rejects.toThrow()
+    await expect(stat(join(checkpointDir, 'head.bundle'))).rejects.toThrow()
+  })
+
+  it('keeps a corrupt HEAD as a generic checkpoint error', async () => {
+    const checkpointId = 'gcp_corrupt_head'
+    await writeFile(join(repoRoot, '.git', 'refs', 'heads', 'main'), 'a'.repeat(40))
+
+    const checkpoint = await createGitCheckpoint({
+      dataDir,
+      workspaceRoot: repoRoot,
+      threadId: 'thr_corrupt_head',
+      checkpointId
+    })
+
+    expect(checkpoint.ok).toBe(false)
+    if (checkpoint.ok) throw new Error('expected corrupt HEAD to fail')
+    expect(checkpoint.reason).toBe('error')
+    await expect(stat(join(dataDir, 'git-checkpoints', checkpointId))).rejects.toThrow()
+  })
+
   it('stores checkpoint heads outside visible git refs', async () => {
     const checkpoint = await createGitCheckpoint({
       dataDir,

--- a/src/main/services/git-checkpoint-service.ts
+++ b/src/main/services/git-checkpoint-service.ts
@@ -75,8 +75,15 @@ type GitCheckpointCleanupState = {
 const DAY_MS = 24 * 60 * 60 * 1_000
 const CHECKPOINT_CLEANUP_STATE_FILE = '.cleanup.json'
 const CHECKPOINT_REFERENCE_FILE_EXTENSIONS = new Set(['.json', '.jsonl'])
+const UNBORN_HEAD_MESSAGE = 'Git repository has no initial commit yet.'
 
-function checkpointFailure(error: unknown): Extract<GitCheckpointCreateResult, { ok: false }> {
+type GitCheckpointCommandFailure = {
+  ok: false
+  reason: 'not_git_repo' | 'git_unavailable' | 'error'
+  message: string
+}
+
+function checkpointFailure(error: unknown): GitCheckpointCommandFailure {
   const message = error instanceof Error ? error.message : String(error)
   if (/not a git repository/i.test(message)) {
     return { ok: false, reason: 'not_git_repo', message: 'The working directory is not a Git repository.' }
@@ -236,6 +243,38 @@ async function resolveRepositoryRoot(workspaceRoot: string): Promise<string | nu
   if (!cwd) return null
   const { stdout } = await runGit(cwd, ['rev-parse', '--show-toplevel'])
   return stdout.trim()
+}
+
+async function hasUnbornHead(repositoryRoot: string): Promise<boolean> {
+  try {
+    const headRef = (await runGit(repositoryRoot, ['symbolic-ref', '--quiet', 'HEAD'])).stdout.trim()
+    if (!headRef) return false
+
+    try {
+      await runGit(repositoryRoot, ['rev-parse', '--verify', '--quiet', headRef])
+      return false
+    } catch (error) {
+      // Only a missing symbolic branch ref is an unborn HEAD. Permission and
+      // other Git failures must retain their original checkpoint error.
+      if (!(typeof error === 'object' && error !== null && 'code' in error && error.code === 1)) {
+        return false
+      }
+    }
+
+    await runGit(repositoryRoot, ['status', '--porcelain=v1'])
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function resolveCheckpointHead(repositoryRoot: string): Promise<string | null> {
+  try {
+    return (await runGit(repositoryRoot, ['rev-parse', '--verify', 'HEAD^{commit}'])).stdout.trim()
+  } catch (error) {
+    if (await hasUnbornHead(repositoryRoot)) return null
+    throw error
+  }
 }
 
 /**
@@ -545,6 +584,10 @@ export async function createGitCheckpoint(params: {
     if (!repositoryRoot) {
       return { ok: false, reason: 'no_workspace', message: 'No working directory selected.' }
     }
+    const head = await resolveCheckpointHead(repositoryRoot)
+    if (head === null) {
+      return { ok: false, reason: 'unborn_head', message: UNBORN_HEAD_MESSAGE }
+    }
     await assertNoUnmerged(repositoryRoot)
 
     const checkpointId = params.checkpointId?.trim() || `gcp_${Date.now()}_${randomUUID()}`
@@ -552,7 +595,6 @@ export async function createGitCheckpoint(params: {
     await rm(dir, { recursive: true, force: true })
     await mkdir(join(dir, 'untracked'), { recursive: true })
 
-    const head = (await runGit(repositoryRoot, ['rev-parse', 'HEAD'])).stdout.trim()
     await writeHeadBundle(repositoryRoot, checkpointHeadBundlePath(root, checkpointId))
     const currentBranchRaw = (await runGit(repositoryRoot, ['branch', '--show-current'])).stdout.trim()
     const currentBranch = currentBranchRaw || null
@@ -788,7 +830,7 @@ export async function restoreGitCheckpoint(params: {
     if (!rescue.ok) {
       return {
         ok: false,
-        reason: rescue.reason,
+        reason: rescue.reason === 'unborn_head' ? 'error' : rescue.reason,
         message: `Cannot safely restore checkpoint because the rescue snapshot failed: ${rescue.message}`
       }
     }

--- a/src/renderer/src/store/chat-store-thread-actions.test.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.test.ts
@@ -600,6 +600,99 @@ describe('chat-store-thread-actions queued messages', () => {
     )
   })
 
+  it('continues a turn when checkpointing finds an unborn repository', async () => {
+    const provider = {
+      connect: vi.fn(async () => undefined),
+      sendUserMessage: vi.fn(async () => ({
+        threadId: 'thr_existing',
+        turnId: 'turn_1',
+        userMessageItemId: 'user_1'
+      })),
+      subscribeThreadEvents: vi.fn(async () => undefined)
+    }
+    const createGitCheckpoint = vi.fn(async () => ({
+      ok: false,
+      reason: 'unborn_head',
+      message: 'Git repository has no initial commit yet.'
+    }))
+    const logError = vi.fn(async () => undefined)
+    registryMock.getProvider.mockReturnValue(provider)
+    vi.stubGlobal('window', {
+      kunGui: {
+        getSettings: vi.fn(async () => ({
+          workspaceRoot: '/workspace/deepseek-gui',
+          agents: { kun: { providerId: 'deepseek', model: 'deepseek-v4-pro' } },
+          codePromptPrefix: ''
+        })),
+        createGitCheckpoint,
+        logError
+      }
+    })
+    const { actions, state } = buildHarness()
+    state.busy = false
+
+    await expect(actions.sendMessage('continue without a checkpoint', 'agent')).resolves.toBe(true)
+
+    expect(createGitCheckpoint).toHaveBeenCalledWith({
+      workspaceRoot: '/workspace/deepseek-gui',
+      threadId: 'thr_existing'
+    })
+    expect(logError).not.toHaveBeenCalled()
+    expect(provider.sendUserMessage).toHaveBeenCalledWith(
+      'thr_existing',
+      'continue without a checkpoint',
+      expect.not.objectContaining({ workspaceCheckpointId: expect.anything() })
+    )
+    expect(state.blocks.find((block) => block.kind === 'user')).not.toMatchObject({
+      meta: expect.objectContaining({ workspaceCheckpointId: expect.anything() })
+    })
+    expect(state.error).toBeNull()
+  })
+
+  it('logs other checkpoint failures while continuing the turn', async () => {
+    const provider = {
+      connect: vi.fn(async () => undefined),
+      sendUserMessage: vi.fn(async () => ({
+        threadId: 'thr_existing',
+        turnId: 'turn_1',
+        userMessageItemId: 'user_1'
+      })),
+      subscribeThreadEvents: vi.fn(async () => undefined)
+    }
+    const logError = vi.fn(async () => undefined)
+    registryMock.getProvider.mockReturnValue(provider)
+    vi.stubGlobal('window', {
+      kunGui: {
+        getSettings: vi.fn(async () => ({
+          workspaceRoot: '/workspace/deepseek-gui',
+          agents: { kun: { providerId: 'deepseek', model: 'deepseek-v4-pro' } },
+          codePromptPrefix: ''
+        })),
+        createGitCheckpoint: vi.fn(async () => ({
+          ok: false,
+          reason: 'error',
+          message: 'Permission denied.'
+        })),
+        logError
+      }
+    })
+    const { actions, state } = buildHarness()
+    state.busy = false
+
+    await expect(actions.sendMessage('continue after a checkpoint error', 'agent')).resolves.toBe(true)
+
+    expect(logError).toHaveBeenCalledWith('git-checkpoint', 'Failed to create Git checkpoint', {
+      message: 'Permission denied.',
+      reason: 'error',
+      workspaceRoot: '/workspace/deepseek-gui'
+    })
+    expect(provider.sendUserMessage).toHaveBeenCalledWith(
+      'thr_existing',
+      'continue after a checkpoint error',
+      expect.not.objectContaining({ workspaceCheckpointId: expect.anything() })
+    )
+  })
+
   it('forwards GUI design canvas turns to the runtime provider', async () => {
     const provider = {
       connect: vi.fn(async () => undefined),

--- a/src/renderer/src/store/chat-store-thread-actions.ts
+++ b/src/renderer/src/store/chat-store-thread-actions.ts
@@ -1152,7 +1152,11 @@ export function createThreadActions(
         }))
         if (checkpoint.ok) {
           workspaceCheckpointId = checkpoint.checkpointId
-        } else if (checkpoint.reason !== 'not_git_repo' && checkpoint.reason !== 'no_workspace') {
+        } else if (
+          checkpoint.reason !== 'not_git_repo' &&
+          checkpoint.reason !== 'no_workspace' &&
+          checkpoint.reason !== 'unborn_head'
+        ) {
           if (checkpoint.reason === 'git_unavailable') {
             checkpointGitAvailability.markUnavailable(checkpointWorkspaceKey)
           }

--- a/src/shared/git-checkpoint.ts
+++ b/src/shared/git-checkpoint.ts
@@ -8,7 +8,7 @@ export type GitCheckpointCreateResult =
     }
   | {
       ok: false
-      reason: 'no_workspace' | 'not_git_repo' | 'git_unavailable' | 'conflict' | 'error'
+      reason: 'no_workspace' | 'not_git_repo' | 'git_unavailable' | 'unborn_head' | 'conflict' | 'error'
       message: string
     }
 


### PR DESCRIPTION
## Problem
A selected workspace can be a valid Git repository before its first commit. Checkpoint creation treated the missing `HEAD` as a generic failure, which polluted diagnostics even though the user turn can safely continue without a rollback checkpoint.

## Root cause
`createGitCheckpoint()` resolved `HEAD` only after creating checkpoint storage and had no distinct contract for an unborn symbolic branch.

## Scope
This PR only makes checkpoint creation safely degrade for an unborn Git repository. It does not change restore semantics, create an initial commit, or hide Git corruption and permission failures.

## Changes
- Classify a verified symbolic HEAD with a missing branch ref as `unborn_head` before checkpoint storage is created.
- Continue the renderer turn without a checkpoint or error log for that one benign condition.
- Preserve existing generic failure behavior for corrupt refs, unavailable Git, and other failures.

## Safety
- The classifier requires a symbolic HEAD, a missing branch ref, and a successful `git status`; it does not treat arbitrary Git errors as unborn.
- Restore keeps its existing public result contract. A rescue snapshot that encounters an unborn HEAD is reported as a normal restore error.

## Typecheck
```bash
npm.cmd run typecheck
```
Passed.

`npm.cmd --prefix kun run typecheck` is currently blocked by an upstream baseline mismatch in `kun/tests/llm-debug-recorder.test.ts` (`captureRequest` is missing); this PR does not touch that module.

## Tests
```bash
npx.cmd vitest run src/main/services/git-checkpoint-service.test.ts src/renderer/src/store/chat-store-thread-actions.test.ts --testTimeout 15000
```
Passed: 2 files, 61 tests.

## Actual validation
Created a real repository using `git init -b main`, added an untracked file without making a commit, and verified checkpoint creation returns `unborn_head` without creating checkpoint metadata or bundle files. The renderer regression test verifies the turn is still sent without a checkpoint ID or error log.

## Review performed
- Functional correctness
- Lifecycle and error classification
- Data integrity and restore contract
- Security and path scope
- Cross-platform Git behavior
- Test validity and PR scope

## PR size
- Production files: 3
- Test files: 2
- Total diff: +185 / -5

## Issue
Part of #988.