### PR TITLE
fix(release): unblock v0.2.34 packaging validation

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -125,6 +125,12 @@ Var /GLOBAL KunInstallerStopResult
 !macro customUnInstallCheckCurrentUser
   StrCpy $KunInstallerSourceDir $KunInstallerSecondarySourceDir
   Call KunHandleOldUninstallerResult
+  # installSection invokes this callback only while an all-users install is
+  # retiring an existing current-user registration. The old uninstaller usually
+  # removes these fixed Kun keys itself; fallback cleanup must finish the same
+  # scoped transition after the validated application payload is gone.
+  DeleteRegKey HKEY_CURRENT_USER "${UNINSTALL_REGISTRY_KEY}"
+  DeleteRegKey HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}"
   StrCpy $KunInstallerSourceDir $KunInstallerPrimarySourceDir
   Call KunRestoreInteractiveInstaller
 !macroend

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -9,6 +9,8 @@ Var /GLOBAL KunInstallerJournalPath
 Var /GLOBAL KunInstallerMigrationPrepared
 Var /GLOBAL KunInstallerSnapshotMode
 Var /GLOBAL KunInstallerRestoreInteractive
+Var /GLOBAL KunInstallerCurrentUserShortcutName
+Var /GLOBAL KunInstallerCurrentUserMenuDirectory
 !endif
 Var /GLOBAL KunInstallerHelperPath
 Var /GLOBAL KunInstallerPowerShellPath
@@ -127,10 +129,9 @@ Var /GLOBAL KunInstallerStopResult
   Call KunHandleOldUninstallerResult
   # installSection invokes this callback only while an all-users install is
   # retiring an existing current-user registration. The old uninstaller usually
-  # removes these fixed Kun keys itself; fallback cleanup must finish the same
-  # scoped transition after the validated application payload is gone.
-  DeleteRegKey HKEY_CURRENT_USER "${UNINSTALL_REGISTRY_KEY}"
-  DeleteRegKey HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}"
+  # removes this shell state itself; fallback cleanup must finish the same scoped
+  # transition after the validated application payload is gone.
+  Call KunRetireCurrentUserShellState
   StrCpy $KunInstallerSourceDir $KunInstallerPrimarySourceDir
   Call KunRestoreInteractiveInstaller
 !macroend
@@ -270,6 +271,34 @@ Var /GLOBAL KunInstallerStopResult
       SetErrorLevel 2
       Quit
     ${endif}
+  FunctionEnd
+
+  Function KunRetireCurrentUserShellState
+    ReadRegStr $KunInstallerCurrentUserShortcutName HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}" ShortcutName
+    ReadRegStr $KunInstallerCurrentUserMenuDirectory HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}" MenuDirectory
+    SetShellVarContext current
+
+    ${if} $KunInstallerCurrentUserShortcutName != ""
+      Delete "$DESKTOP\$KunInstallerCurrentUserShortcutName.lnk"
+      Delete "$SMPROGRAMS\$KunInstallerCurrentUserShortcutName.lnk"
+      ${if} $KunInstallerCurrentUserMenuDirectory != ""
+        Delete "$SMPROGRAMS\$KunInstallerCurrentUserMenuDirectory\$KunInstallerCurrentUserShortcutName.lnk"
+      ${endif}
+    ${endif}
+
+    Delete "$DESKTOP\${SHORTCUT_NAME}.lnk"
+    Delete "$SMPROGRAMS\${SHORTCUT_NAME}.lnk"
+    Delete "$DESKTOP\DeepSeek GUI.lnk"
+    Delete "$SMPROGRAMS\DeepSeek GUI.lnk"
+    ${if} $KunInstallerCurrentUserMenuDirectory != ""
+      Delete "$SMPROGRAMS\$KunInstallerCurrentUserMenuDirectory\${SHORTCUT_NAME}.lnk"
+      Delete "$SMPROGRAMS\$KunInstallerCurrentUserMenuDirectory\DeepSeek GUI.lnk"
+      RMDir "$SMPROGRAMS\$KunInstallerCurrentUserMenuDirectory"
+    ${endif}
+
+    DeleteRegKey HKEY_CURRENT_USER "${UNINSTALL_REGISTRY_KEY}"
+    DeleteRegKey HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}"
+    SetShellVarContext all
   FunctionEnd
 
   Function KunReadRegisteredSource

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -190,6 +190,21 @@ Var /GLOBAL KunInstallerStopResult
       Delete "$KunInstallerResultPath"
   FunctionEnd
 
+  Function KunRecoverSourceFromUninstallString
+    StrCpy $KunInstallerSourceDir ""
+    !insertmacro GetInQuotes $KunInstallerSourceDir "$R9"
+    ${if} $KunInstallerSourceDir != ""
+      Push $KunInstallerSourceDir
+      Call GetFileParent
+      Pop $KunInstallerSourceDir
+    ${endif}
+    ${if} $KunInstallerSourceDir == ""
+      MessageBox MB_OK|MB_ICONSTOP "Kun found an existing uninstall registration but could not recover its installation directory." /SD IDOK
+      SetErrorLevel 2
+      Quit
+    ${endif}
+  FunctionEnd
+
   Function KunReadRegisteredSource
     ReadRegStr $KunInstallerSourceDir SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}" InstallLocation
     ${if} $KunInstallerSourceDir == ""
@@ -199,20 +214,7 @@ Var /GLOBAL KunInstallerStopResult
         ReadRegStr $R9 HKEY_CURRENT_USER "${UNINSTALL_REGISTRY_KEY}" UninstallString
       ${endif}
       ${if} $R9 != ""
-        System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_SOURCE", "").r0'
-        System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_UNINSTALL_STRING", "$R9").r0'
-        Delete "$KunInstallerResultPath"
-        !insertmacro kunRunMigrationHelper ResolveSource
-        ${if} $KunInstallerHelperExitCode == 0
-          Call KunReadMigrationResult
-        ${endif}
-        ${if} $KunInstallerHelperExitCode != 0
-        ${orIf} $KunInstallerHelperOutput == ""
-          MessageBox MB_OK|MB_ICONSTOP "Kun found an existing uninstall registration but could not recover its installation directory.$\r$\n$KunInstallerHelperOutput" /SD IDOK
-          SetErrorLevel 2
-          Quit
-        ${endif}
-        StrCpy $KunInstallerSourceDir $KunInstallerHelperOutput
+        Call KunRecoverSourceFromUninstallString
       ${endif}
     ${endif}
     StrCpy $KunInstallerPrimarySourceDir $KunInstallerSourceDir
@@ -222,20 +224,8 @@ Var /GLOBAL KunInstallerStopResult
       ${if} $KunInstallerSecondarySourceDir == ""
         ReadRegStr $R9 HKEY_CURRENT_USER "${UNINSTALL_REGISTRY_KEY}" UninstallString
         ${if} $R9 != ""
-          System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_SOURCE", "").r0'
-          System::Call 'kernel32::SetEnvironmentVariable(t, t)i ("KUN_INSTALLER_UNINSTALL_STRING", "$R9").r0'
-          Delete "$KunInstallerResultPath"
-          !insertmacro kunRunMigrationHelper ResolveSource
-          ${if} $KunInstallerHelperExitCode == 0
-            Call KunReadMigrationResult
-          ${endif}
-          ${if} $KunInstallerHelperExitCode != 0
-          ${orIf} $KunInstallerHelperOutput == ""
-            MessageBox MB_OK|MB_ICONSTOP "Kun found a current-user uninstall registration but could not recover its installation directory.$\r$\n$KunInstallerHelperOutput" /SD IDOK
-            SetErrorLevel 2
-            Quit
-          ${endif}
-          StrCpy $KunInstallerSecondarySourceDir $KunInstallerHelperOutput
+          Call KunRecoverSourceFromUninstallString
+          StrCpy $KunInstallerSecondarySourceDir $KunInstallerSourceDir
         ${endif}
       ${endif}
     ${endif}

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -190,12 +190,73 @@ Var /GLOBAL KunInstallerStopResult
       Delete "$KunInstallerResultPath"
   FunctionEnd
 
