### PR TITLE
fix(settings): prevent provider changes from reverting

### DIFF
--- a/src/renderer/src/components/settings-section-agents.test.ts
+++ b/src/renderer/src/components/settings-section-agents.test.ts
@@ -1729,6 +1729,329 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
       expect(rendererText(renderer)).not.toContain('Unsaved')
     })
 
+    it('deletes the canonical shared provider before removing it from local settings', async () => {
+      const settings = defaultModelProviderSettings()
+      const target = {
+        id: 'custom-provider-2',
+        name: 'Custom Provider',
+        apiKey: 'sk-custom',
+        baseUrl: 'https://api.example.com/v1',
+        endpointFormat: 'chat_completions',
+        kind: 'http',
+        models: ['custom-model'],
+        modelProfiles: {}
+      } satisfies ModelProviderProfileV1
+      const sharedProvider = {
+        id: target.id,
+        accountId: `account:${target.id}`,
+        name: target.name,
+        kind: 'http',
+        authType: 'api-key',
+        baseUrl: target.baseUrl,
+        endpointFormat: target.endpointFormat,
+        configured: true,
+        models: target.models,
+        selectedModel: target.models[0]
+      }
+      const snapshot = (revision: number, providers = [sharedProvider]) => ({
+        schemaVersion: 1,
+        revision,
+        providers,
+        defaultProviderId: providers[0]?.id,
+        defaultAccountId: providers[0]?.accountId,
+        defaultModel: providers[0]?.selectedModel,
+        proxy: settings.proxy,
+        routePools: settings.routePools,
+        localModelGateway: { enabled: settings.localGateway.enabled }
+      })
+      let resolveDelete!: (value: { ok: true; status: 200; body: string }) => void
+      const deleteRequest = new Promise<{ ok: true; status: 200; body: string }>((resolve) => {
+        resolveDelete = resolve
+      })
+      const runtimeRequest = vi.fn(async (path: string, method: string) => {
+        if (method === 'DELETE') return deleteRequest
+        return { ok: true, status: 200, body: JSON.stringify(snapshot(1)) }
+      })
+      Object.assign(window.kunGui, {
+        runtimeRequest,
+        confirmDialog: vi.fn(async () => true)
+      })
+      const update = vi.fn()
+      const initialCtx = {
+        ...baseCtx(),
+        provider: { ...settings, providers: [...settings.providers, target] },
+        kun: {
+          ...defaultKunRuntimeSettings(),
+          providerId: target.id,
+          model: target.models[0]
+        },
+        saveStatus: 'saving',
+        update
+      }
+      const renderer = await mountProviders(initialCtx)
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      update.mockClear()
+
+      await clickProviderTab(renderer, 'Advanced')
+      let removePromise!: Promise<void>
+      await act(async () => {
+        removePromise = findButton(renderer, 'Remove provider').props.onClick()
+        await Promise.resolve()
+      })
+
+      const unrelatedProvider = {
+        ...settings.providers[0]!,
+        name: 'Edited while delete was pending'
+      }
+      await act(async () => {
+        renderer.update(createElement(ProvidersSettingsSection, {
+          ctx: {
+            ...initialCtx,
+            provider: {
+              ...initialCtx.provider,
+              providers: [unrelatedProvider, target]
+            }
+          }
+        }))
+        await Promise.resolve()
+      })
+      resolveDelete({ ok: true, status: 200, body: JSON.stringify(snapshot(2, [])) })
+      await act(async () => {
+        await removePromise
+      })
+
+      const deleteCallIndex = runtimeRequest.mock.calls.findIndex(([path, method]) =>
+        method === 'DELETE' && path.includes('/v1/model-connections/custom-provider-2?')
+      )
+      expect(deleteCallIndex).toBeGreaterThanOrEqual(0)
+      expect(update).toHaveBeenCalledOnce()
+      expect(update.mock.calls[0]?.[0]?.provider?.providers).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: target.id })])
+      )
+      expect(update.mock.calls[0]?.[0]?.provider?.providers).toEqual(
+        expect.arrayContaining([expect.objectContaining({
+          id: unrelatedProvider.id,
+          name: unrelatedProvider.name
+        })])
+      )
+      expect(runtimeRequest.mock.invocationCallOrder[deleteCallIndex]).toBeLessThan(update.mock.invocationCallOrder[0]!)
+    })
+
+    it('keeps a custom provider rename while a stale registry event races the canonical PATCH', async () => {
+      const settings = defaultModelProviderSettings()
+      const target = {
+        id: 'custom-provider-2',
+        name: 'Custom Provider',
+        apiKey: 'sk-custom',
+        baseUrl: 'https://api.example.com/v1',
+        endpointFormat: 'chat_completions',
+        kind: 'http',
+        models: ['custom-model'],
+        modelProfiles: {
+          'custom-model': {
+            inputModalities: ['text'],
+            outputModalities: ['text'],
+            supportsToolCalling: true,
+            messageParts: ['text']
+          }
+        }
+      } satisfies ModelProviderProfileV1
+      const sharedProvider = (name: string) => ({
+        id: target.id,
+        accountId: `account:${target.id}`,
+        name,
+        kind: 'http',
+        authType: 'api-key',
+        baseUrl: target.baseUrl,
+        endpointFormat: target.endpointFormat,
+        configured: true,
+        models: target.models,
+        selectedModel: target.models[0]
+      })
+      const snapshot = (revision: number, name: string) => ({
+        schemaVersion: 1,
+        revision,
+        providers: [sharedProvider(name)],
+        defaultProviderId: target.id,
+        defaultAccountId: `account:${target.id}`,
+        defaultModel: target.models[0],
+        proxy: settings.proxy,
+        routePools: settings.routePools,
+        localModelGateway: { enabled: settings.localGateway.enabled }
+      })
+      let resolveStaleEvent!: (value: { ok: true; status: 200; body: string }) => void
+      const staleEvent = new Promise<{ ok: true; status: 200; body: string }>((resolve) => {
+        resolveStaleEvent = resolve
+      })
+      let eventRequests = 0
+      const runtimeRequest = vi.fn(async (path: string, method: string, body?: string) => {
+        if (path.includes('/events?')) {
+          eventRequests += 1
+          if (eventRequests === 1) return staleEvent
+          return new Promise<never>(() => undefined)
+        }
+        if (path === '/v1/model-connections' && method === 'GET') {
+          return { ok: true, status: 200, body: JSON.stringify(snapshot(1, target.name)) }
+        }
+        if (path === `/v1/model-connections/${target.id}` && method === 'PATCH') {
+          expect(JSON.parse(body ?? '{}')).toMatchObject({
+            expectedRevision: 1,
+            name: 'Renamed Provider'
+          })
+          return { ok: true, status: 200, body: JSON.stringify(snapshot(2, 'Renamed Provider')) }
+        }
+        throw new Error(`Unexpected runtime request: ${method} ${path}`)
+      })
+      Object.assign(window.kunGui, { runtimeRequest })
+      const update = vi.fn()
+      const initialCtx = {
+        ...baseCtx(),
+        provider: { ...settings, providers: [...settings.providers, target] },
+        kun: {
+          ...defaultKunRuntimeSettings(),
+          providerId: target.id,
+          model: target.models[0]
+        },
+        saveStatus: 'saved',
+        update
+      }
+      const renderer = await mountProviders(initialCtx)
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      update.mockClear()
+
+      const nameInput = renderer.root.findAllByType('input')
+        .find((input) => input.props.value === target.name)
+      expect(nameInput).toBeTruthy()
+      await act(async () => nameInput!.props.onChange({ target: { value: 'Renamed Provider' } }))
+      expect(update).toHaveBeenCalledOnce()
+      const localPatch = update.mock.calls[0]![0]
+      expect(localPatch.provider.providers.find((item: ModelProviderProfileV1) => item.id === target.id)?.name)
+        .toBe('Renamed Provider')
+
+      await act(async () => {
+        renderer.update(createElement(ProvidersSettingsSection, {
+          ctx: {
+            ...initialCtx,
+            provider: { ...initialCtx.provider, ...localPatch.provider },
+            kun: { ...initialCtx.kun, ...localPatch.agents?.kun }
+          }
+        }))
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(runtimeRequest.mock.calls.some(([path, method]) =>
+        path === `/v1/model-connections/${target.id}` && method === 'PATCH'
+      )).toBe(true)
+      resolveStaleEvent({ ok: true, status: 200, body: JSON.stringify(snapshot(1, target.name)) })
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(update.mock.calls.some(([patch]) =>
+        patch.provider?.providers?.some((item: ModelProviderProfileV1) =>
+          item.id === target.id && item.name === target.name
+        )
+      )).toBe(false)
+    })
+
+    it('keeps the local provider and shows an error when the shared registry cannot delete it', async () => {
+      const settings = defaultModelProviderSettings()
+      const target = {
+        id: 'custom-provider-2',
+        name: 'Custom Provider',
+        apiKey: 'sk-custom',
+        baseUrl: 'https://api.example.com/v1',
+        endpointFormat: 'chat_completions',
+        kind: 'http',
+        models: ['custom-model'],
+        modelProfiles: {}
+      } satisfies ModelProviderProfileV1
+      const sharedProvider = {
+        id: target.id,
+        accountId: `account:${target.id}`,
+        name: target.name,
+        kind: 'http',
+        authType: 'api-key',
+        baseUrl: target.baseUrl,
+        endpointFormat: target.endpointFormat,
+        configured: true,
+        models: target.models,
+        selectedModel: target.models[0]
+      }
+      let registryReads = 0
+      const runtimeRequest = vi.fn(async (path: string, method: string) => {
+        if (path.includes('/events?')) return new Promise<never>(() => undefined)
+        if (path === '/v1/model-connections' && method === 'GET') {
+          registryReads += 1
+          if (registryReads > 1) {
+            return {
+              ok: false,
+              status: 503,
+              body: JSON.stringify({ message: 'Shared registry unavailable' })
+            }
+          }
+        }
+        return {
+          ok: true,
+          status: 200,
+          body: JSON.stringify({
+            schemaVersion: 1,
+            revision: 1,
+            providers: [sharedProvider],
+            defaultProviderId: target.id,
+            defaultAccountId: sharedProvider.accountId,
+            defaultModel: target.models[0],
+            proxy: settings.proxy,
+            routePools: settings.routePools,
+            localModelGateway: { enabled: settings.localGateway.enabled }
+          })
+        }
+      })
+      Object.assign(window.kunGui, {
+        runtimeRequest,
+        confirmDialog: vi.fn(async () => true)
+      })
+      const update = vi.fn()
+      const renderer = await mountProviders({
+        ...baseCtx(),
+        provider: { ...settings, providers: [...settings.providers, target] },
+        kun: {
+          ...defaultKunRuntimeSettings(),
+          providerId: target.id,
+          model: target.models[0]
+        },
+        saveStatus: 'saving',
+        update
+      })
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      update.mockClear()
+
+      await clickProviderTab(renderer, 'Advanced')
+      await act(async () => {
+        findButton(renderer, 'Remove provider').props.onClick()
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(runtimeRequest.mock.calls.some(([, method]) => method === 'DELETE')).toBe(false)
+      expect(update).not.toHaveBeenCalled()
+      expect(rendererText(renderer)).toContain('Shared registry unavailable')
+      expect(rendererText(renderer)).toContain('Custom Provider')
+    })
+
     it('configures Ollama Cloud and imports only provider-confirmed models with catalog metadata', async () => {
       const settings = defaultModelProviderSettings()
       const preset = getModelProviderPreset('ollama')

--- a/src/renderer/src/components/settings-section-providers.test.ts
+++ b/src/renderer/src/components/settings-section-providers.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defaultModelProviderSettings } from '@shared/app-settings'
 import {
+  clearPendingSharedProviderDeletionForExplicitAdd,
+  createSharedModelMutationQueue,
+  deleteSharedModelConnection,
   projectSharedModelConnections,
+  reconcilePendingSharedProviderDeletions,
+  reconcilePendingSharedProviderNames,
+  selectSharedModelConnection,
+  sharedProvidersEligibleForSync,
   sharedProviderSetupNeedsApiKey
 } from './settings-section-providers'
 
@@ -45,6 +52,373 @@ describe('shared model connection API-key setup status', () => {
         models: ['deepseek-chat']
       }]
     })).toBe(true)
+  })
+})
+
+describe('shared model connection deletion', () => {
+  it('removes the canonical connection and retries one concurrent revision change', async () => {
+    const connection = {
+      id: 'custom-provider-2',
+      accountId: 'account:custom-provider-2',
+      name: 'Custom Provider',
+      kind: 'http' as const,
+      authType: 'api-key' as const,
+      baseUrl: 'https://api.example.com/v1',
+      endpointFormat: 'chat_completions' as const,
+      configured: true,
+      models: ['custom-model']
+    }
+    const snapshot = (revision: number, providers = [connection]) => ({
+      schemaVersion: 1 as const,
+      revision,
+      providers
+    })
+    const runtimeRequest = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, body: JSON.stringify(snapshot(3)) })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        body: JSON.stringify({ snapshot: snapshot(4) })
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, body: JSON.stringify(snapshot(5, [])) })
+    vi.stubGlobal('window', { kunGui: { runtimeRequest } })
+
+    try {
+      await expect(deleteSharedModelConnection(connection.id)).resolves.toMatchObject({
+        revision: 5,
+        providers: []
+      })
+      expect(runtimeRequest.mock.calls.map(([path, method]) => [path, method])).toEqual([
+        ['/v1/model-connections', 'GET'],
+        ['/v1/model-connections/custom-provider-2?expected_revision=3', 'DELETE'],
+        ['/v1/model-connections/custom-provider-2?expected_revision=4', 'DELETE']
+      ])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('treats a concurrent deletion as an idempotent success', async () => {
+    const connection = {
+      id: 'custom-provider-2',
+      accountId: 'account:custom-provider-2',
+      name: 'Custom Provider',
+      kind: 'http' as const,
+      authType: 'api-key' as const,
+      endpointFormat: 'chat_completions' as const,
+      configured: true,
+      models: ['custom-model']
+    }
+    const runtimeRequest = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: JSON.stringify({ schemaVersion: 1, revision: 9, providers: [connection] })
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        body: JSON.stringify({ snapshot: { schemaVersion: 1, revision: 10, providers: [] } })
+      })
+    vi.stubGlobal('window', { kunGui: { runtimeRequest } })
+
+    try {
+      await expect(deleteSharedModelConnection(connection.id)).resolves.toMatchObject({
+        revision: 10,
+        providers: []
+      })
+      expect(runtimeRequest).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})
+
+describe('shared model connection selection', () => {
+  const connection = (revisionName = 'account:custom-provider-2') => ({
+    id: 'custom-provider-2',
+    accountId: revisionName,
+    name: 'Custom Provider',
+    kind: 'http' as const,
+    authType: 'api-key' as const,
+    baseUrl: 'https://api.example.com/v1',
+    endpointFormat: 'chat_completions' as const,
+    configured: true,
+    models: ['custom-model']
+  })
+  const snapshot = (revision: number, providers = [connection()]) => ({
+    schemaVersion: 1 as const,
+    revision,
+    providers
+  })
+
+  it('reads the latest revision and retries one selection conflict with the refreshed account', async () => {
+    const runtimeRequest = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, body: JSON.stringify(snapshot(7)) })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        body: JSON.stringify({ snapshot: snapshot(8, [connection('account:refreshed')]) })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: JSON.stringify({
+          ...snapshot(9, [connection('account:refreshed')]),
+          defaultProviderId: 'custom-provider-2',
+          defaultAccountId: 'account:refreshed',
+          defaultModel: 'custom-model'
+        })
+      })
+    vi.stubGlobal('window', { kunGui: { runtimeRequest } })
+
+    try {
+      await expect(selectSharedModelConnection('custom-provider-2', 'custom-model'))
+        .resolves.toMatchObject({ revision: 9, defaultAccountId: 'account:refreshed' })
+      expect(runtimeRequest.mock.calls.map(([path, method, body]) => [
+        path,
+        method,
+        body ? JSON.parse(body) : undefined
+      ])).toEqual([
+        ['/v1/model-connections', 'GET', undefined],
+        ['/v1/model-connections/select', 'POST', {
+          expectedRevision: 7,
+          providerId: 'custom-provider-2',
+          accountId: 'account:custom-provider-2',
+          model: 'custom-model'
+        }],
+        ['/v1/model-connections/select', 'POST', {
+          expectedRevision: 8,
+          providerId: 'custom-provider-2',
+          accountId: 'account:refreshed',
+          model: 'custom-model'
+        }]
+      ])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('does not select a provider that is tombstoned or absent from the latest registry', async () => {
+    const runtimeRequest = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, body: JSON.stringify(snapshot(11)) })
+      .mockResolvedValueOnce({ ok: true, status: 200, body: JSON.stringify(snapshot(12, [])) })
+    vi.stubGlobal('window', { kunGui: { runtimeRequest } })
+
+    try {
+      await expect(selectSharedModelConnection(
+        'custom-provider-2',
+        'custom-model',
+        () => true
+      )).rejects.toThrow(/pending deletion/)
+      await expect(selectSharedModelConnection('custom-provider-2', 'custom-model'))
+        .rejects.toThrow(/no longer available/)
+      expect(runtimeRequest.mock.calls.every(([, method]) => method === 'GET')).toBe(true)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})
+
+describe('pending shared model connection deletions', () => {
+  const connection = {
+    id: 'custom-provider-2',
+    accountId: 'account:custom-provider-2',
+    name: 'Custom Provider',
+    kind: 'http' as const,
+    authType: 'api-key' as const,
+    endpointFormat: 'chat_completions' as const,
+    configured: true,
+    models: ['custom-model']
+  }
+  const snapshot = (revision: number, providers = [connection]) => ({
+    schemaVersion: 1 as const,
+    revision,
+    providers
+  })
+
+  it('keeps tombstones through the deletion revision and releases newer snapshots', () => {
+    const pending = new Map<string, number | null>([[connection.id, 5]])
+
+    expect(reconcilePendingSharedProviderDeletions(snapshot(4), pending).has(connection.id)).toBe(true)
+    expect(reconcilePendingSharedProviderDeletions(snapshot(5), pending).has(connection.id)).toBe(true)
+    expect(reconcilePendingSharedProviderDeletions(snapshot(6), pending).has(connection.id)).toBe(false)
+    expect(pending.get(connection.id)).toBe(5)
+  })
+
+  it('keeps an uncommitted tombstone even when a stale snapshot omits the provider', () => {
+    const pending = new Map<string, number | null>([[connection.id, null]])
+
+    expect(reconcilePendingSharedProviderDeletions(snapshot(20), pending).has(connection.id)).toBe(true)
+    expect(reconcilePendingSharedProviderDeletions(snapshot(20, []), pending).has(connection.id)).toBe(true)
+  })
+})
+
+describe('pending shared model connection names', () => {
+  const connection = (name: string) => ({
+    id: 'custom-provider-2',
+    accountId: 'account:custom-provider-2',
+    name,
+    kind: 'http' as const,
+    authType: 'api-key' as const,
+    endpointFormat: 'chat_completions' as const,
+    configured: true,
+    models: ['custom-model']
+  })
+  const snapshot = (revision: number, name: string) => ({
+    schemaVersion: 1 as const,
+    revision,
+    providers: [connection(name)]
+  })
+  const pending = (committedRevision: number | null) => new Map([[
+    'custom-provider-2',
+    {
+      localName: 'Renamed Provider',
+      canonicalName: 'Renamed Provider',
+      committedRevision
+    }
+  ]])
+
+  it('keeps the local name while old registry revisions race the PATCH', () => {
+    expect(reconcilePendingSharedProviderNames(snapshot(4, 'Custom Provider'), pending(null))
+      .has('custom-provider-2')).toBe(true)
+    expect(reconcilePendingSharedProviderNames(snapshot(4, 'Custom Provider'), pending(5))
+      .has('custom-provider-2')).toBe(true)
+  })
+
+  it('releases an uncommitted local name once the canonical registry already matches it', () => {
+    expect(reconcilePendingSharedProviderNames(snapshot(4, 'Renamed Provider'), pending(null))
+      .has('custom-provider-2')).toBe(false)
+  })
+
+  it('releases the local name after observing the PATCH or a newer external rename', () => {
+    expect(reconcilePendingSharedProviderNames(snapshot(5, 'Renamed Provider'), pending(5))
+      .has('custom-provider-2')).toBe(false)
+    expect(reconcilePendingSharedProviderNames(snapshot(6, 'External Rename'), pending(5))
+      .has('custom-provider-2')).toBe(false)
+  })
+
+  it('projects the local name over a stale registry snapshot', () => {
+    const current = defaultModelProviderSettings()
+    current.providers.push({
+      ...current.providers[0]!,
+      id: 'custom-provider-2',
+      name: 'Renamed Provider'
+    })
+
+    const projected = projectSharedModelConnections(
+      current,
+      snapshot(4, 'Custom Provider'),
+      new Set(),
+      pending(null)
+    )
+
+    expect(projected.provider.providers.find((item) => item.id === 'custom-provider-2')?.name)
+      .toBe('Renamed Provider')
+  })
+})
+
+describe('shared model connection mutation ordering', () => {
+  it('finishes an in-flight stale connect before deletion and blocks queued stale reconnects', async () => {
+    const enqueue = createSharedModelMutationQueue()
+    const pendingDeletions = new Set<string>()
+    const providers = [{ id: 'custom-provider-2' }]
+    const operations: string[] = []
+    let releaseConnect!: () => void
+    let markConnectStarted!: () => void
+    const connectGate = new Promise<void>((resolve) => { releaseConnect = resolve })
+    const connectStarted = new Promise<void>((resolve) => { markConnectStarted = resolve })
+    const inFlightSync = enqueue(async () => {
+      operations.push('connect:start')
+      markConnectStarted()
+      await connectGate
+      operations.push('connect:finish')
+    })
+    await connectStarted
+
+    pendingDeletions.add(providers[0]!.id)
+    const deletion = enqueue(async () => { operations.push('delete') })
+    const queuedStaleSync = enqueue(async () => {
+      for (const provider of sharedProvidersEligibleForSync(providers, pendingDeletions)) {
+        operations.push(`connect:after-delete:${provider.id}`)
+      }
+    })
+    releaseConnect()
+    await Promise.all([inFlightSync, deletion, queuedStaleSync])
+
+    expect(operations).toEqual(['connect:start', 'connect:finish', 'delete'])
+  })
+
+  it('queues the selection read and commit between sync and deletion without interleaving', async () => {
+    const enqueue = createSharedModelMutationQueue()
+    const operations: string[] = []
+    let releaseSync!: () => void
+    let markSyncStarted!: () => void
+    const syncGate = new Promise<void>((resolve) => { releaseSync = resolve })
+    const syncStarted = new Promise<void>((resolve) => { markSyncStarted = resolve })
+    const provider = {
+      id: 'custom-provider-2',
+      accountId: 'account:custom-provider-2',
+      name: 'Custom Provider',
+      kind: 'http',
+      authType: 'api-key',
+      configured: true,
+      models: ['custom-model']
+    }
+    const snapshot = (revision: number) => ({
+      schemaVersion: 1,
+      revision,
+      providers: [provider]
+    })
+    const runtimeRequest = vi.fn(async (path: string, method: string, _body?: string) => {
+      operations.push(method === 'GET' ? 'select:read' : 'select:commit')
+      return {
+        ok: true,
+        status: 200,
+        body: JSON.stringify(method === 'GET' ? snapshot(13) : snapshot(14))
+      }
+    })
+    vi.stubGlobal('window', { kunGui: { runtimeRequest } })
+
+    try {
+      const sync = enqueue(async () => {
+        operations.push('sync:start')
+        markSyncStarted()
+        await syncGate
+        operations.push('sync:finish')
+      })
+      await syncStarted
+      const selection = enqueue(() => selectSharedModelConnection(
+        provider.id,
+        'custom-model'
+      ))
+      const deletion = enqueue(async () => { operations.push('delete') })
+
+      expect(runtimeRequest).not.toHaveBeenCalled()
+      releaseSync()
+      await Promise.all([sync, selection, deletion])
+
+      expect(operations).toEqual([
+        'sync:start',
+        'sync:finish',
+        'select:read',
+        'select:commit',
+        'delete'
+      ])
+      expect(JSON.parse(runtimeRequest.mock.calls[1]![2] ?? '{}')).toMatchObject({ expectedRevision: 13 })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('makes an explicitly re-added provider eligible for sync again', () => {
+    const provider = { id: 'custom-provider-2' }
+    const pendingDeletions = new Map<string, number | null>([[provider.id, 17]])
+
+    clearPendingSharedProviderDeletionForExplicitAdd(pendingDeletions, provider.id)
+
+    expect(pendingDeletions.has(provider.id)).toBe(false)
+    expect(sharedProvidersEligibleForSync([provider], pendingDeletions)).toEqual([provider])
   })
 })
 
@@ -129,6 +503,32 @@ describe('shared model connection settings projection', () => {
       localModelGateway: { enabled: false }
     })
 
+    expect(projected.kun).toEqual({ providerId: '', model: '' })
+  })
+
+  it('does not restore a provider while its canonical deletion is pending', () => {
+    const current = defaultModelProviderSettings()
+    const projected = projectSharedModelConnections(current, {
+      schemaVersion: 1,
+      revision: 8,
+      providers: [{
+        id: 'custom-provider-2',
+        accountId: 'account:custom-provider-2',
+        name: 'Custom Provider',
+        kind: 'http',
+        authType: 'api-key',
+        baseUrl: 'https://api.example.com/v1',
+        endpointFormat: 'chat_completions',
+        configured: true,
+        models: ['custom-model'],
+        selectedModel: 'custom-model'
+      }],
+      defaultProviderId: 'custom-provider-2',
+      defaultAccountId: 'account:custom-provider-2',
+      defaultModel: 'custom-model'
+    }, new Set(['custom-provider-2']))
+
+    expect(projected.provider.providers.map((provider) => provider.id)).toEqual(['deepseek'])
     expect(projected.kun).toEqual({ providerId: '', model: '' })
   })
 })

