### PR TITLE
fix(graph): preserve completion-ready runs on lead settlement

### DIFF
--- a/kun/src/graph/graph-run-completion.ts
+++ b/kun/src/graph/graph-run-completion.ts
@@ -59,18 +59,44 @@ export async function finishGraphRun(initialRun: GraphRunV1, options: Completion
 }
 
 /**
- * Summary persistence is the first durable step of terminal finalization.
- * A later cleanup or status-transition failure may temporarily move the run
- * back to supervision. Only summaries whose current revision still satisfies
- * the normal completion gates receive that protection.
+ * Node/completion gates have passed (or the run is already in completing).
+ * Used only to avoid cancelling semantically finished work on incidental Lead
+ * settlement. Does not by itself authorize silent finalization.
+ */
+export function isGraphRunSemanticComplete(run: GraphRunV1): boolean {
+  return run.status === 'completing' || graphRunCompletionGatesPassed(run)
+}
+
+/**
+ * Unresolved holds that make auto-finish unsafe even when gates have passed:
+ * human attention, scheduler errors, or any needs_attention obligation.
+ */
+export function graphRunHasBlockingFinalizationHold(run: GraphRunV1): boolean {
+  if (run.status === 'awaiting_human') return true
+  return run.supervisionObligations.some((obligation) =>
+    obligation.state !== 'resolved' &&
+    (
+      obligation.state === 'needs_attention' ||
+      obligation.kind === 'scheduler_error'
+    ))
+}
+
+/**
+ * Finalization is safe to push through the scheduler without another Lead
+ * episode. Distinct from {@link isGraphRunSemanticComplete}:
+ * - semantic complete: do not cancel on incidental settlement
+ * - finalization safe: resumeRun may complete without bypassing blockers
+ *
+ * Requirements: completing, or (gates passed + no mailbox blockers + no
+ * human/scheduler finalization holds). Missing summary is allowed so the
+ * gates-passed race before tryComplete can finish after resumeRun.
  */
 export function isGraphRunCompletionFinalizing(
   run: GraphRunV1,
   mailbox: Pick<GraphMailbox, 'unresolvedBlockers'>
 ): boolean {
-  return run.status === 'completing' || (
-    run.summary !== undefined &&
-    graphRunCompletionGatesPassed(run) &&
-    mailbox.unresolvedBlockers(run).length === 0
-  )
+  if (run.status === 'completing') return true
+  if (mailbox.unresolvedBlockers(run).length > 0) return false
+  if (graphRunHasBlockingFinalizationHold(run)) return false
+  return graphRunCompletionGatesPassed(run)
 }

--- a/kun/src/server/graph-runtime-factory.test.ts
+++ b/kun/src/server/graph-runtime-factory.test.ts
@@ -5,11 +5,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { InMemoryThreadStore } from '../adapters/in-memory-thread-store.js'
 import { InMemoryArtifactStore } from '../artifacts/artifact-store.js'
 import type { GraphRuntimeConfig } from '../config/kun-config.js'
-import { GRAPH_CONTRACT_VERSION, type GraphRunV1 } from '../contracts/graph.js'
+import {
+  GRAPH_CONTRACT_VERSION,
+  GraphNodeAttemptV1Schema,
+  type GraphRunV1
+} from '../contracts/graph.js'
 import { createThreadRecord } from '../domain/thread.js'
 import { createTurnRecord } from '../domain/turn.js'
 import { GraphRunConflictError } from '../graph/graph-run-store.js'
 import {
+  testAssignmentSnapshot,
   testGraphConfig,
   testGraphPlan
 } from '../graph/graph-test-fixtures.test-support.js'