+  Function KunGetInQuotes
+    Exch $R0
+    Push $R1
+    Push $R2
+
+    StrCpy $R1 -1
+    KunGetInQuotesFindStart:
+      IntOp $R1 $R1 + 1
+      StrCpy $R2 $R0 1 $R1
+      StrCmp $R2 "" KunGetInQuotesInvalid
+      StrCmp $R2 '"' KunGetInQuotesStart KunGetInQuotesFindStart
+
+    KunGetInQuotesStart:
+      IntOp $R1 $R1 + 1
+      StrCpy $R0 $R0 "" $R1
+      StrCpy $R1 0
+
+    KunGetInQuotesFindEnd:
+      IntOp $R1 $R1 + 1
+      StrCpy $R2 $R0 1 $R1
+      StrCmp $R2 "" KunGetInQuotesInvalid
+      StrCmp $R2 '"' KunGetInQuotesDone KunGetInQuotesFindEnd
+
+    KunGetInQuotesInvalid:
+      StrCpy $R0 ""
+      Goto KunGetInQuotesReturn
+
+    KunGetInQuotesDone:
+      StrCpy $R0 $R0 $R1
+
+    KunGetInQuotesReturn:
+      Pop $R2
+      Pop $R1
+      Exch $R0
+  FunctionEnd
+
+  Function KunGetFileParent
+    Exch $R0
+    Push $R1
+    Push $R2
+    Push $R3
+
+    StrCpy $R1 0
+    StrLen $R2 $R0
+
+    KunGetFileParentLoop:
+      IntOp $R1 $R1 + 1
+      IntCmp $R1 $R2 KunGetFileParentDone 0 KunGetFileParentDone
+      StrCpy $R3 $R0 1 -$R1
+      StrCmp $R3 "\" KunGetFileParentDone KunGetFileParentLoop
+
+    KunGetFileParentDone:
+      StrCpy $R0 $R0 -$R1
+      Pop $R3
+      Pop $R2
+      Pop $R1
+      Exch $R0
+  FunctionEnd
+
   Function KunRecoverSourceFromUninstallString
     StrCpy $KunInstallerSourceDir ""
-    !insertmacro GetInQuotes $KunInstallerSourceDir "$R9"
+    Push "$R9"
+    Call KunGetInQuotes
+    Pop $KunInstallerSourceDir
     ${if} $KunInstallerSourceDir != ""
       Push $KunInstallerSourceDir
-      Call GetFileParent
+      Call KunGetFileParent
       Pop $KunInstallerSourceDir
     ${endif}
     ${if} $KunInstallerSourceDir == ""

--- a/build/windows-installer-migration.ps1
+++ b/build/windows-installer-migration.ps1
@@ -579,7 +579,7 @@ function Invoke-Prepare {
     }
   }
 
