### PR TITLE
fix(ci): preserve Windows packaged CLI quoting

### DIFF
--- a/scripts/smoke-packaged-cli.cjs
+++ b/scripts/smoke-packaged-cli.cjs
@@ -77,7 +77,14 @@ function packagedCliInvocation(resourcesDirectory, {
     return {
       command,
       args: ['/d', '/s', '/c', `""${launcher}" ${cliArgs.join(' ')}"`],
-      options: { env: { ...process.env }, shell: false }
+      // The final argument is already a complete cmd.exe command string.
+      // Letting Node quote it again turns it into a literal quoted executable
+      // path on Windows, so the packaged .cmd launcher cannot be found.
+      options: {
+        env: { ...process.env },
+        shell: false,
+        windowsVerbatimArguments: true
+      }
     }
   }
   throw new Error(`Unsupported packaged CLI smoke platform: ${platform}`)

--- a/scripts/smoke-packaged-cli.test.cjs
+++ b/scripts/smoke-packaged-cli.test.cjs
@@ -44,7 +44,10 @@ function packagedFixture(t, platform) {
     writeHelpExecutable(join(root, 'kun-gui'))
   } else {
     mkdirSync(join(root, 'bin'), { recursive: true })
-    writeFileSync(join(root, 'bin', 'kun.cmd'), '@echo off\r\n')
+    writeFileSync(
+      join(root, 'bin', 'kun.cmd'),
+      `@echo off\r\necho ${CLI_HELP_SENTINEL.replace('<', '^<').replace('>', '^>')}\r\n`
+    )
   }
   return { root, resources }
 }
@@ -86,6 +89,17 @@ test('builds a shell-free Windows cmd invocation relative to packaged resources'
   assert.deepEqual(invocation.args.slice(0, 3), ['/d', '/s', '/c'])
   assert.match(invocation.args[3], /bin[\\/]kun\.cmd" --help"$/)
   assert.equal(invocation.options.shell, false)
+  assert.equal(invocation.options.windowsVerbatimArguments, true)
+})
+
+test('executes the packaged Windows cmd launcher without quote re-escaping', {
+  skip: process.platform !== 'win32' && 'requires cmd.exe'
+}, (t) => {
+  const windows = packagedFixture(t, 'win32')
+  assert.match(
+    runPackagedCliSmoke(windows.resources, { platform: 'win32' }),
+    /kun <command>/
+  )
 })
 
 test('extracts a deb and executes its packaged product launcher in CLI mode', {


### PR DESCRIPTION
## Problem

Windows packaged CLI smoke cannot execute `bin/kun.cmd`.

## Root cause

`cmd.exe /c` receives a pre-quoted command string. Node's default Windows argument escaping quotes that complete string again, turning the launcher path into a literal quoted command.

## Scope

Only the Windows packaged CLI smoke invocation and its regression coverage.

## Non-goals

- No runtime or packaged CLI behavior changes.
- No shell-enabled execution.
- No packaging configuration change.

## Changes

- Pass the already constructed `cmd.exe` command string verbatim.
- Keep `shell: false`.
- Execute a real temporary Windows `.cmd` launcher in the regression test.

## Safety

- The launcher is resolved from validated packaged resources.
- Smoke arguments are internal `--help` and `--version` checks.
- No user input is passed to a shell.

## Typecheck

`npm.cmd run typecheck` - passed.

## Tests

`node --test scripts/smoke-packaged-cli.test.cjs` - 3 passed, 2 platform skips.

`npm.cmd run lint` - passed.

`npm.cmd run build` - passed.

## Actual validation

Before this change, a local Windows `cmd.exe` invocation failed with the re-quoted launcher path. After the change, the same temporary `.cmd` fixture emits the expected `kun <command> [options]` help banner.

## Review performed

- Functional correctness
- Lifecycle and cross-platform behavior
- Shell/argument safety
- Scope and test validity

## PR size

```text
Production files: 1
Test files: 1
Total diff: 23 additions / 2 deletions
```

## Follow-up

After this is merged, #1034 can be rebased and its package checks rerun without this unrelated Windows smoke failure.