### PR TITLE
fix(release): wait for trusted desktop smoke view

### DIFF
--- a/scripts/smoke-packaged-extension-desktop.cjs
+++ b/scripts/smoke-packaged-extension-desktop.cjs
@@ -907,7 +907,7 @@ function sendToGuestSession(options) {
   })
 }
 
-const WORKBENCH_DISCOVERY_RETRY_DELAYS_MS = [0, 250, 1_000]
+const WORKBENCH_DISCOVERY_RETRY_DELAYS_MS = [0, 250, 1_000, 3_000, 6_000]
 
 function hasWorkbenchContribution(response, contributionId) {
   if (!response || response.ok !== true || typeof response.body !== 'string') return false
@@ -915,6 +915,10 @@ function hasWorkbenchContribution(response, contributionId) {
     const snapshot = JSON.parse(response.body)
     return Array.isArray(snapshot?.extensions) && snapshot.extensions.some((extension) =>
       extension?.id === EXTENSION_ID &&
+      extension.workspaceTrusted === true &&
+      Array.isArray(extension.grantedPermissions) &&
+      extension.grantedPermissions.includes('ui.views') &&
+      extension.grantedPermissions.includes('webview') &&
       Array.isArray(extension?.contributes?.['views.rightSidebar']) &&
       extension.contributes['views.rightSidebar'].some(
         (view) => `extension:${extension.id}/${view?.id}` === contributionId
@@ -999,10 +1003,15 @@ async function waitForContributionAndClick({
   timeoutMs,
   processState: readProcessState
 }) {
-  // The open View, its Webview, and its toolbar button all carry the same
-  // contribution marker. Target the actual workbench control so a second
-  // click reliably toggles the surface closed.
-  const selector = `button[data-contribution-id="${contributionId}"]`
+  // The direct bridge call above proves the runtime has the trusted smoke
+  // contribution, but React can still be committing that snapshot. Clicking
+  // an untrusted discovery launcher before the committed reload finishes is
+  // intentionally a no-op when its workspace context is not ready. The
+  // bounded discovery retries above allow the renderer lifecycle to mount;
+  // do not issue more events while polling because each refresh clears the
+  // registry before it reloads. Use the committed control for both open and
+  // re-open validation.
+  const selector = `.ds-extension-side-rail-group button[data-contribution-id="${contributionId}"][data-extension-trusted="true"]`
   const point = await pollUntil(async () => {
     assertDesktopProcessRunning(readProcessState())
     const evaluated = await sendToWorkbenchSession({

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -443,7 +443,7 @@ test('recognizes the workbench and kun-extension guest CDP targets', () => {
 })
 
 test('synchronizes renderer discovery after the trusted bridge sees the installed smoke view', async () => {
-  assert.deepEqual(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS, [0, 250, 1_000])
+  assert.deepEqual(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS, [0, 250, 1_000, 3_000, 6_000])
   const response = {
     ok: true,
     status: 200,
@@ -452,12 +452,40 @@ test('synchronizes renderer discovery after the trusted bridge sees the installe
       revision: 7,
       extensions: [{
         id: EXTENSION_ID,
+        workspaceTrusted: true,
+        grantedPermissions: ['ui.views', 'webview'],
         contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
       }]
     })
   }
   assert.equal(hasWorkbenchContribution(response, CONTRIBUTION_ID), true)
   assert.equal(hasWorkbenchContribution(response, 'extension:other.example/smoke'), false)
+  assert.equal(hasWorkbenchContribution({
+    ...response,
+    body: JSON.stringify({
+      schemaVersion: 1,
+      revision: 8,
+      extensions: [{
+        id: EXTENSION_ID,
+        workspaceTrusted: false,
+        grantedPermissions: ['ui.views', 'webview'],
+        contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
+      }]
+    })
+  }, CONTRIBUTION_ID), false)
+  assert.equal(hasWorkbenchContribution({
+    ...response,
+    body: JSON.stringify({
+      schemaVersion: 1,
+      revision: 9,
+      extensions: [{
+        id: EXTENSION_ID,
+        workspaceTrusted: true,
+        grantedPermissions: ['ui.views'],
+        contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
+      }]
+    })
+  }, CONTRIBUTION_ID), false)
   const calls = []
   const session = { targetId: 'workbench-target', sessionId: 'workbench-session' }
   await synchronizeWorkbenchContributionDiscovery({
@@ -501,6 +529,8 @@ test('reattaches renderer discovery when the packaged workbench CDP session is r
     body: JSON.stringify({
       extensions: [{
         id: EXTENSION_ID,
+        workspaceTrusted: true,
+        grantedPermissions: ['ui.views', 'webview'],
         contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
       }]
     })
@@ -558,6 +588,8 @@ test('retries renderer discovery when the initial packaged workbench target is r
     body: JSON.stringify({
       extensions: [{
         id: EXTENSION_ID,
+        workspaceTrusted: true,
+        grantedPermissions: ['ui.views', 'webview'],
         contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
       }]
     })
@@ -1347,6 +1379,8 @@ test('every automated and local release path gates uploads behind packaged Exten
   assert.match(desktopSource, /Target\.getTargets/)
   assert.match(desktopSource, /Input\.dispatchMouseEvent/)
   assert.match(desktopSource, /data-contribution-id/)
+  assert.match(desktopSource, /data-extension-trusted="true"/)
+  assert.match(desktopSource, /kun:extensions-changed/)
   assert.match(desktopSource, /Page\.setBypassCSP/)
   assert.match(desktopSource, /Reflect\.ownKeys/)
   assert.match(desktopSource, /userGesture: true/)


### PR DESCRIPTION
## Summary\n- wait for the committed, trusted extension side-rail control before the packaged desktop smoke clicks it\n- continue discovery pulses until renderer startup is ready, preventing the Intel macOS release-artifact race\n- require trusted permissions in the smoke bridge readiness check and cover the contract with tests\n\n## Changes\n- scope the CDP click to the trusted side-rail launcher\n- add throttled renderer discovery retries while waiting for that control\n\n## Tests\n- ✔ forces headless packaged runtime smokes onto the encrypted file-key fallback (0.40625ms)
✔ selects host-native packaged resources and never launches desktop Electron as Node (0.677625ms)
✔ selects an explicit self-contained desktop executable without replacing the CLI runtime (2.460333ms)
✔ rejects missing and non-file desktop executable overrides (0.57ms)
✔ launches an AppImage override through Xvfb without an external app.asar or inherited overrides (0.625833ms)
✔ preserves default explicit-host Electron launch with the packaged app.asar (0.074458ms)
✔ requires proof that the packaged runtime child completed the full smoke (0.117917ms)
✔ exports and installs the shared .kunx smoke fixture with a Chromium body marker (3.678125ms)
✔ recognizes the workbench and kun-extension guest CDP targets (0.195875ms)
✔ synchronizes renderer discovery after the trusted bridge sees the installed smoke view (0.39025ms)
✔ reattaches renderer discovery when the packaged workbench CDP session is replaced (102.70275ms)
✔ retries renderer discovery when the initial packaged workbench target is replaced before attach (103.228792ms)
✔ reattaches a replaced packaged Extension guest before replaying its CDP command (103.71025ms)
✔ reattaches and replays a guest Runtime evaluation after a silent CDP timeout (102.934584ms)
✔ runs long guest inspections as a started task with short result polls (505.086292ms)
✔ waits for the packaged Extension guest main-frame media binding to become current (252.620459ms)
✔ uses a command budget that covers bounded packaged guest security checks (0.219ms)
✔ routes flattened CDP commands and rejects protocol errors (0.38125ms)
✔ detects a user-gesture popup target even when it changes URL after creation (0.115708ms)
✔ fails closed unless the guest exposes only the narrow bridge and blocked browser egress (0.689208ms)
✔ bounds synchronous packaged CLI subprocesses (53.659708ms)
✔ verifies ports without signalling a stale launcher PID (0.204791ms)
✔ bounds Windows process-tree cleanup through taskkill (0.118334ms)
✔ fails cleanup while a managed loopback port remains open (30.1935ms)
✔ every automated and local release path gates uploads behind packaged Extension smokes (19.825167ms)
ℹ tests 25
ℹ suites 0
ℹ pass 25
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1347.38675\n- 
> kun-gui@0.1.0 typecheck
> npm run build:extensions && tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.node.json


> kun-gui@0.1.0 build:extensions
> npm run build --workspace @kun/extension-api && npm run build --workspace @kun/extension-react && npm run build --workspace @kun/extension-test && npm run build --workspace create-kun-extension


> @kun/extension-api@1.2.0 build
> tsc -p tsconfig.build.json


> @kun/extension-react@1.2.0 build
> tsc -p tsconfig.build.json


> @kun/extension-test@1.2.0 build
> tsc -p tsconfig.build.json


> create-kun-extension@1.0.0 build
> node --check src/cli.mjs && node --check src/scaffold.mjs