--- a/src/renderer/src/components/settings-section-providers.tsx
+++ b/src/renderer/src/components/settings-section-providers.tsx
@@ -424,6 +424,129 @@ async function requestSharedModelConnections(
   return parseSharedModelConnections(result.body)
 }
 
+export async function deleteSharedModelConnection(
+  providerId: string
+): Promise<SharedModelConnectionsSnapshot> {
+  let snapshot = await requestSharedModelConnections('/v1/model-connections')
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (!snapshot.providers.some((connection) => connection.id === providerId)) return snapshot
+    try {
+      const deleted = await requestSharedModelConnections(
+        `/v1/model-connections/${encodeURIComponent(providerId)}?expected_revision=${snapshot.revision}`,
+        'DELETE'
+      )
+      if (deleted.providers.some((connection) => connection.id === providerId)) {
+        throw new Error(`Shared model connection ${providerId} was not deleted`)
+      }
+      return deleted
+    } catch (error) {
+      if (!(error instanceof SharedModelConnectionConflictError)) throw error
+      snapshot = error.snapshot
+      if (!snapshot.providers.some((connection) => connection.id === providerId)) return snapshot
+      if (attempt === 1) throw error
+    }
+  }
+  return snapshot
+}
+
+export async function selectSharedModelConnection(
+  providerId: string,
+  model: string,
+  isProviderTombstoned: (providerId: string) => boolean = () => false
+): Promise<SharedModelConnectionsSnapshot> {
+  let snapshot = await requestSharedModelConnections('/v1/model-connections')
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (isProviderTombstoned(providerId)) {
+      throw new Error(`Shared model connection ${providerId} is pending deletion`)
+    }
+    const connection = snapshot.providers.find((entry) => entry.id === providerId)
+    if (!connection) {
+      throw new Error(`Shared model connection ${providerId} is no longer available`)
+    }
+    if (!connection.configured) {
+      throw new Error(`Shared model connection ${providerId} is not configured`)
+    }
+    if (!connection.models.includes(model)) {
+      throw new Error(`Model ${model} is no longer available for ${providerId}`)
+    }
+    try {
+      return await requestSharedModelConnections('/v1/model-connections/select', 'POST', {
+        expectedRevision: snapshot.revision,
+        providerId: connection.id,
+        accountId: connection.accountId,
+        model
+      })
+    } catch (error) {
+      if (!(error instanceof SharedModelConnectionConflictError) || attempt === 1) throw error
+      snapshot = error.snapshot
+    }
+  }
+  return snapshot
+}
+
+export function reconcilePendingSharedProviderDeletions(
+  snapshot: SharedModelConnectionsSnapshot,
+  pending: ReadonlyMap<string, number | null>
+): Map<string, number | null> {
+  const next = new Map(pending)
+  for (const [providerId, deletedAtRevision] of next) {
+    if (deletedAtRevision !== null && snapshot.revision > deletedAtRevision) {
+      next.delete(providerId)
+    }
+  }
+  return next
+}
+
+export type PendingSharedProviderName = {
+  localName: string
+  canonicalName: string
+  committedRevision: number | null
+}
+
+export function reconcilePendingSharedProviderNames(
+  snapshot: SharedModelConnectionsSnapshot,
+  pending: ReadonlyMap<string, PendingSharedProviderName>
+): Map<string, PendingSharedProviderName> {
+  const next = new Map(pending)
+  for (const [providerId, rename] of next) {
+    const connection = snapshot.providers.find((item) => item.id === providerId)
+    if (!connection) {
+      next.delete(providerId)
+      continue
+    }
+    const canonicalNameObserved = connection.name === rename.canonicalName
+    const committedRevisionPassed =
+      rename.committedRevision !== null && snapshot.revision > rename.committedRevision
+    if (canonicalNameObserved || committedRevisionPassed) {
+      next.delete(providerId)
+    }
+  }
+  return next
+}
+
+export function createSharedModelMutationQueue(): <T>(operation: () => Promise<T>) => Promise<T> {
+  let tail: Promise<void> = Promise.resolve()
+  return <T,>(operation: () => Promise<T>): Promise<T> => {
+    const result = tail.then(operation, operation)
+    tail = result.then(() => undefined, () => undefined)
+    return result
+  }
+}
+
+export function sharedProvidersEligibleForSync<T extends { id: string }>(
+  providers: readonly T[],
+  pendingDeletions: Pick<ReadonlySet<string>, 'has'>
+): T[] {
+  return providers.filter((provider) => !pendingDeletions.has(provider.id))
+}
+
+export function clearPendingSharedProviderDeletionForExplicitAdd(
+  pendingDeletions: Map<string, number | null>,
+  providerId: string
+): void {
+  pendingDeletions.delete(providerId)
+}
+
 function sharedModelProfiles(
   connection: SharedModelConnection,
   existing: ModelProviderProfileV1 | undefined
@@ -460,13 +583,16 @@ function sharedModelProfiles(
 
 export function projectSharedModelConnections(
   current: ModelProviderSettingsV1,
-  snapshot: SharedModelConnectionsSnapshot
+  snapshot: SharedModelConnectionsSnapshot,
+  pendingDeletions: Pick<ReadonlySet<string>, 'has'> = new Set(),
+  pendingNames: Pick<ReadonlyMap<string, PendingSharedProviderName>, 'get'> = new Map()
 ): {
   provider: Pick<ModelProviderSettingsV1, 'providers' | 'proxy' | 'routePools' | 'localGateway'>
   kun: Pick<KunRuntimeSettingsV1, 'providerId' | 'model'>
 } {
   const existingById = new Map(current.providers.map((item) => [item.id, item]))
-  const projectedProviders = snapshot.providers.map((connection): ModelProviderProfileV1 => {
+  const visibleConnections = snapshot.providers.filter((connection) => !pendingDeletions.has(connection.id))
+  const projectedProviders = visibleConnections.map((connection): ModelProviderProfileV1 => {
     const existing = existingById.get(connection.id)
     return {
       ...(existing ?? {
@@ -480,7 +606,7 @@ export function projectSharedModelConnections(
         modelProfiles: {}
       }),
       id: connection.id,
-      name: connection.name,
+      name: pendingNames.get(connection.id)?.localName ?? connection.name,
       // Preserve the ephemeral compatibility value already loaded from the
       // protected settings binding. Replacing it with an empty string makes
       // the settings save path interpret a registry projection as an explicit
@@ -496,7 +622,7 @@ export function projectSharedModelConnections(
   // AppSettings keeps a normalized DeepSeek editor as its legacy fallback.
   // When the canonical registry intentionally has no DeepSeek profile, retain
   // that local placeholder without treating it as a connected profile.
-  const compatibilityDefault = !snapshot.providers.some((entry) => entry.id === DEFAULT_MODEL_PROVIDER_ID)
+  const compatibilityDefault = !visibleConnections.some((entry) => entry.id === DEFAULT_MODEL_PROVIDER_ID)
     ? existingById.get(DEFAULT_MODEL_PROVIDER_ID)
     : undefined
   const providers = compatibilityDefault
@@ -513,8 +639,12 @@ export function projectSharedModelConnections(
       }
     },
     kun: {
-      providerId: snapshot.defaultProviderId ?? '',
-      model: snapshot.defaultModel ?? ''
+      providerId: snapshot.defaultProviderId && !pendingDeletions.has(snapshot.defaultProviderId)
+        ? snapshot.defaultProviderId
+        : '',
+      model: snapshot.defaultProviderId && !pendingDeletions.has(snapshot.defaultProviderId)
+        ? snapshot.defaultModel ?? ''
+        : ''
     }
   }
 }
@@ -1960,9 +2090,11 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
   const sharedSyncFingerprint = useRef('')
   const sharedProjectionPending = useRef(false)
   const dirtyCredentialProviderIds = useRef(new Set<string>())
-  const deletedSharedProviderIds = useRef(new Set<string>())
-  const sharedProjectionInput = useRef({ provider, kun, update })
-  sharedProjectionInput.current = { provider, kun, update }
+  const pendingSharedProviderDeletions = useRef(new Map<string, number | null>())
+  const pendingSharedProviderNames = useRef(new Map<string, PendingSharedProviderName>())
+  const enqueueSharedMutation = useMemo(() => createSharedModelMutationQueue(), [])
+  const sharedProjectionInput = useRef({ provider, kun, update, form })
+  sharedProjectionInput.current = { provider, kun, update, form }
   const [selectedProviderId, setSelectedProviderId] = useState<string>(
     kun.providerId?.trim() || modelProviders[0]?.id || DEFAULT_MODEL_PROVIDER_ID
   )
@@ -2067,7 +2199,20 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
           setSharedConnections(snapshot)
           setSharedConnectionsError('')
           const current = sharedProjectionInput.current
-          const projected = projectSharedModelConnections(current.provider, snapshot)
+          pendingSharedProviderDeletions.current = reconcilePendingSharedProviderDeletions(
+            snapshot,
+            pendingSharedProviderDeletions.current
+          )
+          pendingSharedProviderNames.current = reconcilePendingSharedProviderNames(
+            snapshot,
+            pendingSharedProviderNames.current
+          )
+          const projected = projectSharedModelConnections(
+            current.provider,
+            snapshot,
+            pendingSharedProviderDeletions.current,
+            pendingSharedProviderNames.current
+          )
           const fingerprint = sharedSettingsFingerprint({
             providers: projected.provider.providers,
             providerId: projected.kun.providerId,
@@ -2125,15 +2270,22 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
     if (fingerprint === sharedSyncFingerprint.current) return
     let disposed = false
     const syncOnce = async (): Promise<void> => {
+      if (disposed) return
       let snapshot = await requestSharedModelConnections('/v1/model-connections')
-      const desiredProviders = modelProviders.filter((item) =>
-        item.id !== DEFAULT_MODEL_PROVIDER_ID ||
-        snapshot.providers.some((entry) => entry.id === item.id) ||
-        dirtyCredentialProviderIds.current.has(item.id) ||
-        kun.providerId === item.id
+      if (disposed) return
+      const desiredProviders = sharedProvidersEligibleForSync(
+        modelProviders,
+        pendingSharedProviderDeletions.current
+      ).filter((item) =>
+        (
+          item.id !== DEFAULT_MODEL_PROVIDER_ID ||
+          snapshot.providers.some((entry) => entry.id === item.id) ||
+          dirtyCredentialProviderIds.current.has(item.id) ||
+          kun.providerId === item.id
+        )
       )
-      const desiredProviderIds = new Set(desiredProviders.map((item) => item.id))
       for (const item of desiredProviders) {
+        if (disposed || pendingSharedProviderDeletions.current.has(item.id)) continue
         const baseUrlOptional =
           item.kind === 'agent-sdk' ||
           item.kind === 'antigravity-cli' ||
@@ -2142,6 +2294,7 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
         const existing = snapshot.providers.find((entry) => entry.id === item.id)
         const selectedModel = item.models.includes(kun.model) ? kun.model : item.models[0]
         if (!existing) {
+          if (pendingSharedProviderDeletions.current.has(item.id)) continue
           snapshot = await requestSharedModelConnections('/v1/model-connections/connect', 'POST', {
             expectedRevision: snapshot.revision,
             id: item.id,
@@ -2168,12 +2321,14 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
             JSON.stringify(existing.modelCapabilities ?? {}) !== JSON.stringify(modelCapabilities ?? {}) ||
             existing.selectedModel !== selectedModel
           if (needsPatch) {
+            if (pendingSharedProviderDeletions.current.has(item.id)) continue
+            const canonicalName = item.name.trim() || item.id
             snapshot = await requestSharedModelConnections(
               `/v1/model-connections/${encodeURIComponent(item.id)}`,
               'PATCH',
               {
                 expectedRevision: snapshot.revision,
-                name: item.name.trim() || item.id,
+                name: canonicalName,
                 kind: item.kind ?? 'http',
                 authType: isSubscriptionProvider(item) ? 'subscription' : 'api-key',
                 ...(baseUrlOptional ? {} : { baseUrl: item.baseUrl }),
@@ -2183,8 +2338,16 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
                 ...(selectedModel ? { selectedModel } : {})
               }
             )
+            const pendingName = pendingSharedProviderNames.current.get(item.id)
+            if (pendingName?.canonicalName === canonicalName) {
+              pendingSharedProviderNames.current.set(item.id, {
+                ...pendingName,
+                committedRevision: snapshot.revision
+              })
+            }
           }
           if (dirtyCredentialProviderIds.current.has(item.id)) {
+            if (pendingSharedProviderDeletions.current.has(item.id)) continue
             snapshot = item.apiKey.trim()
               ? await requestSharedModelConnections(
                   `/v1/model-connections/${encodeURIComponent(item.id)}/credential`,
@@ -2200,15 +2363,13 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
         }
       }
       for (const existing of [...snapshot.providers]) {
-        if (
-          desiredProviderIds.has(existing.id) ||
-          !deletedSharedProviderIds.current.has(existing.id)
-        ) continue
+        if (!pendingSharedProviderDeletions.current.has(existing.id)) continue
         snapshot = await requestSharedModelConnections(
           `/v1/model-connections/${encodeURIComponent(existing.id)}?expected_revision=${snapshot.revision}`,
           'DELETE'
         )
-        deletedSharedProviderIds.current.delete(existing.id)
+        pendingSharedProviderDeletions.current.set(existing.id, snapshot.revision)
+        dirtyCredentialProviderIds.current.delete(existing.id)
       }
       const globalsChanged =
         JSON.stringify(snapshot.proxy) !== JSON.stringify(provider.proxy ?? { enabled: false, url: '' }) ||
@@ -2224,7 +2385,7 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
       }
       const active = snapshot.providers.find((entry) => entry.id === kun.providerId)
       const model = active && (active.models.includes(kun.model) ? kun.model : active.models[0])
-      if (active?.configured && model && (
+      if (active?.configured && model && !pendingSharedProviderDeletions.current.has(active.id) && (
         snapshot.defaultProviderId !== active.id || snapshot.defaultModel !== model
       )) {
         snapshot = await requestSharedModelConnections('/v1/model-connections/select', 'POST', {
@@ -2242,7 +2403,7 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
     }
     const sync = async (): Promise<void> => {
       try {
-        await syncOnce()
+        await enqueueSharedMutation(syncOnce)
       } catch (error) {
         if (error instanceof SharedModelConnectionConflictError && !disposed) {
           setSharedConnections(error.snapshot)
@@ -2263,36 +2424,26 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
     provider.proxy,
     provider.routePools,
     saveStatus,
-    sharedConnections
+    sharedConnections,
+    enqueueSharedMutation
   ])
 
   const selectSharedModel = async (connection: SharedModelConnection, model: string): Promise<void> => {
-    if (!sharedConnections) return
     try {
-      let expectedRevision = sharedConnections.revision
-      let snapshot: SharedModelConnectionsSnapshot | undefined
-      for (let attempt = 0; attempt < 2; attempt += 1) {
-        try {
-          snapshot = await requestSharedModelConnections('/v1/model-connections/select', 'POST', {
-            expectedRevision,
-            providerId: connection.id,
-            accountId: connection.accountId,
-            model
-          })
-          break
-        } catch (error) {
-          if (!(error instanceof SharedModelConnectionConflictError) || attempt === 1) throw error
-          const latest = error.snapshot.providers.find((entry) => entry.id === connection.id)
-          if (!latest?.models.includes(model)) throw error
-          expectedRevision = error.snapshot.revision
-          setSharedConnections(error.snapshot)
-        }
-      }
-      if (!snapshot) return
-      setSharedConnections(snapshot)
-      setSharedConnectionsError('')
-      update({ agents: { kun: { providerId: connection.id, model } } })
+      await enqueueSharedMutation(async () => {
+        const snapshot = await selectSharedModelConnection(
+          connection.id,
+          model,
+          (providerId) => pendingSharedProviderDeletions.current.has(providerId)
+        )
+        setSharedConnections(snapshot)
+        setSharedConnectionsError('')
+        update({ agents: { kun: { providerId: connection.id, model } } })
+      })
     } catch (error) {
+      if (error instanceof SharedModelConnectionConflictError) {
+        setSharedConnections(error.snapshot)
+      }
       setSharedConnectionsError(error instanceof Error ? error.message : String(error))
     }
   }
@@ -2411,6 +2562,18 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
       patch.apiKey !== target.apiKey
     ) {
       dirtyCredentialProviderIds.current.add(id)
+    }
+    if (
+      !draftProvider &&
+      Object.prototype.hasOwnProperty.call(patch, 'name') &&
+      typeof patch.name === 'string' &&
+      patch.name !== target.name
+    ) {
+      pendingSharedProviderNames.current.set(id, {
+        localName: patch.name,
+        canonicalName: patch.name.trim() || id,
+        committedRevision: null
+      })
     }
     patchProviderProfile(target, (item) => ({ ...item, ...patch }))
   }
@@ -2552,6 +2715,10 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
   const commitProviderDraft = (): void => {
     if (!draftProvider) return
     const hasKey = Boolean(draftProvider.apiKey.trim())
+    clearPendingSharedProviderDeletionForExplicitAdd(
+      pendingSharedProviderDeletions.current,
+      draftProvider.id
+    )
     updateModelProviders(
       [...modelProviders, draftProvider],
       hasKey
@@ -2684,32 +2851,58 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
       cancelLabel: t('modelProviderCancel')
     })
     if (!confirmed) return
-    if (sharedConnections?.providers.some((connection) => connection.id === id)) {
-      deletedSharedProviderIds.current.add(id)
+    pendingSharedProviderDeletions.current.set(id, null)
+    try {
+      const snapshot = await enqueueSharedMutation(() => deleteSharedModelConnection(id))
+      pendingSharedProviderDeletions.current.set(id, snapshot.revision)
+      pendingSharedProviderNames.current.delete(id)
+      dirtyCredentialProviderIds.current.delete(id)
+      setSharedConnections(snapshot)
+      setSharedConnectionsError('')
+    } catch (error) {
+      pendingSharedProviderDeletions.current.delete(id)
+      setSharedConnectionsError(error instanceof Error ? error.message : String(error))
+      return
     }
-    const nextProviders = modelProviders.filter((item) => item.id !== id)
+    // The canonical delete can wait behind an in-flight registry sync. Build
+    // the local patch from the latest settings after that wait so unrelated
+    // edits made while the request was pending are not overwritten.
+    const latest = sharedProjectionInput.current
+    const latestProviders = latest.provider.providers as ModelProviderProfileV1[]
+    const latestKun = latest.kun as KunRuntimeSettingsV1
+    const latestUsedByChat = (latestKun.providerId?.trim() || DEFAULT_MODEL_PROVIDER_ID) === id
+    const latestUsedByImage = (latestKun.imageGeneration?.providerId ?? '').trim() === id
+    const latestUsedBySpeech = (latestKun.speechToText?.providerId ?? '').trim() === id
+    const latestUsedByTextToSpeech = (latestKun.textToSpeech?.providerId ?? '').trim() === id
+    const latestUsedByMusic = (latestKun.musicGeneration?.providerId ?? '').trim() === id
+    const latestUsedByVideo = (latestKun.videoGeneration?.providerId ?? '').trim() === id
+    const latestWriteInline = latest.form?.write?.inlineCompletion
+    const latestUsedByWrite = Boolean(
+      latestWriteInline && !latestWriteInline.inheritProvider && latestWriteInline.providerId === id
+    )
+    const nextProviders = latestProviders.filter((item) => item.id !== id)
     const kunPatch: KunRuntimeSettingsPatchV1 | undefined =
-      usedByChat || usedByImage || usedBySpeech || usedByTextToSpeech || usedByMusic || usedByVideo
+      latestUsedByChat || latestUsedByImage || latestUsedBySpeech || latestUsedByTextToSpeech || latestUsedByMusic || latestUsedByVideo
         ? {
-            ...(usedByChat ? { providerId: DEFAULT_MODEL_PROVIDER_ID } : {}),
-            ...(usedByImage ? { imageGeneration: { providerId: '' } } : {}),
-            ...(usedBySpeech ? { speechToText: { providerId: '' } } : {}),
-            ...(usedByTextToSpeech ? { textToSpeech: { providerId: '' } } : {}),
-            ...(usedByMusic ? { musicGeneration: { providerId: '' } } : {}),
-            ...(usedByVideo ? { videoGeneration: { providerId: '' } } : {})
+            ...(latestUsedByChat ? { providerId: DEFAULT_MODEL_PROVIDER_ID } : {}),
+            ...(latestUsedByImage ? { imageGeneration: { providerId: '' } } : {}),
+            ...(latestUsedBySpeech ? { speechToText: { providerId: '' } } : {}),
+            ...(latestUsedByTextToSpeech ? { textToSpeech: { providerId: '' } } : {}),
+            ...(latestUsedByMusic ? { musicGeneration: { providerId: '' } } : {}),
+            ...(latestUsedByVideo ? { videoGeneration: { providerId: '' } } : {})
           }
         : undefined
     const patch = modelProvidersSettingsPatch({
-      provider,
+      provider: latest.provider,
       providers: nextProviders,
       kun: kunPatch,
-      currentKun: kun
+      currentKun: latestKun
     })
-    if (usedByWrite) {
+    if (latestUsedByWrite) {
       patch.write = { inlineCompletion: { inheritProvider: true, providerId: '' } }
     }
     setSelectedProviderId(DEFAULT_MODEL_PROVIDER_ID)
-    update(patch)
+    latest.update(patch)
   }
 
   const fetchModelsDevCatalogFor = async (
@@ -3689,6 +3882,9 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
                   value={activeTab}
                   onChange={setActiveTab}
                 />
+                {sharedConnectionsError ? (
+                  <InlineNoticeView notice={{ tone: 'error', message: sharedConnectionsError }} />
+                ) : null}
                 {probeNotice ? <InlineNoticeView notice={probeNotice} /> : null}
                 <SettingsTabPanel<ProviderTaskTab>
                   baseId="provider-settings"


### PR DESCRIPTION
## Problem

Deleting a configured provider only removed the renderer settings copy. The canonical `/v1/model-connections` registry could publish a later snapshot and recreate it. Custom provider names had the same race and reverted when an older registry event arrived.

## Root cause

Provider settings and the shared model connection registry were concurrent state owners without serialized mutations or pending-operation reconciliation.

## Changes

- Delete the canonical shared connection before removing the local provider, with idempotency and one revision-conflict retry.
- Serialize registry synchronization, deletion, credential, and selection mutations.
- Keep deletion tombstones and rename overlays until a newer canonical revision confirms the operation.
- Preserve unrelated settings changed while a deletion is waiting, and keep the local provider when canonical deletion fails.
- Add pure concurrency tests and mounted component regressions for delete, rename, stale events, conflict retry, failure, and explicit same-ID re-add behavior.

## Safety

No provider is removed locally unless its canonical deletion succeeds. Delete failures stay visible to the user, stale sync work cannot reconnect a tombstoned provider, and an explicit same-ID re-add clears the tombstone.

## Validation

- `npm.cmd run audit:production`: passed after rebasing onto current `develop`.
- `npm.cmd exec vitest run src/renderer/src/components/settings-section-agents.test.ts src/renderer/src/components/settings-section-providers.test.ts`: 2 files, 60 tests passed.
- `npm.cmd run typecheck`: passed.
- `npm.cmd run lint`: passed with 0 errors and 0 warnings.
- `npm.cmd run build`: passed.
- `git diff --check`: passed.

## Scope

One production component and two focused test files. No runtime, IPC, schema, dependency, or packaging changes are included.

Fixes #1066