### PR TITLE
release: v0.2.30

### DIFF
--- a/scripts/smoke-packaged-extension-desktop.cjs
+++ b/scripts/smoke-packaged-extension-desktop.cjs
@@ -907,7 +907,7 @@ function sendToGuestSession(options) {
   })
 }
 
-const WORKBENCH_DISCOVERY_RETRY_DELAYS_MS = [0, 250, 1_000]
+const WORKBENCH_DISCOVERY_RETRY_DELAYS_MS = [0, 250, 1_000, 3_000, 6_000]
 
 function hasWorkbenchContribution(response, contributionId) {
   if (!response || response.ok !== true || typeof response.body !== 'string') return false
@@ -915,6 +915,10 @@ function hasWorkbenchContribution(response, contributionId) {
     const snapshot = JSON.parse(response.body)
     return Array.isArray(snapshot?.extensions) && snapshot.extensions.some((extension) =>
       extension?.id === EXTENSION_ID &&
+      extension.workspaceTrusted === true &&
+      Array.isArray(extension.grantedPermissions) &&
+      extension.grantedPermissions.includes('ui.views') &&
+      extension.grantedPermissions.includes('webview') &&
       Array.isArray(extension?.contributes?.['views.rightSidebar']) &&
       extension.contributes['views.rightSidebar'].some(
         (view) => `extension:${extension.id}/${view?.id}` === contributionId
@@ -999,10 +1003,15 @@ async function waitForContributionAndClick({
   timeoutMs,
   processState: readProcessState
 }) {
-  // The open View, its Webview, and its toolbar button all carry the same
-  // contribution marker. Target the actual workbench control so a second
-  // click reliably toggles the surface closed.
-  const selector = `button[data-contribution-id="${contributionId}"]`
+  // The direct bridge call above proves the runtime has the trusted smoke
+  // contribution, but React can still be committing that snapshot. Clicking
+  // an untrusted discovery launcher before the committed reload finishes is
+  // intentionally a no-op when its workspace context is not ready. The
+  // bounded discovery retries above allow the renderer lifecycle to mount;
+  // do not issue more events while polling because each refresh clears the
+  // registry before it reloads. Use the committed control for both open and
+  // re-open validation.
+  const selector = `.ds-extension-side-rail-group button[data-contribution-id="${contributionId}"][data-extension-trusted="true"]`
   const point = await pollUntil(async () => {
     assertDesktopProcessRunning(readProcessState())
     const evaluated = await sendToWorkbenchSession({

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -443,7 +443,7 @@ test('recognizes the workbench and kun-extension guest CDP targets', () => {
 })
 
 test('synchronizes renderer discovery after the trusted bridge sees the installed smoke view', async () => {
-  assert.deepEqual(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS, [0, 250, 1_000])
+  assert.deepEqual(WORKBENCH_DISCOVERY_RETRY_DELAYS_MS, [0, 250, 1_000, 3_000, 6_000])
   const response = {
     ok: true,
     status: 200,
@@ -452,12 +452,40 @@ test('synchronizes renderer discovery after the trusted bridge sees the installe
       revision: 7,
       extensions: [{
         id: EXTENSION_ID,
+        workspaceTrusted: true,
+        grantedPermissions: ['ui.views', 'webview'],
         contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
       }]
     })
   }
   assert.equal(hasWorkbenchContribution(response, CONTRIBUTION_ID), true)
   assert.equal(hasWorkbenchContribution(response, 'extension:other.example/smoke'), false)
+  assert.equal(hasWorkbenchContribution({
+    ...response,
+    body: JSON.stringify({
+      schemaVersion: 1,
+      revision: 8,
+      extensions: [{
+        id: EXTENSION_ID,
+        workspaceTrusted: false,
+        grantedPermissions: ['ui.views', 'webview'],
+        contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
+      }]
+    })
+  }, CONTRIBUTION_ID), false)
+  assert.equal(hasWorkbenchContribution({
+    ...response,
+    body: JSON.stringify({
+      schemaVersion: 1,
+      revision: 9,
+      extensions: [{
+        id: EXTENSION_ID,
+        workspaceTrusted: true,
+        grantedPermissions: ['ui.views'],
+        contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
+      }]
+    })
+  }, CONTRIBUTION_ID), false)
   const calls = []
   const session = { targetId: 'workbench-target', sessionId: 'workbench-session' }
   await synchronizeWorkbenchContributionDiscovery({
@@ -501,6 +529,8 @@ test('reattaches renderer discovery when the packaged workbench CDP session is r
     body: JSON.stringify({
       extensions: [{
         id: EXTENSION_ID,
+        workspaceTrusted: true,
+        grantedPermissions: ['ui.views', 'webview'],
         contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
       }]
     })
@@ -558,6 +588,8 @@ test('retries renderer discovery when the initial packaged workbench target is r
     body: JSON.stringify({
       extensions: [{
         id: EXTENSION_ID,
+        workspaceTrusted: true,
+        grantedPermissions: ['ui.views', 'webview'],
         contributes: { 'views.rightSidebar': [{ id: 'smoke' }] }
       }]
     })
@@ -1347,6 +1379,8 @@ test('every automated and local release path gates uploads behind packaged Exten
   assert.match(desktopSource, /Target\.getTargets/)
   assert.match(desktopSource, /Input\.dispatchMouseEvent/)
   assert.match(desktopSource, /data-contribution-id/)
+  assert.match(desktopSource, /data-extension-trusted="true"/)
+  assert.match(desktopSource, /kun:extensions-changed/)
   assert.match(desktopSource, /Page\.setBypassCSP/)
   assert.match(desktopSource, /Reflect\.ownKeys/)
   assert.match(desktopSource, /userGesture: true/)


### PR DESCRIPTION
## Summary

Release v0.2.30 with the verified packaged-extension desktop smoke synchronization fix.

## Changes

- Wait for a trusted side-rail extension contribution before clicking it in the packaged desktop smoke test.
- Keep discovery retries bounded so the contribution registry can settle.

## Tests

- Typecheck and test
- CodeQL
- Linux AppImage packaged validation
- Windows NSIS packaged validation
- macOS x64 and arm64 packaged validation
- Intel macOS packaged validation