### PR TITLE
fix(settings): accept model service tiers

### DIFF
--- a/release/release-v0.2.33.md
+++ b/release/release-v0.2.33.md
@@ -1,0 +1,21 @@
+# Kun v0.2.33
+
+v0.2.33 修复 ChatGPT 订阅配置无法保存的问题。升级后，包含 Codex Fast / priority 能力元数据的模型配置可以正常通过主进程校验，不会再出现 `Unrecognized key: "serviceTiers"`。
+
+### 设置保存修复
+
+- `settings:set` 和静默设置保存现在接受模型 profile 中的 `serviceTiers` 字段。
+- `serviceTiers` 仍只允许 `priority` 和 `flex`，无效或空的配置会继续被拒绝。
+- Provider profile 与 Kun Runtime 的 model profile 使用同一套校验规则，避免相同模型元数据在不同设置入口表现不一致。
+- 增加共享设置类型与 IPC schema 的编译期字段完整性检查。以后新增模型 profile 字段但遗漏主进程校验时，类型检查会直接失败。
+- 增加 IPC schema 与 `settings:set` handler 回归测试，覆盖 ChatGPT 订阅生成 `serviceTiers: ["priority"]` 的真实保存路径。
+
+### 升级说明
+
+- 从 `v0.2.32` 升级无需迁移工作区、会话或 Provider 配置。
+- 在 `v0.2.32` 中无法完成 ChatGPT 订阅设置的用户，升级后可直接重新点击保存或完成配置。
+- 已保存的 API Key、模型连接和会话数据不受影响。
+
+### 完整变更
+
+https://github.com/KunAgent/Kun/compare/v0.2.32...v0.2.33

