### PR TITLE
fix(ci): terminate Graph smoke before Playwright close

### DIFF
--- a/scripts/smoke-development-graph-workbench.cjs
+++ b/scripts/smoke-development-graph-workbench.cjs
@@ -355,25 +355,11 @@ async function main() {
       diagnostics ? `\n\n${diagnostics}` : ''
     }`)
   } finally {
-    if (electronApplication) {
-      await withTimeout(
-        electronApplication.close(),
-        MAX_CLEANUP_TIMEOUT_MS,
-        'closing the Graph workbench Electron application'
-      ).catch(() => undefined)
-    }
-    if (electronProcess) {
-      await terminateProcessTree(electronProcess, process.platform, {
-        timeoutMs: MAX_CLEANUP_TIMEOUT_MS,
-        detached: process.platform !== 'win32'
-      }).catch(() => undefined)
-    }
-    if (rendererProcess) {
-      await terminateProcessTree(rendererProcess, process.platform, {
-        timeoutMs: MAX_CLEANUP_TIMEOUT_MS,
-        detached: process.platform !== 'win32'
-      }).catch(() => undefined)
-    }
+    await cleanupGraphWorkbenchProcesses({
+      electronApplication,
+      electronProcess,
+      rendererProcess
+    })
     await Promise.all([
       makeTreeWritable(temporaryRoot),
       makeTreeWritable(workspaceRoot)
@@ -413,6 +399,36 @@ async function withTimeout(operation, timeoutMs, description) {
     ])
   } finally {
     if (timeout) clearTimeout(timeout)
+  }
+}
+
+async function cleanupGraphWorkbenchProcesses({
+  electronApplication,
+  electronProcess,
+  rendererProcess,
+  platform = process.platform,
+  terminate = terminateProcessTree,
+  closeTimeoutMs = MAX_CLEANUP_TIMEOUT_MS
+}) {
+  const terminateOptions = {
+    timeoutMs: MAX_CLEANUP_TIMEOUT_MS,
+    detached: platform !== 'win32'
+  }
+
+  // Playwright's close can wait forever while its Electron process is still
+  // alive. Stop the process tree first so its transport can close.
+  if (electronProcess) {
+    await terminate(electronProcess, platform, terminateOptions).catch(() => undefined)
+  }
+  if (electronApplication) {
+    await withTimeout(
+      Promise.resolve().then(() => electronApplication.close()),
+      closeTimeoutMs,
+      'closing the Graph workbench Electron application'
+    ).catch(() => undefined)
+  }
+  if (rendererProcess) {
+    await terminate(rendererProcess, platform, terminateOptions).catch(() => undefined)
   }
 }
 
@@ -483,4 +499,4 @@ if (require.main === module) {
   })
 }
 
-module.exports = { withTimeout }
+module.exports = { cleanupGraphWorkbenchProcesses, withTimeout }

--- a/scripts/smoke-packaged-extension-desktop.test.cjs
+++ b/scripts/smoke-packaged-extension-desktop.test.cjs
@@ -47,6 +47,7 @@ const {
   waitForPortsClosed
 } = require('./smoke-packaged-extension-desktop.cjs')
 const {
+  cleanupGraphWorkbenchProcesses,
   withTimeout: withGraphWorkbenchTimeout
 } = require('./smoke-development-graph-workbench.cjs')
 
@@ -86,6 +87,30 @@ test('bounds Graph workbench browser operations', async () => {
     ),
     /Timed out while running a stalled fixture/
   )
+})
+
+test('terminates the Graph workbench Electron tree before closing Playwright', async () => {
+  const events = []
+  const electronProcess = { pid: 101 }
+  const rendererProcess = { pid: 102 }
+
+  await cleanupGraphWorkbenchProcesses({
+    electronApplication: {
+      close: async () => events.push('close-playwright')
+    },
+    electronProcess,
+    rendererProcess,
+    platform: 'linux',
+    terminate: async (child) => {
+      events.push(child === electronProcess ? 'terminate-electron' : 'terminate-renderer')
+    }
+  })
+
+  assert.deepEqual(events, [
+    'terminate-electron',
+    'close-playwright',
+    'terminate-renderer'
+  ])
 })
 
 test('selects host-native packaged resources and never launches desktop Electron as Node', () => {


### PR DESCRIPTION
## Problem

The native Graph Workbench pointer smoke can finish every interaction and print its success payload, then leave its Electron/Playwright lifecycle alive until the workflow's 10-minute step limit kills it.

## Root cause

Cleanup called `ElectronApplication.close()` before terminating the Electron process tree. When that close operation stalled, the timeout only stopped awaiting its promise; it did not cancel the underlying Playwright transport or release its event-loop handles.

## Scope

Only Graph Workbench development smoke cleanup ordering and regression coverage.

## Non-goals

- No Graph product behavior change.
- No change to interaction assertions or package configuration.
- No new runtime process-management abstraction.

## Changes

- Terminate the launched Electron process tree before closing Playwright.
- Keep the bounded close as a connection-release step after process termination.
- Preserve bounded Vite cleanup.
- Add an ordering regression test.

## Safety

- The helper only receives child processes created by this smoke.
- Cleanup remains bounded on every platform.
- No user workspace, settings, or production process is targeted.

## Typecheck

`npm.cmd run typecheck` - passed.

## Tests

`node --test scripts/smoke-packaged-extension-desktop.test.cjs` - 27 passed.

`npm.cmd run lint` - passed.

`npm.cmd run build` - passed.

## Actual validation

On Windows, `npm.cmd run smoke:development-graph-workbench -- --timeout-ms 45000` completed the real Electron/Vite/Graph interaction workflow and exited successfully in 43.7 seconds. A post-run process query found no Graph smoke Electron, Vite, or runtime child process.

## Review performed

- Functional correctness and failure mode
- Process lifecycle and stale child cleanup
- Cross-platform signaling behavior
- Scope, test validity, and generated-file hygiene

## PR size

```text
Production files: 1
Test files: 1
Total diff: 61 additions / 20 deletions
```

## Follow-up

Rebase #1034 after this lands so its Linux and Windows package checks exercise the fixed smoke exit path.