### PR TITLE
fix(release): extract Windows TUI archive locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "package:tui": "node ./scripts/package-tui.mjs",
     "assemble:tui-release": "node ./scripts/assemble-tui-release.mjs",
     "smoke:standalone-tui": "node ./scripts/smoke-standalone-tui.mjs",
-    "test:tui-release": "node --test ./scripts/package-tui.test.mjs ./scripts/assemble-tui-release.test.mjs ./scripts/publish-r2.test.mjs ./scripts/smoke-packaged-cli.test.cjs",
+    "test:tui-release": "node --test ./scripts/package-tui.test.mjs ./scripts/smoke-standalone-tui.test.mjs ./scripts/assemble-tui-release.test.mjs ./scripts/publish-r2.test.mjs ./scripts/smoke-packaged-cli.test.cjs",
     "build:extensions": "npm run build --workspace @kun/provider-catalog && npm run build --workspace @kun/extension-api && npm run build --workspace @kun/extension-react && npm run build --workspace @kun/extension-test && npm run build --workspace create-kun-extension",
     "test:extensions": "npm run test --workspace @kun/provider-catalog && npm run test --workspace @kun/extension-api && npm run test --workspace @kun/extension-react && npm run test --workspace @kun/extension-test && npm run test --workspace create-kun-extension",
     "check:extension-schema": "npm run schema:check --workspace @kun/extension-api",

--- a/scripts/smoke-standalone-tui.mjs
+++ b/scripts/smoke-standalone-tui.mjs
@@ -4,7 +4,23 @@ import { execFileSync, spawn } from 'node:child_process'
 import { once } from 'node:events'
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export function createArchiveExtractionInvocation(
+  artifact,
+  destination,
+  pathApi = { basename, dirname }
+) {
+  return {
+    command: 'tar',
+    args: ['-xf', pathApi.basename(artifact), '-C', destination],
+    options: {
+      cwd: pathApi.dirname(artifact),
+      stdio: 'inherit'
+    }
+  }
+}
 
 async function main() {
   const flags = readFlags(process.argv.slice(2))
@@ -13,7 +29,8 @@ async function main() {
   const expectedTarget = required(flags, 'target')
   const temporary = await mkdtemp(join(tmpdir(), 'kun-tui-smoke-'))
   try {
-    execFileSync('tar', ['-xf', artifact, '-C', temporary], { stdio: 'inherit' })
+    const extraction = createArchiveExtractionInvocation(artifact, temporary)
+    execFileSync(extraction.command, extraction.args, extraction.options)
     const root = join(temporary, 'kun')
     const release = JSON.parse(await readFile(join(root, 'release.json'), 'utf8'))
     if (release.version !== expectedVersion || release.target !== expectedTarget) {
@@ -177,7 +194,10 @@ function required(flags, name) {
   return value
 }
 
-main().catch((error) => {
-  process.stderr.write(`[smoke-standalone-tui] ${error instanceof Error ? error.message : String(error)}\n`)
-  process.exitCode = 1
-})
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : ''
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(`[smoke-standalone-tui] ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/smoke-standalone-tui.test.mjs
+++ b/scripts/smoke-standalone-tui.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { win32 } from 'node:path'
+import test from 'node:test'
+import { createArchiveExtractionInvocation } from './smoke-standalone-tui.mjs'
+
+test('extracts a Windows TUI archive without passing the drive-qualified path to tar', () => {
+  assert.deepEqual(
+    createArchiveExtractionInvocation(
+      'D:\\a\\Kun\\Kun\\dist\\Kun-TUI-0.2.32-win-x64.zip',
+      'C:\\Users\\runner\\Temp\\kun-tui-smoke',
+      win32
+    ),
+    {
+      command: 'tar',
+      args: [
+        '-xf',
+        'Kun-TUI-0.2.32-win-x64.zip',
+        '-C',
+        'C:\\Users\\runner\\Temp\\kun-tui-smoke'
+      ],
+      options: {
+        cwd: 'D:\\a\\Kun\\Kun\\dist',
+        stdio: 'inherit'
+      }
+    }
+  )
+})


### PR DESCRIPTION
## Summary

Fix the v0.2.32 Windows standalone TUI smoke failure caused by GNU tar interpreting the `D:` drive prefix as a remote host.

## Changes

- run tar from the archive directory and pass only the archive filename
- keep extraction shell-free and compatible with GNU tar and bsdtar
- add regression coverage for Windows drive-qualified artifact paths

## Tests

- `npm run test:tui-release`
- `npx eslint scripts/smoke-standalone-tui.mjs scripts/smoke-standalone-tui.test.mjs`
- `git diff --check`