--- a/src/main/ipc/app-ipc-schemas.test.ts
+++ b/src/main/ipc/app-ipc-schemas.test.ts
@@ -478,7 +478,8 @@ describe('app-ipc-schemas', () => {
               inputModalities: ['text', 'image'],
               outputModalities: ['text'],
               supportsToolCalling: true,
-              messageParts: ['text', 'image_url']
+              messageParts: ['text', 'image_url'],
+              serviceTiers: ['priority']
             }
           },
           tokenEconomy: {
@@ -529,6 +530,7 @@ describe('app-ipc-schemas', () => {
     expect(payload.agents?.kun?.approvalReviewer).toBe('agent')
     expect(payload.agents?.kun?.modelProfiles?.['custom-vision-model']?.inputModalities).toEqual(['text', 'image'])
     expect(payload.agents?.kun?.modelProfiles?.['custom-vision-model']?.maxOutputTokens).toBe(32000)
+    expect(payload.agents?.kun?.modelProfiles?.['custom-vision-model']?.serviceTiers).toEqual(['priority'])
     expect(payload.agents?.kun?.tokenEconomy?.enabled).toBe(true)
     expect(payload.agents?.kun?.tokenEconomy?.historyHygiene?.maxToolResultTokens).toBe(4000)
     expect(payload.agents?.kun?.toolOutputLimits?.maxLines).toBe(30000)
@@ -675,6 +677,49 @@ describe('app-ipc-schemas', () => {
 
     expect(payload.provider?.providers?.[0]?.retry?.maxAttempts).toBe(3)
     expect(payload.agents?.kun?.retry?.httpStatusCodes).toEqual([429, 503])
+  })
+
+  it('accepts service-tier metadata in provider and runtime model profiles', () => {
+    const payload = settingsPatchSchema.parse({
+      provider: {
+        providers: [{
+          id: 'codex',
+          modelProfiles: {
+            'gpt-5.6-sol': {
+              serviceTiers: ['priority']
+            }
+          }
+        }]
+      },
+      agents: {
+        kun: {
+          modelProfiles: {
+            'gpt-5.6-sol': {
+              serviceTiers: ['priority']
+            }
+          }
+        }
+      }
+    })
+
+    expect(
+      payload.provider?.providers?.[0]?.modelProfiles?.['gpt-5.6-sol']?.serviceTiers
+    ).toEqual(['priority'])
+    expect(
+      payload.agents?.kun?.modelProfiles?.['gpt-5.6-sol']?.serviceTiers
+    ).toEqual(['priority'])
+    expect(() => settingsPatchSchema.parse({
+      provider: {
+        providers: [{
+          id: 'codex',
+          modelProfiles: {
+            'gpt-5.6-sol': {
+              serviceTiers: ['express']
+            }
+          }
+        }]
+      }
+    })).toThrow()
   })
 
   it('accepts long provider model ids imported from upstream catalogs', () => {

--- a/src/main/ipc/app-ipc-schemas/settings.ts
+++ b/src/main/ipc/app-ipc-schemas/settings.ts
@@ -10,6 +10,7 @@ import {
   MODEL_PROVIDER_MESSAGE_PARTS,
   MODEL_REASONING_EFFORTS,
   MODEL_REASONING_REQUEST_PROTOCOLS,
+  MODEL_SERVICE_TIERS,
   MAX_WRITE_AUTOSAVE_DELAY_MS,
   MIN_WRITE_AUTOSAVE_DELAY_MS,
   MIN_KUN_LOCAL_PORT,
@@ -25,7 +26,8 @@ import {
   CHAT_CONTENT_MAX_WIDTH_MIN,
   CHAT_CONTENT_MAX_WIDTH_MAX,
   UI_FONT_SCALE_MIN,
-  UI_FONT_SCALE_MAX
+  UI_FONT_SCALE_MAX,
+  type ModelProviderModelProfilePatchV1
 } from '../../../shared/app-settings'
 import { GUI_UPDATE_CHANNELS } from '../../../shared/gui-update'
 import { KEYBOARD_SHORTCUT_COMMANDS } from '../../../shared/keyboard-shortcuts'
@@ -104,7 +106,8 @@ const modelProviderInputModalitySchema = z.enum(MODEL_PROVIDER_INPUT_MODALITIES)
 const modelProviderMessagePartSchema = z.enum(MODEL_PROVIDER_MESSAGE_PARTS)
 const modelReasoningEffortSchema = z.enum(MODEL_REASONING_EFFORTS)
 const modelReasoningRequestProtocolSchema = z.enum(MODEL_REASONING_REQUEST_PROTOCOLS)
-const modelProfilePatchSchema = z.object({
+const modelServiceTierSchema = z.enum(MODEL_SERVICE_TIERS)
+const modelProfilePatchShape = {
   aliases: z.array(modelIdSchema).max(50).optional(),
   contextWindowTokens: z.number().int().positive().max(10_000_000).optional(),
   maxOutputTokens: z.number().int().positive().max(1_000_000).optional(),
@@ -117,9 +120,11 @@ const modelProfilePatchSchema = z.object({
     defaultEffort: modelReasoningEffortSchema,
     requestProtocol: modelReasoningRequestProtocolSchema
   }).strict().optional(),
+  serviceTiers: z.array(modelServiceTierSchema).min(1).max(MODEL_SERVICE_TIERS.length).optional(),
   endpointFormat: modelEndpointFormatSchema.optional(),
   responsesMode: z.literal('lite').optional()
-}).strict()
+} satisfies Record<keyof ModelProviderModelProfilePatchV1, z.ZodTypeAny>
+const modelProfilePatchSchema = z.object(modelProfilePatchShape).strict()
 
 const modelProviderPatchSchema = z.object({
   apiKey: z.string().max(MAX_BODY_BYTES).optional(),

--- a/src/main/ipc/register-app-ipc-handlers.test.ts
+++ b/src/main/ipc/register-app-ipc-handlers.test.ts
@@ -349,6 +349,27 @@ describe('registerAppIpcHandlers', () => {
     expect(applySettingsPatch).toHaveBeenCalledWith(payload)
   })
 
+  it('accepts ChatGPT subscription service tiers at the settings boundary', async () => {
+    const applySettingsPatch = vi.fn(async () => settings())
+    registerAppIpcHandlers(registerOptions({ applySettingsPatch }))
+    const payload = {
+      provider: {
+        providers: [{
+          id: 'codex',
+          name: 'ChatGPT 订阅',
+          modelProfiles: {
+            'gpt-5.6-sol': {
+              serviceTiers: ['priority' as const]
+            }
+          }
+        }]
+      }
+    }
+
+    await expect(handlers.get('settings:set')?.({}, payload)).resolves.toEqual(settings())
+    expect(applySettingsPatch).toHaveBeenCalledWith(payload)
+  })
+
   it('accepts strict multi-account provider source metadata with routing settings', async () => {
     const applySettingsPatch = vi.fn(async () => settings())
     registerAppIpcHandlers(registerOptions({ applySettingsPatch }))


### PR DESCRIPTION
## Summary

Fixes the Kun 0.2.32 settings validation failure that prevented ChatGPT subscription profiles from being saved when Codex Fast metadata included `serviceTiers: ["priority"]`.

## Root cause

`ModelProviderModelProfileV1` and the provider normalizer supported `serviceTiers`, but the strict main-process `modelProfilePatchSchema` did not declare it. The renderer therefore generated a valid shared settings profile that `settings:set` rejected as an unknown key.

## Changes

- Accept bounded `priority` / `flex` service-tier metadata in provider and Kun Runtime model profiles.
- Keep unknown and empty service-tier values rejected.
- Add a compile-time key-completeness guard between the shared model-profile patch type and its IPC schema.
- Add schema and `settings:set` handler regression coverage for ChatGPT subscription profiles.
- Add the v0.2.33 release note.

## Tests

- `npm run test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run audit:production`
- `npm run check:extensions`
- `npm run test:tui-release`
- `git diff --check`