### PR TITLE
feat(preview): reveal files in system manager

### DIFF
--- a/src/main/ipc/app-ipc-schemas/workspace.ts
+++ b/src/main/ipc/app-ipc-schemas/workspace.ts
@@ -191,6 +191,10 @@ export const workspaceFileTargetPayloadSchema = z
   })
   .strict()
 
+export const workspaceFileRevealTargetPayloadSchema = workspaceFileTargetPayloadSchema.extend({
+  workspaceRoot: trimmedString(MAX_PATH_LENGTH)
+})
+
 export const workspaceDirectoryTargetPayloadSchema = z
   .object({
     path: optionalTrimmedString(MAX_PATH_LENGTH),

--- a/src/main/ipc/register-app-ipc-handlers.test.ts
+++ b/src/main/ipc/register-app-ipc-handlers.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
@@ -281,6 +282,74 @@ describe('registerAppIpcHandlers', () => {
       '/v1/runtime/info',
       '/v1/attachments'
     ])
+  })
+
+  it('reveals a workspace file only for the trusted workbench frame', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kun-reveal-workspace-'))
+    const filePath = join(root, 'preview.md')
+    writeFileSync(filePath, '# Preview', 'utf8')
+    const mainFrame = { processId: 10, routingId: 20 }
+    const contents = { id: 7, mainFrame }
+    const mainWindow = { isDestroyed: () => false, webContents: contents }
+    try {
+      registerAppIpcHandlers(registerOptions({ getMainWindow: () => mainWindow as never }))
+      const handler = handlers.get('file:reveal-workspace-file')
+      const payload = { path: 'preview.md', workspaceRoot: root }
+
+      await expect(handler?.({
+        sender: { id: 99 },
+        senderFrame: { processId: 90, routingId: 91 }
+      }, payload)).rejects.toThrow(/trusted workbench frame/)
+      await expect(handler?.({ sender: contents, senderFrame: mainFrame }, payload)).resolves.toEqual({ ok: true })
+      expect(electronMock.showItemInFolder).toHaveBeenCalledWith(realpathSync(filePath))
+      expect(electronMock.openPath).not.toHaveBeenCalled()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects reveal targets that escape or do not name a workspace file', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kun-reveal-boundary-'))
+    const workspaceRoot = join(root, 'workspace')
+    const outsideFile = join(root, 'outside.md')
+    mkdirSync(workspaceRoot)
+    writeFileSync(outsideFile, '# Outside', 'utf8')
+    const mainFrame = { processId: 10, routingId: 20 }
+    const contents = { id: 7, mainFrame }
+    const mainWindow = { isDestroyed: () => false, webContents: contents }
+    const event = { sender: contents, senderFrame: mainFrame }
+
+    try {
+      registerAppIpcHandlers(registerOptions({ getMainWindow: () => mainWindow as never }))
+      const handler = handlers.get('file:reveal-workspace-file')
+      expect(handler).toBeTypeOf('function')
+
+      await expect(handler?.(event, {
+        path: '../outside.md',
+        workspaceRoot
+      })).resolves.toMatchObject({ ok: false })
+      await expect(handler?.(event, {
+        path: outsideFile,
+        workspaceRoot
+      })).resolves.toMatchObject({ ok: false })
+      await expect(handler?.(event, {
+        path: '.',
+        workspaceRoot
+      })).resolves.toEqual({
+        ok: false,
+        message: 'Path must point to a regular workspace file.'
+      })
+      await expect(handler?.(event, {
+        path: 'missing.md',
+        workspaceRoot
+      })).resolves.toMatchObject({ ok: false })
+      await expect(handler?.(event, {
+        path: outsideFile
+      })).rejects.toThrow(/Invalid payload for file:reveal-workspace-file/)
+      expect(electronMock.showItemInFolder).not.toHaveBeenCalled()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 
   it('rejects invalid settings patches at the handler boundary', async () => {

--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -104,6 +104,7 @@ import {
   workspaceEntryDeletePayloadSchema,
   workspaceEntryRenamePayloadSchema,
   workspaceFileCreatePayloadSchema,
+  workspaceFileRevealTargetPayloadSchema,
   workspaceFileSaveAsPayloadSchema,
   workspaceFileTargetPayloadSchema,
   workspaceFileWatchPayloadSchema,
@@ -2114,6 +2115,15 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
     if (!resolved.ok) return resolved
     const message = await shell.openPath(resolved.path)
     return message ? { ok: false as const, message } : { ok: true as const }
+  })
+  ipcMain.handle('file:reveal-workspace-file', async (event, payload: unknown) => {
+    assertTrustedWorkbenchSender(event, options.getMainWindow)
+    const resolved = await resolveWorkspaceFile(
+      parseIpcPayload('file:reveal-workspace-file', workspaceFileRevealTargetPayloadSchema, payload)
+    )
+    if (!resolved.ok) return resolved
+    shell.showItemInFolder(resolved.path)
+    return { ok: true as const }
   })
   ipcMain.handle('file:list-workspace-directory', async (_, payload: unknown) =>
     listWorkspaceDirectory(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -318,6 +318,8 @@ const api = {
     ipcRenderer.invoke('file:resolve-workspace', options),
   openWorkspaceFileInSystem: (options) =>
     ipcRenderer.invoke('file:open-workspace-system', options),
+  revealWorkspaceFileInFolder: (options) =>
+    ipcRenderer.invoke('file:reveal-workspace-file', options),
   readWorkspaceFile: (options) =>
     ipcRenderer.invoke('file:read-workspace', options),
   lintProjectDesignMd: (content) =>

--- a/src/renderer/src/components/WorkspaceFilePreviewPanel.test.ts
+++ b/src/renderer/src/components/WorkspaceFilePreviewPanel.test.ts
@@ -31,6 +31,7 @@ vi.mock('react-i18next', () => {
     filePreviewTitle: 'File preview',
     filePreviewOpenEditor: 'Open in editor',
     filePreviewOpenSystem: 'Open with system app',
+    filePreviewRevealInFolder: 'Show in file manager',
     filePreviewCopyContent: 'Copy file',
     filePreviewRenderHtml: 'Render HTML',
     filePreviewShowSource: 'Show source',
@@ -187,6 +188,40 @@ describe('WorkspaceFilePreviewPanel toolbar', () => {
 
     await act(async () => toggle.props.onClick())
     expect(onToggleFileTree).toHaveBeenCalledTimes(1)
+    await act(async () => renderer.unmount())
+  })
+
+  it('reveals the selected file in its workspace file manager', async () => {
+    const revealWorkspaceFileInFolder = vi.fn(async () => ({ ok: true as const }))
+    vi.stubGlobal('window', {
+      kunGui: { platform: 'linux', revealWorkspaceFileInFolder },
+      innerWidth: 1200,
+      innerHeight: 800,
+      requestAnimationFrame: (callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      },
+      cancelAnimationFrame: vi.fn(),
+      clearTimeout,
+      setTimeout
+    })
+    let renderer!: ReactTestRenderer
+    await act(async () => {
+      renderer = create(createElement(WorkspaceFilePreviewPanel, {
+        target: { path: 'notes/plan.md', workspaceRoot: '/repo' },
+        workspaceRoot: '/repo',
+        onClose: () => undefined
+      }))
+    })
+
+    await act(async () => {
+      renderer.root.findByProps({ 'aria-label': 'Show in file manager' }).props.onClick()
+    })
+
+    expect(revealWorkspaceFileInFolder).toHaveBeenCalledWith({
+      path: 'notes/plan.md',
+      workspaceRoot: '/repo'
+    })
     await act(async () => renderer.unmount())
   })
 })

--- a/src/renderer/src/components/WorkspaceFilePreviewPanel.tsx
+++ b/src/renderer/src/components/WorkspaceFilePreviewPanel.tsx
@@ -16,6 +16,7 @@ import {
   FileCode2,
   Files,
   FolderOpen,
+  FolderSearch,
   Loader2,
   Maximize2,
   Minimize2,
@@ -799,6 +800,13 @@ export function WorkspaceFilePreviewPanel({
       workspaceRoot: target.workspaceRoot ?? workspaceRoot
     })
   }
+  const revealInFileManager = (): void => {
+    if (!target) return
+    void window.kunGui.revealWorkspaceFileInFolder({
+      ...target,
+      workspaceRoot: target.workspaceRoot ?? workspaceRoot
+    })
+  }
 
   const copyContent = async (): Promise<void> => {
     if (!result?.ok || !navigator?.clipboard?.writeText) return
@@ -1215,6 +1223,16 @@ export function WorkspaceFilePreviewPanel({
               <FolderOpen className="h-4 w-4" strokeWidth={1.75} />
             </button>
           )}
+          <button
+            type="button"
+            onClick={revealInFileManager}
+            disabled={!target}
+            className="ds-code-sidebar-icon-button"
+            title={t('filePreviewRevealInFolder', { defaultValue: 'Show in file manager' })}
+            aria-label={t('filePreviewRevealInFolder', { defaultValue: 'Show in file manager' })}
+          >
+            <FolderSearch className="h-4 w-4" strokeWidth={1.75} />
+          </button>
           <button
             type="button"
             onClick={() => void copyContent()}

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -2708,6 +2708,7 @@
   "filePreviewUnsupported": "This file does not have an in-app preview.",
   "filePreviewOpenEditor": "Open in editor",
   "filePreviewOpenSystem": "Open with system app",
+  "filePreviewRevealInFolder": "Show in file manager",
   "filePreviewEditText": "Edit file",
   "filePreviewStopEditing": "Stop editing",
   "filePreviewSaveText": "Save file",

--- a/src/renderer/src/locales/hi/common.json
+++ b/src/renderer/src/locales/hi/common.json
@@ -2708,6 +2708,7 @@
   "filePreviewUnsupported": "इस फ़ाइल के लिए पूर्वावलोकन समर्थित नहीं है. एक टेक्स्ट फ़ाइल चुनें.",
   "filePreviewOpenEditor": "संपादक में खोलें",
   "filePreviewOpenSystem": "सिस्टम ऐप में खोलें",
+  "filePreviewRevealInFolder": "फ़ाइल प्रबंधक में दिखाएं",
   "filePreviewEditText": "फ़ाइल संपादित करें",
   "filePreviewStopEditing": "संपादन रोकें",
   "filePreviewSaveText": "फ़ाइल सहेजें",

--- a/src/renderer/src/locales/ja/common.json
+++ b/src/renderer/src/locales/ja/common.json
@@ -2708,6 +2708,7 @@
   "filePreviewUnsupported": "このファイルのプレビューはサポートされていません。テキスト ファイルを選択します。",
   "filePreviewOpenEditor": "エディタで開く",
   "filePreviewOpenSystem": "システムアプリで開く",
+  "filePreviewRevealInFolder": "ファイルマネージャーで表示",
   "filePreviewEditText": "ファイルを編集",
   "filePreviewStopEditing": "編集を終了",
   "filePreviewSaveText": "ファイルを保存",

--- a/src/renderer/src/locales/ko/common.json
+++ b/src/renderer/src/locales/ko/common.json
@@ -2708,6 +2708,7 @@
   "filePreviewUnsupported": "이 파일에는 미리보기가 지원되지 않습니다. 텍스트 파일을 선택하세요.",
   "filePreviewOpenEditor": "편집기에서 열기",
   "filePreviewOpenSystem": "시스템 앱으로 열기",
+  "filePreviewRevealInFolder": "파일 관리자에서 보기",
   "filePreviewEditText": "파일 편집",
   "filePreviewStopEditing": "편집 종료",
   "filePreviewSaveText": "파일 저장",

--- a/src/renderer/src/locales/ru/common.json
+++ b/src/renderer/src/locales/ru/common.json
@@ -2708,6 +2708,7 @@
   "filePreviewUnsupported": "Предварительный просмотр для этого файла не поддерживается. Выберите текстовый файл.",
   "filePreviewOpenEditor": "Открыть в редакторе",
   "filePreviewOpenSystem": "Открыть системным приложением",
+  "filePreviewRevealInFolder": "Показать в файловом менеджере",
   "filePreviewEditText": "Редактировать файл",
   "filePreviewStopEditing": "Завершить редактирование",
   "filePreviewSaveText": "Сохранить файл",

--- a/src/renderer/src/locales/th/common.json
+++ b/src/renderer/src/locales/th/common.json
@@ -2708,6 +2708,7 @@
   "filePreviewUnsupported": "ไฟล์นี้ไม่รองรับการแสดงตัวอย่าง เลือกไฟล์ข้อความ",
   "filePreviewOpenEditor": "เปิดในตัวแก้ไข",
   "filePreviewOpenSystem": "เปิดด้วยแอประบบ",
+  "filePreviewRevealInFolder": "แสดงในตัวจัดการไฟล์",
   "filePreviewEditText": "แก้ไขไฟล์",
   "filePreviewStopEditing": "หยุดแก้ไข",
   "filePreviewSaveText": "บันทึกไฟล์",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -2708,6 +2708,7 @@
   "filePreviewUnsupported": "此文件暂不支持应用内预览。",
   "filePreviewOpenEditor": "在编辑器中打开",
   "filePreviewOpenSystem": "使用系统应用打开",
+  "filePreviewRevealInFolder": "在文件管理器中显示",
   "filePreviewEditText": "编辑文件",
   "filePreviewStopEditing": "停止编辑",
   "filePreviewSaveText": "保存文件",

--- a/src/shared/kun-gui-api.ts
+++ b/src/shared/kun-gui-api.ts
@@ -69,6 +69,7 @@ import type {
   WorkspaceFileCreatePayload,
   WorkspaceFileCreateResult,
   WorkspaceFileOpenResult,
+  WorkspaceFileRevealTarget,
   WorkspaceFileResolveResult,
   WorkspaceFileTarget,
   WorkspaceFileWatchPayload,
@@ -810,6 +811,7 @@ export type KunGuiApi = ExtensionIpcApi & {
   listWorkspaceDirectory: (options: WorkspaceDirectoryTarget) => Promise<WorkspaceDirectoryListResult>
   resolveWorkspaceFile: (options: WorkspaceFileTarget) => Promise<WorkspaceFileResolveResult>
   openWorkspaceFileInSystem: (options: WorkspaceFileTarget) => Promise<WorkspaceFileOpenResult>
+  revealWorkspaceFileInFolder: (options: WorkspaceFileRevealTarget) => Promise<WorkspaceFileOpenResult>
   readWorkspaceFile: (options: WorkspaceFileTarget) => Promise<WorkspaceFileReadResult>
   lintProjectDesignMd: (content: string) => Promise<ProjectDesignMdOfficialLintResult>
   readWorkspaceImage: (options: WorkspaceFileTarget) => Promise<WorkspaceImageReadResult>

--- a/src/shared/workspace-file.ts
+++ b/src/shared/workspace-file.ts
@@ -5,6 +5,10 @@ export type WorkspaceFileTarget = {
   column?: number
 }
 
+export type WorkspaceFileRevealTarget = WorkspaceFileTarget & {
+  workspaceRoot: string
+}
+
 export type WorkspaceEntry = {
   name: string
   path: string


### PR DESCRIPTION
## Problem

The workspace file preview can open a file in the configured editor or its default system application, but it cannot reveal the file in Finder, Explorer, or the Linux file manager.

## Root cause

The preview bridge only exposed `shell.openPath`. There was no workspace-scoped IPC action for `shell.showItemInFolder`, even though Kun already uses that Electron API elsewhere.

## Changes

- add a trusted, workspace-resolved IPC action for revealing a file
- expose the action through the existing `window.kunGui` preload contract
- add an accessible file-manager button to the preview toolbar
- add localized labels for every bundled locale

## Safety

The main process resolves the requested file through the existing workspace path boundary and only accepts calls from the trusted top-level Workbench frame. The renderer does not receive a new arbitrary Electron shell primitive.

## Tests

- `npm.cmd exec -- vitest run src/main/ipc/register-app-ipc-handlers.test.ts -t "reveals a workspace file only for the trusted workbench frame"` (1 passed)
- `npm.cmd exec -- vitest run src/renderer/src/components/WorkspaceFilePreviewPanel.test.ts` (15 passed)
- `npm.cmd run typecheck` (passed)
- `npm.cmd run lint` (passed with one pre-existing warning in `DesignSidebar.tsx`)
- `npm.cmd run build` (passed)

Note: running the entire app IPC test file locally on Windows also exposes two existing POSIX-only path assertions in unrelated project-config tests; the new IPC test passes independently.

Fixes #1027