@@ -43,7 +48,8 @@ async function transitionRun(
 async function recordFinalSummary(
   runtime: GraphRuntimeComposition,
   run: GraphRunV1,
-  commandId: string
+  commandId: string,
+  finalAnswer = 'A stale Graph report was persisted before later work.'
 ): Promise<GraphRunV1> {
   return (await runtime.store.append(run.id, {
     expectedSeq: run.lastEventSeq,
@@ -55,7 +61,7 @@ async function recordFinalSummary(
       payload: {
         summary: {
           version: GRAPH_CONTRACT_VERSION,
-          finalAnswer: 'A stale Graph report was persisted before later work.',
+          finalAnswer,
           evidenceRefs: [],
           unresolvedRisks: [],
           changedFiles: [],
@@ -67,6 +73,167 @@ async function recordFinalSummary(
       }
     }
   })).state
+}
+
+/** Force every plan node into accepted so completion gates pass. */
+async function acceptAllNodes(
+  runtime: GraphRuntimeComposition,
+  run: GraphRunV1,
+  label: string
+): Promise<GraphRunV1> {
+  let current = run
+  for (const node of Object.values(current.nodes)) {
+    if (node.status === 'accepted' || node.status === 'superseded') continue
+    const nodeId = node.node.id
+    if (current.nodes[nodeId]!.status === 'pending') {
+      current = (await runtime.store.append(current.id, {
+        expectedSeq: current.lastEventSeq,
+        graphRevision: current.currentRevision,
+        commandId: `${label}_${nodeId}_ready`,
+        idempotencyKey: `${label}_${nodeId}_ready`,
+        event: {
+          type: 'node_status_changed',
+          payload: {
+            nodeId,
+            from: 'pending',
+            to: 'ready',
+            reason: 'test fixture: semantic work complete'
+          }
+        }
+      })).state
+    }
+    const attemptId = `attempt_${label}_${nodeId}`
+    const attempt = GraphNodeAttemptV1Schema.parse({
+      version: GRAPH_CONTRACT_VERSION,
+      id: attemptId,
+      runId: current.id,
+      nodeId,
+      revision: current.currentRevision,
+      attemptNumber: 1,
+      iteration: 0,
+      commandId: `${label}_${nodeId}_attempt`,
+      idempotencyKey: `${label}_${nodeId}_attempt`,
+      status: 'queued',
+      assignment: testAssignmentSnapshot(),
+      queuedAt: '2026-07-26T00:00:00.000Z',
+      tokenUsage: 0,
+      elapsedMs: 0
+    })
+    // attempt_created admits on ready and moves the node to queued.
+    const events = [
+      { type: 'attempt_created' as const, payload: { attempt } },
+      {
+        type: 'attempt_status_changed' as const,
+        payload: {
+          nodeId,
+          attemptId,
+          from: 'queued' as const,
+          to: 'running' as const
+        }
+      },
+      {
+        type: 'node_status_changed' as const,
+        payload: {
+          nodeId,
+          from: 'queued' as const,
+          to: 'running' as const,
+          reason: 'test fixture: semantic work complete'
+        }
+      },
+      {
+        type: 'attempt_status_changed' as const,
+        payload: {
+          nodeId,
+          attemptId,
+          from: 'running' as const,
+          to: 'submitted' as const
+        }
+      },
+      {
+        type: 'node_status_changed' as const,
+        payload: {
+          nodeId,
+          from: 'running' as const,
+          to: 'submitted' as const,
+          reason: 'test fixture: semantic work complete'
+        }
+      },
+      {
+        type: 'attempt_status_changed' as const,
+        payload: {
+          nodeId,
+          attemptId,
+          from: 'submitted' as const,
+          to: 'accepted' as const
+        }
+      },
+      {
+        type: 'node_status_changed' as const,
+        payload: {
+          nodeId,
+          from: 'submitted' as const,
+          to: 'accepted' as const,
+          reason: 'test fixture: semantic work complete'
+        }
+      }
+    ]
+    for (const [index, event] of events.entries()) {
+      current = (await runtime.store.append(current.id, {
+        expectedSeq: current.lastEventSeq,
+        graphRevision: current.currentRevision,
+        commandId: `${label}_${nodeId}_accept_${index}`,
+        idempotencyKey: `${label}_${nodeId}_accept_${index}`,
+        event
+      })).state
+    }
+  }
+  return current
+}
+
+async function createOwnedGraphRuntime(label: string): Promise<{
+  runtime: GraphRuntimeComposition
+  threadId: string
+  sourceTurnId: string
+  workspace: string
+  root: string
+  threadStore: InMemoryThreadStore
+}> {
+  const root = await mkdtemp(join(tmpdir(), `kun-graph-runtime-${label}-`))
+  const workspace = join(root, 'workspace')
+  await mkdir(workspace)
+  roots.push(root)
+  let id = 0
+  const threadStore = new InMemoryThreadStore()
+  const threadId = `thread_${label}`
+  const sourceTurnId = `turn_${label}`
+  const thread = createThreadRecord({
+    id: threadId,
+    title: `Graph ${label}`,
+    workspace,
+    model: 'test-model'
+  })
+  await threadStore.upsert({
+    ...thread,
+    turns: [
+      createTurnRecord({
+        id: sourceTurnId,
+        threadId,
+        prompt: 'Build a graph.',
+        orchestration: 'graph',
+        status: 'running'
+      })
+    ]
+  })
+  const runtime = new GraphRuntimeComposition({
+    dataDir: root,
+    config: () => testGraphConfig(),
+    artifactStore: new InMemoryArtifactStore(),
+    runtimeEvents: { record: vi.fn(async (event) => event as never) },
+    threadStore,
+    ids: { next: (prefix) => `${prefix}_${++id}` },
+    nowIso: () => '2026-07-26T00:00:00.000Z'
+  })
+  return { runtime, threadId, sourceTurnId, workspace, root, threadStore }
 }
 
 describe('GraphRuntimeComposition creation authority', () => {
@@ -716,6 +883,487 @@ describe('GraphRuntimeComposition creation authority', () => {
         reasons: ['recovery'],
         digest: expect.stringContaining('Recovered stale Graph planning lifecycle')
       }))
+    })
+    await runtime.stop()
+  })
+})
+
+function testAuthority(workspace: string) {
+  return {
+    workspaceRoot: workspace,
+    model: 'test-model',
+    providerId: 'default',
+    allowedModelProviderIds: ['default'],
+    allowedModels: ['test-model'],
+    allowedProviderIds: [],
+    reasoningEffort: 'off' as const,
+    approvalPolicy: 'never' as const,
+    sandboxMode: 'read-only' as const,
+    allowedTools: [] as string[],
+    blockedTools: [] as string[],
+    allowedSkills: [] as string[],
+    blockedSkills: [] as string[],
+    allowedMcpServers: [] as string[],
+    blockedMcpServers: [] as string[],
+    readScopes: ['.'],
+    writeScopes: [] as string[],
+    networkAllowed: false
+  }
+}
+
+async function startOwnedRuntime(
+  runtime: GraphRuntimeComposition,
+  workspace: string
+): Promise<void> {
+  await runtime.start({
+    delegation: () => undefined,
+    leadTurn: async () => undefined,
+    authorityForRun: () => testAuthority(workspace)
+  })
+}
+
+async function settleSourceTurn(
+  threadStore: InMemoryThreadStore,
+  threadId: string,
+  sourceTurnId: string,
+  status: 'failed' | 'aborted'
+): Promise<void> {
+  const thread = await threadStore.get(threadId)
+  if (!thread) throw new Error(`missing thread ${threadId}`)
+  await threadStore.upsert({
+    ...thread,
+    turns: thread.turns.map((turn) =>
+      turn.id === sourceTurnId ? { ...turn, status } : turn)
+  })
+}
+
+function spyResumeRun(runtime: GraphRuntimeComposition) {
+  const original = runtime.scheduler.resumeRun.bind(runtime.scheduler)
+  return vi.spyOn(runtime.scheduler, 'resumeRun').mockImplementation(async (runId) =>
+    original(runId))
+}
+
+async function expectNoCancelledTransition(
+  runtime: GraphRuntimeComposition,
+  runId: string
+): Promise<void> {
+  expect(
+    (await runtime.store.events(runId, 0)).some((envelope) =>
+      envelope.event.type === 'run_status_changed' &&
+      envelope.event.payload.to === 'cancelled')
+  ).toBe(false)
+}
+
+describe('GraphRuntimeComposition source-turn terminal semantics (#1071)', () => {
+  it('converges a completing run to completed after incidental aborted when scheduler is started', async () => {
+    // start() first so the initial scheduler tick is empty; then construct the
+    // completing run. That way completed can only come from preserve→resumeRun.
+    const { runtime, threadId, sourceTurnId, workspace, threadStore } =
+      await createOwnedGraphRuntime('completing_live')
+    await startOwnedRuntime(runtime, workspace)
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_completing_live',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_completing_live',
+      idempotencyKey: 'create_completing_live'
+    })
+    let run = await runtime.control.get('run_completing_live')
+    run = await transitionRun(runtime, run, 'running', 'to_running_completing_live')
+    run = await acceptAllNodes(runtime, run, 'completing_live')
+    run = await transitionRun(runtime, run, 'completing', 'to_completing_live')
+    expect(run.status).toBe('completing')
+    expect(run.summary).toBeUndefined()
+
+    await settleSourceTurn(threadStore, threadId, sourceTurnId, 'aborted')
+    const resume = spyResumeRun(runtime)
+    await runtime.handleSourceTurnTerminal(threadId, sourceTurnId, 'aborted')
+
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(resume).toHaveBeenCalledWith(run.id)
+    const after = await runtime.control.get(run.id)
+    expect(after.status).toBe('completed')
+    expect(after.summary).toBeDefined()
+    expect(after.summary!.finalAnswer.length).toBeGreaterThan(0)
+    await expectNoCancelledTransition(runtime, run.id)
+    await runtime.stop()
+  })
+
+  it('converges gates-passed running work to completed after incidental failure when scheduler is started', async () => {
+    // Remaining race beyond v0.2.35: gates passed, no summary/completing yet.
+    // start() first → empty tick; then install the running gates-passed snapshot.
+    const { runtime, threadId, sourceTurnId, workspace, threadStore } =
+      await createOwnedGraphRuntime('gates_live')
+    await startOwnedRuntime(runtime, workspace)
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_gates_live',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_gates_live',
+      idempotencyKey: 'create_gates_live'
+    })
+    let run = await runtime.control.get('run_gates_live')
+    run = await transitionRun(runtime, run, 'running', 'to_running_gates_live')
+    run = await acceptAllNodes(runtime, run, 'gates_live')
+    expect(run.status).toBe('running')
+    expect(run.summary).toBeUndefined()
+    expect(Object.values(run.nodes).every((node) => node.status === 'accepted')).toBe(true)
+
+    await settleSourceTurn(threadStore, threadId, sourceTurnId, 'failed')
+    const resume = spyResumeRun(runtime)
+    await runtime.handleSourceTurnTerminal(threadId, sourceTurnId, 'failed')
+
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(resume).toHaveBeenCalledWith(run.id)
+    const after = await runtime.control.get(run.id)
+    expect(after.status).toBe('completed')
+    expect(after.summary).toBeDefined()
+    expect(after.summary!.finalAnswer.length).toBeGreaterThan(0)
+    expect(after.finishedAt).toBeTruthy()
+    await expectNoCancelledTransition(runtime, run.id)
+    await runtime.stop()
+  })
+
+  it('preserves accepted+summary awaiting_supervision and finishes when finalization is safe', async () => {
+    const { runtime, threadId, sourceTurnId, workspace, threadStore } =
+      await createOwnedGraphRuntime('accepted_summary_live')
+    await startOwnedRuntime(runtime, workspace)
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_accepted_summary_live',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_accepted_summary_live',
+      idempotencyKey: 'create_accepted_summary_live'
+    })
+    let run = await runtime.control.get('run_accepted_summary_live')
+    run = await transitionRun(runtime, run, 'running', 'to_running_accepted_live')
+    run = await acceptAllNodes(runtime, run, 'accepted_summary_live')
+    run = await recordFinalSummary(
+      runtime,
+      run,
+      'summary_accepted_live',
+      'All nodes accepted and the final report is complete.'
+    )
+    run = await transitionRun(runtime, run, 'awaiting_supervision', 'hold_after_summary_live')
+    expect(run.status).toBe('awaiting_supervision')
+    expect(run.summary?.finalAnswer).toContain('final report is complete')
+
+    await settleSourceTurn(threadStore, threadId, sourceTurnId, 'failed')
+    const resume = spyResumeRun(runtime)
+    await runtime.handleSourceTurnTerminal(threadId, sourceTurnId, 'failed')
+
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(resume).toHaveBeenCalledWith(run.id)
+    const after = await runtime.control.get(run.id)
+    expect(after.status).toBe('completed')
+    expect(after.summary?.finalAnswer).toContain('final report is complete')
+    await expectNoCancelledTransition(runtime, run.id)
+    await runtime.stop()
+  })
+
+  it('does not auto-finish gates-passed work with an unresolved blocking mailbox message', async () => {
+    const { runtime, threadId, sourceTurnId, workspace, threadStore } =
+      await createOwnedGraphRuntime('mailbox_block')
+    await startOwnedRuntime(runtime, workspace)
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_mailbox_block',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_mailbox_block',
+      idempotencyKey: 'create_mailbox_block'
+    })
+    let run = await runtime.control.get('run_mailbox_block')
+    run = await transitionRun(runtime, run, 'running', 'to_running_mailbox')
+    run = await acceptAllNodes(runtime, run, 'mailbox_block')
+    await runtime.mailbox.send({
+      id: 'message_blocking_1',
+      runId: run.id,
+      sender: { kind: 'system' },
+      recipients: [{ kind: 'worker', nodeId: 'finish' }],
+      type: 'system',
+      priority: 'blocking',
+      summary: 'Confirm the handoff before finalization.',
+      artifactRefs: [],
+      replyRequired: true
+    }, { commandId: 'send_block_1', idempotencyKey: 'send_block_1' })
+    run = (await runtime.store.get(run.id))!
+    expect(runtime.mailbox.unresolvedBlockers(run).length).toBeGreaterThan(0)
+    expect(run.status).toBe('running')
+
+    await settleSourceTurn(threadStore, threadId, sourceTurnId, 'failed')
+    const resume = spyResumeRun(runtime)
+    await runtime.handleSourceTurnTerminal(threadId, sourceTurnId, 'failed')
+
+    // Semantic complete forbids cancel; finalization unsafe forbids resumeRun.
+    expect(resume).not.toHaveBeenCalled()
+    const after = await runtime.control.get(run.id)
+    expect(after.status).not.toBe('cancelled')
+    expect(after.status).not.toBe('completed')
+    expect(runtime.mailbox.unresolvedBlockers(after).length).toBeGreaterThan(0)
+    await runtime.stop()
+  })
+
+  it('keeps awaiting_human with needs_attention after incidental settlement', async () => {
+    const { runtime, threadId, sourceTurnId, workspace, threadStore } =
+      await createOwnedGraphRuntime('human_hold')
+    await startOwnedRuntime(runtime, workspace)
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_human_hold',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_human_hold',
+      idempotencyKey: 'create_human_hold'
+    })
+    let run = await runtime.control.get('run_human_hold')
+    run = await transitionRun(runtime, run, 'running', 'to_running_human')
+    run = await acceptAllNodes(runtime, run, 'human_hold')
+    run = await recordFinalSummary(runtime, run, 'summary_human', 'Semantic work finished.')
+    const obligation = {
+      version: GRAPH_CONTRACT_VERSION,
+      id: 'graph_obligation_human_hold',
+      kind: 'help' as const,
+      reason: 'help' as const,
+      graphRevision: run.currentRevision,
+      nodeIds: [] as string[],
+      attemptIds: [] as string[],
+      digest: 'Human attention required before finalization.',
+      state: 'needs_attention' as const,
+      deliveryAttempts: 1,
+      noProgressCount: 3,
+      lastProgressSeq: run.lastEventSeq,
+      attentionReason: 'Source Lead made no progress; human review required.',
+      createdAt: '2026-07-26T00:00:00.000Z',
+      updatedAt: '2026-07-26T00:00:00.000Z'
+    }
+    run = (await runtime.store.append(run.id, {
+      expectedSeq: run.lastEventSeq,
+      graphRevision: run.currentRevision,
+      commandId: 'open_human_hold',
+      idempotencyKey: 'open_human_hold',
+      event: {
+        type: 'supervision_obligation_updated',
+        payload: { obligation }
+      }
+    })).state
+    run = await transitionRun(runtime, run, 'awaiting_human', 'to_awaiting_human')
+    expect(run.status).toBe('awaiting_human')
+
+    await settleSourceTurn(threadStore, threadId, sourceTurnId, 'failed')
+    const resume = spyResumeRun(runtime)
+    await runtime.handleSourceTurnTerminal(threadId, sourceTurnId, 'failed')
+
+    expect(resume).not.toHaveBeenCalled()
+    const after = await runtime.control.get(run.id)
+    expect(after.status).toBe('awaiting_human')
+    expect(after.status).not.toBe('completed')
+    expect(after.status).not.toBe('cancelled')
+    expect(after.supervisionObligations.some((entry) =>
+      entry.id === obligation.id && entry.state === 'needs_attention')).toBe(true)
+    expect(after.summary?.finalAnswer).toContain('Semantic work finished')
+    await runtime.stop()
+  })
+
+  it('does not auto-complete awaiting_supervision with an unresolved scheduler_error obligation', async () => {
+    const { runtime, threadId, sourceTurnId, workspace, threadStore } =
+      await createOwnedGraphRuntime('sched_err')
+    await startOwnedRuntime(runtime, workspace)
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_sched_err',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_sched_err',
+      idempotencyKey: 'create_sched_err'
+    })
+    let run = await runtime.control.get('run_sched_err')
+    run = await transitionRun(runtime, run, 'running', 'to_running_sched_err')
+    run = await acceptAllNodes(runtime, run, 'sched_err')
+    run = await recordFinalSummary(runtime, run, 'summary_sched_err', 'Gates passed.')
+    const obligation = {
+      version: GRAPH_CONTRACT_VERSION,
+      id: 'graph_obligation_sched_err',
+      kind: 'scheduler_error' as const,
+      reason: 'scheduler_error' as const,
+      graphRevision: run.currentRevision,
+      nodeIds: [] as string[],
+      attemptIds: [] as string[],
+      digest: 'Scheduler failed while finalizing.',
+      state: 'pending' as const,
+      deliveryAttempts: 0,
+      noProgressCount: 0,
+      lastProgressSeq: run.lastEventSeq,
+      createdAt: '2026-07-26T00:00:00.000Z',
+      updatedAt: '2026-07-26T00:00:00.000Z'
+    }
+    run = (await runtime.store.append(run.id, {
+      expectedSeq: run.lastEventSeq,
+      graphRevision: run.currentRevision,
+      commandId: 'open_sched_err',
+      idempotencyKey: 'open_sched_err',
+      event: {
+        type: 'supervision_obligation_opened',
+        payload: { obligation }
+      }
+    })).state
+    run = await transitionRun(runtime, run, 'awaiting_supervision', 'to_awaiting_sched_err')
+    expect(run.status).toBe('awaiting_supervision')
+
+    await settleSourceTurn(threadStore, threadId, sourceTurnId, 'failed')
+    const resume = spyResumeRun(runtime)
+    await runtime.handleSourceTurnTerminal(threadId, sourceTurnId, 'failed')
+
+    expect(resume).not.toHaveBeenCalled()
+    const after = await runtime.control.get(run.id)
+    expect(after.status).not.toBe('completed')
+    expect(after.status).not.toBe('cancelled')
+    expect(after.status).toBe('awaiting_supervision')
+    expect(after.supervisionObligations.some((entry) =>
+      entry.id === obligation.id && entry.state !== 'resolved')).toBe(true)
+    await runtime.stop()
+  })
+
+  it('leaves gates-passed work uncancelled without finishing when scheduler is not started (cold-start)', async () => {
+    // Cold composition before runtime.start: incidental settlement must not
+    // cancel, but cannot finish without a scheduler. Explicit cold-start semantics.
+    const { runtime, threadId, sourceTurnId, workspace } = await createOwnedGraphRuntime('cold_start')
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_cold_start',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_cold_start',
+      idempotencyKey: 'create_cold_start'
+    })
+    let run = await runtime.control.get('run_cold_start')
+    run = await transitionRun(runtime, run, 'running', 'to_running_cold')
+    run = await acceptAllNodes(runtime, run, 'cold_start')
+
+    await runtime.handleSourceTurnTerminal(threadId, sourceTurnId, 'failed')
+    const after = await runtime.control.get(run.id)
+    expect(after.status).not.toBe('cancelled')
+    expect(['running', 'completing']).toContain(after.status)
+    expect(after.summary).toBeUndefined()
+    await runtime.stop()
+  })
+
+  it('force-cancels even a completing run for explicit user Stop', async () => {
+    const { runtime, threadId, sourceTurnId, workspace } = await createOwnedGraphRuntime('force_stop')
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_force_stop',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_force_stop',
+      idempotencyKey: 'create_force_stop'
+    })
+    let run = await runtime.control.get('run_force_stop')
+    run = await transitionRun(runtime, run, 'running', 'to_running_force')
+    run = await acceptAllNodes(runtime, run, 'force_stop')
+    run = await recordFinalSummary(runtime, run, 'summary_force_stop', 'Semantic work finished.')
+    run = await transitionRun(runtime, run, 'completing', 'to_completing_force')
+    // Do not start the scheduler first: a tick would finish completing before
+    // Stop. Explicit cancel must work against a durable completing snapshot.
+
+    await runtime.cancelSourceTurnRunsExplicitly(threadId, sourceTurnId)
+    await expect(runtime.control.get(run.id)).resolves.toMatchObject({
+      status: 'cancelled'
+    })
+    expect(
+      (await runtime.store.events(run.id, 0)).some((envelope) =>
+        envelope.event.type === 'run_status_changed' &&
+        envelope.event.payload.to === 'cancelled' &&
+        envelope.event.payload.reason === 'user interrupted the owning source turn')
+    ).toBe(true)
+    await runtime.stop()
+  })
+
+  it('still cancels unfinished owned runs on incidental settlement', async () => {
+    const { runtime, threadId, sourceTurnId, workspace } = await createOwnedGraphRuntime('unfinished')
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_unfinished',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_unfinished',
+      idempotencyKey: 'create_unfinished'
+    })
+    let run = await runtime.control.get('run_unfinished')
+    run = await transitionRun(runtime, run, 'running', 'to_running_unfinished')
+    expect(run.nodes.research?.status).not.toBe('accepted')
+    await startOwnedRuntime(runtime, workspace)
+
+    await runtime.handleSourceTurnTerminal(threadId, sourceTurnId, 'aborted')
+    await expect(runtime.control.get(run.id)).resolves.toMatchObject({
+      status: 'cancelled'
+    })
+    await runtime.stop()
+  })
+
+  it('treats concurrent completion as a successful terminal fence for cancel races', async () => {
+    const { runtime, threadId, sourceTurnId, workspace } = await createOwnedGraphRuntime('race')
+    const identity = await runtime.registry.identify(workspace)
+    await runtime.control.create({
+      runId: 'run_race',
+      threadId,
+      projectId: identity.projectId,
+      sourceTurnId,
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_race',
+      idempotencyKey: 'create_race'
+    })
+    let run = await runtime.control.get('run_race')
+    run = await transitionRun(runtime, run, 'running', 'to_running_race')
+    run = await transitionRun(runtime, run, 'completing', 'to_completing_race')
+
+    const originalList = runtime.store.list.bind(runtime.store)
+    vi.spyOn(runtime.store, 'list').mockImplementation(async (query) => {
+      const listed = await originalList(query)
+      for (const item of listed) {
+        if (item.id !== run.id || item.status === 'completed') continue
+        const latest = (await runtime.store.get(item.id))!
+        if (latest.status === 'completed') continue
+        await runtime.store.append(latest.id, {
+          expectedSeq: latest.lastEventSeq,
+          graphRevision: latest.currentRevision,
+          commandId: 'complete_race_win',
+          idempotencyKey: 'complete_race_win',
+          event: {
+            type: 'run_status_changed',
+            payload: { from: latest.status, to: 'completed' }
+          }
+        })
+      }
+      return listed
+    })
+
+    await expect(
+      runtime.cancelSourceTurnRunsExplicitly(threadId, sourceTurnId)
+    ).resolves.toBeUndefined()
+    await expect(runtime.control.get(run.id)).resolves.toMatchObject({
+      status: 'completed'
     })
     await runtime.stop()
   })

