### PR TITLE
fix(renderer): settle terminal thread status

### DIFF
--- a/src/renderer/src/agent/kun-event-normalizer.ts
+++ b/src/renderer/src/agent/kun-event-normalizer.ts
@@ -206,7 +206,11 @@ export function normalizeKunRuntimeEvent(
         const tool = deps.childTool(event)
         return tool ? [{ type: 'tool_updated', payload: tool }] : []
       }
-      return [{ type: 'turn_completed' }]
+      return [{
+        type: 'turn_completed',
+        ...(event.threadId ? { threadId: event.threadId } : {}),
+        ...(event.turnId ? { turnId: event.turnId } : {})
+      }]
     case 'turn_failed': {
       if (event.child) {
         const tool = deps.childTool(event)
@@ -216,7 +220,12 @@ export function normalizeKunRuntimeEvent(
       const terminal: RuntimeProjectionAction = {
         type: 'turn_failed',
         error: deps.errorFromRuntime(payload),
-        options: { terminal: true, scope: 'conversation' }
+        options: {
+          terminal: true,
+          scope: 'conversation',
+          ...(event.threadId ? { threadId: event.threadId } : {}),
+          ...(event.turnId ? { turnId: event.turnId } : {})
+        }
       }
       // A message-less terminal event normally follows a more useful
       // structured `error` event. Settle the turn without adding a generic

--- a/src/renderer/src/agent/kun-mapper.test.ts
+++ b/src/renderer/src/agent/kun-mapper.test.ts
@@ -238,6 +238,20 @@ describe('runtime projection action normalization', () => {
       payload: { itemId: 'input_unknown', status: 'cancelled' }
     }])
   })