-  $preservationSets = @()
+  $preparedSources = @()
   foreach ($source in $sources) {
     if (-not (Test-Path -LiteralPath $source -PathType Container)) {
       continue
@@ -599,16 +599,16 @@ function Invoke-Prepare {
       Assert-NoReparsePointsInTree $directory 'Recognized application directory'
     }
     $unknown = @($entries | Where-Object { -not (Test-KnownApplicationEntry $_) })
+    $stash = Get-PreservationRoot $source
     if ($unknown.Count -gt 0) {
-      $stash = Get-PreservationRoot $source
       if (Test-Path -LiteralPath $stash) {
         throw "A preservation directory already exists without a recoverable journal: $stash"
       }
-      $preservationSets += @{
-        Source = $source
-        Stash = $stash
-        Unknown = $unknown
-      }
+    }
+    $preparedSources += @{
+      Source = $source
+      Stash = $stash
+      Unknown = $unknown
     }
   }
 
@@ -619,11 +619,7 @@ function Invoke-Prepare {
     Phase = 'preserving'
     Records = @()
   }
-  foreach ($set in $preservationSets) {
-    $content = Join-Path $set.Stash 'content'
-    [IO.Directory]::CreateDirectory($content) | Out-Null
-    $stashItem = Get-Item -LiteralPath $set.Stash -Force
-    $stashItem.Attributes = $stashItem.Attributes -bor [IO.FileAttributes]::Hidden
+  foreach ($set in $preparedSources) {
     $record = @{
       Source = $set.Source
       Target = $target
@@ -633,6 +629,13 @@ function Invoke-Prepare {
     }
     $journal.Records += $record
     Write-Journal $journal
+    if ($set.Unknown.Count -eq 0) {
+      continue
+    }
+    $content = Join-Path $set.Stash 'content'
+    [IO.Directory]::CreateDirectory($content) | Out-Null
+    $stashItem = Get-Item -LiteralPath $set.Stash -Force
+    $stashItem.Attributes = $stashItem.Attributes -bor [IO.FileAttributes]::Hidden
     foreach ($entry in $set.Unknown) {
       Move-Item -LiteralPath $entry.FullName -Destination (Join-Path $content $entry.Name)
     }

--- a/build/windows-installer-migration.ps1
+++ b/build/windows-installer-migration.ps1
@@ -12,6 +12,25 @@ function Get-EnvironmentValue([string]$Name) {
   return [Environment]::GetEnvironmentVariable($Name, 'Process')
 }
 
+function Write-InstallerDiagnostic([string]$Message) {
+  $diagnosticPath = Get-EnvironmentValue 'KUN_INSTALLER_DIAGNOSTIC_PATH'
+  if ([string]::IsNullOrWhiteSpace($diagnosticPath)) {
+    return
+  }
+
+  try {
+    $fullPath = [IO.Path]::GetFullPath($diagnosticPath)
+    [IO.Directory]::CreateDirectory((Split-Path -Parent $fullPath)) | Out-Null
+    [IO.File]::AppendAllText(
+      $fullPath,
+      ([DateTime]::UtcNow.ToString('o') + ' ' + $Message + [Environment]::NewLine),
+      [Text.Encoding]::UTF8
+    )
+  } catch {
+    # Diagnostics are opt-in test evidence and must never change installer behavior.
+  }
+}
+
 function Normalize-FullPath([string]$PathValue) {
   if ([string]::IsNullOrWhiteSpace($PathValue)) {
     return ''
@@ -733,6 +752,11 @@ function Update-UserPath {
 }
 
 try {
+  Write-InstallerDiagnostic (
+    "START action=$Action source=$(Get-EnvironmentValue 'KUN_INSTALLER_SOURCE') " +
+    "target=$(Get-EnvironmentValue 'KUN_INSTALLER_TARGET') " +
+    "journal=$(Get-EnvironmentValue 'KUN_INSTALLER_JOURNAL')"
+  )
   switch ($Action) {
     'ResolvePath' {
       Write-ResolvedInstallTarget (Resolve-InstallTarget)
@@ -760,7 +784,9 @@ try {
       Update-UserPath
     }
   }
+  Write-InstallerDiagnostic "SUCCESS action=$Action"
 } catch {
+  Write-InstallerDiagnostic "FAIL action=$Action error=$($_.Exception.Message)"
   [Console]::Error.WriteLine($_.Exception.Message)
   exit 1
 }

--- a/kun/src/graph/graph-scheduler-supervision-liveness.test.ts
+++ b/kun/src/graph/graph-scheduler-supervision-liveness.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../tests/graph-scheduler-test-harness.js'
 
 const supervisors: GraphSupervisor[] = []
+const supervisionLivenessTimeoutMs = 60_000
 
 afterEach(async () => {
   await Promise.all(supervisors.splice(0).map((supervisor) => supervisor.stop()))
@@ -146,7 +147,7 @@ describe('Graph scheduler supervision liveness', () => {
     ]))
     await harness.scheduler.stop()
     await runtimeSupervisor.stop()
-  }, 20_000)
+  }, supervisionLivenessTimeoutMs)
 
   it('continues an independent ready branch while another result awaits Lead review', async () => {
     const base = testGraphPlan()

--- a/openspec/changes/fix-linux-graph-shutdown-validation/.openspec.yaml
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The Linux PR/release packaging job runs `npm run test:graph:platform` before
+`npm run dist:linux`. The shutdown-recovery test deliberately pauses write-lease
+admission, calls `GraphScheduler.stop()`, then verifies that an attempt admitted
+after the first shutdown snapshot is interrupted and excluded from effective
+attempt counts. The scheduler's existing double snapshot and active-promise
+drain are durable and correct, but file-backed persistence can exceed 500 ms on
+loaded Ubuntu runners.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the late-admission shutdown scenario deterministic and retain its durable
+  state assertions.
+- Allow normal Linux filesystem/lease persistence latency while still failing a
+  genuinely hung shutdown within the test's overall timeout.
+- Unblock the native Linux package and smoke gates without changing runtime code.
+
+**Non-Goals:**
+
+- No changes to `GraphScheduler`, graph contracts, persistence format, or
+  Electron/electron-builder configuration.
+- No suppression or removal of the intentionally logged synthesis failure
+  fixture.
+- No cross-compilation claim for local macOS; native Linux evidence remains a PR
+  CI responsibility.
+
+## Decisions
+
+- **Use a 5-second stop assertion budget on every platform.** This matches the
+  existing Windows allowance and accommodates durable file-backed cleanup on
+  Ubuntu. Keeping the `Promise.race` preserves an explicit no-deadlock guard.
+  Removing the race entirely was rejected because a future scheduler deadlock
+  should still fail at the assertion boundary.
+- **Change only the test constant.** The scheduler already sets the stopping
+  fence, takes a second active-attempt snapshot, aborts late admissions, and
+  awaits active promises. Adding new production checkpoints would alter the
+  audited shutdown behavior without evidence of a runtime defect.
+- **Use PR CI for native Linux verification.** The current host is macOS arm64
+  and its Docker daemon is unavailable; Ubuntu CI already runs the exact Node 22
+  packaging dependencies and all downstream Linux smoke/evidence gates.
+- **Keep the release-gate fixture explicit about extracted AppImage paths.**
+  The desktop smoke launcher now runs the verified extracted `AppRun` with
+  `APPDIR`/`APPIMAGE` set. The release-gate fixture must provide those paths so
+  it validates the same invocation shape instead of calling `resolve(undefined)`.
+
+## Risks / Trade-offs
+
+- [Risk] A real shutdown deadlock can now take up to 5 seconds to fail at the
+  race instead of 500 ms → Mitigated by the existing 15-second test timeout and
+  the complete durable-state assertions after the race.
+- [Risk] Mac-local tests cannot prove Linux-native AppImage behavior → Mitigated
+  by requiring the native Linux PR job to pass before merge and release.
+
+## Migration Plan
+
+No runtime or data migration is needed. Update the test, run the local checks,
+align the release-gate fixture with the launcher contract, then rely on the
+native Linux PR job for package/smoke evidence. Revert the scoped changes if CI
+exposes a new regression.

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -76,8 +76,11 @@ loaded Ubuntu runners.
   electron-builder invokes `customUnInstallCheckCurrentUser` only when an
   all-users install retires a current-user copy. Because Kun's callback replaces
   the default result handler to support validated fallback cleanup, it also
-  removes the exact Kun HKCU install/uninstall keys after that cleanup succeeds.
-  No dynamic or parent registry path is deleted.
+  reads the registered shortcut metadata, removes the old user's registered,
+  canonical, and legacy application links, and removes the exact Kun HKCU
+  install/uninstall keys after that cleanup succeeds. No dynamic or parent
+  registry path is deleted, and the shell context is restored to all-users
+  before the new installation continues.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -72,6 +72,12 @@ loaded Ubuntu runners.
   `Restore`. Native runner startup can put the correct round trip just beyond
   Vitest's 5-second default, so that one test receives a 15-second ceiling while
   keeping every behavioral assertion intact.
+- **Finish the cross-scope registration transition in the custom callback.**
+  electron-builder invokes `customUnInstallCheckCurrentUser` only when an
+  all-users install retires a current-user copy. Because Kun's callback replaces
+  the default result handler to support validated fallback cleanup, it also
+  removes the exact Kun HKCU install/uninstall keys after that cleanup succeeds.
+  No dynamic or parent registry path is deleted.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -17,6 +17,8 @@ loaded Ubuntu runners.
 - Allow normal Linux filesystem/lease persistence latency while still failing a
   genuinely hung shutdown within the test's overall timeout.
 - Unblock the native Linux package and smoke gates without changing runtime code.
+- Keep the native Windows migration gate fail-closed while allowing a validated
+  source to be cleaned after its old uninstaller removes the identity executable.
 
 **Non-Goals:**
 
@@ -45,6 +47,13 @@ loaded Ubuntu runners.
   The desktop smoke launcher now runs the verified extracted `AppRun` with
   `APPDIR`/`APPIMAGE` set. The release-gate fixture must provide those paths so
   it validates the same invocation shape instead of calling `resolve(undefined)`.
+- **Use the preparation journal as the fallback-cleanup authorization record.**
+  `Prepare` already validates source identity, safe roots, reparse points, and
+  recognized payload before the old uninstaller runs. It now records every
+  validated source, including sources with no unknown content, because the old
+  uninstaller legitimately removes `Kun.exe` before fallback cleanup. Cleanup
+  without a matching record remains rejected unless the source still equals the
+  target and retains a valid identity executable.
 
 ## Risks / Trade-offs
 
@@ -53,10 +62,13 @@ loaded Ubuntu runners.
   the complete durable-state assertions after the race.
 - [Risk] Mac-local tests cannot prove Linux-native AppImage behavior → Mitigated
   by requiring the native Linux PR job to pass before merge and release.
+- [Risk] A preparation record could authorize the wrong Windows directory →
+  Mitigated by writing it only after the existing safe-root, application
+  identity, recognized-payload, and reparse-point checks all pass.
 
 ## Migration Plan
 
-No runtime or data migration is needed. Update the test, run the local checks,
-align the release-gate fixture with the launcher contract, then rely on the
-native Linux PR job for package/smoke evidence. Revert the scoped changes if CI
-exposes a new regression.
+No runtime or data migration is needed. Update the tests and release-gate
+fixtures, run the local checks, then rely on native Linux and Windows PR jobs
+for package/smoke evidence. Revert the scoped changes if CI exposes a new
+regression.

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -59,13 +59,14 @@ loaded Ubuntu runners.
   supplied through `KUN_INSTALLER_DIAGNOSTIC_PATH`. The Windows smoke sets that
   path inside its disposable root and prints it only after an unexpected exit;
   diagnostic write failures are ignored so production behavior is unchanged.
-- **Recover registered sources natively in NSIS.** electron-builder already
-  parses its quoted `UninstallString` with `GetInQuotes` and `GetFileParent`
-  before launching the old uninstaller. The migration snapshot now uses the
-  same functions, avoiding the environment-variable and UTF-16 result-file
-  round trip that returned an empty source even though `ResolveSource` exited
-  successfully. PowerShell still normalizes the resulting source and enforces
-  all target, identity, payload, journal, and reparse-point checks.
+- **Recover registered sources natively in NSIS.** electron-builder parses its
+  quoted `UninstallString` before launching the old uninstaller, but its
+  `installUtil.nsh` is loaded after `customHeader`. Kun therefore owns equivalent
+  quoted-path and parent-directory functions inside `customHeader`, avoiding
+  both the late macro dependency and the environment-variable/UTF-16 result-file
+  round trip that returned an empty source. PowerShell still normalizes the
+  resulting source and enforces all target, identity, payload, journal, and
+  reparse-point checks.
 - **Budget the full Windows preservation round trip explicitly.** The focused
   test synchronously starts PowerShell for `Prepare`, `FallbackCleanup`, and
   `Restore`. Native runner startup can put the correct round trip just beyond

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -54,6 +54,11 @@ loaded Ubuntu runners.
   uninstaller legitimately removes `Kun.exe` before fallback cleanup. Cleanup
   without a matching record remains rejected unless the source still equals the
   target and retains a valid identity executable.
+- **Make native installer failures observable only when the smoke opts in.**
+  The helper appends action boundaries and caught error messages to a path
+  supplied through `KUN_INSTALLER_DIAGNOSTIC_PATH`. The Windows smoke sets that
+  path inside its disposable root and prints it only after an unexpected exit;
+  diagnostic write failures are ignored so production behavior is unchanged.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -59,6 +59,13 @@ loaded Ubuntu runners.
   supplied through `KUN_INSTALLER_DIAGNOSTIC_PATH`. The Windows smoke sets that
   path inside its disposable root and prints it only after an unexpected exit;
   diagnostic write failures are ignored so production behavior is unchanged.
+- **Recover registered sources natively in NSIS.** electron-builder already
+  parses its quoted `UninstallString` with `GetInQuotes` and `GetFileParent`
+  before launching the old uninstaller. The migration snapshot now uses the
+  same functions, avoiding the environment-variable and UTF-16 result-file
+  round trip that returned an empty source even though `ResolveSource` exited
+  successfully. PowerShell still normalizes the resulting source and enforces
+  all target, identity, payload, journal, and reparse-point checks.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -66,6 +66,11 @@ loaded Ubuntu runners.
   round trip that returned an empty source even though `ResolveSource` exited
   successfully. PowerShell still normalizes the resulting source and enforces
   all target, identity, payload, journal, and reparse-point checks.
+- **Budget the full Windows preservation round trip explicitly.** The focused
+  test synchronously starts PowerShell for `Prepare`, `FallbackCleanup`, and
+  `Restore`. Native runner startup can put the correct round trip just beyond
+  Vitest's 5-second default, so that one test receives a 15-second ceiling while
+  keeping every behavioral assertion intact.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -91,6 +91,11 @@ loaded Ubuntu runners.
   Windows PowerShell helpers can exceed the cross-platform five-second default
   during runner load; assertions, process exit checks, and fail-closed behavior
   remain unchanged.
+- Desktop Chromium smokes already create and populate an isolated app-data
+  directory. When their dedicated environment flag is present, main bootstrap
+  now binds Electron's `appData` special path to that directory before its first
+  `getPath` call. This avoids dependence on Windows Known Folder discovery after
+  installer mutation tests and does not affect ordinary or packaged launches.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -86,6 +86,11 @@ loaded Ubuntu runners.
   Windows runner even though no checkpoint had demonstrated a deadlock. The
   fixture now uses the repository's existing 60-second Vitest ceiling; every
   10-second checkpoint and all liveness assertions remain unchanged.
+- Root Vitest keeps its existing two-worker Windows concurrency but uses a
+  15-second per-test ceiling there. Native filesystem migration and synchronous
+  Windows PowerShell helpers can exceed the cross-platform five-second default
+  during runner load; assertions, process exit checks, and fail-closed behavior
+  remain unchanged.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/design.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/design.md
@@ -81,6 +81,11 @@ loaded Ubuntu runners.
   install/uninstall keys after that cleanup succeeds. No dynamic or parent
   registry path is deleted, and the shell context is restored to all-users
   before the new installation continues.
+- The supervision-liveness fixture drives four independently bounded scheduler
+  checkpoints. Its former 20-second outer timeout could expire first on a busy
+  Windows runner even though no checkpoint had demonstrated a deadlock. The
+  fixture now uses the repository's existing 60-second Vitest ceiling; every
+  10-second checkpoint and all liveness assertions remain unchanged.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -23,6 +23,8 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
 - Recover quoted registered uninstaller paths with the same native NSIS
   `GetInQuotes`/`GetFileParent` path used by electron-builder, avoiding an empty
   cross-process `ResolveSource` result.
+- Give the three-process Windows preservation round-trip test a 15-second native
+  startup budget while retaining all migration safety assertions.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
 - Do not change GraphScheduler production behavior, public APIs,

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -34,6 +34,8 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
   state waits and liveness assertions.
 - Give root Vitest cases a 15-second per-test budget on Windows so synchronous
   native filesystem and PowerShell validation can complete under runner load.
+- Bind Electron's `appData` special path to the already-created isolated desktop
+  smoke directory before development smoke startup.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
 - Do not change GraphScheduler production behavior, public APIs,

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -17,6 +17,9 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
 - Record every validated Windows installation source before invoking the old
   uninstaller, so fallback cleanup remains authorized after the old executable
   has been removed even when there is no unknown content to preserve.
+- Surface opt-in Windows helper action/error diagnostics when the native smoke
+  observes an unexpected installer exit, without changing normal installer
+  output or behavior.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
 - Do not change GraphScheduler production behavior, public APIs,

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -25,6 +25,8 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
   include and an empty cross-process `ResolveSource` result.
 - Give the three-process Windows preservation round-trip test a 15-second native
   startup budget while retaining all migration safety assertions.
+- Remove only the fixed Kun HKCU install/uninstall registrations after a
+  validated current-user to all-users transition succeeds.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
 - Do not change GraphScheduler production behavior, public APIs,

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The native Linux packaging job currently fails before `dist:linux` because the
+Graph scheduler shutdown-recovery test treats durable file-backed cleanup as a
+500 ms operation. Under normal Ubuntu CI load the scheduler completes correctly,
+but the test reports a timeout and blocks all Linux packaging and release gates.
+
+## What Changes
+
+- Raise the shutdown completion assertion budget to 5 seconds on all platforms,
+  matching the existing Windows allowance while retaining the test's 15-second
+  overall timeout.
+- Keep the late-admission shutdown scenario and durable interrupted-attempt
+  assertions unchanged.
+- Keep the extension release-gate fixture aligned with the AppImage smoke
+  invocation contract by supplying the extracted AppDir and `AppRun` paths.
+- Record the Linux Graph CI validation contract in a standalone OpenSpec
+  capability.
+- Do not change GraphScheduler production behavior, public APIs, packaging
+  configuration, or user-facing release notes.
+
+## Capabilities
+
+### New Capabilities
+
+- `linux-graph-ci-validation`: Native Linux Graph tests must tolerate durable
+  shutdown persistence latency while still detecting a real shutdown deadlock,
+  allowing the downstream Linux package and smoke gates to run.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Test: `kun/src/graph/graph-scheduler-shutdown-recovery.test.ts`.
+- Release-gate validation: `scripts/check-extension-release-gate.mjs` must pass
+  the resolved AppImage extraction paths to the final desktop smoke fixture.
+- CI/release eligibility: the Graph platform suite can proceed to Linux
+  AppImage/deb packaging and native smoke validation.
+- No runtime protocol, API, dependency, or packaged application behavior
+  changes.

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -20,6 +20,9 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
 - Surface opt-in Windows helper action/error diagnostics when the native smoke
   observes an unexpected installer exit, without changing normal installer
   output or behavior.
+- Recover quoted registered uninstaller paths with the same native NSIS
+  `GetInQuotes`/`GetFileParent` path used by electron-builder, avoiding an empty
+  cross-process `ResolveSource` result.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
 - Do not change GraphScheduler production behavior, public APIs,

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -29,6 +29,9 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
   validated current-user to all-users transition succeeds.
 - Remove the retired current-user Kun/legacy shortcuts while preserving the
   new all-users shortcut scope.
+- Allow the deterministic supervision-liveness fixture its full configured
+  Vitest budget on slower native Windows runners while retaining its bounded
+  state waits and liveness assertions.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
 - Do not change GraphScheduler production behavior, public APIs,

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -32,6 +32,8 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
 - Allow the deterministic supervision-liveness fixture its full configured
   Vitest budget on slower native Windows runners while retaining its bounded
   state waits and liveness assertions.
+- Give root Vitest cases a 15-second per-test budget on Windows so synchronous
+  native filesystem and PowerShell validation can complete under runner load.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
 - Do not change GraphScheduler production behavior, public APIs,

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -20,9 +20,9 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
 - Surface opt-in Windows helper action/error diagnostics when the native smoke
   observes an unexpected installer exit, without changing normal installer
   output or behavior.
-- Recover quoted registered uninstaller paths with the same native NSIS
-  `GetInQuotes`/`GetFileParent` path used by electron-builder, avoiding an empty
-  cross-process `ResolveSource` result.
+- Recover quoted registered uninstaller paths with installer-local NSIS parsing
+  available during `customHeader`, avoiding both electron-builder's later macro
+  include and an empty cross-process `ResolveSource` result.
 - Give the three-process Windows preservation round-trip test a 15-second native
   startup budget while retaining all migration safety assertions.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -27,6 +27,8 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
   startup budget while retaining all migration safety assertions.
 - Remove only the fixed Kun HKCU install/uninstall registrations after a
   validated current-user to all-users transition succeeds.
+- Remove the retired current-user Kun/legacy shortcuts while preserving the
+  new all-users shortcut scope.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
 - Do not change GraphScheduler production behavior, public APIs,

--- a/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/proposal.md
@@ -14,10 +14,13 @@ but the test reports a timeout and blocks all Linux packaging and release gates.
   assertions unchanged.
 - Keep the extension release-gate fixture aligned with the AppImage smoke
   invocation contract by supplying the extracted AppDir and `AppRun` paths.
+- Record every validated Windows installation source before invoking the old
+  uninstaller, so fallback cleanup remains authorized after the old executable
+  has been removed even when there is no unknown content to preserve.
 - Record the Linux Graph CI validation contract in a standalone OpenSpec
   capability.
-- Do not change GraphScheduler production behavior, public APIs, packaging
-  configuration, or user-facing release notes.
+- Do not change GraphScheduler production behavior, public APIs,
+  electron-builder configuration, or user-facing release notes.
 
 ## Capabilities
 
@@ -36,7 +39,9 @@ None.
 - Test: `kun/src/graph/graph-scheduler-shutdown-recovery.test.ts`.
 - Release-gate validation: `scripts/check-extension-release-gate.mjs` must pass
   the resolved AppImage extraction paths to the final desktop smoke fixture.
+- Windows migration helper: `build/windows-installer-migration.ps1` records
+  validated cleanup sources before the old uninstaller removes their identity
+  executable.
 - CI/release eligibility: the Graph platform suite can proceed to Linux
   AppImage/deb packaging and native smoke validation.
-- No runtime protocol, API, dependency, or packaged application behavior
-  changes.
+- No runtime protocol, API, dependency, or release-note changes.

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -80,3 +80,16 @@ them when an installer exits with an unexpected code.
 - **THEN** the smoke log SHALL identify the failed action and its caught error
 - **AND** normal installer runs without the diagnostic environment variable
   SHALL not create that log
+
+### Requirement: Windows registered source recovery is process-local
+
+The Windows installer SHALL recover the parent directory from its quoted
+registered uninstaller path inside NSIS before resolving the canonical target.
+
+#### Scenario: InstallLocation is empty but UninstallString is valid
+
+- **WHEN** a current-user registration has an empty `InstallLocation` and a
+  quoted `UninstallString` under the legacy installation directory
+- **THEN** NSIS SHALL recover that directory with its native quoted-path parser
+- **AND** target resolution SHALL receive the non-empty recovered source without
+  depending on a child-process result file

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -127,3 +127,18 @@ during a current-user to all-users migration.
   desktop/start-menu shortcuts SHALL be removed
 - **AND** registration cleanup SHALL occur only after fail-closed payload cleanup
   succeeds
+
+### Requirement: Supervision liveness validation tolerates native runner load
+
+The deterministic Graph supervision-liveness fixture SHALL retain its bounded
+state checks while allowing the complete multi-checkpoint scenario the existing
+60-second Vitest test budget.
+
+#### Scenario: A loaded native runner completes deterministic supervision
+
+- **WHEN** the fixture redelivers two parked prose-only Lead episodes and
+  completes the reviewed run
+- **THEN** each scheduler-state wait SHALL remain bounded at 10 seconds
+- **AND** the test-level timeout SHALL be 60 seconds
+- **AND** the Lead episode, worker start, accepted node, and resolved obligation
+  assertions SHALL remain unchanged

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -142,3 +142,16 @@ state checks while allowing the complete multi-checkpoint scenario the existing
 - **AND** the test-level timeout SHALL be 60 seconds
 - **AND** the Lead episode, worker start, accepted node, and resolved obligation
   assertions SHALL remain unchanged
+
+### Requirement: Root Windows tests allow native process startup
+
+The root Vitest configuration SHALL give Windows tests a bounded 15-second
+per-test budget while retaining the existing two-worker concurrency.
+
+#### Scenario: Native migration checks run under Windows runner load
+
+- **WHEN** root migration tests perform synchronous filesystem operations or
+  launch the Windows PowerShell migration helper
+- **THEN** Vitest SHALL allow the test up to 15 seconds to return
+- **AND** non-Windows platforms SHALL retain the default timeout
+- **AND** migration assertions and helper exit validation SHALL remain unchanged

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -155,3 +155,19 @@ per-test budget while retaining the existing two-worker concurrency.
 - **THEN** Vitest SHALL allow the test up to 15 seconds to return
 - **AND** non-Windows platforms SHALL retain the default timeout
 - **AND** migration assertions and helper exit validation SHALL remain unchanged
+
+### Requirement: Desktop smoke app data is explicitly isolated
+
+The Electron main bootstrap SHALL bind the `appData` special path to the
+pre-created isolated desktop-smoke directory only when the dedicated desktop
+smoke environment is active.
+
+#### Scenario: Windows Known Folder discovery is unavailable after installer smoke
+
+- **WHEN** a desktop smoke launches with
+  `KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE=1` and a non-empty `APPDATA`
+- **THEN** main bootstrap SHALL call `app.setPath('appData', APPDATA)` before the
+  first `app.getPath('appData')`
+- **AND** an isolated smoke without `APPDATA` SHALL fail closed
+- **AND** an ordinary application launch SHALL not override Electron's `appData`
+  path

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -46,3 +46,25 @@ artifacts when that suite passes.
 - **WHEN** any Graph platform test fails
 - **THEN** the workflow SHALL stop before `dist:linux` and SHALL not publish
   Linux artifacts
+
+### Requirement: Windows fallback cleanup uses a validated preparation record
+
+The Windows migration helper SHALL record each existing installation source
+after validating its safe root, application identity, recognized payload, and
+reparse-point boundaries, even when that source has no unknown content to
+preserve.
+
+#### Scenario: Old uninstaller removes the identity executable
+
+- **WHEN** preparation validates a registered source and the old uninstaller
+  subsequently removes its identity executable
+- **THEN** fallback cleanup SHALL accept that exact source through its matching
+  preparation record
+- **AND** the helper SHALL remove only recognized application payload
+
+#### Scenario: Unprepared source is presented for fallback cleanup
+
+- **WHEN** fallback cleanup receives a source without a matching preparation
+  record
+- **THEN** it SHALL reject a source that differs from the install target or no
+  longer contains an application identity executable

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Graph shutdown recovery tolerates durable CI persistence latency
+
+The native Graph platform test SHALL allow up to 5 seconds for
+`GraphScheduler.stop()` to finish after an attempt is admitted behind the first
+shutdown snapshot, while retaining the test's 15-second overall timeout.
+
+#### Scenario: Late admission is interrupted within the CI budget
+
+- **WHEN** shutdown begins while write-lease admission is paused and admission
+  is released after the first shutdown snapshot
+- **THEN** the test SHALL wait for `scheduler.stop()` for no more than 5 seconds
+  before failing as a possible deadlock
+- **AND** the scheduler SHALL persist the late attempt as interrupted with the
+  host-shutdown failure and an effective attempt count of zero
+
+### Requirement: AppImage release-gate validation supplies extracted paths
+
+The extension release-gate fixture SHALL invoke the final AppImage desktop
+smoke with explicit extracted `appRoot` and `appRun` paths, matching the
+packaged smoke launcher contract and avoiding undefined path resolution.
+
+#### Scenario: Final AppImage smoke invocation is validated
+
+- **WHEN** the release gate constructs the final Linux AppImage desktop smoke
+- **THEN** it SHALL provide the extracted AppDir and its `AppRun` executable
+- **AND** the fixture SHALL validate `APPDIR`/`APPIMAGE` and the `AppRun` command
+  without enabling AppImage self-extraction mode
+
+### Requirement: Linux packaging remains gated by the complete Graph platform suite
+
+The Linux PR and release workflows SHALL run the Graph platform suite before
+Linux packaging, and SHALL only continue to package and smoke-test Linux
+artifacts when that suite passes.
+
+#### Scenario: Graph suite passes and Linux gates continue
+
+- **WHEN** `npm run test:graph:platform` passes on the native Ubuntu/Node 22
+  runner
+- **THEN** the workflow SHALL continue to `dist:linux` and its deb/AppImage,
+  CLI, extension, migration, Chromium/AppImage, and native-evidence checks
+
+#### Scenario: Graph suite fails and packaging is blocked
+
+- **WHEN** any Graph platform test fails
+- **THEN** the workflow SHALL stop before `dist:linux` and SHALL not publish
+  Linux artifacts

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -110,3 +110,18 @@ content on a native runner.
 - **THEN** the test SHALL continue for no more than 15 seconds
 - **AND** all preparation, cleanup, restoration, and journal assertions SHALL
   remain unchanged
+
+### Requirement: Windows scope migration retires the old registration
+
+The Windows installer SHALL remove the fixed Kun current-user install and
+uninstall registration keys after validated cleanup succeeds during a
+current-user to all-users migration.
+
+#### Scenario: Current-user installation is migrated for all users
+
+- **WHEN** an all-users install successfully retires the validated current-user
+  application payload
+- **THEN** the exact Kun `INSTALL_REGISTRY_KEY` and `UNINSTALL_REGISTRY_KEY`
+  entries under `HKEY_CURRENT_USER` SHALL be removed
+- **AND** registration cleanup SHALL occur only after fail-closed payload cleanup
+  succeeds

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -111,11 +111,11 @@ content on a native runner.
 - **AND** all preparation, cleanup, restoration, and journal assertions SHALL
   remain unchanged
 
-### Requirement: Windows scope migration retires the old registration
+### Requirement: Windows scope migration retires old user shell state
 
-The Windows installer SHALL remove the fixed Kun current-user install and
-uninstall registration keys after validated cleanup succeeds during a
-current-user to all-users migration.
+The Windows installer SHALL remove the fixed Kun current-user install/uninstall
+registration keys and application shortcuts after validated cleanup succeeds
+during a current-user to all-users migration.
 
 #### Scenario: Current-user installation is migrated for all users
 
@@ -123,5 +123,7 @@ current-user to all-users migration.
   application payload
 - **THEN** the exact Kun `INSTALL_REGISTRY_KEY` and `UNINSTALL_REGISTRY_KEY`
   entries under `HKEY_CURRENT_USER` SHALL be removed
+- **AND** the registered, canonical Kun, and legacy DeepSeek GUI current-user
+  desktop/start-menu shortcuts SHALL be removed
 - **AND** registration cleanup SHALL occur only after fail-closed payload cleanup
   succeeds

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -93,3 +93,17 @@ registered uninstaller path inside NSIS before resolving the canonical target.
 - **THEN** NSIS SHALL recover that directory with its native quoted-path parser
 - **AND** target resolution SHALL receive the non-empty recovered source without
   depending on a child-process result file
+
+### Requirement: Windows preservation validation tolerates native process startup
+
+The Windows migration test SHALL allow up to 15 seconds for its three
+synchronous PowerShell helper processes to prepare, clean, and restore preserved
+content on a native runner.
+
+#### Scenario: Native helper startup exceeds the default unit-test budget
+
+- **WHEN** the preservation round trip is correct but three native PowerShell
+  startups take longer than the default 5-second unit-test timeout
+- **THEN** the test SHALL continue for no more than 15 seconds
+- **AND** all preparation, cleanup, restoration, and journal assertions SHALL
+  remain unchanged

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -90,9 +90,12 @@ registered uninstaller path inside NSIS before resolving the canonical target.
 
 - **WHEN** a current-user registration has an empty `InstallLocation` and a
   quoted `UninstallString` under the legacy installation directory
-- **THEN** NSIS SHALL recover that directory with its native quoted-path parser
+- **THEN** NSIS SHALL recover that directory with installer-local quoted-path
+  and parent-directory parsers available during `customHeader` expansion
 - **AND** target resolution SHALL receive the non-empty recovered source without
   depending on a child-process result file
+- **AND** compilation SHALL not depend on macros loaded later by
+  electron-builder's `installUtil.nsh`
 
 ### Requirement: Windows preservation validation tolerates native process startup
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/specs/linux-graph-ci-validation/spec.md
@@ -68,3 +68,15 @@ preserve.
   record
 - **THEN** it SHALL reject a source that differs from the install target or no
   longer contains an application identity executable
+
+### Requirement: Windows migration smoke exposes helper failures
+
+The Windows migration smoke SHALL opt into bounded helper diagnostics and print
+them when an installer exits with an unexpected code.
+
+#### Scenario: Silent installer helper fails
+
+- **WHEN** a helper action fails inside a silent NSIS migration scenario
+- **THEN** the smoke log SHALL identify the failed action and its caught error
+- **AND** normal installer runs without the diagnostic environment variable
+  SHALL not create that log

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -11,6 +11,7 @@
 - [x] 1.9 Retire the fixed Kun HKCU registration after validated current-user to all-users cleanup.
 - [x] 1.10 Retire registered, canonical, and legacy current-user shortcuts during that scope migration.
 - [x] 1.11 Align the multi-checkpoint Graph supervision-liveness fixture with the existing 60-second Vitest budget.
+- [x] 1.12 Use a bounded 15-second root Vitest timeout for native Windows filesystem and PowerShell checks.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -8,6 +8,7 @@
 - [x] 1.6 Recover the registered source natively in NSIS and remove the failing `ResolveSource` child-process round trip.
 - [x] 1.7 Allow the Windows preservation round-trip test 15 seconds for its three native PowerShell helper processes.
 - [x] 1.8 Make quoted uninstall-source parsing self-contained during NSIS `customHeader` expansion.
+- [x] 1.9 Retire the fixed Kun HKCU registration after validated current-user to all-users cleanup.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -12,6 +12,7 @@
 - [x] 1.10 Retire registered, canonical, and legacy current-user shortcuts during that scope migration.
 - [x] 1.11 Align the multi-checkpoint Graph supervision-liveness fixture with the existing 60-second Vitest budget.
 - [x] 1.12 Use a bounded 15-second root Vitest timeout for native Windows filesystem and PowerShell checks.
+- [x] 1.13 Bind Electron appData to the pre-created isolated directory for desktop smokes.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -6,6 +6,7 @@
 - [x] 1.4 Record every validated Windows installation source before old-uninstaller cleanup and cover the no-unknown-content path.
 - [x] 1.5 Add opt-in helper diagnostics so the native Windows smoke reports the exact silent installer failure.
 - [x] 1.6 Recover the registered source natively in NSIS and remove the failing `ResolveSource` child-process round trip.
+- [x] 1.7 Allow the Windows preservation round-trip test 15 seconds for its three native PowerShell helper processes.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -5,6 +5,7 @@
 - [x] 1.3 Update the release-gate AppImage fixture to pass explicit extracted `appRoot` and `appRun` paths to the smoke invocation helper.
 - [x] 1.4 Record every validated Windows installation source before old-uninstaller cleanup and cover the no-unknown-content path.
 - [x] 1.5 Add opt-in helper diagnostics so the native Windows smoke reports the exact silent installer failure.
+- [x] 1.6 Recover the registered source natively in NSIS and remove the failing `ResolveSource` child-process round trip.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -1,0 +1,18 @@
+## 1. Test fix
+
+- [x] 1.1 Set the Graph shutdown completion assertion budget to 5 seconds for all platforms while preserving the existing 15-second test timeout and durable-state assertions.
+- [x] 1.2 Verify the production scheduler, packaging configuration, and release notes remain unchanged.
+- [x] 1.3 Update the release-gate AppImage fixture to pass explicit extracted `appRoot` and `appRun` paths to the smoke invocation helper.
+
+## 2. Local verification
+
+- [x] 2.1 Run the shutdown-recovery test serially 10 times and confirm every run passes.
+- [x] 2.2 Run `npm run test:graph:platform` and confirm the Kun and renderer Graph suites pass.
+- [x] 2.3 Run `npm run build:kun`, `npm run typecheck`, `npm run lint`, `npm run test`, `npm run build`, and `git diff --check`.
+
+## 3. Native CI and release
+
+- [x] 3.1 Commit the scoped change, push the `codex/fix-linux-graph-shutdown-timeout` branch, and open a PR targeting `develop`.
+- [ ] 3.2 Confirm native Ubuntu/Node 22 Graph, Linux packaging, smoke, evidence, macOS, Windows, and general PR checks are green before merge.
+- [ ] 3.3 Merge the hotfix into `develop`, wait for release PR #1054 to refresh and pass all gates, then merge it to `master`.
+- [ ] 3.4 Verify the automated `v0.2.34` release, cross-platform assets, and R2 stable/latest promotion; stop if the computed version differs.

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -7,6 +7,7 @@
 - [x] 1.5 Add opt-in helper diagnostics so the native Windows smoke reports the exact silent installer failure.
 - [x] 1.6 Recover the registered source natively in NSIS and remove the failing `ResolveSource` child-process round trip.
 - [x] 1.7 Allow the Windows preservation round-trip test 15 seconds for its three native PowerShell helper processes.
+- [x] 1.8 Make quoted uninstall-source parsing self-contained during NSIS `customHeader` expansion.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -10,6 +10,7 @@
 - [x] 1.8 Make quoted uninstall-source parsing self-contained during NSIS `customHeader` expansion.
 - [x] 1.9 Retire the fixed Kun HKCU registration after validated current-user to all-users cleanup.
 - [x] 1.10 Retire registered, canonical, and legacy current-user shortcuts during that scope migration.
+- [x] 1.11 Align the multi-checkpoint Graph supervision-liveness fixture with the existing 60-second Vitest budget.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -9,6 +9,7 @@
 - [x] 1.7 Allow the Windows preservation round-trip test 15 seconds for its three native PowerShell helper processes.
 - [x] 1.8 Make quoted uninstall-source parsing self-contained during NSIS `customHeader` expansion.
 - [x] 1.9 Retire the fixed Kun HKCU registration after validated current-user to all-users cleanup.
+- [x] 1.10 Retire registered, canonical, and legacy current-user shortcuts during that scope migration.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -4,6 +4,7 @@
 - [x] 1.2 Verify the production scheduler, packaging configuration, and release notes remain unchanged.
 - [x] 1.3 Update the release-gate AppImage fixture to pass explicit extracted `appRoot` and `appRun` paths to the smoke invocation helper.
 - [x] 1.4 Record every validated Windows installation source before old-uninstaller cleanup and cover the no-unknown-content path.
+- [x] 1.5 Add opt-in helper diagnostics so the native Windows smoke reports the exact silent installer failure.
 
 ## 2. Local verification
 

--- a/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
+++ b/openspec/changes/fix-linux-graph-shutdown-validation/tasks.md
@@ -3,12 +3,14 @@
 - [x] 1.1 Set the Graph shutdown completion assertion budget to 5 seconds for all platforms while preserving the existing 15-second test timeout and durable-state assertions.
 - [x] 1.2 Verify the production scheduler, packaging configuration, and release notes remain unchanged.
 - [x] 1.3 Update the release-gate AppImage fixture to pass explicit extracted `appRoot` and `appRun` paths to the smoke invocation helper.
+- [x] 1.4 Record every validated Windows installation source before old-uninstaller cleanup and cover the no-unknown-content path.
 
 ## 2. Local verification
 
 - [x] 2.1 Run the shutdown-recovery test serially 10 times and confirm every run passes.
 - [x] 2.2 Run `npm run test:graph:platform` and confirm the Kun and renderer Graph suites pass.
 - [x] 2.3 Run `npm run build:kun`, `npm run typecheck`, `npm run lint`, `npm run test`, `npm run build`, and `git diff --check`.
+- [x] 2.4 Re-run the focused packaging configuration and release-gate checks after the Windows migration fix.
 
 ## 3. Native CI and release
 

--- a/scripts/check-extension-release-gate.mjs
+++ b/scripts/check-extension-release-gate.mjs
@@ -942,23 +942,25 @@ check(
 if (typeof packagedAppImageSmokeModule.createAppImageSmokeInvocation === 'function') {
   const invocation = packagedAppImageSmokeModule.createAppImageSmokeInvocation({
     appImage: '/release/Kun-1.2.3-linux-x86_64.AppImage',
+    appRoot: '/extract/squashfs-root',
+    appRun: '/extract/squashfs-root/AppRun',
     resourcesDir: '/extract/squashfs-root/resources',
     desktopSmokePath: '/repo/scripts/smoke-packaged-extension-desktop.cjs',
     environment: { APPDIR: '/untrusted', APPIMAGE: '/untrusted', ELECTRON_RUN_AS_NODE: '1' }
   })
   check(
     invocation.command === process.execPath &&
-      invocation.options.env.APPIMAGE_EXTRACT_AND_RUN === '1' &&
+      invocation.options.env.APPIMAGE_EXTRACT_AND_RUN === undefined &&
       invocation.options.env.ELECTRON_RUN_AS_NODE === undefined &&
-      invocation.options.env.APPDIR === undefined &&
-      invocation.options.env.APPIMAGE === undefined &&
+      invocation.options.env.APPDIR === resolve('/extract/squashfs-root') &&
+      invocation.options.env.APPIMAGE === resolve('/release/Kun-1.2.3-linux-x86_64.AppImage') &&
       invocation.args.includes('--desktop-executable') &&
-      invocation.args.includes(resolve('/release/Kun-1.2.3-linux-x86_64.AppImage')) &&
+      invocation.args.includes(resolve('/extract/squashfs-root/AppRun')) &&
       invocation.args.includes(resolve('/extract/squashfs-root/resources')) &&
       invocation.options.timeout === undefined &&
       invocation.options.killSignal === undefined &&
       !invocation.args.some((argument) => argument.endsWith('app.asar')),
-    'Final Linux AppImage smoke must let the desktop smoke own bounded cleanup while directly launching the final artifact'
+    'Final Linux AppImage smoke must launch the verified AppRun with bounded desktop cleanup'
   )
 }
 

--- a/scripts/smoke-windows-installer-migration.ps1
+++ b/scripts/smoke-windows-installer-migration.ps1
@@ -14,6 +14,8 @@ if (-not $AllowLocal -and $env:CI -ne 'true') {
 }
 
 $root = Join-Path ([IO.Path]::GetTempPath()) ('kun-installer-migration-smoke-' + [guid]::NewGuid().ToString('N'))
+$diagnosticPath = Join-Path $root 'installer-helper-diagnostics.log'
+$previousDiagnosticPath = [Environment]::GetEnvironmentVariable('KUN_INSTALLER_DIAGNOSTIC_PATH', 'Process')
 $markerName = '.kun-installer-migration-smoke-' + [guid]::NewGuid().ToString('N')
 $installRegistryPath = $null
 $uninstallRegistryPath = $null
@@ -48,6 +50,10 @@ function Invoke-Installer(
   $process = Start-Process -FilePath $script:InstallerPath -ArgumentList $Arguments -Wait -PassThru
   $stopwatch.Stop()
   Write-Host "[$Scenario] Installer exited with $($process.ExitCode) after $([math]::Round($stopwatch.Elapsed.TotalSeconds, 1))s."
+  if ($process.ExitCode -ne $ExpectedExitCode -and (Test-Path -LiteralPath $script:diagnosticPath -PathType Leaf)) {
+    Write-Host "[$Scenario] Installer helper diagnostics:"
+    Write-Host (Get-Content -LiteralPath $script:diagnosticPath -Raw)
+  }
   Assert-True ($process.ExitCode -eq $ExpectedExitCode) "Installer exited with $($process.ExitCode), expected $ExpectedExitCode. Arguments: $argumentText"
 }
 
@@ -169,6 +175,7 @@ function Add-DataSentinel([string]$Directory) {
 
 try {
   [IO.Directory]::CreateDirectory($root) | Out-Null
+  [Environment]::SetEnvironmentVariable('KUN_INSTALLER_DIAGNOSTIC_PATH', $diagnosticPath, 'Process')
   if ([string]::IsNullOrWhiteSpace($InstallerPath)) {
     $candidate = Get-ChildItem -Path (Join-Path (Get-Location) 'dist') -Filter 'Kun-*-win-x64.exe' |
       Sort-Object LastWriteTimeUtc -Descending |
@@ -300,6 +307,7 @@ try {
 
   Write-Host 'Windows installer migration smoke passed.'
 } finally {
+  [Environment]::SetEnvironmentVariable('KUN_INSTALLER_DIAGNOSTIC_PATH', $previousDiagnosticPath, 'Process')
   foreach ($sentinel in $sentinels) {
     Remove-Item -LiteralPath $sentinel -Force -ErrorAction SilentlyContinue
   }

--- a/src/main/app-identity.test.ts
+++ b/src/main/app-identity.test.ts
@@ -52,4 +52,28 @@ describe('app identity bootstrap', () => {
     configureAppIdentity()
     expect(setAppUserModelId).not.toHaveBeenCalled()
   })
+
+  it('pins appData to the existing isolated desktop smoke directory', async () => {
+    const { configureDesktopSmokeAppDataPath } = await import('./app-identity')
+    expect(configureDesktopSmokeAppDataPath({
+      KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE: '1',
+      APPDATA: ' C:\\smoke\\app-data '
+    })).toBe('C:\\smoke\\app-data')
+    expect(setPath).toHaveBeenCalledWith('appData', 'C:\\smoke\\app-data')
+    expect(getPath).not.toHaveBeenCalled()
+  })
+
+  it('leaves appData untouched outside isolated desktop smoke launches', async () => {
+    const { configureDesktopSmokeAppDataPath } = await import('./app-identity')
+    expect(configureDesktopSmokeAppDataPath({ APPDATA: 'C:\\ordinary\\app-data' })).toBeUndefined()
+    expect(setPath).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when an isolated desktop smoke omits APPDATA', async () => {
+    const { configureDesktopSmokeAppDataPath } = await import('./app-identity')
+    expect(() => configureDesktopSmokeAppDataPath({
+      KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE: '1'
+    })).toThrow('requires an APPDATA path')
+    expect(setPath).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/app-identity.ts
+++ b/src/main/app-identity.ts
@@ -12,6 +12,18 @@ import {
 /** Kept for production branding and compatibility tests. */
 export const APP_PRODUCT_NAME = PRODUCTION_APP_NAME
 
+export function configureDesktopSmokeAppDataPath(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  if (env.KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE !== '1') return undefined
+  const appDataPath = env.APPDATA?.trim()
+  if (!appDataPath) {
+    throw new Error('The isolated desktop smoke requires an APPDATA path')
+  }
+  app.setPath('appData', appDataPath)
+  return appDataPath
+}
+
 export function configureAppIdentity(options: {
   flavor?: AppFlavor
   appDataPath?: string

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,7 +51,11 @@ import {
   configureDevelopmentRendererHttpCache,
   reloadRenderer
 } from './dev-renderer-cache'
-import { configureAppIdentity, readPackagedAppFlavor } from './app-identity'
+import {
+  configureAppIdentity,
+  configureDesktopSmokeAppDataPath,
+  readPackagedAppFlavor
+} from './app-identity'
 import { shouldStartHidden, syncLoginItemSettings } from './desktop-behavior'
 import { resolveLogDirectory, resolveNamedPreloadPath, resolvePreloadPath } from './main-paths'
 import {
@@ -405,9 +409,10 @@ const appFlavor = resolveAppFlavor({
   env: process.env,
   packagedFlavor: app.isPackaged ? readPackagedAppFlavor(app.getAppPath()) : undefined
 })
+const desktopSmokeAppDataPath = configureDesktopSmokeAppDataPath()
 const appIdentity = configureAppIdentity({
   flavor: appFlavor,
-  appDataPath: app.getPath('appData')
+  appDataPath: desktopSmokeAppDataPath ?? app.getPath('appData')
 })
 process.env.KUN_APP_FLAVOR = appIdentity.flavor
 process.env.KUN_RUNTIME_FLAVOR = appIdentity.runtimeFlavor

--- a/src/main/packaging-config.test.ts
+++ b/src/main/packaging-config.test.ts
@@ -495,11 +495,13 @@ describe('electron-builder Kun packaging', () => {
     )
     expect(installerScript).toContain('Function KunReadMigrationResult')
     expect(installerScript).toContain('IfErrors KunMigrationResultMissing')
+    expect(installerScript).toContain('Function KunGetInQuotes')
+    expect(installerScript).toContain('Function KunGetFileParent')
     expect(installerScript).toContain('Function KunRecoverSourceFromUninstallString')
-    expect(installerScript).toContain(
-      '!insertmacro GetInQuotes $KunInstallerSourceDir "$R9"'
-    )
-    expect(installerScript).toContain('Call GetFileParent')
+    expect(installerScript).toContain('Call KunGetInQuotes')
+    expect(installerScript).toContain('Call KunGetFileParent')
+    expect(installerScript).not.toContain('!insertmacro GetInQuotes')
+    expect(installerScript).not.toContain('Call GetFileParent')
     expect(installerScript).not.toContain('!insertmacro kunRunMigrationHelper ResolveSource')
     expect(installerScript).toContain('${if} $KunInstallerSnapshotMode != $installMode')
     expect(installerScript).toContain('${andIf} $installMode != "all"')

--- a/src/main/packaging-config.test.ts
+++ b/src/main/packaging-config.test.ts
@@ -516,6 +516,12 @@ describe('electron-builder Kun packaging', () => {
     expect(installerScript).toContain('customCheckAppRunning')
     expect(installerScript).toContain('customUnInstallCheck')
     expect(installerScript).toContain('customUnInstallCheckCurrentUser')
+    expect(installerScript).toContain(
+      'DeleteRegKey HKEY_CURRENT_USER "${UNINSTALL_REGISTRY_KEY}"'
+    )
+    expect(installerScript).toContain(
+      'DeleteRegKey HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}"'
+    )
     expect(installerScript).toContain('KunHandleOldUninstallerResult')
     expect(installerScript).toContain('FallbackCleanup')
     expect(installerScript).toContain('Restore')

--- a/src/main/packaging-config.test.ts
+++ b/src/main/packaging-config.test.ts
@@ -536,6 +536,8 @@ describe('electron-builder Kun packaging', () => {
     expect(migrationScript).toContain('function Assert-ApplicationSourceIdentity')
     expect(migrationScript).toContain('function Assert-FallbackCleanupSource')
     expect(migrationScript).toContain('The cleanup source does not match the preservation journal')
+    expect(migrationScript).toContain('function Write-InstallerDiagnostic')
+    expect(migrationScript).toContain("Get-EnvironmentValue 'KUN_INSTALLER_DIAGNOSTIC_PATH'")
     expect(migrationScript).toContain('$preparedSources += @{')
     expect(migrationScript).toContain('if ($set.Unknown.Count -eq 0)')
     expect(migrationScript).toContain('function Assert-TrustedSecondarySource')

--- a/src/main/packaging-config.test.ts
+++ b/src/main/packaging-config.test.ts
@@ -495,6 +495,12 @@ describe('electron-builder Kun packaging', () => {
     )
     expect(installerScript).toContain('Function KunReadMigrationResult')
     expect(installerScript).toContain('IfErrors KunMigrationResultMissing')
+    expect(installerScript).toContain('Function KunRecoverSourceFromUninstallString')
+    expect(installerScript).toContain(
+      '!insertmacro GetInQuotes $KunInstallerSourceDir "$R9"'
+    )
+    expect(installerScript).toContain('Call GetFileParent')
+    expect(installerScript).not.toContain('!insertmacro kunRunMigrationHelper ResolveSource')
     expect(installerScript).toContain('${if} $KunInstallerSnapshotMode != $installMode')
     expect(installerScript).toContain('${andIf} $installMode != "all"')
     expect(installerScript).not.toContain('KUN_INSTALLER_RESULT')

--- a/src/main/packaging-config.test.ts
+++ b/src/main/packaging-config.test.ts
@@ -536,6 +536,8 @@ describe('electron-builder Kun packaging', () => {
     expect(migrationScript).toContain('function Assert-ApplicationSourceIdentity')
     expect(migrationScript).toContain('function Assert-FallbackCleanupSource')
     expect(migrationScript).toContain('The cleanup source does not match the preservation journal')
+    expect(migrationScript).toContain('$preparedSources += @{')
+    expect(migrationScript).toContain('if ($set.Unknown.Count -eq 0)')
     expect(migrationScript).toContain('function Assert-TrustedSecondarySource')
     expect(migrationScript).toContain('function Assert-NoReparsePointsInTree')
     expect(migrationScript).toContain(

--- a/src/main/packaging-config.test.ts
+++ b/src/main/packaging-config.test.ts
@@ -516,6 +516,14 @@ describe('electron-builder Kun packaging', () => {
     expect(installerScript).toContain('customCheckAppRunning')
     expect(installerScript).toContain('customUnInstallCheck')
     expect(installerScript).toContain('customUnInstallCheckCurrentUser')
+    expect(installerScript).toContain('Function KunRetireCurrentUserShellState')
+    expect(installerScript).toContain(
+      'ReadRegStr $KunInstallerCurrentUserShortcutName HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}" ShortcutName'
+    )
+    expect(installerScript).toContain('Delete "$DESKTOP\\${SHORTCUT_NAME}.lnk"')
+    expect(installerScript).toContain('Delete "$SMPROGRAMS\\${SHORTCUT_NAME}.lnk"')
+    expect(installerScript).toContain('SetShellVarContext current')
+    expect(installerScript).toContain('SetShellVarContext all')
     expect(installerScript).toContain(
       'DeleteRegKey HKEY_CURRENT_USER "${UNINSTALL_REGISTRY_KEY}"'
     )

--- a/src/main/windows-installer-migration.test.ts
+++ b/src/main/windows-installer-migration.test.ts
@@ -175,6 +175,30 @@ windowsOnly('Windows installer migration helper', () => {
     expect(existsSync(journal)).toBe(false)
   })
 
+  it('authorizes fallback cleanup for a validated source without unknown content', () => {
+    const root = makeTempRoot()
+    const source = join(root, 'DeepSeek GUI')
+    const target = join(root, 'Kun')
+    const journal = join(root, 'recovery', 'journal.json')
+    mkdirSync(join(source, 'resources'), { recursive: true })
+    writeFileSync(join(source, 'Kun.exe'), 'app')
+
+    const prepared = runHelper({ action: 'Prepare', source, target, journal })
+    expect(prepared.status, processError(prepared)).toBe(0)
+    expect(existsSync(journal)).toBe(true)
+
+    // The old uninstaller removes the identity executable before fallback
+    // cleanup, so the validated preparation record becomes the authorization.
+    rmSync(join(source, 'Kun.exe'))
+    const cleaned = runHelper({ action: 'FallbackCleanup', source, target, journal })
+    expect(cleaned.status, processError(cleaned)).toBe(0)
+    expect(existsSync(source)).toBe(false)
+
+    const restored = runHelper({ action: 'Restore', source, target, journal })
+    expect(restored.status, processError(restored)).toBe(0)
+    expect(existsSync(journal)).toBe(false)
+  })
+
   it('recovers an interrupted preservation journal idempotently', () => {
     const root = makeTempRoot()
     const source = join(root, 'Custom Install')

--- a/src/main/windows-installer-migration.test.ts
+++ b/src/main/windows-installer-migration.test.ts
@@ -173,7 +173,7 @@ windowsOnly('Windows installer migration helper', () => {
     expect(restored.status, processError(restored)).toBe(0)
     expect(readFileSync(join(source, 'notes.txt'), 'utf8')).toBe('keep me')
     expect(existsSync(journal)).toBe(false)
-  })
+  }, 15_000)
 
   it('authorizes fallback cleanup for a validated source without unknown content', () => {
     const root = makeTempRoot()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
       KUN_DISABLE_OS_CREDENTIAL_STORE: '1'
     },
     include: ['src/**/*.test.ts'],
-    ...(process.platform === 'win32' ? { maxWorkers: 2 } : {})
+    ...(process.platform === 'win32' ? { maxWorkers: 2, testTimeout: 15_000 } : {})
   }
 })


### PR DESCRIPTION
## Summary

- Unblock the v0.2.34 release validation without changing GraphScheduler production semantics.
- Keep the shutdown-recovery assertion bounded at 5 seconds while preserving its 15-second test timeout and durable-state assertions.
- Repair Linux AppImage smoke input wiring, Windows installer migration cleanup, and isolated packaged Electron smoke startup.
- Track the scoped release validation in OpenSpec change `fix-linux-graph-shutdown-validation`.

## Root causes

- Ubuntu CI can require more than 500 ms to complete durable file-backed scheduler shutdown cleanup; the logged deterministic synthesis fixture failure is expected fault injection.
- The final AppImage release-gate fixture omitted the extracted `appRoot` and `appRun` paths and reached `resolve(undefined)`.
- Windows cross-scope migration needed process-local registered-source recovery plus exact cleanup of obsolete HKCU registration and user shortcuts.
- Several native Windows filesystem and PowerShell checks inherited Vitest's 5-second default despite performing multiple real subprocess operations.
- The packaged desktop Graph smoke inherited a runner `APPDATA` value that Electron could not resolve after installer migration; its pre-created isolated app-data directory was not explicitly bound before first use.

## Changes

- Use a 5-second test-only scheduler stop budget and a 60-second outer budget for the existing multi-checkpoint liveness fixture.
- Pass explicit extracted AppDir/AppRun paths to the AppImage smoke helper.
- Recover and validate registered Windows install sources inside NSIS, preserve fail-closed fallback cleanup, and add opt-in native diagnostics.
- Retire the exact migrated HKCU registration plus registered, canonical, and legacy current-user shortcuts during current-user to all-users migration.
- Use a bounded 15-second root Vitest timeout on native Windows checks.
- Bind Electron `appData` to the smoke harness's isolated directory only when `KUN_PACKAGED_EXTENSION_DESKTOP_SMOKE=1`; ordinary launches are unchanged.

## Local tests

- Shutdown-recovery fixture: 10 serial passes.
- `npm run test:graph:platform` passed.
- Focused packaging configuration, migration, release-gate, app-identity, and desktop Graph smoke checks passed.
- `npm run build:kun`, `npm run typecheck`, `npm run lint`, `npm run test`, `npm run build`, `git diff --check`, and strict OpenSpec validation passed. Lint retains one pre-existing warning.

## Native CI evidence

- [PR Checks run 30753798985](https://github.com/KunAgent/Kun/actions/runs/30753798985) passed on commit `cca569244d4b1edad028316f3b827c97bc9f5e76`.
- Ubuntu/Node 22 Graph, Linux deb/AppImage, CLI, Extension, FFmpeg, migration, final AppImage Chromium smoke, and native evidence passed.
- Windows Graph, Extension gate, TUI, NSIS build, full installer migration, packaged CLI, Graph workbench desktop smoke, Extension Node/Chromium, FFmpeg, runtime migration, and native evidence passed.
- macOS arm64/x64 packaging and smokes, Intel macOS validation, general tests, and CodeQL passed.