--- a/kun/src/server/graph-runtime-factory.ts
+++ b/kun/src/server/graph-runtime-factory.ts
@@ -35,7 +35,10 @@ import type { SessionStore } from '../ports/session-store.js'
 import type { ThreadStore } from '../ports/thread-store.js'
 import type { RuntimeEventRecorder } from '../services/runtime-event-recorder.js'
 import { createGraphCheckVerifier } from '../graph/graph-check-verifier.js'
-import { isGraphRunCompletionFinalizing } from '../graph/graph-run-completion.js'
+import {
+  isGraphRunCompletionFinalizing,
+  isGraphRunSemanticComplete
+} from '../graph/graph-run-completion.js'
 import {
   recoverGraphLeadOwnership,
   recoverGraphPlanningCommits
@@ -419,6 +422,21 @@ export class GraphRuntimeComposition {
     }
   }
 
+  /**
+   * Explicit user Stop / interruptTurn fence. Always cancels owned nonterminal
+   * GraphRuns before the source turn is persisted as aborted. Do not use for
+   * incidental Lead settlement (model failure, approval expiry, normal
+   * completed turn) — call {@link handleSourceTurnTerminal} without force.
+   */
+  async cancelSourceTurnRunsExplicitly(
+    threadId: string,
+    sourceTurnId: string
+  ): Promise<void> {
+    await this.handleSourceTurnTerminal(threadId, sourceTurnId, 'aborted', {
+      forceCancel: true
+    })
+  }
+
   async handleSourceTurnTerminal(
     threadId: string,
     sourceTurnId: string,
@@ -437,19 +455,30 @@ export class GraphRuntimeComposition {
       }
       if (
         options.forceCancel !== true &&
-        isGraphRunCompletionFinalizing(run, this.mailbox)
+        isGraphRunSemanticComplete(run)
       ) {
-        // Scheduler owns idempotent cleanup and completion. Wake it when the
-        // source Lead has just failed so a persisted final summary can finish
-        // without needing another Lead episode.
-        await this.scheduler?.resumeRun(run.id)
+        // Incidental settlement: never cancel semantically finished work.
+        // resumeRun only auto-finishes when finalization is also safe
+        // (no mailbox / human / scheduler holds). Explicit Stop uses
+        // forceCancel and must not take this branch (#1071).
+        if (isGraphRunCompletionFinalizing(run, this.mailbox)) {
+          await this.scheduler?.resumeRun(run.id)
+        }
         continue
       }
       try {
         await this.control.cancel(run.id, {
-          commandId: this.options.ids.next('graph_source_turn_terminal'),
-          idempotencyKey: `source-turn-terminal:${threadId}:${sourceTurnId}:${run.id}:${status}`,
-          reason: `owning source turn ended with status ${status}`
+          commandId: this.options.ids.next(
+            options.forceCancel === true
+              ? 'graph_source_turn_stop'
+              : 'graph_source_turn_terminal'
+          ),
+          idempotencyKey: options.forceCancel === true
+            ? `source-turn-stop:${threadId}:${sourceTurnId}:${run.id}`
+            : `source-turn-terminal:${threadId}:${sourceTurnId}:${run.id}:${status}`,
+          reason: options.forceCancel === true
+            ? 'user interrupted the owning source turn'
+            : `owning source turn ended with status ${status}`
         })
       } catch (error) {
         // Completion may win after list() but before cancel(). That is already

--- a/kun/src/server/runtime-factory.ts
+++ b/kun/src/server/runtime-factory.ts
@@ -930,9 +930,7 @@ export async function createKunServeRuntime(
 	    transitionGraphPlanningDraft: (input) =>
 	      graphRuntime.transitionPlanningDraft(input),
 	    cancelGraphSourceRuns: ({ threadId, sourceTurnId }) =>
-	      graphRuntime.handleSourceTurnTerminal(threadId, sourceTurnId, 'aborted', {
-	        forceCancel: true
-	      }),
+	      graphRuntime.cancelSourceTurnRunsExplicitly(threadId, sourceTurnId),
 	    migrationMaintenance,
 	    ids,
 	    nowIso


### PR DESCRIPTION
## 背景

这是对 #1071 在 v0.2.35 修复基础上的完成边界补强。

当来源 Lead 轮次失败或中止时，已经满足完成条件的 Graph 不应被统一取消。特别是处于 `completing`、已经生成摘要，或能够由调度器继续收尾的运行，应保留其语义结果。

## 修改

- 将 Graph 完成门槛判断抽取为共享逻辑。
- 来源轮次终止时，区分可继续完成与必须取消的运行。
- 对可自动完成的状态调用 `resumeRun`，而不是执行强制取消。
- mailbox、人工审批、scheduler error 等真实阻塞状态仍保持原有保护。
- cold-start 场景不会伪造 `completed` 或摘要。

## 验证

- graph-runtime-factory：16/16
- bootstrap：11/11
- shutdown-recovery：3/3
- turn-service：29/29
- host-shutdown：4/4
- supervision-liveness：4/4
- `npm run typecheck`：通过
- `git diff --check`：通过

Fixes #1071
