### PR TITLE
fix(loop): require bounded recovery after tool storm

### DIFF
--- a/kun/src/loop/round-outcome-coordinator.test.ts
+++ b/kun/src/loop/round-outcome-coordinator.test.ts
@@ -7,6 +7,10 @@ import type { ToolHostContext } from '../ports/tool-host.js'
 import type { RuntimeEventRecorder } from '../services/runtime-event-recorder.js'
 import type { TurnService } from '../services/turn-service.js'
 import { CREATE_PLAN_TOOL_NAME } from '../adapters/tool/create-plan-tool.js'
+import {
+  DESIGN_SVG_EDIT_TOOL_NAME,
+  DESIGN_SVG_VALIDATE_TOOL_NAME
+} from '../adapters/tool/design-svg-tool.js'
 import { GRAPH_DEFINE_PLAN_TOOL_NAME } from '../adapters/tool/graph-define-plan-tool.js'
 import type { ModelRoundStreamResult } from './model-round-engine.js'
 import {
@@ -16,7 +20,11 @@ import {
   type RoundOutcomeInput
 } from './round-outcome-coordinator.js'
 import { svgArtifactCompletionState } from './svg-artifact-completion.js'
-import type { PreparedTurnContext, ToolDispatchInput } from './turn-execution-types.js'
+import type {
+  PreparedTurnContext,
+  ToolDispatchInput,
+  ToolDispatchOutcome
+} from './turn-execution-types.js'
 
 const threadId = 'thread_round_outcome'
 const turnId = 'turn_round_outcome'
@@ -102,7 +110,7 @@ function harness(options: {
   const failures: unknown[] = []
   const metadataPatches: unknown[] = []
   const suppressGoalResume = vi.fn()
-  const dispatchToolCalls = vi.fn(async (input: ToolDispatchInput) => {
+  const dispatchToolCalls = vi.fn(async (input: ToolDispatchInput): Promise<ToolDispatchOutcome> => {
     effects.push('dispatch')
     dispatches.push(input)
     for (const call of input.calls) {
@@ -122,7 +130,7 @@ function harness(options: {
         isError: result.isError
       }))
     }
-    return 'continue' as const
+    return 'continue'
   })
   const turns = {
     applyItem: vi.fn(async (_threadId: string, item: TurnItem) => {
@@ -270,6 +278,177 @@ describe('RoundOutcomeCoordinator', () => {
     expect(h.effects).toEqual(['event:error', 'item:error'])
     expect(h.eventDrafts[0]).toMatchObject({ code: 'required_tool_missing' })
     expect(h.items[0]).toMatchObject({ kind: 'error', code: 'required_tool_missing' })
+  })
+
+  it('continues once after all_suppressed then fails empty recovery stop (#1081)', async () => {
+    const h = harness()
+    h.dispatchToolCalls.mockResolvedValueOnce('all_suppressed')
+    const toolRound = input(completed({
+      toolCalls: [{
+        callId: 'call_1',
+        toolName: 'bash',
+        toolKind: 'tool_call',
+        arguments: { command: 'true' }
+      }]
+    }))
+
+    await expect(h.coordinator.resolve(toolRound)).resolves.toBe('continue')
+    expect(h.coordinator.toolStormRecoveryRounds(turnId)).toBe(1)
+    expect(h.dispatchToolCalls).toHaveBeenCalledOnce()
+
+    await expect(h.coordinator.resolve(input(completed({ text: '' })))).resolves.toBe('failed')
+    expect(h.effects).toEqual(expect.arrayContaining(['event:error', 'item:error']))
+    expect(h.items.some((item) =>
+      item.kind === 'error' && item.code === 'tool_storm_no_final_response'
+    )).toBe(true)
+    expect(h.failures[0]).toMatchObject({ code: 'tool_storm_no_final_response' })
+  })
+
+  it('clears tool-storm recovery after a non-empty final answer', async () => {
+    const h = harness()
+    h.dispatchToolCalls.mockResolvedValueOnce('all_suppressed')
+    await expect(h.coordinator.resolve(input(completed({
+      toolCalls: [{
+        callId: 'call_1',
+        toolName: 'bash',
+        toolKind: 'tool_call',
+        arguments: { command: 'true' }
+      }]
+    })))).resolves.toBe('continue')
+    expect(h.coordinator.toolStormRecoveryRounds(turnId)).toBe(1)
+
+    await expect(h.coordinator.resolve(input(completed({
+      text: 'Here is the answer without more tools.'
+    })))).resolves.toBe('stop')
+    expect(h.coordinator.toolStormRecoveryRounds(turnId)).toBe(0)
+  })
+
+  it('fails a second consecutive all_suppressed after the recovery budget', async () => {
+    const h = harness()
+    h.dispatchToolCalls.mockResolvedValue('all_suppressed')
+    let callSeq = 0
+    const toolRound = () => {
+      callSeq += 1
+      return input(completed({
+        toolCalls: [{
+          callId: `call_storm_${callSeq}`,
+          toolName: 'bash',
+          toolKind: 'tool_call',
+          arguments: { command: 'true' }
+        }]
+      }))
+    }
+
+    await expect(h.coordinator.resolve(toolRound())).resolves.toBe('continue')
+    await expect(h.coordinator.resolve(toolRound())).resolves.toBe('failed')
+    expect(h.items.some((item) =>
+      item.kind === 'error' && item.code === 'tool_storm_no_final_response'
+    )).toBe(true)
+  })
+
+  it('stops validated dedicated SVG turns on all_suppressed without storm recovery', async () => {
+    const revision = 'rev_svg_1'
+    const mutation = makeToolResultItem({
+      id: 'item_svg_edit',
+      threadId,
+      turnId,
+      callId: 'call_svg_edit',
+      toolName: DESIGN_SVG_EDIT_TOOL_NAME,
+      output: { ok: true, revision }
+    })
+    const validation = makeToolResultItem({
+      id: 'item_svg_validate',
+      threadId,
+      turnId,
+      callId: 'call_svg_validate',
+      toolName: DESIGN_SVG_VALIDATE_TOOL_NAME,
+      output: { ok: true, revision }
+    })
+    const h = harness({ latestItems: [mutation, validation] })
+    h.dispatchToolCalls.mockResolvedValueOnce('all_suppressed')
+    const completion = svgArtifactCompletionState([mutation, validation], turnId)
+    expect(completion.validationAfterMutation).toBe(true)
+
+    await expect(h.coordinator.resolve(input(completed({
+      toolCalls: [{
+        callId: 'call_svg_storm',
+        toolName: DESIGN_SVG_VALIDATE_TOOL_NAME,
+        toolKind: 'tool_call',
+        arguments: {}
+      }]
+    }), {
+      prepared: prepared({ dedicatedSvgTurn: true, history: [mutation, validation] }),
+      svgCompletion: completion
+    }))).resolves.toBe('stop')
+
+    expect(h.coordinator.toolStormRecoveryRounds(turnId)).toBe(0)
+    expect(h.items.some((item) =>
+      item.kind === 'error' && item.code === 'tool_storm_no_final_response'
+    )).toBe(false)
+    expect(h.failures).toEqual([])
+  })
+
+  it('uses SVG completion recovery when all_suppressed before mutation/validation', async () => {
+    const h = harness()
+    h.dispatchToolCalls.mockResolvedValue('all_suppressed')
+    const incompleteRound = input(completed({
+      toolCalls: [{
+        callId: 'call_svg_inspect_storm',
+        toolName: 'design_svg_inspect',
+        toolKind: 'tool_call',
+        arguments: {}
+      }]
+    }), {
+      prepared: prepared({ dedicatedSvgTurn: true }),
+      svgCompletion: svgArtifactCompletionState([], turnId)
+    })
+
+    await expect(h.coordinator.resolve(incompleteRound)).resolves.toBe('continue')
+    expect(h.coordinator.toolStormRecoveryRounds(turnId)).toBe(0)
+    expect(h.eventDrafts[0]).toMatchObject({ code: 'required_svg_mutation_missing' })
+
+    const mutationOnly = makeToolResultItem({
+      id: 'item_svg_edit_only',
+      threadId,
+      turnId,
+      callId: 'call_svg_edit_only',
+      toolName: DESIGN_SVG_EDIT_TOOL_NAME,
+      output: { ok: true, revision: 'rev_svg_2' }
+    })
+    const h2 = harness({ latestItems: [mutationOnly] })
+    h2.dispatchToolCalls.mockResolvedValueOnce('all_suppressed')
+    await expect(h2.coordinator.resolve(input(completed({
+      toolCalls: [{
+        callId: 'call_svg_edit_storm',
+        toolName: DESIGN_SVG_EDIT_TOOL_NAME,
+        toolKind: 'tool_call',
+        arguments: {}
+      }]
+    }), {
+      prepared: prepared({ dedicatedSvgTurn: true, history: [mutationOnly] }),
+      svgCompletion: svgArtifactCompletionState([mutationOnly], turnId)
+    }))).resolves.toBe('continue')
+    expect(h2.coordinator.toolStormRecoveryRounds(turnId)).toBe(0)
+    expect(h2.eventDrafts[0]).toMatchObject({ code: 'required_svg_validation_missing' })
+    expect(h2.items.some((item) =>
+      item.kind === 'error' && item.code === 'tool_storm_no_final_response'
+    )).toBe(false)
+  })
+
+  it('clears tool-storm recovery state on clearTurn', async () => {
+    const h = harness()
+    h.dispatchToolCalls.mockResolvedValueOnce('all_suppressed')
+    await h.coordinator.resolve(input(completed({
+      toolCalls: [{
+        callId: 'call_1',
+        toolName: 'bash',
+        toolKind: 'tool_call',
+        arguments: { command: 'true' }
+      }]
+    })))
+    expect(h.coordinator.toolStormRecoveryRounds(turnId)).toBe(1)
+    h.coordinator.clearTurn(turnId)
+    expect(h.coordinator.toolStormRecoveryRounds(turnId)).toBe(0)
   })
 
   it('recovers a missing Graph creation call and clears recovery state only on success or cleanup', async () => {

--- a/kun/src/loop/round-outcome-coordinator.ts
+++ b/kun/src/loop/round-outcome-coordinator.ts
@@ -35,6 +35,9 @@ import type {
 } from './turn-execution-types.js'
 
 const MAX_SVG_COMPLETION_RECOVERY_STEPS = 3
+/** Extra model rounds allowed after a tool-storm all_suppressed outcome (#1081). */
+export const MAX_TOOL_STORM_RECOVERY_ROUNDS = 1
+export const TOOL_STORM_NO_FINAL_RESPONSE_CODE = 'tool_storm_no_final_response'
 export const GRAPH_CREATE_RUN_TOOL_NAME = 'graph_create_run'
 export const MAX_GRAPH_CREATE_RUN_ATTEMPTS = 3
 /** @deprecated Use MAX_GRAPH_CREATE_RUN_ATTEMPTS for the total request cap. */
@@ -94,6 +97,8 @@ export class RoundOutcomeCoordinator {
   private readonly svgCompletionRecoveryStepsByTurn = new Map<string, number>()
   private readonly graphCreateRunRecoveryByTurn = new Map<string, GraphCreateRunRecoveryState>()
   private readonly graphPlanNoToolRecoveryByTurn = new Map<string, number>()
+  /** Recovery model rounds issued after all_suppressed in this turn (#1081). */
+  private readonly toolStormRecoveryRoundsByTurn = new Map<string, number>()
 
   constructor(private readonly deps: RoundOutcomeCoordinatorDeps) {}
 
@@ -107,6 +112,10 @@ export class RoundOutcomeCoordinator {
 
   emptyPostToolRecoverySteps(turnId: string): number {
     return this.emptyPostToolRecoveryStepsByTurn.get(turnId) ?? 0
+  }
+
+  toolStormRecoveryRounds(turnId: string): number {
+    return this.toolStormRecoveryRoundsByTurn.get(turnId) ?? 0
   }
 
   graphCreateRunRecoverySteps(turnId: string): number {
@@ -128,6 +137,7 @@ export class RoundOutcomeCoordinator {
     this.svgCompletionRecoveryStepsByTurn.delete(turnId)
     this.graphCreateRunRecoveryByTurn.delete(turnId)
     this.graphPlanNoToolRecoveryByTurn.delete(turnId)
+    this.toolStormRecoveryRoundsByTurn.delete(turnId)
   }
 
   async resolve(input: RoundOutcomeInput): Promise<ModelRoundOutcome> {
@@ -146,6 +156,22 @@ export class RoundOutcomeCoordinator {
       if (input.softRequiredToolName) {
         return this.resolveMissingSoftRequiredTool(input, streamSnapshot.text)
       }
+      const assistantText = streamSnapshot.text.trim()
+      // After a tool-storm recovery round, an empty stop is a failed turn (#1081).
+      if (
+        streamSnapshot.stopReason === 'stop' &&
+        !assistantText &&
+        (this.toolStormRecoveryRoundsByTurn.get(input.turnId) ?? 0) > 0
+      ) {
+        return this.failToolStormNoFinalResponse(
+          input,
+          'Tool-loop recovery ended without a final assistant response after repeated tool calls were suppressed.'
+        )
+      }
+      if (assistantText) {
+        // A non-empty final answer closes the storm recovery window.
+        this.toolStormRecoveryRoundsByTurn.delete(input.turnId)
+      }
       const hasCurrentTurnFileChange = input.prepared.history.some(
         (item) =>
           item.turnId === input.turnId &&
@@ -155,7 +181,7 @@ export class RoundOutcomeCoordinator {
       )
       if (
         streamSnapshot.stopReason === 'stop' &&
-        !streamSnapshot.text.trim() &&
+        !assistantText &&
         hasCurrentTurnFileChange
       ) {
         return this.resolveEmptyPostToolResponse(input)
@@ -268,15 +294,10 @@ export class RoundOutcomeCoordinator {
       }
     }
     if (dispatched === 'all_suppressed') {
-      if (input.prepared.dedicatedSvgTurn) {
-        const latestItems = await this.deps.sessionStore.loadItems(input.threadId)
-        const latestCompletion = svgArtifactCompletionState(latestItems, input.turnId)
-        if (!latestCompletion.validationAfterMutation) {
-          return this.recoverRequiredSvgCompletion(input, latestCompletion)
-        }
-      }
-      return 'stop'
+      return this.resolveAllSuppressed(input)
     }
+    // At least one tool executed: storm recovery is no longer pending.
+    this.toolStormRecoveryRoundsByTurn.delete(input.turnId)
     if (input.prepared.dedicatedSvgTurn && completedToolCalls.some((call) =>
       call.toolName === DESIGN_SVG_EDIT_TOOL_NAME ||
       call.toolName === DESIGN_SVG_ANIMATE_TOOL_NAME ||
@@ -293,6 +314,65 @@ export class RoundOutcomeCoordinator {
       this.svgCompletionRecoveryStepsByTurn.delete(input.turnId)
     }
     return 'continue'
+  }
+
+  /**
+   * After every tool call in a step is storm-suppressed, allow a bounded
+   * recovery model round so the model can answer without tools. Empty stop or
+   * further all_suppressed after the budget fails the turn (#1081).
+   */
+  private async resolveAllSuppressed(input: RoundOutcomeInput): Promise<ModelRoundOutcome> {
+    // Dedicated SVG workflow owns its own terminal: a completed mutation + later
+    // validation is already a valid tool terminal and must stop without the
+    // generic storm-recovery / tool_storm_no_final_response path (#1081).
+    if (input.prepared.dedicatedSvgTurn) {
+      const latestItems = await this.deps.sessionStore.loadItems(input.threadId)
+      const latestCompletion = svgArtifactCompletionState(latestItems, input.turnId)
+      if (!latestCompletion.validationAfterMutation) {
+        return this.recoverRequiredSvgCompletion(input, latestCompletion)
+      }
+      return 'stop'
+    }
+    const recoveryRounds = this.toolStormRecoveryRoundsByTurn.get(input.turnId) ?? 0
+    if (recoveryRounds < MAX_TOOL_STORM_RECOVERY_ROUNDS) {
+      this.toolStormRecoveryRoundsByTurn.set(input.turnId, recoveryRounds + 1)
+      return 'continue'
+    }
+    return this.failToolStormNoFinalResponse(
+      input,
+      'Repeated identical tool calls were suppressed and the model did not produce a final response after recovery.'
+    )
+  }
+
+  private async failToolStormNoFinalResponse(
+    input: RoundOutcomeInput,
+    message: string
+  ): Promise<ModelRoundOutcome> {
+    this.deps.rememberFailure(input.turnId, {
+      error: message,
+      code: TOOL_STORM_NO_FINAL_RESPONSE_CODE,
+      severity: 'error'
+    })
+    await this.deps.events.record({
+      kind: 'error',
+      threadId: input.threadId,
+      turnId: input.turnId,
+      message,
+      code: TOOL_STORM_NO_FINAL_RESPONSE_CODE,
+      severity: 'error'
+    })
+    await this.deps.turns.applyItem(
+      input.threadId,
+      makeErrorItem({
+        id: this.deps.ids.next('item_error'),
+        turnId: input.turnId,
+        threadId: input.threadId,
+        message,
+        code: TOOL_STORM_NO_FINAL_RESPONSE_CODE,
+        severity: 'error'
+      })
+    )
+    return 'failed'
   }
 
   private async resolveMissingSoftRequiredTool(
@@ -370,7 +450,7 @@ export class RoundOutcomeCoordinator {
       )
       if (dispatched === 'aborted') return 'aborted'
       if (dispatched === 'budget_exhausted') return 'failed'
-      if (dispatched === 'all_suppressed') return 'stop'
+      if (dispatched === 'all_suppressed') return this.resolveAllSuppressed(input)
       return 'continue'
     }
 

--- a/kun/tests/loop.test.ts
+++ b/kun/tests/loop.test.ts
@@ -1265,8 +1265,8 @@ describe('AgentLoop', () => {
     })
   })
 
-	  it('suppresses repeated identical tool calls within a turn', async () => {
-	    let executions = 0
+  it('suppresses repeated identical tool calls and fails when recovery has no final answer (#1081)', async () => {
+    let executions = 0
     const echoTool = LocalToolHost.defineTool({
       name: 'echo',
       description: 'Echo text',
@@ -1298,6 +1298,7 @@ describe('AgentLoop', () => {
             yield { kind: 'completed', stopReason: 'tool_calls' }
             return
           }
+          // Recovery round after all_suppressed: empty stop (#1081).
           yield { kind: 'completed', stopReason: 'stop' }
         }
       },
@@ -1305,30 +1306,213 @@ describe('AgentLoop', () => {
     )
     await bootstrapThread(h)
 
-	    const status = await h.loop.runTurn(h.threadId, h.turnId)
-	    const items = await h.sessionStore.loadItems(h.threadId)
-	    const events = await h.sessionStore.loadEventsSince(h.threadId, 0)
-	    const stormResult = items.find(
-	      (item) => item.kind === 'tool_result' && item.callId === 'call_echo_3'
-	    )
+    const status = await h.loop.runTurn(h.threadId, h.turnId)
+    const items = await h.sessionStore.loadItems(h.threadId)
+    const events = await h.sessionStore.loadEventsSince(h.threadId, 0)
+    const stormResult = items.find(
+      (item) => item.kind === 'tool_result' && item.callId === 'call_echo_3'
+    )
     const thirdCall = items.find(
       (item) => item.kind === 'tool_call' && item.callId === 'call_echo_3'
     )
+    const assistantTexts = items.filter(
+      (item) => item.kind === 'assistant_text' && item.turnId === h.turnId && item.text.trim()
+    )
+    const stormError = items.find(
+      (item) => item.kind === 'error' && item.code === 'tool_storm_no_final_response'
+    )
 
+    expect(status).toBe('failed')
+    expect(status).not.toBe('completed')
+    expect(assistantTexts).toHaveLength(0)
+    expect(executions).toBe(2)
+    expect(calls).toBe(4) // 3 tool rounds + 1 recovery empty stop
+    expect(thirdCall).toMatchObject({ kind: 'tool_call', status: 'failed' })
+    expect(stormResult?.kind === 'tool_result' ? stormResult.isError : false).toBe(true)
+    expect(stormResult?.kind === 'tool_result' ? JSON.stringify(stormResult.output) : '')
+      .toContain('repeat-loop guard suppressed')
+    expect(events.find((event) => event.kind === 'tool_storm_suppressed')).toMatchObject({
+      kind: 'tool_storm_suppressed',
+      callId: 'call_echo_3',
+      toolName: 'echo'
+    })
+    expect(stormError).toMatchObject({
+      kind: 'error',
+      code: 'tool_storm_no_final_response',
+      severity: 'error'
+    })
+    expect(events.find((event) =>
+      event.kind === 'error' && event.code === 'tool_storm_no_final_response'
+    )).toBeTruthy()
+  })
+
+  it('completes after tool-storm suppression when recovery produces a final assistant answer', async () => {
+    let executions = 0
+    const echoTool = LocalToolHost.defineTool({
+      name: 'echo',
+      description: 'Echo text',
+      inputSchema: {
+        type: 'object',
+        properties: { text: { type: 'string' } },
+        required: ['text']
+      },
+      policy: 'auto',
+      execute: async () => {
+        executions += 1
+        return { output: { ok: executions } }
+      }
+    })
+    let calls = 0
+    const h = makeHarness(
+      {
+        provider: 'storm-recover-text-model',
+        model: 'storm-recover-text-model',
+        async *stream(): AsyncIterable<ModelStreamChunk> {
+          calls += 1
+          if (calls <= 3) {
+            yield {
+              kind: 'tool_call_complete',
+              callId: `call_echo_${calls}`,
+              toolName: 'echo',
+              arguments: { text: 'repeat me' }
+            }
+            yield { kind: 'completed', stopReason: 'tool_calls' }
+            return
+          }
+          yield { kind: 'assistant_text_delta', text: 'I stopped repeating tools and answered.' }
+          yield { kind: 'completed', stopReason: 'stop' }
+        }
+      },
+      { tools: [echoTool] }
+    )
+    await bootstrapThread(h)
+
+    const status = await h.loop.runTurn(h.threadId, h.turnId)
+    const items = await h.sessionStore.loadItems(h.threadId)
     expect(status).toBe('completed')
     expect(executions).toBe(2)
-    expect(thirdCall).toMatchObject({ kind: 'tool_call', status: 'failed' })
-	    expect(stormResult?.kind === 'tool_result' ? stormResult.isError : false).toBe(true)
-	    expect(stormResult?.kind === 'tool_result' ? JSON.stringify(stormResult.output) : '')
-	      .toContain('repeat-loop guard suppressed')
-	    expect(events.find((event) => event.kind === 'tool_storm_suppressed')).toMatchObject({
-	      kind: 'tool_storm_suppressed',
-	      callId: 'call_echo_3',
-	      toolName: 'echo'
-	    })
-	  })
+    expect(calls).toBe(4)
+    expect(items.some((item) =>
+      item.kind === 'assistant_text' &&
+      item.turnId === h.turnId &&
+      item.text.includes('stopped repeating tools')
+    )).toBe(true)
+    expect(items.some((item) =>
+      item.kind === 'error' && item.code === 'tool_storm_no_final_response'
+    )).toBe(false)
+  })
 
-  it('suppresses the third identical Graph run inspection within a turn', async () => {
+  it('bounds recovery when the model keeps storming after suppression', async () => {
+    let executions = 0
+    const echoTool = LocalToolHost.defineTool({
+      name: 'echo',
+      description: 'Echo text',
+      inputSchema: {
+        type: 'object',
+        properties: { text: { type: 'string' } },
+        required: ['text']
+      },
+      policy: 'auto',
+      execute: async () => {
+        executions += 1
+        return { output: { ok: executions } }
+      }
+    })
+    let calls = 0
+    const h = makeHarness(
+      {
+        provider: 'storm-bounded-model',
+        model: 'storm-bounded-model',
+        async *stream(): AsyncIterable<ModelStreamChunk> {
+          calls += 1
+          yield {
+            kind: 'tool_call_complete',
+            callId: `call_echo_${calls}`,
+            toolName: 'echo',
+            arguments: { text: 'repeat me' }
+          }
+          yield { kind: 'completed', stopReason: 'tool_calls' }
+        }
+      },
+      { tools: [echoTool] }
+    )
+    await bootstrapThread(h)
+
+    const status = await h.loop.runTurn(h.threadId, h.turnId)
+    const items = await h.sessionStore.loadItems(h.threadId)
+    // rounds: 1 exec, 2 exec, 3 all_suppressed→continue, 4 all_suppressed→failed
+    expect(status).toBe('failed')
+    expect(executions).toBe(2)
+    expect(calls).toBe(4)
+    expect(items.some((item) =>
+      item.kind === 'error' && item.code === 'tool_storm_no_final_response'
+    )).toBe(true)
+  })
+
+  it('does not leak tool-storm recovery state across turns', async () => {
+    let executions = 0
+    const echoTool = LocalToolHost.defineTool({
+      name: 'echo',
+      description: 'Echo text',
+      inputSchema: {
+        type: 'object',
+        properties: { text: { type: 'string' } },
+        required: ['text']
+      },
+      policy: 'auto',
+      execute: async () => {
+        executions += 1
+        return { output: { ok: executions } }
+      }
+    })
+    let calls = 0
+    const h = makeHarness(
+      {
+        provider: 'storm-isolation-model',
+        model: 'storm-isolation-model',
+        async *stream(): AsyncIterable<ModelStreamChunk> {
+          calls += 1
+          // Turn 1: storm then empty recovery → failed
+          if (calls <= 3) {
+            yield {
+              kind: 'tool_call_complete',
+              callId: `call_echo_t1_${calls}`,
+              toolName: 'echo',
+              arguments: { text: 'repeat me' }
+            }
+            yield { kind: 'completed', stopReason: 'tool_calls' }
+            return
+          }
+          if (calls === 4) {
+            yield { kind: 'completed', stopReason: 'stop' }
+            return
+          }
+          // Turn 2: normal answer without tools
+          yield { kind: 'assistant_text_delta', text: 'second turn is fine' }
+          yield { kind: 'completed', stopReason: 'stop' }
+        }
+      },
+      { tools: [echoTool] }
+    )
+    await bootstrapThread(h)
+    const first = await h.loop.runTurn(h.threadId, h.turnId)
+    expect(first).toBe('failed')
+
+    const secondTurn = await h.turns.startTurn({
+      threadId: h.threadId,
+      request: { prompt: 'follow up' }
+    })
+    const second = await h.loop.runTurn(h.threadId, secondTurn.turnId)
+    const items = await h.sessionStore.loadItems(h.threadId)
+    expect(second).toBe('completed')
+    expect(items.some((item) =>
+      item.kind === 'assistant_text' &&
+      item.turnId === secondTurn.turnId &&
+      item.text.includes('second turn is fine')
+    )).toBe(true)
+  })
+
+  it('suppresses the third identical Graph run inspection and fails empty storm recovery (#1081)', async () => {
     let executions = 0
     const inspectTool = LocalToolHost.defineTool({
       name: 'graph_control_run',
@@ -1381,7 +1565,7 @@ describe('AgentLoop', () => {
       (item) => item.kind === 'tool_call' && item.callId === 'call_graph_inspect_3'
     )
 
-    expect(status).toBe('completed')
+    expect(status).toBe('failed')
     expect(executions).toBe(2)
     expect(thirdCall).toMatchObject({ kind: 'tool_call', status: 'failed' })
     expect(stormResult?.kind === 'tool_result' ? stormResult.isError : false).toBe(true)
@@ -1392,6 +1576,9 @@ describe('AgentLoop', () => {
       callId: 'call_graph_inspect_3',
       toolName: 'graph_control_run'
     })
+    expect(items.some((item) =>
+      item.kind === 'error' && item.code === 'tool_storm_no_final_response'
+    )).toBe(true)
   })
 
 	  it('can disable the storm breaker through loop config', async () => {


### PR DESCRIPTION
## 背景

当一轮中的工具调用全部被 repeat-loop guard 抑制时，当前实现会直接把 turn 记为成功完成，即使没有任何最终 assistant 文本。用户因此看到回答无声终止。

## 修改

- `all_suppressed` 后最多允许一次有界恢复轮次。
- 恢复轮次产生非空 assistant 文本时正常完成。
- 恢复仍为空或再次形成 tool storm 时，以 `tool_storm_no_final_response` 明确失败。
- 恢复预算按 `turnId` 隔离，并在 turn 清理时释放。
- 保留 validated dedicated SVG 的既有终态语义；未完成 SVG 继续使用专用恢复路径。
- 测试 call ID 改为确定性递增值，并收紧持续 storm 的调用次数断言。

## 验证

- tool-call-dispatcher：3/3
- round-outcome-coordinator：20/20
- storm/suppressed/SVG 集成：5/5
- Plan/Graph/SVG/storm 相关回归：18/18
- design-mode：2/2
- `npm run typecheck`：通过
- `git diff --check`：通过

Fixes #1081
