### PR TITLE
fix(graph): preserve cancellation intent during recovery

### DIFF
--- a/kun/src/graph/graph-control-service.ts
+++ b/kun/src/graph/graph-control-service.ts
@@ -38,6 +38,9 @@ import { applyPatchToPlan } from './graph-patch-service.js'
 export { applyPatchToPlan } from './graph-patch-service.js'
 export { graphReviewSemanticKey } from './graph-review-idempotency.js'
 
+/** Durable marker used to distinguish cancel fencing from an ordinary pause. */
+export const GRAPH_CANCELLATION_DISPATCH_FENCE_REASON = 'cancellation dispatch fence'
+
 export type GraphCommandContext = {
   commandId: string
   idempotencyKey: string
@@ -591,7 +594,7 @@ export class GraphControlService {
         return await this.transitionRun(run, 'pausing', {
           commandId: `${command.commandId}_fence`,
           idempotencyKey: `${command.idempotencyKey}:fence`
-        }, 'cancellation dispatch fence')
+        }, GRAPH_CANCELLATION_DISPATCH_FENCE_REASON)
       } catch (error) {
         if (!(error instanceof GraphRunConflictError) ||
             command.expectedSeq !== undefined ||

--- a/kun/src/graph/graph-recovery-service.test.ts
+++ b/kun/src/graph/graph-recovery-service.test.ts
@@ -470,6 +470,193 @@ describe('GraphRecoveryService', () => {
     expect(report.pausedRuns).toBe(0)
     expect((await store.get('run_completing'))?.status).toBe('completing')
   })
+
+  it('preserves explicit cancel intent when recovery sees a pausing cancellation fence', async () => {
+    // Production path: GraphControlService.cancel fences running → pausing with
+    // reason "cancellation dispatch fence", then finishes as cancelled. A crash
+    // after the fence but before the final cancelled transition leaves durable
+    // status=pausing. GraphRecoveryService.reconcile() must not demote that to
+    // resumable paused (reliability audit P1 cancel/recovery).
+    const root = await mkdtemp(join(tmpdir(), 'kun-graph-recovery-cancel-fence-'))
+    roots.push(root)
+    const workspace = join(root, 'workspace')
+    await mkdir(workspace)
+    const config = testGraphConfig()
+    let id = 0
+    const nextId = (prefix: string) => `${prefix}_${++id}`
+    const store = new FileGraphRunStore({
+      rootDir: join(root, 'graphs'),
+      artifactStore: new FileArtifactStore(join(root, 'artifacts')),
+      config: () => config,
+      nextId
+    })
+    const control = new GraphControlService({
+      store,
+      config: () => config,
+      nextId,
+      cancelActive: async () => {
+        throw new Error('simulated process death after cancel fence')
+      }
+    })
+    await control.create({
+      runId: 'run_cancel_fence',
+      threadId: 'thread_cancel',
+      projectId: 'project_1',
+      sourceTurnId: 'turn_1',
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_cancel_fence',
+      idempotencyKey: 'create_cancel_fence',
+      start: true
+    })
+    let cancellable = (await store.get('run_cancel_fence'))!
+    cancellable = (await store.append(cancellable.id, {
+      expectedSeq: cancellable.lastEventSeq,
+      graphRevision: cancellable.currentRevision,
+      commandId: 'ready_cancel_fence',
+      idempotencyKey: 'ready_cancel_fence',
+      event: {
+        type: 'node_status_changed',
+        payload: { nodeId: 'research', from: 'pending', to: 'ready' }
+      }
+    })).state
+    const activeAttempt = GraphNodeAttemptV1Schema.parse({
+      version: GRAPH_CONTRACT_VERSION,
+      id: 'attempt_cancel_fence',
+      runId: cancellable.id,
+      nodeId: 'research',
+      revision: cancellable.currentRevision,
+      attemptNumber: 1,
+      iteration: 0,
+      commandId: 'attempt_cancel_fence',
+      idempotencyKey: 'attempt_cancel_fence',
+      status: 'queued',
+      assignment: {
+        ...testAssignmentSnapshot(),
+        workspaceRoot: workspace
+      },
+      childThreadId: 'child_cancel_fence',
+      queuedAt: new Date().toISOString(),
+      tokenUsage: 0,
+      elapsedMs: 0
+    })
+    cancellable = (await store.append(cancellable.id, {
+      expectedSeq: cancellable.lastEventSeq,
+      graphRevision: cancellable.currentRevision,
+      commandId: 'attempt_created_cancel_fence',
+      idempotencyKey: 'attempt_created_cancel_fence',
+      event: { type: 'attempt_created', payload: { attempt: activeAttempt } }
+    })).state
+    await expect(control.cancel('run_cancel_fence', {
+      commandId: 'cancel_mid_crash',
+      idempotencyKey: 'cancel_mid_crash',
+      reason: 'user cancelled the Graph run'
+    })).rejects.toThrow(/simulated process death after cancel fence/)
+
+    const fenced = (await store.get('run_cancel_fence'))!
+    expect(fenced.status).toBe('pausing')
+    expect(fenced.nodes.research.status).toBe('queued')
+    expect(fenced.nodes.research.attempts[0]?.status).toBe('queued')
+
+    const signal = vi.fn(async () => undefined)
+    const recovery = new GraphRecoveryService({
+      store,
+      config: () => config,
+      writes: new FileGraphWriteCoordinator({
+        rootDir: join(root, 'writes'),
+        config: () => config,
+        nextId
+      }),
+      delegation: () => undefined,
+      supervision: () => ({ signal }),
+      nextId
+    })
+    const report = await recovery.reconcile()
+    const recovered = (await store.get('run_cancel_fence'))!
+
+    // Cancelled work must not become resumable. Preferred terminal is cancelled;
+    // at minimum recovery must not leave status=paused after an explicit cancel fence.
+    expect(recovered.status).toBe('cancelled')
+    expect(recovered.status).not.toBe('paused')
+    expect(recovered.nodes.research.status).toBe('cancelled')
+    expect(recovered.nodes.research.attempts[0]?.status).toBe('cancelled')
+    expect(recovered.cleanup).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        resourceKind: 'journal',
+        resourceId: recovered.id,
+        state: 'completed'
+      })
+    ]))
+    expect(report.pausedRuns).toBe(0)
+    expect(report.retriedNodes).toBe(0)
+    expect(report.orphanedAttempts).toBe(0)
+    expect(signal).toHaveBeenCalledOnce()
+    expect(signal).toHaveBeenCalledWith({
+      runId: recovered.id,
+      reason: 'completion',
+      nodeIds: [],
+      digest: 'GraphRun cancellation completed after runtime restart.'
+    })
+
+    const recoveredSeq = recovered.lastEventSeq
+    const second = await recovery.reconcile()
+    expect(second.runsInspected).toBe(0)
+    expect((await store.get(recovered.id))?.lastEventSeq).toBe(recoveredSeq)
+  })
+
+  it('still recovers an interrupted ordinary pause as resumable paused', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-graph-recovery-pause-fence-'))
+    roots.push(root)
+    const workspace = join(root, 'workspace')
+    await mkdir(workspace)
+    const config = testGraphConfig()
+    let id = 0
+    const nextId = (prefix: string) => `${prefix}_${++id}`
+    const store = new FileGraphRunStore({
+      rootDir: join(root, 'graphs'),
+      artifactStore: new FileArtifactStore(join(root, 'artifacts')),
+      config: () => config,
+      nextId
+    })
+    const control = new GraphControlService({
+      store,
+      config: () => config,
+      nextId,
+      pauseActive: async () => {
+        throw new Error('simulated process death after pause fence')
+      }
+    })
+    await control.create({
+      runId: 'run_pause_fence',
+      threadId: 'thread_pause',
+      projectId: 'project_1',
+      sourceTurnId: 'turn_1',
+      plan: testGraphPlan({ workspaceRoot: workspace }),
+      commandId: 'create_pause_fence',
+      idempotencyKey: 'create_pause_fence',
+      start: true
+    })
+    await expect(control.pause('run_pause_fence', {
+      commandId: 'pause_mid_crash',
+      idempotencyKey: 'pause_mid_crash'
+    })).rejects.toThrow(/simulated process death after pause fence/)
+    expect((await store.get('run_pause_fence'))?.status).toBe('pausing')
+
+    const recovery = new GraphRecoveryService({
+      store,
+      config: () => config,
+      writes: new FileGraphWriteCoordinator({
+        rootDir: join(root, 'writes'),
+        config: () => config,
+        nextId
+      }),
+      delegation: () => undefined,
+      nextId
+    })
+    const report = await recovery.reconcile()
+
+    expect((await store.get('run_pause_fence'))?.status).toBe('paused')
+    expect(report.pausedRuns).toBe(1)
+  })
 })
 
 async function git(cwd: string, args: string[]): Promise<void> {

--- a/kun/src/graph/graph-recovery-service.ts
+++ b/kun/src/graph/graph-recovery-service.ts
@@ -13,6 +13,7 @@ import type {
 } from './graph-run-store.js'
 import type { FileGraphWriteCoordinator } from './graph-write-coordinator.js'
 import { createGraphCheckVerifier } from './graph-check-verifier.js'
+import { GRAPH_CANCELLATION_DISPATCH_FENCE_REASON } from './graph-control-service.js'
 import { finalizeGraphWorkerResult } from './graph-worker-result-finalizer.js'
 import {
   currentIterationAttemptCount,
@@ -20,6 +21,7 @@ import {
   GRAPH_RUNTIME_RESTART_ATTEMPT_FAILURE
 } from './graph-scheduler-policy.js'
 import type { GraphSchedulerOptions } from './graph-scheduler-types.js'
+import { recordGraphTerminalCleanup } from './graph-terminal-cleanup.js'
 
 export type GraphRecoveryReport = {
   runsInspected: number
@@ -85,6 +87,17 @@ export class GraphRecoveryService {
     let pausedRuns = 0
     for (const initial of runs) {
       let run = initial
+      if (await this.hasDurableCancellationFence(run)) {
+        run = await this.finishInterruptedCancellation(run)
+        await this.options.supervision?.()?.signal({
+          runId: run.id,
+          reason: 'completion',
+          nodeIds: [],
+          digest: 'GraphRun cancellation completed after runtime restart.'
+        })
+        await this.options.store.snapshot(run.id)
+        continue
+      }
       const affected: string[] = []
       for (const node of Object.values(run.nodes)) {
         const attempt = node.attempts.at(-1)
@@ -150,6 +163,85 @@ export class GraphRecoveryService {
       orphanedChildRuns,
       storeDiagnostics: await this.options.store.diagnostics?.() ?? []
     }
+  }
+
+  private async hasDurableCancellationFence(run: GraphRunV1): Promise<boolean> {
+    if (run.status !== 'pausing') return false
+    const events = await this.options.store.events(run.id)
+    for (let index = events.length - 1; index >= 0; index -= 1) {
+      const event = events[index]!.event
+      if (event.type !== 'run_status_changed') continue
+      return event.payload.to === 'pausing' &&
+        event.payload.reason === GRAPH_CANCELLATION_DISPATCH_FENCE_REASON
+    }
+    return false
+  }
+
+  /**
+   * A cancellation fence is durable user intent. If the process died before
+   * GraphControlService could finish cancellation, settle active work without
+   * scheduling retries, clean terminal resources, and close the run.
+   */
+  private async finishInterruptedCancellation(initialRun: GraphRunV1): Promise<GraphRunV1> {
+    let run = initialRun
+    for (const nodeId of Object.keys(run.nodes)) {
+      for (const attempt of run.nodes[nodeId]!.attempts) {
+        if (!['queued', 'running', 'waiting'].includes(attempt.status)) continue
+        run = await this.transitionAttemptToCancelled(run, attempt)
+      }
+      const node = run.nodes[nodeId]!
+      if (node.status === 'queued' || node.status === 'running') {
+        run = await this.transitionNode(
+          run,
+          nodeId,
+          'cancelled',
+          'explicit cancellation recovered after runtime restart'
+        )
+      }
+    }
+    run = await recordGraphTerminalCleanup({
+      run,
+      writes: this.options.writes,
+      nextId: this.nextId,
+      nowIso: this.nowIso,
+      append: async (current, event, idempotencyKey) => (await this.options.store.append(
+        current.id,
+        {
+          expectedSeq: current.lastEventSeq,
+          graphRevision: current.currentRevision,
+          commandId: this.nextId('graph_recovery'),
+          idempotencyKey,
+          event
+        }
+      )).state
+    })
+    return this.transitionRun(
+      run,
+      'cancelled',
+      'completed interrupted cancellation during recovery'
+    )
+  }
+
+  private async transitionAttemptToCancelled(
+    run: GraphRunV1,
+    attempt: GraphNodeAttemptV1
+  ): Promise<GraphRunV1> {
+    return (await this.options.store.append(run.id, {
+      expectedSeq: run.lastEventSeq,
+      graphRevision: run.currentRevision,
+      commandId: this.nextId('graph_recovery'),
+      idempotencyKey: `recovery:cancel-attempt:${attempt.id}`,
+      event: {
+        type: 'attempt_status_changed',
+        payload: {
+          nodeId: attempt.nodeId,
+          attemptId: attempt.id,
+          from: attempt.status,
+          to: 'cancelled',
+          normalizedFailure: 'Explicit cancellation completed after runtime restart.'
+        }
+      }
+    })).state
   }
 
   private async recoverCompletedChild(


### PR DESCRIPTION
## 背景

Graph pause 与 cancel 共用中间状态 `pausing`。如果进程在 cancellation fence 持久化之后、最终 `cancelled` 写入之前退出，恢复逻辑会把用户明确取消的运行恢复成可继续执行的 `paused`。

## 修改

- 为 cancellation dispatch fence 使用稳定、可识别的持久原因。
- 恢复时检查最近的 durable `run_status_changed -> pausing` 事件。
- cancellation fence 恢复为 `cancelled`，普通 pause fence 仍恢复为 `paused`。
- 取消活跃 attempt 与 node，不创建 retry/orphan。
- 执行 Graph terminal cleanup、supervision completion signal 与 snapshot。
- 重复 reconcile 保持幂等，不增加事件。

## 验证

- 原始回归：修复前稳定得到 `expected cancelled, received paused`
- graph-recovery-service：6/6
- control/reducer/store/scheduler/concurrency：35/35
- recovery/supervision 相关：20/20
- `npm run test:graph:platform`：606 pass，1 skipped
- `npm run build:kun`：通过
- `npm run typecheck`：通过
- 目标 ESLint：通过
- `git diff --check`：通过

Fixes #1083
