### PR TITLE
fix(release): package Windows TUI without cmd shim

### DIFF
--- a/scripts/package-tui.mjs
+++ b/scripts/package-tui.mjs
@@ -49,6 +49,19 @@ export function tuiArtifactName(artifactVersion, target) {
   return `Kun-TUI-${artifactVersion}-${target.os}-${target.arch}.${target.format}`
 }
 
+export function resolveNpmCliInvocation({
+  execPath = process.execPath,
+  npmExecPath = process.env.npm_execpath
+} = {}) {
+  if (typeof npmExecPath !== 'string' || npmExecPath.length === 0) {
+    throw new Error('npm_execpath is required to install standalone TUI dependencies')
+  }
+  return {
+    command: execPath,
+    args: [npmExecPath]
+  }
+}
+
 export function createTuiReleaseMetadata(input) {
   if (!SEMVER.test(input.version)) throw new Error(`Invalid TUI version: ${input.version}`)
   if (!ARTIFACT_VERSION.test(input.artifactVersion)) {
@@ -225,8 +238,8 @@ async function copyOptionalFile(source, destination) {
 }
 
 function runNpmInstall(packagedKun) {
-  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-  execFileSync(npm, ['ci', '--omit=dev', '--no-audit', '--no-fund'], {
+  const npm = resolveNpmCliInvocation()
+  execFileSync(npm.command, [...npm.args, 'ci', '--omit=dev', '--no-audit', '--no-fund'], {
     cwd: packagedKun,
     env: {
       ...process.env,

--- a/scripts/package-tui.test.mjs
+++ b/scripts/package-tui.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   TUI_NODE_VERSION,
   createTuiReleaseMetadata,
+  resolveNpmCliInvocation,
   resolveTuiTarget,
   tuiArtifactName
 } from './package-tui.mjs'
@@ -25,6 +26,20 @@ test('maps the supported standalone TUI targets to canonical release names', () 
 test('rejects unsupported target architectures', () => {
   assert.throws(() => resolveTuiTarget('linux', 'arm64'), /Unsupported standalone TUI target/)
   assert.throws(() => resolveTuiTarget('win32', 'arm64'), /Unsupported standalone TUI target/)
+})
+
+test('runs npm through Node instead of a Windows cmd shim', () => {
+  assert.deepEqual(resolveNpmCliInvocation({
+    execPath: 'C:\\node\\node.exe',
+    npmExecPath: 'C:\\node\\node_modules\\npm\\bin\\npm-cli.js'
+  }), {
+    command: 'C:\\node\\node.exe',
+    args: ['C:\\node\\node_modules\\npm\\bin\\npm-cli.js']
+  })
+  assert.throws(
+    () => resolveNpmCliInvocation({ execPath: '/node', npmExecPath: '' }),
+    /npm_execpath is required/
+  )
 })
 
 test('creates release metadata from the shared GUI release version', () => {


### PR DESCRIPTION
## Summary

Fix the v0.2.32 Windows standalone TUI packaging failure caused by executing `npm.cmd` with `execFileSync`.

## Changes

- invoke npm CLI through the current Node executable using `npm_execpath`
- keep the install shell-free on all platforms
- add regression coverage for Windows npm paths and missing npm CLI metadata

## Tests

- `npm run test:tui-release`
- `npx eslint scripts/package-tui.mjs scripts/package-tui.test.mjs`
- `git diff --check`