+
+  it('preserves the terminal thread and turn identity for sidebar settlement', () => {
+    expect(runtimeProjectionActionsFromEvent({
+      kind: 'turn_completed',
+      seq: 10,
+      timestamp: '2026-07-30T00:00:00.000Z',
+      threadId: 'thread_1',
+      turnId: 'turn_1'
+    })).toEqual([{
+      type: 'turn_completed',
+      threadId: 'thread_1',
+      turnId: 'turn_1'
+    }])
+  })
 })
 
 describe('assistant stream mapping', () => {
@@ -424,6 +438,26 @@ describe('review mapping', () => {
 })
 
 describe('create_plan tool mapping', () => {
+  it('forwards terminal thread identity from the runtime event to the sink', async () => {
+    let completion: { threadId?: string; turnId?: string } | undefined
+    const sink: ThreadEventSink = {
+      ...makeSink(),
+      onTurnComplete: (event) => {
+        completion = event
+      }
+    }
+
+    await dispatchKunRuntimeEvent({
+      kind: 'turn_completed',
+      seq: 8,
+      timestamp: '2024-01-01T00:00:00.000Z',
+      threadId: 'thr_1',
+      turnId: 'turn_1'
+    }, sink, async () => undefined)
+
+    expect(completion).toEqual({ threadId: 'thr_1', turnId: 'turn_1' })
+  })
+
   it('surfaces turn failure messages from Kun lifecycle events', async () => {
     let capturedError: string | null = null
     let capturedErrorOptions: ThreadErrorOptions | null = null
@@ -457,7 +491,12 @@ describe('create_plan tool mapping', () => {
       message: 'model stream exploded',
       severity: 'error'
     })
-    expect(capturedErrorOptions).toEqual({ terminal: true, scope: 'conversation' })
+    expect(capturedErrorOptions).toEqual({
+      terminal: true,
+      scope: 'conversation',
+      threadId: 'thr_1',
+      turnId: 'turn_1'
+    })
   })
 
   it('settles message-less turn failures without adding a generic duplicate error', async () => {
@@ -482,7 +521,12 @@ describe('create_plan tool mapping', () => {
     }, sink, async () => undefined)
 
     expect(runtimeErrorCount).toBe(0)
-    expect(capturedErrorOptions).toEqual({ terminal: true, scope: 'conversation' })
+    expect(capturedErrorOptions).toEqual({
+      terminal: true,
+      scope: 'conversation',
+      threadId: 'thr_1',
+      turnId: 'turn_1'
+    })
   })
 
   it('does not finish the parent turn for child lifecycle events', async () => {

--- a/src/renderer/src/agent/kun-mapper.ts
+++ b/src/renderer/src/agent/kun-mapper.ts
@@ -1852,7 +1852,7 @@ async function applyRuntimeProjectionAction(
     case 'context_snapshot_received': sink.onContextSnapshot?.(action.payload); return
     case 'delegated_runtime_received': sink.onDelegatedRuntimeState?.(action.payload); return
     case 'usage_received': sink.onUsage?.(action.payload); return
-    case 'turn_completed': sink.onTurnComplete(); return
+    case 'turn_completed': sink.onTurnComplete({ threadId: action.threadId, turnId: action.turnId }); return
     case 'turn_failed': sink.onError(action.error, action.options); return
   }
 }

--- a/src/renderer/src/agent/runtime-projection-actions.ts
+++ b/src/renderer/src/agent/runtime-projection-actions.ts
@@ -66,7 +66,7 @@ export type RuntimeProjectionAction =
         userBlockId?: string | null
       }
     }
-  | { type: 'turn_completed' }
+  | { type: 'turn_completed'; threadId?: string; turnId?: string }
   | { type: 'turn_failed'; error: Error; options?: ThreadErrorOptions }
 
 export type RuntimeProjectionActionBatch = readonly RuntimeProjectionAction[]

--- a/src/renderer/src/agent/types.ts
+++ b/src/renderer/src/agent/types.ts
@@ -580,6 +580,9 @@ export type AssistantItemSnapshotPayload = {
 
 export type ThreadErrorOptions = {
   terminal?: boolean
+  /** Runtime terminal identity prevents a replayed old turn from settling a newer one. */
+  threadId?: string
+  turnId?: string
   /**
    * Conversation-scoped failures already have a durable runtime-error card in
    * the owning thread. Runtime-scoped failures use the global recovery banner.
@@ -669,7 +672,7 @@ export type ThreadEventSink = {
   onTodos?(ev: { threadId: string; todos: ThreadTodoList | null; cleared?: boolean; createdAt?: string }): void
   /** Thread metadata changed out-of-band (e.g. the backend LLM titler upgraded the title). */
   onThreadUpdated?(ev: { threadId: string; title?: string; titleAuto?: boolean; status?: string }): void
-  onTurnComplete(): void
+  onTurnComplete(event?: { threadId?: string; turnId?: string }): void
   onError(err: Error, options?: ThreadErrorOptions): void
   /** Optional: cumulative usage update for the thread. */
   onUsage?(usage: ThreadUsageSnapshot): void

--- a/src/renderer/src/store/chat-projection-reducer.test.ts
+++ b/src/renderer/src/store/chat-projection-reducer.test.ts
@@ -231,6 +231,78 @@ describe('chat projection reducer', () => {
     expect(live.error).toBeNull()
   })
 
+  it('settles the completed thread summary immediately instead of waiting for a sidebar refresh', () => {
+    const initial = state()
+    initial.busy = true
+    initial.currentTurnId = 'turn_1'
+    initial.currentTurnUserId = 'user_1'
+    initial.turnStartedAtByUserId = { user_1: NOW }
+    initial.threads = [{
+      id: 'thread_1',
+      title: 'Goal task',
+      updatedAt: '2026-07-11T00:00:00.000Z',
+      model: 'model',
+      mode: 'agent',
+      status: 'running'
+    }]
+
+    const projected = project(initial, [{
+      type: 'turn_completed',
+      threadId: 'thread_1',
+      turnId: 'turn_1'
+    }])
+
+    expect(projected.busy).toBe(false)
+    expect(projected.threads[0]?.status).toBe('idle')
+  })
+
+  it('settles a replayed terminal thread summary without repeating turn effects', () => {
+    const initial = state()
+    initial.threads = [{
+      id: 'thread_1',
+      title: 'Goal task',
+      updatedAt: '2026-07-11T00:00:00.000Z',
+      model: 'model',
+      mode: 'agent',
+      status: 'running'
+    }]
+
+    const projected = project(initial, [{
+      type: 'turn_completed',
+      threadId: 'thread_1',
+      turnId: 'turn_1'
+    }])
+
+    expect(projected.threads[0]?.status).toBe('idle')
+    expect(projected.busy).toBeUndefined()
+  })
+
+  it('settles a replayed terminal failure by its event thread identity', () => {
+    const initial = state()
+    initial.threads = [{
+      id: 'thread_1',
+      title: 'Goal task',
+      updatedAt: '2026-07-11T00:00:00.000Z',
+      model: 'model',
+      mode: 'agent',
+      status: 'running'
+    }]
+
+    const projected = project(initial, [{
+      type: 'turn_failed',
+      error: new Error('provider stopped'),
+      options: {
+        terminal: true,
+        scope: 'conversation',
+        threadId: 'thread_1',
+        turnId: 'turn_1'
+      }
+    }])
+
+    expect(projected.threads[0]?.status).toBe('idle')
+    expect(projected.threads[0]?.latestTurnStatus).toBe('failed')
+  })
+
   it('stores context snapshots only for the active thread', () => {
     const activeSnapshot: RuntimeProjectionAction = {
       type: 'context_snapshot_received',

--- a/src/renderer/src/store/chat-projection-reducer.ts
+++ b/src/renderer/src/store/chat-projection-reducer.ts
@@ -685,7 +685,11 @@ export function reduceChatProjection(
       }
     }
     case 'turn_completed': {
-      const threadId = state.activeThreadId
+      const terminalThreadId = action.threadId?.trim()
+      const terminalTurnId = action.turnId?.trim()
+      if (terminalThreadId && state.activeThreadId && terminalThreadId !== state.activeThreadId) return {}
+      if (terminalTurnId && state.currentTurnId && terminalTurnId !== state.currentTurnId) return {}
+      const threadId = terminalThreadId ?? state.activeThreadId
       const threads = threadId
         ? settleProjectedThreadStatus(state.threads, threadId, 'completed')
         : state.threads
@@ -705,15 +709,24 @@ export function reduceChatProjection(
       const unreadThreadIds = { ...state.unreadThreadIds }
       delete watchTurnCompletion[threadId]
       delete unreadThreadIds[threadId]
-      return { ...patch, watchTurnCompletion, unreadThreadIds }
+      return {
+        ...patch,
+        watchTurnCompletion,
+        unreadThreadIds
+      }
     }
     case 'turn_failed': {
+      const terminalThreadId = action.options?.terminal ? action.options.threadId?.trim() : undefined
+      const terminalTurnId = action.options?.terminal ? action.options.turnId?.trim() : undefined
+      if (terminalThreadId && state.activeThreadId && terminalThreadId !== state.activeThreadId) return {}
+      if (terminalTurnId && state.currentTurnId && terminalTurnId !== state.currentTurnId) return {}
       const message = context.formatRuntimeError(action.error)
       const detail = context.runtimeErrorDetail(action.error)
       const terminal = action.options?.terminal === true
       const conversationScoped = action.options?.scope === 'conversation'
       const interrupted = context.isInterruptSettledError(action.error, message)
       const shouldSettle = terminal || !state.busy || interrupted
+      const terminalThread = terminalThreadId ?? state.activeThreadId
       const patch = flushLiveProjection(state, context.now, {
         ...finalizeTurnTimingAt(state, context.now),
         error: interrupted || conversationScoped ? null : message,
@@ -725,19 +738,19 @@ export function reduceChatProjection(
       patch.currentTurnOrchestration = null
       patch.currentTurnUserId = null
       patch.blocks = context.settlePendingRuntimeWork(patch.blocks ?? state.blocks)
-      if (state.activeThreadId) {
+      if (terminalThread) {
         const threads = settleProjectedThreadStatus(
           state.threads,
-          state.activeThreadId,
+          terminalThread,
           interrupted ? 'aborted' : 'failed'
         )
         if (threads !== state.threads) patch.threads = threads
       }
-      if (terminal && state.activeThreadId) {
+      if (terminal && terminalThread) {
         const watchTurnCompletion = { ...state.watchTurnCompletion }
         const unreadThreadIds = { ...state.unreadThreadIds }
-        delete watchTurnCompletion[state.activeThreadId]
-        delete unreadThreadIds[state.activeThreadId]
+        delete watchTurnCompletion[terminalThread]
+        delete unreadThreadIds[terminalThread]
         patch.watchTurnCompletion = watchTurnCompletion
         patch.unreadThreadIds = unreadThreadIds
       }
@@ -754,8 +767,9 @@ function updateProjectedThreadStatus(
   status: string,
   latestTurnStatus?: string
 ): ChatState['threads'] {
+  const currentThreads = threads ?? []
   let changed = false
-  const next = threads.map((thread) => {
+  const next = currentThreads.map((thread) => {
     if (thread.id !== threadId) return thread
     if (thread.status === status && (
       latestTurnStatus === undefined || thread.latestTurnStatus === latestTurnStatus
@@ -769,7 +783,7 @@ function updateProjectedThreadStatus(
       ...(latestTurnStatus ? { latestTurnStatus } : {})
     }
   })
-  return changed ? next : threads
+  return changed ? next : currentThreads
 }
 
 function settleProjectedThreadStatus(
@@ -777,9 +791,10 @@ function settleProjectedThreadStatus(
   threadId: string,
   latestTurnStatus: 'completed' | 'failed' | 'aborted'
 ): ChatState['threads'] {
-  const thread = threads.find((candidate) => candidate.id === threadId)
-  if (!thread || thread.status?.trim().toLowerCase() !== 'running') return threads
-  return updateProjectedThreadStatus(threads, threadId, 'idle', latestTurnStatus)
+  const currentThreads = threads ?? []
+  const thread = currentThreads.find((candidate) => candidate.id === threadId)
+  if (!thread || thread.status?.trim().toLowerCase() !== 'running') return currentThreads
+  return updateProjectedThreadStatus(currentThreads, threadId, 'idle', latestTurnStatus)
 }
 
 function runtimeEventStartedAt(createdAt: string | undefined, now: number): number {

--- a/src/renderer/src/store/chat-store-navigation-actions.test.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.test.ts
@@ -104,6 +104,17 @@ describe('requirement session lifecycle', () => {
   })
 })
 
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((complete) => {
+    resolve = complete
+  })
+  return { promise, resolve }
+}
+
 function buildHarness(overrides?: {
   subscribeThreadEventsLive?: ReturnType<typeof vi.fn>
   recoverActiveTurn?: ReturnType<typeof vi.fn>
@@ -191,6 +202,40 @@ describe('chat-store navigation workspace selection', () => {
   afterEach(() => {
     rendererRuntimeClient.invalidateSettings()
     vi.unstubAllGlobals()
+  })
+
+  it('does not let an older running snapshot overwrite a newer completed thread refresh', async () => {
+    const first = deferred<NormalizedThread[]>()
+    const second = deferred<NormalizedThread[]>()
+    const listThreads = vi.fn()
+      .mockImplementationOnce(async () => first.promise)
+      .mockImplementationOnce(async () => second.promise)
+    registryMock.getProvider.mockReturnValue({ listThreads })
+    const harness = buildHarness()
+    harness.state.refreshThreads = harness.actions.refreshThreads
+
+    const staleRefresh = harness.actions.refreshThreads()
+    const currentRefresh = harness.actions.refreshThreads()
+    second.resolve([thread({
+      id: 'thread_1',
+      title: 'Goal task',
+      workspace: '/Users/zxy/project',
+      status: 'idle'
+    })])
+    await currentRefresh
+
+    first.resolve([thread({
+      id: 'thread_1',
+      title: 'Goal task',
+      workspace: '/Users/zxy/project',
+      status: 'running'
+    })])
+    await staleRefresh
+
+    expect(harness.state.threads.find((item) => item.id === 'thread_1')).toEqual(expect.objectContaining({
+      id: 'thread_1',
+      status: 'idle'
+    }))
   })
 
   it('does not move the only default thread into a newly picked empty workspace', async () => {

--- a/src/renderer/src/store/chat-store-navigation-actions.ts
+++ b/src/renderer/src/store/chat-store-navigation-actions.ts
@@ -137,6 +137,7 @@ let trayActionUnsubscribe: (() => void) | null = null
 export function createNavigationActions(
   { set, get, sseAbortRef }: StoreActionContext
 ): Pick<ChatState, 'openCode' | 'openWrite' | 'openDesign' | 'clearActiveThreadSelection' | 'ensureWriteThreadForWorkspace' | 'createWriteThread' | 'selectWriteThread' | 'ensureDesignThreadForWorkspace' | 'createDesignThread' | 'probeRuntime' | 'boot' | 'chooseWorkspace' | 'selectWorkspaceRoot' | 'clearWorkspace' | 'deleteWorkspace' | 'refreshThreads' | 'setThreadSearch' | 'setShowArchivedThreads'> {
+  let threadRefreshGeneration = 0
   return {
   openCode: async () => {
     const state = get()
@@ -868,6 +869,7 @@ export function createNavigationActions(
 
   refreshThreads: async () => {
     if (get().runtimeConnection !== 'ready') return
+    const refreshGeneration = ++threadRefreshGeneration
     try {
       const p = getProvider()
       let rawThreads: NormalizedThread[]
@@ -886,8 +888,8 @@ export function createNavigationActions(
       const sddThreadRegistry = readSddThreadRegistry()
       const designRegistry = readDesignThreadRegistry()
       const sidebarThreads = await filterThreadsForSidebar(threads, p)
+      if (refreshGeneration !== threadRefreshGeneration) return
       const forkRegistry = hydrateThreadForkRegistry(sidebarThreads, readThreadForkRegistry())
-      saveThreadForkRegistry(forkRegistry)
       const enrichedThreads = enrichThreadsWithForkInfo(sidebarThreads, forkRegistry)
       // Preserve the active Kun thread when it is not in the listing yet.
       // A brand-new thread can be absent from `listThreads` until the first
@@ -930,6 +932,8 @@ export function createNavigationActions(
         displayThreads = [preservedSddActiveThread, ...displayThreads]
       }
       const writeWorkspaceRoots = await readWriteWorkspaceRoots()
+      if (refreshGeneration !== threadRefreshGeneration) return
+      saveThreadForkRegistry(forkRegistry)
       const writeRegistry = hydrateWriteThreadRegistry(
         displayThreads,
         writeWorkspaceRoots,
@@ -981,6 +985,7 @@ export function createNavigationActions(
           isInternalDeepSeekGuiWorkspace(activeThread.workspace))
       const shouldClearSelection =
         activeThreadId != null && !displayThreads.some((thread) => thread.id === activeThreadId)
+      if (refreshGeneration !== threadRefreshGeneration) return
       if (shouldClearSelection) {
         sseAbortRef.current?.abort()
         sseAbortRef.current = null
@@ -1012,6 +1017,7 @@ export function createNavigationActions(
         await get().openCode()
       }
     } catch (e) {
+      if (refreshGeneration !== threadRefreshGeneration) return
       stopTurnCompletionPoll()
       set({
         runtimeConnection: 'offline',

--- a/src/renderer/src/store/chat-store-runtime.test.ts
+++ b/src/renderer/src/store/chat-store-runtime.test.ts
@@ -468,6 +468,22 @@ describe('thread event sink binding', () => {
     expect(getState().liveAssistant).toBe('')
   })
 
+  it('ignores a late terminal event from an earlier turn', () => {
+    const { getState, set, get } = makeSinkHarness({
+      activeThreadId: 'thread-current',
+      currentTurnId: 'turn-current',
+      currentTurnUserId: 'user-current',
+      threads: [makeThread({ id: 'thread-current', status: 'running' })]
+    })
+    const sink = buildThreadEventSink(set, get, { threadId: 'thread-current' })
+
+    sink.onTurnComplete({ threadId: 'thread-current', turnId: 'turn-earlier' })
+
+    expect(getState().busy).toBe(true)
+    expect(getState().currentTurnId).toBe('turn-current')
+    expect(getState().threads).toContainEqual(makeThread({ id: 'thread-current', status: 'running' }))
+  })
+
   it('projects a replayed duplicate completion once, including external effects', () => {
     const showTurnCompleteNotification = vi.fn(async () => ({ ok: true }))
     vi.stubGlobal('window', {

--- a/src/renderer/src/store/chat-store-runtime.ts
+++ b/src/renderer/src/store/chat-store-runtime.ts
@@ -1008,13 +1008,26 @@ export function buildThreadEventSink(
       if (!isCurrentStream()) return
       set((state) => reduce(state, { type: 'thread_metadata_changed', payload: event }))
     },
-    onTurnComplete: () => {
+    onTurnComplete: (event) => {
       if (!isCurrentStream()) return
+      const terminalThreadId = event?.threadId?.trim()
+      const terminalTurnId = event?.turnId?.trim()
+      if (terminalThreadId && boundThreadId && terminalThreadId !== boundThreadId) return
+      if (terminalTurnId && get().currentTurnId && get().currentTurnId !== terminalTurnId) return
       // Reconnect/replay can deliver the same terminal event after the first
       // projection already cleared the active turn. Treat it as a no-op so
       // notifications, mirrors, workspace refreshes and queue drains remain
       // once-only for one completion identity.
-      if (!get().busy && !get().currentTurnId) return
+      if (!get().busy && !get().currentTurnId) {
+        if (terminalThreadId) {
+          set((state) => reduce(state, {
+            type: 'turn_completed',
+            threadId: terminalThreadId,
+            ...(terminalTurnId ? { turnId: terminalTurnId } : {})
+          }))
+        }
+        return
+      }
       resetBusyRecoveryAttempts()
       clearBusyWatchdog()
       const completedState = get()
@@ -1033,7 +1046,11 @@ export function buildThreadEventSink(
               completedState.liveAssistant
             )
           : ''
-      set((state) => reduce(state, { type: 'turn_completed' }))
+      set((state) => reduce(state, {
+        type: 'turn_completed',
+        ...(terminalThreadId ? { threadId: terminalThreadId } : {}),
+        ...(terminalTurnId ? { turnId: terminalTurnId } : {})
+      }))
       if (completedThreadId) clearWatchedCompletionNotification(completedThreadId)
       runEffects(completionProjectionEffects({
         state: completedState,
@@ -1049,6 +1066,10 @@ export function buildThreadEventSink(
     },
     onError: (err, options) => {
       if (!isCurrentStream()) return
+      if (options?.terminal && options.threadId?.trim() && boundThreadId && options.threadId.trim() !== boundThreadId) return
+      if (options?.terminal && options.turnId?.trim() && get().currentTurnId && get().currentTurnId !== options.turnId.trim()) {
+        return
+      }
       resetBusyRecoveryAttempts()
       clearBusyWatchdog()
       const state = get()


### PR DESCRIPTION
## Problem

A completed Goal-mode turn could leave its sidebar conversation marked as running indefinitely.

## Root cause

Terminal runtime events discarded their thread/turn identity before reaching the renderer store. The store therefore could not safely settle the sidebar entry immediately, and a slower pre-completion thread refresh could overwrite a newer terminal snapshot.

## Scope

This PR only fixes terminal thread-state projection and refresh ordering for the affected renderer path.

## Non-goals

- No runtime protocol or persistence changes.
- No change to Goal-mode behavior itself.
- No broad timeline refactor.

## Changes

- Preserve terminal thread and turn identity through normalization and mapping.
- Ignore stale terminal events from a different thread or earlier turn.
- Set a running sidebar entry to idle immediately on terminal completion/failure, including replayed terminal events.
- Prevent an older asynchronous thread-list refresh from overwriting a later terminal state.

## Safety

- Terminal side effects remain once-only for replayed events.
- Archived entries are not revived.
- No credentials, paths, or persisted thread data are changed.

## Typecheck

```text
npm.cmd run typecheck
```

Passed.

## Tests

```text
npm.cmd exec -- vitest run src/renderer/src/agent/kun-mapper.test.ts src/renderer/src/store/chat-projection-reducer.test.ts src/renderer/src/store/chat-store-navigation-actions.test.ts src/renderer/src/store/chat-store-runtime.test.ts
node --test scripts/smoke-packaged-extension-desktop.test.cjs
```

Passed: 4 files / 166 tests; packaged smoke script: 28 tests.

## Actual validation

- Exercised the runtime event -> normalizer -> mapper -> sink path with terminal completion and failure events.
- Exercised immediate sidebar settlement, terminal replay, stale earlier-turn events, and competing asynchronous refreshes.
- `npm.cmd run smoke:development-graph-workbench -- --timeout-ms 45000` passed on Windows and confirmed runtime cleanup.
- `npm.cmd run lint` and `npm.cmd run build` passed after rebasing onto current `develop`.

## Review performed

- Functional correctness
- Architecture and state ownership
- Concurrency/lifecycle
- Data integrity
- Security
- Cross-platform risk
- Scope and test quality

## PR size

```text
Production files: 7
Test files: 4
Production LOC: 78 added / 16 removed
Total diff: 254 added / 23 removed
```

Fixes #1028
