### PR TITLE
[High Priority] fix(deps): patch electron-updater credential leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "better-sqlite3": "12.11.1",
         "diff": "^8.0.4",
         "electron-store": "^10.1.0",
-        "electron-updater": "^6.8.3",
+        "electron-updater": "^6.8.9",
         "extract-zip": "^2.0.1",
         "html-to-docx": "^1.8.0",
         "i18next": "^25.4.2",
@@ -7433,9 +7433,9 @@
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmmirror.com/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -8747,12 +8747,12 @@
       "license": "ISC"
     },
     "node_modules/electron-updater": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmmirror.com/electron-updater/-/electron-updater-6.8.3.tgz",
-      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
       "license": "MIT",
       "dependencies": {
-        "builder-util-runtime": "9.5.1",
+        "builder-util-runtime": "9.7.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "better-sqlite3": "12.11.1",
     "diff": "^8.0.4",
     "electron-store": "^10.1.0",
-    "electron-updater": "^6.8.3",
+    "electron-updater": "^6.8.9",
     "extract-zip": "^2.0.1",
     "html-to-docx": "^1.8.0",
     "i18next": "^25.4.2",


### PR DESCRIPTION
## Summary

- Upgrade `electron-updater` from 6.8.3 to 6.8.9.
- Upgrade its transitive `builder-util-runtime` dependency from 9.5.1 to 9.7.0.
- Patch the high-severity credential disclosure advisory [GHSA-p2f4-r6v6-j797](https://github.com/advisories/GHSA-p2f4-r6v6-j797).

## Root Cause

The newly published advisory marks `electron-updater` versions through 6.8.8 and `builder-util-runtime` versions below 9.7.0 as vulnerable. The production audit therefore fails on the current `develop` lockfile even for unrelated pull requests.

A cross-origin update redirect could forward `PRIVATE-TOKEN` or mixed-case `Authorization` credentials. The patched runtime strips those credentials at the redirect boundary.

## Impact

- Restores the production dependency audit on `develop`.
- Unblocks #1020 and other pull requests that run the same audit gate.
- Keeps the change limited to the root dependency manifest and lockfile.

## Tests

- `npm ci`
- `npm run audit:production`
- `npx vitest run src/main/gui-updater.test.ts` (11 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
