### PR TITLE
fix(release): allow unsigned Windows artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,11 +328,6 @@ jobs:
       DEEPSEEK_GUI_UPDATE_CHANNEL: stable
       RELEASE_CHANNEL: stable
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
-      KUN_REQUIRE_WINDOWS_SIGNING: '1'
-      WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-      WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-      WIN_CSC_PUBLISHER_NAME: ${{ secrets.WIN_CSC_PUBLISHER_NAME }}
-      WIN_CSC_TIMESTAMP_SERVER: 'http://timestamp.digicert.com'
     steps:
       - name: Check out merge commit
         uses: actions/checkout@v4
@@ -373,19 +368,6 @@ jobs:
 
       - name: Build Windows installer
         run: npm run dist:win
-
-      - name: Verify Windows code signatures
-        shell: pwsh
-        run: |
-          $installer = @(Get-ChildItem -Path dist -Filter 'Kun-*-win-x64.exe' -File)
-          if ($installer.Count -ne 1) {
-            throw "Expected exactly one Windows installer, found $($installer.Count)."
-          }
-          & powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify-windows-signing.ps1 `
-            -FilePath $installer.FullName, (Join-Path $PWD 'dist\win-unpacked\Kun.exe')
-          if ($LASTEXITCODE -ne 0) {
-            throw "Windows code-signing verification failed with exit code $LASTEXITCODE."
-          }
 
       - name: Smoke Windows installer migration
         shell: pwsh

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -49,28 +49,6 @@ const hasExplicitMacSigningIdentity = Boolean(
     process.env.MAC_SIGN === '1'
 )
 
-const requireWindowsCodeSigning = process.env.KUN_REQUIRE_WINDOWS_SIGNING === '1'
-const hasWindowsSigningCredential = Boolean(
-  process.env.WIN_CSC_LINK?.trim() ||
-    process.env.CSC_LINK?.trim()
-)
-const windowsPublisherName = (process.env.WIN_CSC_PUBLISHER_NAME || '').trim()
-const windowsTimestampServer = (
-  process.env.WIN_CSC_TIMESTAMP_SERVER || 'http://timestamp.digicert.com'
-).trim() || 'http://timestamp.digicert.com'
-
-if (requireWindowsCodeSigning && !hasWindowsSigningCredential) {
-  throw new Error(
-    'KUN_REQUIRE_WINDOWS_SIGNING=1 requires WIN_CSC_LINK (or CSC_LINK).'
-  )
-}
-
-if (requireWindowsCodeSigning && !windowsPublisherName) {
-  throw new Error(
-    'KUN_REQUIRE_WINDOWS_SIGNING=1 requires WIN_CSC_PUBLISHER_NAME to match the signing certificate subject.'
-  )
-}
-
 const hasNotaryToolCredentials = Boolean(
   process.env.APPLE_API_KEY_ID &&
     process.env.APPLE_API_ISSUER &&
@@ -295,22 +273,6 @@ module.exports = {
     // the desktop render crisp icons at small sizes (#222). Regenerate with:
     // npx --yes png2icons src/asset/img/kun_mac.png build/icon -icowe -bc
     icon: './build/icon.ico',
-    // Release scripts set KUN_REQUIRE_WINDOWS_SIGNING=1. Keep developer and
-    // unsigned CI builds available, but make a release fail before publishing
-    // if the code-signing certificate cannot be used.
-    ...(requireWindowsCodeSigning
-      ? {
-          forceCodeSigning: true,
-          signtoolOptions: {
-            // electron-updater reads publisherName from app-update.yml when it
-            // verifies downloaded installers. The timestamp settings apply to
-            // both modern and legacy Authenticode signatures.
-            publisherName: windowsPublisherName,
-            rfc3161TimeStampServer: windowsTimestampServer,
-            timeStampServer: windowsTimestampServer
-          }
-        }
-      : {}),
     target: [{ target: 'nsis', arch: ['x64'] }]
   },
   nsis: {

--- a/scripts/release-win.ps1
+++ b/scripts/release-win.ps1
@@ -51,20 +51,6 @@ function Require-Command([string]$Name) {
   }
 }
 
-function Assert-WindowsSigningConfiguration {
-  $hasCredential = -not [string]::IsNullOrWhiteSpace($env:WIN_CSC_LINK) -or
-    -not [string]::IsNullOrWhiteSpace($env:CSC_LINK)
-  if (-not $hasCredential) {
-    Write-Err 'Windows release signing requires WIN_CSC_LINK (or CSC_LINK).'
-    exit 1
-  }
-
-  if ([string]::IsNullOrWhiteSpace($env:WIN_CSC_PUBLISHER_NAME)) {
-    Write-Err 'Windows release signing requires WIN_CSC_PUBLISHER_NAME to match the signing certificate subject.'
-    exit 1
-  }
-}
-
 function Load-LocalReleaseEnv([string]$RootPath) {
   $configured = [Environment]::GetEnvironmentVariable('KUN_RELEASE_ENV', 'Process')
   if (-not $configured) {
@@ -97,8 +83,6 @@ function Load-LocalReleaseEnv([string]$RootPath) {
 $Root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 Set-Location $Root
 Load-LocalReleaseEnv $Root
-Assert-WindowsSigningConfiguration
-$env:KUN_REQUIRE_WINDOWS_SIGNING = '1'
 
 if ($Stable -and $Frontier) {
   Write-Err 'Use only one of -Stable or -Frontier.'
@@ -224,15 +208,6 @@ if ($LASTEXITCODE -ne 0) {
 $installer = @(Get-ChildItem -Path (Join-Path $Root 'dist') -Filter 'Kun-*-win-x64.exe' -File)
 if ($installer.Count -ne 1) {
   Write-Err "Expected exactly one Windows installer, found $($installer.Count)."
-  exit 1
-}
-
-Write-Info 'Verifying Windows code signatures and secure timestamps...'
-try {
-  & (Join-Path $Root 'scripts\verify-windows-signing.ps1') `
-    -FilePath $installer.FullName, (Join-Path $Root 'dist\win-unpacked\Kun.exe')
-} catch {
-  Write-Err "Windows code-signing verification failed: $($_.Exception.Message)"
   exit 1
 }
 


### PR DESCRIPTION
## Summary
- restore unsigned Windows release artifacts
- remove the unavailable Authenticode credential gate from automated and local Windows release paths

## Root cause
The v0.2.35 release workflow forced Windows code signing even though this project does not ship signed Windows installers. The required repository Secrets do not exist, so the release failed before packaging.

## Validation
- `npm run check:extension-release-gate`
- `node --check electron-builder.config.cjs`
- PowerShell parser validation for `scripts/release-win.ps1`