### PR TITLE
feat(provider): add Atlas Cloud preset

### DIFF
--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -1213,8 +1213,9 @@ describe('model provider settings', () => {
 })
 
 describe('provider presets', () => {
-  it('includes optional LiteLLM and Vercel AI Gateway presets', () => {
+  it('includes optional LiteLLM, Atlas Cloud, and Vercel AI Gateway presets', () => {
     const litellm = getModelProviderPreset('litellm')
+    const atlascloud = getModelProviderPreset('atlascloud')
     const vercel = getModelProviderPreset('vercel-ai-gateway')
 
     expect(litellm).not.toBeNull()
@@ -1225,6 +1226,35 @@ describe('provider presets', () => {
       endpointFormat: 'chat_completions',
       models: []
     })
+
+    expect(atlascloud).not.toBeNull()
+    expect(atlascloud && modelProviderPresetProfile(atlascloud, 'sk-atlas')).toMatchObject({
+      id: 'atlascloud',
+      name: 'Atlas Cloud',
+      apiKey: 'sk-atlas',
+      baseUrl: 'https://api.atlascloud.ai/v1',
+      endpointFormat: 'chat_completions',
+      models: ['qwen/qwen3.5-flash', 'deepseek-ai/deepseek-v4-pro'],
+      modelProfiles: {
+        'qwen/qwen3.5-flash': expect.objectContaining({
+          contextWindowTokens: 1_000_000,
+          maxOutputTokens: 67_072,
+          inputModalities: ['text', 'image'],
+          messageParts: ['text', 'image_url']
+        }),
+        'deepseek-ai/deepseek-v4-pro': expect.objectContaining({
+          contextWindowTokens: 1_048_576,
+          maxOutputTokens: 393_216,
+          inputModalities: ['text'],
+          reasoning: {
+            supportedEfforts: ['off', 'high', 'max'],
+            defaultEffort: 'max',
+            requestProtocol: 'deepseek-chat-completions'
+          }
+        })
+      }
+    })
+    expect(atlascloud?.apiKeyUrl).toBe('https://www.atlascloud.ai/console/api-keys')
 
     expect(vercel).not.toBeNull()
     expect(vercel && modelProviderPresetProfile(vercel)).toMatchObject({
@@ -1363,6 +1393,7 @@ describe('provider presets', () => {
   it('resolves new OpenAI-compatible presets through the selected provider', () => {
     const cases = [
       ['longcat', 'https://api.longcat.chat/openai', 'LongCat-2.0-Preview'],
+      ['atlascloud', 'https://api.atlascloud.ai/v1', 'qwen/qwen3.5-flash'],
       ['zhipu-coding-plan', 'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions', 'glm-5.2', 'custom_endpoint'],
       ['zai-coding-plan', 'https://api.z.ai/api/coding/paas/v4/chat/completions', 'glm-5.1', 'custom_endpoint'],
       ['kimi-code', 'https://api.kimi.com/coding/v1', 'kimi-for-coding'],

--- a/src/shared/model-provider-presets.ts
+++ b/src/shared/model-provider-presets.ts
@@ -22,6 +22,7 @@ import {
 
 export type ModelProviderPresetId =
   | 'litellm'
+  | 'atlascloud'
   | 'longcat'
   | 'zhipu-coding-plan'
   | 'zai-coding-plan'
@@ -235,6 +236,11 @@ const MOONSHOT_CHAT_MODELS = [
   'moonshot-v1-8k'
 ]
 
+const ATLASCLOUD_CHAT_MODELS = [
+  'qwen/qwen3.5-flash',
+  'deepseek-ai/deepseek-v4-pro'
+]
+
 export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
   {
     id: 'litellm',
@@ -244,6 +250,25 @@ export const MODEL_PROVIDER_PRESETS: ModelProviderPreset[] = [
     models: [],
     docsUrl: 'https://docs.litellm.ai/docs/',
     apiKeyUrl: 'https://docs.litellm.ai/docs/proxy/quick_start'
+  },
+  {
+    id: 'atlascloud',
+    name: 'Atlas Cloud',
+    baseUrl: 'https://api.atlascloud.ai/v1',
+    endpointFormat: 'chat_completions',
+    models: [...ATLASCLOUD_CHAT_MODELS],
+    modelProfiles: {
+      'qwen/qwen3.5-flash': {
+        ...visionChatProfile(1_000_000),
+        maxOutputTokens: 67_072
+      },
+      'deepseek-ai/deepseek-v4-pro': {
+        ...textChatProfile(1_048_576, DEEPSEEK_REASONING),
+        maxOutputTokens: 393_216
+      }
+    },
+    docsUrl: 'https://www.atlascloud.ai/docs',
+    apiKeyUrl: 'https://www.atlascloud.ai/console/api-keys'
   },
   {
     id: 'longcat',


### PR DESCRIPTION
### Summary
- add Atlas Cloud as an OpenAI-compatible model provider preset
- preconfigure `https://api.atlascloud.ai/v1` with `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`
- include focused coverage for preset creation and Kun runtime provider resolution

### Validation
- `npm ci --ignore-scripts`
- `npm run build:extensions`
- `npm exec -- vitest run src/shared/app-settings-provider.test.ts`
- `npm exec -- eslint src/shared/model-provider-presets.ts src/shared/app-settings-provider.test.ts`
- `npm exec -- tsc --noEmit -p tsconfig.web.json`
- `git diff --check`
- Atlas Cloud live `/v1/models` returned 120 models and confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

Note: `npm exec -- tsc --noEmit -p tsconfig.node.json` currently still reports unrelated existing missing/type issues around extension/design dependencies such as `@xmldom/xmldom`, `safe-regex2`, and `semver`.

No README changes.