### PR TITLE
fix(graph): keep dashboard synchronized after lead settles

### DIFF
--- a/src/renderer/src/components/graph/GraphModePanel.test.ts
+++ b/src/renderer/src/components/graph/GraphModePanel.test.ts
@@ -19,6 +19,7 @@ import {
   graphElements,
   GRAPH_DASHBOARD_SNAPSHOT_REFRESH_INTERVAL_MS,
   graphDashboardNeedsSnapshotRefresh,
+  graphProjectionOwnedByThread,
   plannedAssignmentLabel,
   runProgress,
   selectGraphPlanningDraft,
@@ -26,6 +27,18 @@ import {
 } from './GraphModePanel'
 import { reconcileInteractiveGraphNodes } from './graph-canvas-state'
 import { clampGraphInspectorWidth } from './graph-workspace-layout'
+
+const graphClient = vi.hoisted(() => ({
+  listRuns: vi.fn(),
+  listDrafts: vi.fn(),
+  delegationDiagnostics: vi.fn()
+}))
+
+vi.mock('../../graph/graph-runtime-client', () => ({
+  graphRuntimeClient: graphClient
+}))
+
+import { useGraphStore } from '../../graph/graph-store'
 
 function node(id: string, phaseId: string): GraphPlanNode {
   return {
@@ -144,22 +157,68 @@ function SnapshotRefreshHarness({
   return null
 }
 
+/**
+ * Drives the real #1072 poll gate from store state — must not hard-code shouldRefresh.
+ */
+function StoreDrivenSnapshotRefreshHarness({
+  active,
+  sourceGraphTurnActive = false
+}: {
+  active: boolean
+  sourceGraphTurnActive?: boolean
+}): null {
+  const threadId = useGraphStore((state) => state.threadId)
+  const runs = useGraphStore((state) => state.runs)
+  const drafts = useGraphStore((state) => state.drafts)
+  const refreshThread = useGraphStore((state) => state.refreshThread)
+  const shouldRefresh = graphDashboardNeedsSnapshotRefresh(
+    runs,
+    drafts,
+    sourceGraphTurnActive
+  )
+  useGraphDashboardSnapshotRefresh({
+    active,
+    threadId,
+    shouldRefresh,
+    refreshThread
+  })
+  return null
+}
+
 describe('Graph Mode panel projection', () => {
   afterEach(() => {
     vi.useRealTimers()
   })
 
-  it('reconciles nonterminal Graph work and an active source turn even before a run is visible', () => {
+  it('keeps the v0.2.35 snapshot poll contract independent of SSE live status', () => {
     const liveRun = graphRun([node('work', 'phase_1')], [])
-    const terminalRun = { ...liveRun, status: 'completed' as const }
+    const completed = { ...liveRun, status: 'completed' as const }
+    const failed = { ...liveRun, status: 'failed' as const }
+    const cancelled = { ...liveRun, status: 'cancelled' as const }
     const pausedRun = { ...liveRun, status: 'paused' as const }
+    const awaitingHuman = { ...liveRun, status: 'awaiting_human' as const }
 
+    // Non-terminal + SSE live must still poll (silent event bridge failure path).
     expect(graphDashboardNeedsSnapshotRefresh([liveRun], [], false)).toBe(true)
-    expect(graphDashboardNeedsSnapshotRefresh([terminalRun], [], false)).toBe(false)
-    expect(graphDashboardNeedsSnapshotRefresh([pausedRun], [], false)).toBe(false)
+    expect(graphDashboardNeedsSnapshotRefresh([pausedRun], [], false)).toBe(true)
+    expect(graphDashboardNeedsSnapshotRefresh([awaitingHuman], [], false)).toBe(true)
+
+    // Hard terminals without live drafts / source turn stop poll.
+    expect(graphDashboardNeedsSnapshotRefresh([completed], [], false)).toBe(false)
+    expect(graphDashboardNeedsSnapshotRefresh([failed], [], false)).toBe(false)
+    expect(graphDashboardNeedsSnapshotRefresh([cancelled], [], false)).toBe(false)
+
+    // Planning draft / source turn still force poll with no runs.
     expect(graphDashboardNeedsSnapshotRefresh([], [planningDraft('draft_1', 'planning')], false))
       .toBe(true)
     expect(graphDashboardNeedsSnapshotRefresh([], [], true)).toBe(true)
+  })
+
+  it('gates rendered projection on store thread ownership', () => {
+    expect(graphProjectionOwnedByThread('thread_a', 'thread_a')).toBe(true)
+    expect(graphProjectionOwnedByThread('thread_a', 'thread_b')).toBe(false)
+    expect(graphProjectionOwnedByThread(null, 'thread_b')).toBe(false)
+    expect(graphProjectionOwnedByThread('thread_b', null)).toBe(false)
   })
 
   it('polls durable Graph snapshots without overlapping requests and stops when hidden', async () => {
@@ -220,6 +279,64 @@ describe('Graph Mode panel projection', () => {
       await Promise.resolve()
     })
     expect(refreshThread).toHaveBeenCalledTimes(2)
+
+    await act(async () => renderer.unmount())
+  })
+
+  it('covers fully missed SSE by low-frequency snapshot fallback (seq 2 → 5, fake timers)', async () => {
+    vi.useFakeTimers()
+    graphClient.listDrafts.mockResolvedValue([])
+    graphClient.delegationDiagnostics.mockResolvedValue({
+      enabled: true,
+      active: 0,
+      childRuns: []
+    })
+    const runAt = (seq: number): GraphRun => ({
+      ...graphRun([node('work', 'phase_1')], []),
+      lastEventSeq: seq,
+      status: 'running'
+    })
+
+    useGraphStore.setState({
+      threadId: 'thread_1',
+      runs: [runAt(2)],
+      drafts: [],
+      childRuns: {},
+      syncStatus: 'live',
+      threadEventSeq: 40,
+      loading: false,
+      error: null
+    })
+    // Gate must be true from real contract math — not a hard-coded shouldRefresh.
+    expect(graphDashboardNeedsSnapshotRefresh(
+      useGraphStore.getState().runs,
+      useGraphStore.getState().drafts,
+      false
+    )).toBe(true)
+    expect(useGraphStore.getState().syncStatus).toBe('live')
+    expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(2)
+
+    graphClient.listRuns.mockResolvedValue([runAt(5)])
+
+    let renderer!: ReactTestRenderer
+    await act(async () => {
+      renderer = createRenderer(createElement(StoreDrivenSnapshotRefreshHarness, {
+        active: true
+      }))
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(GRAPH_DASHBOARD_SNAPSHOT_REFRESH_INTERVAL_MS)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await vi.waitFor(() => {
+      expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(5)
+    })
+    expect(graphClient.listRuns).toHaveBeenCalled()
+    // No SSE Graph events were delivered; snapshot alone converged the projection.
+    expect(useGraphStore.getState().syncStatus).toBe('live')
 
     await act(async () => renderer.unmount())
   })

--- a/src/renderer/src/components/graph/GraphModePanel.tsx
+++ b/src/renderer/src/components/graph/GraphModePanel.tsx
@@ -9,7 +9,8 @@ import { useTranslation } from 'react-i18next'
 import { useChatStore } from '../../store/chat-store'
 import { openGraphChildThread } from '../../graph/graph-child-navigation'
 import { useGraphStore } from '../../graph/graph-store'
-import type { GraphPlanningDraftView, GraphRun } from '../../graph/graph-types'
+import type { GraphPlanningDraftView, GraphRun, GraphRunStatus } from '../../graph/graph-types'
+import { useGraphThreadObserver } from '../../graph/use-graph-thread-observer'
 import { GraphAgentsView } from './GraphAgentsView'
 import { GraphLearningView } from './GraphLearningView'
 import { GraphPlanningCard } from './GraphPlanningCard'
@@ -35,15 +36,16 @@ type View = 'run' | 'agents' | 'learning'
 
 export const GRAPH_DASHBOARD_SNAPSHOT_REFRESH_INTERVAL_MS = 5_000
 
-const liveGraphRunStatuses = new Set<GraphRun['status']>([
-  'draft',
-  'validating',
-  'ready',
-  'running',
-  'pausing',
-  'awaiting_supervision',
-  'completing'
+/** Hard terminal Graph run statuses — only these may stop fallback polling. */
+export const GRAPH_RUN_TERMINAL_STATUSES = new Set<GraphRunStatus>([
+  'completed',
+  'failed',
+  'cancelled'
 ])
+
+export function graphRunStatusIsTerminal(status: GraphRunStatus): boolean {
+  return GRAPH_RUN_TERMINAL_STATUSES.has(status)
+}
 
 const livePlanningDraftStatuses = new Set<GraphPlanningDraftView['draft']['status']>([
   'planning',
@@ -52,14 +54,30 @@ const livePlanningDraftStatuses = new Set<GraphPlanningDraftView['draft']['statu
   'committing'
 ])
 
+/**
+ * v0.2.35 / #1072 contract: while any non-terminal run, live planning draft, or
+ * active Graph source turn exists, poll durable snapshots every 5s — independent
+ * of SSE syncStatus. Live SSE is the low-latency path; HTTP snapshot is the
+ * reliability backstop when the event bridge is silently stuck.
+ */
 export function graphDashboardNeedsSnapshotRefresh(
   runs: readonly Pick<GraphRun, 'status'>[],
   drafts: readonly Pick<GraphPlanningDraftView, 'draft'>[],
   sourceGraphTurnActive: boolean
 ): boolean {
-  return sourceGraphTurnActive ||
-    runs.some((run) => liveGraphRunStatuses.has(run.status)) ||
-    drafts.some((draft) => livePlanningDraftStatuses.has(draft.draft.status))
+  if (sourceGraphTurnActive) return true
+  if (drafts.some((draft) => livePlanningDraftStatuses.has(draft.draft.status))) {
+    return true
+  }
+  return runs.some((run) => !graphRunStatusIsTerminal(run.status))
+}
+
+/** True only when the store binding matches the panel's target thread. */
+export function graphProjectionOwnedByThread(
+  storeThreadId: string | null,
+  graphThreadId: string | null
+): boolean {
+  return Boolean(graphThreadId) && storeThreadId === graphThreadId
 }
 
 export function useGraphDashboardSnapshotRefresh({
@@ -125,9 +143,10 @@ export function GraphModePanel({
   const [view, setView] = useState<View>('run')
   const [steering, setSteering] = useState('')
   const {
-    runs,
-    drafts,
-    childRuns,
+    threadId: storeThreadId,
+    runs: storeRuns,
+    drafts: storeDrafts,
+    childRuns: storeChildRuns,
     childReturnTarget,
     selectedRunId,
     selectedNodeId,
@@ -144,6 +163,7 @@ export function GraphModePanel({
     identity,
     loading,
     error,
+    syncStatus,
     refreshThread,
     refreshProject,
     refreshSelectedRun,
@@ -175,13 +195,23 @@ export function GraphModePanel({
   const graphThreadId = childReturnTarget?.childThreadId === activeThreadId
     ? childReturnTarget.parentThreadId
     : activeThreadId
+  // Render gate: never show thread-A projection under thread-B before bind runs.
+  const projectionOwned = graphProjectionOwnedByThread(storeThreadId, graphThreadId)
+  const runs = projectionOwned ? storeRuns : []
+  const drafts = projectionOwned ? storeDrafts : []
+  const childRuns = projectionOwned ? storeChildRuns : {}
   const sourceGraphTurnActive = graphThreadId === activeThreadId &&
     threadBusy && currentTurnOrchestration === 'graph'
+  // Polling decision uses owned projection only; syncStatus is display-only.
   const shouldRefreshSnapshot = graphDashboardNeedsSnapshotRefresh(
     runs,
     drafts,
     sourceGraphTurnActive
   )
+
+  // Independent of chat busy: Graph SSE keeps projecting after Lead settles.
+  // Ownership is atomic via bindGraphThread (not effect order with refreshThread).
+  useGraphThreadObserver(graphThreadId, active)
 
   useEffect(() => {
     if (!active) return
@@ -199,7 +229,9 @@ export function GraphModePanel({
     void refreshProject(workspaceRoot)
   }, [refreshProject, workspaceRoot])
 
-  const run = runs.find((item) => item.id === selectedRunId) ?? runs[0] ?? null
+  const run = projectionOwned
+    ? (runs.find((item) => item.id === selectedRunId) ?? runs[0] ?? null)
+    : null
   const planningDraft = selectGraphPlanningDraft(drafts, Boolean(run))
   const selectedNode = run && selectedNodeId ? run.nodes[selectedNodeId] : undefined
   const canvasFocusRequestKey = run && selectedNodeId
@@ -271,6 +303,18 @@ export function GraphModePanel({
             </div>
             <div className="truncate text-[10px] text-ds-faint">
               {identity?.source.replaceAll('_', ' ') ?? 'project orchestration'}
+              {syncStatus === 'live'
+                ? ` · ${t('graphObserver_live')}`
+                : null}
+              {syncStatus === 'connecting'
+                ? ` · ${t('graphObserver_connecting')}`
+                : null}
+              {syncStatus === 'reconnecting'
+                ? ` · ${t('graphObserver_reconnecting')}`
+                : null}
+              {syncStatus === 'stopped'
+                ? ` · ${t('graphObserver_stopped')}`
+                : null}
             </div>
           </div>
         </div>

--- a/src/renderer/src/graph/graph-store.test.ts
+++ b/src/renderer/src/graph/graph-store.test.ts
@@ -161,7 +161,9 @@ describe('Graph renderer store', () => {
       artifactLoading: false,
       wakingObligationId: null,
       loading: false,
-      error: null
+      error: null,
+      syncStatus: 'idle',
+      threadEventSeq: 0
     })
     client.delegationDiagnostics.mockResolvedValue({
       enabled: true,
@@ -305,26 +307,164 @@ describe('Graph renderer store', () => {
     expect(client.resumeDraft).toHaveBeenLastCalledWith('draft_1', 4)
   })
 
-  it('does not let an older concurrent refresh overwrite a newer Graph snapshot', async () => {
-    let resolveOlder!: (runs: GraphRun[]) => void
-    let resolveNewer!: (runs: GraphRun[]) => void
+  it('coalesces concurrent refreshThread calls and never regresses lastEventSeq', async () => {
+    let resolveFirst!: (runs: GraphRun[]) => void
+    let resolveSecond!: (runs: GraphRun[]) => void
     client.listRuns
-      .mockReturnValueOnce(new Promise<GraphRun[]>((resolve) => { resolveOlder = resolve }))
-      .mockReturnValueOnce(new Promise<GraphRun[]>((resolve) => { resolveNewer = resolve }))
+      .mockReturnValueOnce(new Promise<GraphRun[]>((resolve) => { resolveFirst = resolve }))
+      .mockReturnValueOnce(new Promise<GraphRun[]>((resolve) => { resolveSecond = resolve }))
 
-    const olderRefresh = useGraphStore.getState().refreshThread('thread_1')
-    const newerRefresh = useGraphStore.getState().refreshThread('thread_1')
-    resolveNewer([runWithNode('run_1', 3, 'node_1')])
-    await newerRefresh
-    expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(3)
+    const first = useGraphStore.getState().refreshThread('thread_1')
+    const second = useGraphStore.getState().refreshThread('thread_1', { silent: true })
+    // Single-flight: only one HTTP snapshot is in flight until it settles.
+    expect(client.listRuns).toHaveBeenCalledTimes(1)
 
-    resolveOlder([run('run_1', 2)])
-    await olderRefresh
+    resolveFirst([run('run_1', 2)])
+    await Promise.resolve()
+    await Promise.resolve()
+    // Pending request starts after the leader finishes.
+    await vi.waitFor(() => expect(client.listRuns).toHaveBeenCalledTimes(2))
+    resolveSecond([runWithNode('run_1', 5, 'node_1')])
+    await Promise.all([first, second])
 
     expect(useGraphStore.getState().runs[0]).toMatchObject({
-      lastEventSeq: 3,
+      lastEventSeq: 5,
       nodes: { node_1: { status: 'running' } }
     })
+
+    // A late, weaker snapshot still cannot move lastEventSeq backwards.
+    client.listRuns.mockResolvedValueOnce([run('run_1', 3)])
+    await useGraphStore.getState().refreshThread('thread_1', { silent: true })
+    expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(5)
+  })
+
+  it('backfills via snapshot when graphSeq jumps ahead of lastEventSeq (gap)', async () => {
+    client.listRuns.mockResolvedValueOnce([run('run_1', 2)])
+    await useGraphStore.getState().refreshThread('thread_1')
+    expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(2)
+
+    client.listRuns.mockResolvedValueOnce([run('run_1', 4)])
+    receiveGraphRuntimeEvent({
+      version: 1,
+      eventId: 'event_4',
+      runId: 'run_1',
+      threadId: 'thread_1',
+      graphSeq: 4,
+      graphRevision: 1,
+      timestamp: '2026-07-26T00:00:04.000Z',
+      event: { type: 'node_status_changed', payload: {} }
+    } satisfies GraphEventEnvelope)
+
+    await vi.waitFor(() => {
+      expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(4)
+    })
+    // Snapshot recovery — listEvents is intentionally not used for projection.
+    expect(client.listRuns).toHaveBeenCalledTimes(2)
+    expect(useGraphStore.getState().runs).toHaveLength(1)
+  })
+
+  it('drops a late refresh from a previous thread after a thread switch', async () => {
+    let resolveOld!: (runs: GraphRun[]) => void
+    client.listRuns
+      .mockReturnValueOnce(new Promise<GraphRun[]>((resolve) => { resolveOld = resolve }))
+      .mockResolvedValueOnce([run('run_new', 1)])
+
+    const oldRefresh = useGraphStore.getState().refreshThread('thread_old')
+    await useGraphStore.getState().refreshThread('thread_new')
+    expect(useGraphStore.getState().threadId).toBe('thread_new')
+    expect(useGraphStore.getState().runs[0]?.id).toBe('run_new')
+
+    resolveOld([run('run_old', 9)])
+    await oldRefresh
+
+    expect(useGraphStore.getState().threadId).toBe('thread_new')
+    expect(useGraphStore.getState().runs[0]?.id).toBe('run_new')
+    expect(useGraphStore.getState().runs.some((item) => item.id === 'run_old')).toBe(false)
+  })
+
+  it('atomically clears thread-scoped projection when binding a different thread', async () => {
+    useGraphStore.setState({
+      threadId: 'thread_a',
+      threadEventSeq: 100,
+      runs: [runWithNode('run_a', 8, 'node_a')],
+      drafts: [planningDraft('needs_correction', 1)],
+      childRuns: {
+        child_a: {
+          childId: 'child_a',
+          parentThreadId: 'thread_a',
+          parentTurnId: 'turn_a',
+          status: 'running',
+          updatedAt: '2026-07-26T00:00:00.000Z'
+        }
+      },
+      selectedRunId: 'run_a',
+      selectedNodeId: 'node_a',
+      artifactPage: null,
+      artifactContent: 'artifact from A',
+      artifactLoading: true,
+      syncStatus: 'live'
+    })
+
+    const { switched } = useGraphStore.getState().bindGraphThread('thread_b')
+    expect(switched).toBe(true)
+    expect(useGraphStore.getState()).toMatchObject({
+      threadId: 'thread_b',
+      threadEventSeq: 0,
+      runs: [],
+      drafts: [],
+      childRuns: {},
+      selectedRunId: null,
+      selectedNodeId: null,
+      artifactContent: '',
+      artifactLoading: false,
+      artifactPage: null,
+      loading: true,
+      syncStatus: 'connecting'
+    })
+
+    // Failed snapshot for B must not resurrect A.
+    client.listRuns.mockRejectedValueOnce(new Error('network down'))
+    client.listDrafts.mockRejectedValueOnce(new Error('network down'))
+    await useGraphStore.getState().refreshThread('thread_b')
+    expect(useGraphStore.getState().runs).toEqual([])
+    expect(useGraphStore.getState().drafts).toEqual([])
+    expect(useGraphStore.getState().runs.some((item) => item.id === 'run_a')).toBe(false)
+  })
+
+  it('keeps the same-thread snapshot across reconnect binds', () => {
+    useGraphStore.setState({
+      threadId: 'thread_1',
+      threadEventSeq: 12,
+      runs: [run('run_1', 12)],
+      syncStatus: 'live'
+    })
+    const { switched } = useGraphStore.getState().bindGraphThread('thread_1')
+    expect(switched).toBe(false)
+    expect(useGraphStore.getState()).toMatchObject({
+      threadId: 'thread_1',
+      threadEventSeq: 12,
+      runs: [{ id: 'run_1', lastEventSeq: 12 }],
+      syncStatus: 'live'
+    })
+  })
+
+  it('advances threadEventSeq monotonically only for the owning thread', () => {
+    useGraphStore.setState({ threadId: 'thread_a', threadEventSeq: 0 })
+    useGraphStore.getState().advanceThreadEventSeq(2, 'thread_a')
+    useGraphStore.getState().advanceThreadEventSeq(5, 'thread_a')
+    useGraphStore.getState().advanceThreadEventSeq(4, 'thread_a')
+    expect(useGraphStore.getState().threadEventSeq).toBe(5)
+
+    useGraphStore.getState().bindGraphThread('thread_b')
+    useGraphStore.getState().advanceThreadEventSeq(99, 'thread_a')
+    useGraphStore.getState().setSyncStatus('live', 'thread_a')
+    expect(useGraphStore.getState()).toMatchObject({
+      threadId: 'thread_b',
+      threadEventSeq: 0,
+      syncStatus: 'connecting'
+    })
+    useGraphStore.getState().advanceThreadEventSeq(3, 'thread_b')
+    expect(useGraphStore.getState().threadEventSeq).toBe(3)
   })
 
   it('preserves a durable node selection when the selected run refreshes', async () => {

--- a/src/renderer/src/graph/graph-store.ts
+++ b/src/renderer/src/graph/graph-store.ts
@@ -9,6 +9,7 @@ import {
   mergeGraphChildRuntime,
   type GraphChildReturnTarget
 } from './graph-child-runtime'
+import type { GraphThreadSyncStatus } from './graph-thread-observer'
 import type {
   GraphAgentEvidence,
   GraphAgentProfile,
@@ -27,9 +28,32 @@ import type {
 } from './graph-types'
 
 export { selectGraphPlanningCorrectionDraft } from './graph-planning-selection'
+export type { GraphThreadSyncStatus } from './graph-thread-observer'
 
 type GraphThreadRefreshOptions = {
   silent?: boolean
+}
+
+type ThreadRefreshGate = {
+  inFlight: Promise<void> | null
+  pending: boolean
+  /** Pending refresh is silent only when every coalesced request asked for silent. */
+  pendingSilent: boolean
+}
+
+/** One in-flight HTTP snapshot per thread; later requests mark pending. */
+const threadRefreshGates = new Map<string, ThreadRefreshGate>()
+
+function refreshGateFor(threadId: string): ThreadRefreshGate {
+  const existing = threadRefreshGates.get(threadId)
+  if (existing) return existing
+  const created: ThreadRefreshGate = {
+    inFlight: null,
+    pending: false,
+    pendingSilent: true
+  }
+  threadRefreshGates.set(threadId, created)
+  return created
 }
 
 type GraphViewState = {
@@ -55,6 +79,16 @@ type GraphViewState = {
   wakingObligationId: string | null
   loading: boolean
   error: string | null
+  /** Graph-owned SSE / observer lifecycle (independent of chat busy). */
+  syncStatus: GraphThreadSyncStatus
+  /** Monotonic thread SSE cursor for the bound Graph panel thread. */
+  threadEventSeq: number
+  /**
+   * Atomic thread ownership transition for the Graph panel. Switching to a
+   * different thread clears all thread-scoped projection and resets the SSE
+   * cursor to 0. Same-thread calls are no-ops (reconnect keeps the snapshot).
+   */
+  bindGraphThread: (threadId: string | null) => { switched: boolean }
   refreshThread: (threadId: string | null, options?: GraphThreadRefreshOptions) => Promise<void>
   refreshProject: (workspace: string) => Promise<void>
   refreshSelectedRun: () => Promise<void>
@@ -69,6 +103,8 @@ type GraphViewState = {
     status: GraphChildReturnTarget['childSessionStatus']
   ) => void
   clearChildReturnTarget: () => void
+  setSyncStatus: (status: GraphThreadSyncStatus, ownerThreadId?: string) => void
+  advanceThreadEventSeq: (seq: number, ownerThreadId?: string) => void
   receiveChildRuntimeEvent: (event: RuntimeChildEventPayload) => void
   receiveEvent: (event: GraphEventEnvelope) => void
   receivePlanningEvent: (event: GraphPlanningLifecycleEvent) => void
@@ -108,6 +144,56 @@ function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+async function applyThreadSnapshot(
+  get: () => GraphViewState,
+  set: (
+    partial:
+      | Partial<GraphViewState>
+      | ((state: GraphViewState) => Partial<GraphViewState>)
+  ) => void,
+  threadId: string,
+  silent: boolean
+): Promise<void> {
+  if (!silent) set({ loading: true, error: null })
+  try {
+    const [runs, drafts, diagnostics] = await Promise.all([
+      graphRuntimeClient.listRuns(threadId),
+      graphRuntimeClient.listDrafts(threadId),
+      graphRuntimeClient.delegationDiagnostics(threadId).catch(() => null)
+    ])
+    if (get().threadId !== threadId) return
+    const current = get()
+    const mergedRuns = mergeGraphRunSnapshots(current.runs, runs)
+    const previousRunId = current.selectedRunId
+    const previousNodeId = current.selectedNodeId
+    const selectedRunId = mergedRuns.some((run) => run.id === previousRunId)
+      ? previousRunId
+      : mergedRuns[0]?.id ?? null
+    const selectedRun = mergedRuns.find((run) => run.id === selectedRunId)
+    const selectedNodeId = previousNodeId && selectedRun?.nodes[previousNodeId]
+      ? previousNodeId
+      : null
+    set({
+      runs: mergedRuns,
+      drafts,
+      childRuns: mergeGraphChildDiagnostics(current.childRuns, diagnostics, threadId),
+      selectedRunId,
+      selectedNodeId,
+      artifactPage: null,
+      artifactContent: '',
+      artifactLoading: false,
+      // Always clear loading after a successful snapshot so a silent follow-up
+      // cannot leave the panel stuck after bindGraphThread set loading=true.
+      loading: false,
+      ...(silent ? {} : { error: null })
+    })
+  } catch (error) {
+    if (get().threadId !== threadId) return
+    if (!silent) set({ loading: false, error: message(error) })
+    else if (get().loading) set({ loading: false })
+  }
+}
+
 export const useGraphStore = create<GraphViewState>((set, get) => ({
   threadId: null,
   workspace: '',
@@ -131,12 +217,17 @@ export const useGraphStore = create<GraphViewState>((set, get) => ({
   wakingObligationId: null,
   loading: false,
   error: null,
+  syncStatus: 'idle',
+  threadEventSeq: 0,
 
-  refreshThread: async (threadId, options) => {
-    const silent = options?.silent === true
-    set(silent ? { threadId } : { threadId, loading: true, error: null })
-    if (!threadId) {
+  bindGraphThread: (nextThreadId) => {
+    const current = get()
+    if (nextThreadId === null) {
+      if (current.threadId === null && current.runs.length === 0) {
+        return { switched: false }
+      }
       set({
+        threadId: null,
         runs: [],
         drafts: [],
         childRuns: {},
@@ -145,42 +236,79 @@ export const useGraphStore = create<GraphViewState>((set, get) => ({
         artifactPage: null,
         artifactContent: '',
         artifactLoading: false,
-        loading: false
+        loading: false,
+        error: null,
+        syncStatus: 'idle',
+        threadEventSeq: 0
       })
+      return { switched: true }
+    }
+    if (current.threadId === nextThreadId) {
+      return { switched: false }
+    }
+    // Different thread: never show the previous thread's Graph projection.
+    set({
+      threadId: nextThreadId,
+      runs: [],
+      drafts: [],
+      childRuns: {},
+      selectedRunId: null,
+      selectedNodeId: null,
+      artifactPage: null,
+      artifactContent: '',
+      artifactLoading: false,
+      loading: true,
+      error: null,
+      syncStatus: 'connecting',
+      threadEventSeq: 0
+    })
+    return { switched: true }
+  },
+
+  refreshThread: async (threadId, options) => {
+    const silent = options?.silent === true
+    if (!threadId) {
+      get().bindGraphThread(null)
       return
     }
-    try {
-      const [runs, drafts, diagnostics] = await Promise.all([
-        graphRuntimeClient.listRuns(threadId),
-        graphRuntimeClient.listDrafts(threadId),
-        graphRuntimeClient.delegationDiagnostics(threadId).catch(() => null)
-      ])
-      if (get().threadId !== threadId) return
-      const current = get()
-      const mergedRuns = mergeGraphRunSnapshots(current.runs, runs)
-      const previousRunId = current.selectedRunId
-      const previousNodeId = current.selectedNodeId
-      const selectedRunId = mergedRuns.some((run) => run.id === previousRunId)
-        ? previousRunId
-        : mergedRuns[0]?.id ?? null
-      const selectedRun = mergedRuns.find((run) => run.id === selectedRunId)
-      const selectedNodeId = previousNodeId && selectedRun?.nodes[previousNodeId]
-        ? previousNodeId
-        : null
-      set({
-        runs: mergedRuns,
-        drafts,
-        childRuns: mergeGraphChildDiagnostics(current.childRuns, diagnostics, threadId),
-        selectedRunId,
-        selectedNodeId,
-        artifactPage: null,
-        artifactContent: '',
-        artifactLoading: false,
-        ...(silent ? {} : { loading: false, error: null })
-      })
-    } catch (error) {
-      if (!silent) set({ loading: false, error: message(error) })
+
+    // Atomic ownership transition — does not depend on React effect order.
+    const { switched } = get().bindGraphThread(threadId)
+    if (!switched && !silent) {
+      set({ loading: true, error: null })
+    } else if (!switched && silent) {
+      // same thread silent reconcile: leave projection untouched until apply
     }
+
+    const gate = refreshGateFor(threadId)
+    if (gate.inFlight) {
+      gate.pending = true
+      gate.pendingSilent = gate.pendingSilent && silent
+      await gate.inFlight
+      return
+    }
+
+    gate.pending = true
+    gate.pendingSilent = silent
+    const run = (async () => {
+      try {
+        while (gate.pending && get().threadId === threadId) {
+          const useSilent = gate.pendingSilent
+          gate.pending = false
+          gate.pendingSilent = true
+          await applyThreadSnapshot(get, set, threadId, useSilent)
+        }
+      } finally {
+        gate.inFlight = null
+        // A request may have marked pending after the while-check but before
+        // inFlight was cleared; start a follow-up leader without dropping it.
+        if (gate.pending && get().threadId === threadId) {
+          void get().refreshThread(threadId, { silent: gate.pendingSilent })
+        }
+      }
+    })()
+    gate.inFlight = run
+    await run
   },
 
   refreshProject: async (workspace) => {
@@ -273,6 +401,16 @@ export const useGraphStore = create<GraphViewState>((set, get) => ({
   }),
   clearChildReturnTarget: () => set({ childReturnTarget: null }),
 
+  setSyncStatus: (syncStatus, ownerThreadId) => set((state) => {
+    if (ownerThreadId !== undefined && state.threadId !== ownerThreadId) return {}
+    return { syncStatus }
+  }),
+
+  advanceThreadEventSeq: (seq, ownerThreadId) => set((state) => {
+    if (ownerThreadId !== undefined && state.threadId !== ownerThreadId) return {}
+    return { threadEventSeq: Math.max(state.threadEventSeq, seq) }
+  }),
+
   receiveChildRuntimeEvent: (event) => {
     if (event.child.parentThreadId !== get().threadId) return
     const incoming = graphChildRuntimeFromEvent(event)
@@ -290,9 +428,11 @@ export const useGraphStore = create<GraphViewState>((set, get) => ({
   receiveEvent: (event) => {
     if (event.threadId !== get().threadId) return
     const known = get().runs.find((run) => run.id === event.runId)
-    if (!known || event.graphSeq > known.lastEventSeq) {
-      void get().refreshThread(event.threadId)
-    }
+    // graphSeq is run-local; thread SSE cursor is separate. Gaps and advances
+    // both converge via a coalesced silent snapshot — domain listEvents is not
+    // projected because the renderer owns HTTP run snapshots, not event replay.
+    if (known && event.graphSeq <= known.lastEventSeq) return
+    void get().refreshThread(event.threadId, { silent: true })
   },
 
   receivePlanningEvent: (event) => {

--- a/src/renderer/src/graph/graph-thread-observer.test.ts
+++ b/src/renderer/src/graph/graph-thread-observer.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ThreadEventSink } from '../agent/types'
+import {
+  GRAPH_THREAD_OBSERVER_RECONNECT_BASE_MS,
+  startGraphThreadObserver
+} from './graph-thread-observer'
+
+describe('Graph thread observer', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('subscribes independently of chat busy and advances a monotonic SSE cursor', async () => {
+    const statuses: string[] = []
+    const seqs: number[] = []
+    let cursor = 2
+    const subscribe = vi.fn(async (
+      threadId: string,
+      sinceSeq: number,
+      sink: ThreadEventSink,
+      signal: AbortSignal
+    ) => {
+      expect(threadId).toBe('thread_graph')
+      expect(sinceSeq).toBe(2)
+      sink.onConnected?.()
+      sink.onSeq(5)
+      sink.onGraphEvent?.({ graphSeq: 4 })
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    })
+
+    const observer = startGraphThreadObserver({
+      threadId: 'thread_graph',
+      getSinceSeq: () => cursor,
+      onSeq: (seq) => {
+        cursor = Math.max(cursor, seq)
+        seqs.push(seq)
+      },
+      onStatus: (status) => statuses.push(status),
+      onGraphEvent: vi.fn(),
+      subscribe
+    })
+
+    await vi.waitFor(() => {
+      expect(subscribe).toHaveBeenCalledTimes(1)
+      expect(seqs).toEqual([5])
+    })
+    expect(statuses).toContain('connecting')
+    expect(statuses).toContain('live')
+    expect(cursor).toBe(5)
+
+    observer.stop()
+    expect(statuses.at(-1)).toBe('stopped')
+  })
+
+  it('reconnects from the latest cursor after disconnect without requiring a remount', async () => {
+    vi.useFakeTimers()
+    const subscribe = vi.fn()
+    let cursor = 0
+    subscribe
+      .mockImplementationOnce(async (
+        _threadId: string,
+        sinceSeq: number,
+        sink: ThreadEventSink
+      ) => {
+        expect(sinceSeq).toBe(0)
+        sink.onSeq(3)
+      })
+      .mockImplementationOnce(async (
+        _threadId: string,
+        sinceSeq: number,
+        sink: ThreadEventSink,
+        signal: AbortSignal
+      ) => {
+        expect(sinceSeq).toBe(3)
+        sink.onConnected?.()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+      })
+
+    const observer = startGraphThreadObserver({
+      threadId: 'thread_graph',
+      getSinceSeq: () => cursor,
+      onSeq: (seq) => {
+        cursor = Math.max(cursor, seq)
+      },
+      onStatus: vi.fn(),
+      onGraphEvent: vi.fn(),
+      subscribe
+    })
+
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(1))
+    await vi.advanceTimersByTimeAsync(GRAPH_THREAD_OBSERVER_RECONNECT_BASE_MS)
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(2))
+    expect(subscribe.mock.calls[1]?.[1]).toBe(3)
+
+    observer.stop()
+  })
+
+  it('stops reconnecting when shouldReconnect becomes false (terminal Graph)', async () => {
+    vi.useFakeTimers()
+    let live = true
+    const statuses: string[] = []
+    const subscribe = vi.fn(async () => {
+      live = false
+    })
+
+    startGraphThreadObserver({
+      threadId: 'thread_graph',
+      getSinceSeq: () => 0,
+      onSeq: vi.fn(),
+      onStatus: (status) => statuses.push(status),
+      onGraphEvent: vi.fn(),
+      subscribe,
+      shouldReconnect: () => live
+    })
+
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(1))
+    await vi.advanceTimersByTimeAsync(GRAPH_THREAD_OBSERVER_RECONNECT_BASE_MS * 4)
+    expect(subscribe).toHaveBeenCalledTimes(1)
+    expect(statuses.at(-1)).toBe('stopped')
+  })
+
+  it('aborts the active subscription on stop so thread switches cannot leak', async () => {
+    let aborted = false
+    const subscribe = vi.fn(async (
+      _threadId: string,
+      _sinceSeq: number,
+      _sink: ThreadEventSink,
+      signal: AbortSignal
+    ) => {
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => {
+          aborted = true
+          resolve()
+        }, { once: true })
+      })
+    })
+
+    const observer = startGraphThreadObserver({
+      threadId: 'thread_old',
+      getSinceSeq: () => 1,
+      onSeq: vi.fn(),
+      onStatus: vi.fn(),
+      onGraphEvent: vi.fn(),
+      subscribe
+    })
+
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(1))
+    observer.stop()
+    await vi.waitFor(() => expect(aborted).toBe(true))
+  })
+})

--- a/src/renderer/src/graph/graph-thread-observer.ts
+++ b/src/renderer/src/graph/graph-thread-observer.ts
@@ -1,0 +1,135 @@
+import type { ThreadEventSink } from '../agent/types'
+
+/** Reachable Graph panel observer lifecycle values (no unused placeholders). */
+export type GraphThreadSyncStatus =
+  | 'idle'
+  | 'connecting'
+  | 'live'
+  | 'reconnecting'
+  | 'stopped'
+
+export const GRAPH_THREAD_OBSERVER_RECONNECT_BASE_MS = 1_000
+export const GRAPH_THREAD_OBSERVER_RECONNECT_MAX_MS = 5_000
+
+export type GraphThreadObserverHandles = {
+  stop: () => void
+}
+
+export type GraphThreadObserverDeps = {
+  threadId: string
+  getSinceSeq: () => number
+  onSeq: (seq: number) => void
+  onStatus: (status: GraphThreadSyncStatus) => void
+  onGraphEvent: (event: unknown) => void
+  onChildRuntimeEvent?: ThreadEventSink['onChildRuntimeEvent']
+  onGraphPlanningEvent?: ThreadEventSink['onGraphPlanningEvent']
+  subscribe: (
+    threadId: string,
+    sinceSeq: number,
+    sink: ThreadEventSink,
+    signal: AbortSignal
+  ) => Promise<void>
+  /** When false after a stream ends, the observer stops reconnecting. */
+  shouldReconnect?: () => boolean
+  waitForReconnect?: (ms: number, signal: AbortSignal) => Promise<void>
+}
+
+function defaultWait(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    const id = globalThis.setTimeout(resolve, ms)
+    signal.addEventListener('abort', () => {
+      globalThis.clearTimeout(id)
+      resolve()
+    }, { once: true })
+  })
+}
+
+function reconnectDelayMs(attempt: number): number {
+  return Math.min(
+    GRAPH_THREAD_OBSERVER_RECONNECT_MAX_MS,
+    GRAPH_THREAD_OBSERVER_RECONNECT_BASE_MS * (2 ** Math.min(2, Math.max(0, attempt - 1)))
+  )
+}
+
+/**
+ * Independent Graph SSE lifecycle for the Graph panel. Not gated by chat busy:
+ * reconnects from a monotonic thread event cursor, and only projects Graph
+ * envelopes (plus safe child/planning events) into the Graph store.
+ */
+export function startGraphThreadObserver(
+  deps: GraphThreadObserverDeps
+): GraphThreadObserverHandles {
+  const controller = new AbortController()
+  const wait = deps.waitForReconnect ?? defaultWait
+  let reconnectAttempt = 0
+  let stopped = false
+
+  const sink: ThreadEventSink = {
+    onConnected: () => {
+      if (stopped || controller.signal.aborted) return
+      reconnectAttempt = 0
+      deps.onStatus('live')
+    },
+    onSeq: (seq) => {
+      if (stopped || controller.signal.aborted) return
+      reconnectAttempt = 0
+      deps.onSeq(seq)
+      deps.onStatus('live')
+    },
+    onDeltas: () => undefined,
+    onUserMessage: () => undefined,
+    onTool: () => undefined,
+    onCompaction: () => undefined,
+    onApproval: () => undefined,
+    onUserInput: () => undefined,
+    onUserInputStatus: () => undefined,
+    onGoal: () => undefined,
+    onTurnComplete: () => undefined,
+    onError: () => {
+      if (stopped || controller.signal.aborted) return
+      deps.onStatus('reconnecting')
+    },
+    onChildRuntimeEvent: deps.onChildRuntimeEvent,
+    onGraphEvent: deps.onGraphEvent,
+    onGraphPlanningEvent: deps.onGraphPlanningEvent
+  }
+
+  const loop = async (): Promise<void> => {
+    while (!controller.signal.aborted && !stopped) {
+      deps.onStatus(reconnectAttempt === 0 ? 'connecting' : 'reconnecting')
+      try {
+        await deps.subscribe(
+          deps.threadId,
+          deps.getSinceSeq(),
+          sink,
+          controller.signal
+        )
+      } catch {
+        if (controller.signal.aborted || stopped) return
+      }
+      if (controller.signal.aborted || stopped) return
+      if (deps.shouldReconnect && !deps.shouldReconnect()) {
+        deps.onStatus('stopped')
+        return
+      }
+      reconnectAttempt += 1
+      deps.onStatus('reconnecting')
+      await wait(reconnectDelayMs(reconnectAttempt), controller.signal)
+    }
+  }
+
+  void loop()
+
+  return {
+    stop: () => {
+      if (stopped) return
+      stopped = true
+      controller.abort()
+      deps.onStatus('stopped')
+    }
+  }
+}

--- a/src/renderer/src/graph/use-graph-thread-observer.test.ts
+++ b/src/renderer/src/graph/use-graph-thread-observer.test.ts
@@ -1,0 +1,324 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ThreadEventSink } from '../agent/types'
+import { useGraphStore } from './graph-store'
+import { useGraphThreadObserver } from './use-graph-thread-observer'
+
+const provider = vi.hoisted(() => ({
+  subscribeThreadEvents: vi.fn()
+}))
+
+const client = vi.hoisted(() => ({
+  listRuns: vi.fn(),
+  listDrafts: vi.fn(),
+  delegationDiagnostics: vi.fn()
+}))
+
+vi.mock('../agent/registry', () => ({
+  getProvider: () => provider
+}))
+
+vi.mock('./graph-runtime-client', () => ({
+  graphRuntimeClient: client
+}))
+
+function Harness({
+  threadId,
+  active
+}: {
+  threadId: string | null
+  active: boolean
+}): null {
+  useGraphThreadObserver(threadId, active)
+  return null
+}
+
+function run(id: string, seq: number, status: 'running' | 'completed' = 'running') {
+  return {
+    version: 1 as const,
+    id,
+    projectId: 'project_1',
+    threadId: 'thread_1',
+    sourceTurnId: 'turn_1',
+    status,
+    currentRevision: 1,
+    plans: [],
+    nodes: {
+      node_1: {
+        node: {
+          id: 'node_1',
+          phaseId: 'phase_1',
+          kind: 'work' as const,
+          title: 'Work',
+          objective: 'Do work',
+          priority: 1,
+          required: true,
+          riskClass: 'low' as const,
+          readScopes: [],
+          writeScopes: []
+        },
+        status: status === 'completed' ? 'accepted' as const : 'running' as const,
+        attempts: [],
+        loopIteration: 0
+      }
+    },
+    reviews: [],
+    messages: [],
+    artifacts: [],
+    cleanup: [],
+    steering: [],
+    budget: {
+      limits: { maxWallTimeMs: 60_000, maxAttemptsPerNode: 3 },
+      attempts: 0,
+      revisions: 0,
+      loopIterations: 0,
+      elapsedMs: 0,
+      totalTokens: 0,
+      messages: 0,
+      artifactBytes: 0,
+      warningKinds: [],
+      closed: false
+    },
+    lastEventSeq: seq,
+    createdAt: '2026-07-26T00:00:00.000Z',
+    updatedAt: '2026-07-26T00:00:00.000Z'
+  }
+}
+
+describe('useGraphThreadObserver', () => {
+  beforeAll(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterAll(() => {
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useGraphStore.setState({
+      threadId: null,
+      runs: [],
+      drafts: [],
+      childRuns: {},
+      syncStatus: 'idle',
+      threadEventSeq: 0,
+      loading: false,
+      error: null
+    })
+    client.listDrafts.mockResolvedValue([])
+    client.delegationDiagnostics.mockResolvedValue({
+      enabled: true,
+      active: 0,
+      childRuns: []
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps observing after Lead settles (chat busy=false) and projects later Graph status', async () => {
+    client.listRuns.mockResolvedValue([run('run_1', 2)])
+    provider.subscribeThreadEvents.mockImplementation(
+      async (
+        _threadId: string,
+        _seq: number,
+        sink: ThreadEventSink,
+        signal: AbortSignal
+      ) => {
+        sink.onConnected?.()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+      }
+    )
+
+    let renderer: ReactTestRenderer
+    await act(async () => {
+      renderer = create(createElement(Harness, { threadId: 'thread_1', active: true }))
+    })
+
+    await act(async () => {
+      await useGraphStore.getState().refreshThread('thread_1')
+    })
+    expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(2)
+    expect(useGraphStore.getState().syncStatus).toBe('live')
+
+    client.listRuns.mockResolvedValue([run('run_1', 6)])
+    const sink = provider.subscribeThreadEvents.mock.calls[0]![2] as ThreadEventSink
+    await act(async () => {
+      sink.onGraphEvent?.({
+        version: 1,
+        eventId: 'event_6',
+        runId: 'run_1',
+        threadId: 'thread_1',
+        graphSeq: 6,
+        graphRevision: 1,
+        timestamp: '2026-07-26T00:00:06.000Z',
+        event: { type: 'node_status_changed', payload: {} }
+      })
+    })
+
+    await vi.waitFor(() => {
+      expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(6)
+    })
+
+    await act(async () => renderer!.unmount())
+  })
+
+  it('aborts the previous thread observer when the Graph panel switches threads', async () => {
+    const signals: AbortSignal[] = []
+    provider.subscribeThreadEvents.mockImplementation(
+      (_threadId: string, _seq: number, _sink: ThreadEventSink, signal: AbortSignal) => {
+        signals.push(signal)
+        return new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+      }
+    )
+
+    let renderer: ReactTestRenderer
+    await act(async () => {
+      renderer = create(createElement(Harness, { threadId: 'thread_a', active: true }))
+    })
+    await vi.waitFor(() => expect(provider.subscribeThreadEvents).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      renderer!.update(createElement(Harness, { threadId: 'thread_b', active: true }))
+    })
+    await vi.waitFor(() => expect(provider.subscribeThreadEvents).toHaveBeenCalledTimes(2))
+    expect(signals[0]?.aborted).toBe(true)
+    expect(provider.subscribeThreadEvents.mock.calls[1]?.[0]).toBe('thread_b')
+
+    await act(async () => renderer!.unmount())
+  })
+
+  it('resets the SSE cursor to 0 on thread switch and ignores late owner callbacks', async () => {
+    useGraphStore.setState({
+      threadId: 'thread_a',
+      threadEventSeq: 100,
+      runs: [run('run_a', 100)],
+      syncStatus: 'live'
+    })
+
+    const sinks: ThreadEventSink[] = []
+    provider.subscribeThreadEvents.mockImplementation(
+      (_threadId: string, _seq: number, sink: ThreadEventSink, signal: AbortSignal) => {
+        sinks.push(sink)
+        return new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+      }
+    )
+
+    let renderer: ReactTestRenderer
+    await act(async () => {
+      renderer = create(createElement(Harness, { threadId: 'thread_a', active: true }))
+    })
+    await vi.waitFor(() => expect(provider.subscribeThreadEvents).toHaveBeenCalledTimes(1))
+    // Same thread remount/bind must keep cursor (subscribe still sees 100).
+    expect(provider.subscribeThreadEvents.mock.calls[0]?.[1]).toBe(100)
+
+    await act(async () => {
+      renderer!.update(createElement(Harness, { threadId: 'thread_b', active: true }))
+    })
+    await vi.waitFor(() => expect(provider.subscribeThreadEvents).toHaveBeenCalledTimes(2))
+
+    // Critical: second subscribe must not reuse thread-A's cursor.
+    expect(provider.subscribeThreadEvents.mock.calls[1]?.slice(0, 2)).toEqual([
+      'thread_b',
+      0
+    ])
+    expect(useGraphStore.getState().threadEventSeq).toBe(0)
+    expect(useGraphStore.getState().runs).toEqual([])
+
+    await act(async () => {
+      sinks[1]!.onSeq(3)
+      sinks[1]!.onConnected?.()
+    })
+    expect(useGraphStore.getState()).toMatchObject({
+      threadId: 'thread_b',
+      threadEventSeq: 3,
+      syncStatus: 'live'
+    })
+
+    // Late callbacks from the aborted thread-A observer must not pollute B.
+    await act(async () => {
+      sinks[0]!.onSeq(250)
+      sinks[0]!.onConnected?.()
+      // startGraphThreadObserver sets reconnecting on error; ownership must drop it.
+      sinks[0]!.onError(new Error('stale a'))
+    })
+    expect(useGraphStore.getState()).toMatchObject({
+      threadId: 'thread_b',
+      threadEventSeq: 3,
+      syncStatus: 'live'
+    })
+
+    await act(async () => renderer!.unmount())
+  })
+
+  it('preserves cursor when the same thread is hidden and reopened', async () => {
+    provider.subscribeThreadEvents.mockImplementation(
+      (_threadId: string, _seq: number, sink: ThreadEventSink, signal: AbortSignal) => {
+        sink.onSeq(7)
+        return new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+      }
+    )
+
+    let renderer: ReactTestRenderer
+    await act(async () => {
+      renderer = create(createElement(Harness, { threadId: 'thread_1', active: true }))
+    })
+    await vi.waitFor(() => expect(useGraphStore.getState().threadEventSeq).toBe(7))
+
+    await act(async () => {
+      renderer!.update(createElement(Harness, { threadId: 'thread_1', active: false }))
+    })
+    expect(useGraphStore.getState().threadEventSeq).toBe(7)
+
+    await act(async () => {
+      renderer!.update(createElement(Harness, { threadId: 'thread_1', active: true }))
+    })
+    await vi.waitFor(() => expect(provider.subscribeThreadEvents).toHaveBeenCalledTimes(2))
+    expect(provider.subscribeThreadEvents.mock.calls[1]?.[1]).toBe(7)
+
+    await act(async () => renderer!.unmount())
+  })
+
+  it('does not clear durable Graph runs while reconnecting', async () => {
+    useGraphStore.setState({
+      threadId: 'thread_1',
+      runs: [run('run_1', 3)],
+      syncStatus: 'live'
+    })
+    provider.subscribeThreadEvents
+      .mockImplementationOnce(async (_t, _s, sink: ThreadEventSink) => {
+        sink.onConnected?.()
+        sink.onError(new Error('socket dropped'))
+      })
+      .mockImplementation(
+        (_threadId: string, _seq: number, _sink: ThreadEventSink, signal: AbortSignal) =>
+          new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true })
+          })
+      )
+
+    vi.useFakeTimers()
+    let renderer: ReactTestRenderer
+    await act(async () => {
+      renderer = create(createElement(Harness, { threadId: 'thread_1', active: true }))
+      await Promise.resolve()
+    })
+
+    expect(useGraphStore.getState().runs).toHaveLength(1)
+    expect(useGraphStore.getState().runs[0]?.lastEventSeq).toBe(3)
+    expect(useGraphStore.getState().syncStatus).toMatch(/reconnecting|connecting|live|stopped/)
+
+    await act(async () => renderer!.unmount())
+  })
+})

--- a/src/renderer/src/graph/use-graph-thread-observer.ts
+++ b/src/renderer/src/graph/use-graph-thread-observer.ts
@@ -1,0 +1,81 @@
+import { useEffect } from 'react'
+import { getProvider } from '../agent/registry'
+import {
+  receiveGraphChildRuntimeEvent,
+  receiveGraphPlanningRuntimeEvent,
+  receiveGraphRuntimeEvent,
+  useGraphStore
+} from './graph-store'
+import {
+  startGraphThreadObserver,
+  type GraphThreadSyncStatus
+} from './graph-thread-observer'
+
+/**
+ * Owns Graph projection SSE for the Graph panel itself (not child-transcript
+ * foregrounding). Independent of chat busy: Lead can finish while Graph runs
+ * continue and this observer keeps projecting runtime state.
+ *
+ * Thread ownership is established only through `bindGraphThread` (atomic). This
+ * hook never patches `threadId` alone, so React effect order cannot leave a
+ * stale SSE cursor bound to a new thread.
+ */
+export function useGraphThreadObserver(
+  threadId: string | null,
+  active: boolean
+): void {
+  useEffect(() => {
+    if (!active || !threadId) {
+      const state = useGraphStore.getState()
+      // Hide/reopen the same thread: keep projection + cursor; only mark idle.
+      if (threadId && state.threadId === threadId) {
+        state.setSyncStatus('idle', threadId)
+      } else if (!threadId && state.syncStatus !== 'idle') {
+        state.setSyncStatus('idle')
+      }
+      return
+    }
+
+    // Atomic: different thread clears projection + zeros threadEventSeq.
+    useGraphStore.getState().bindGraphThread(threadId)
+    const ownedThreadId = threadId
+
+    const observer = startGraphThreadObserver({
+      threadId: ownedThreadId,
+      getSinceSeq: () => {
+        const current = useGraphStore.getState()
+        return current.threadId === ownedThreadId ? current.threadEventSeq : 0
+      },
+      onSeq: (seq) => {
+        useGraphStore.getState().advanceThreadEventSeq(seq, ownedThreadId)
+      },
+      onStatus: (status: GraphThreadSyncStatus) => {
+        useGraphStore.getState().setSyncStatus(status, ownedThreadId)
+      },
+      onGraphEvent: (event) => {
+        if (useGraphStore.getState().threadId !== ownedThreadId) return
+        receiveGraphRuntimeEvent(event)
+      },
+      onChildRuntimeEvent: (event) => {
+        if (useGraphStore.getState().threadId !== ownedThreadId) return
+        receiveGraphChildRuntimeEvent(event)
+      },
+      onGraphPlanningEvent: (event) => {
+        if (useGraphStore.getState().threadId !== ownedThreadId) return
+        receiveGraphPlanningRuntimeEvent(event)
+      },
+      subscribe: (id, sinceSeq, sink, signal) =>
+        getProvider().subscribeThreadEvents(id, sinceSeq, sink, signal),
+      shouldReconnect: () => useGraphStore.getState().threadId === ownedThreadId
+    })
+
+    return () => {
+      observer.stop()
+      const current = useGraphStore.getState()
+      // Do not force 'stopped' over a newer thread's status after a switch.
+      if (current.threadId === ownedThreadId) {
+        current.setSyncStatus('stopped', ownedThreadId)
+      }
+    }
+  }, [active, threadId])
+}


### PR DESCRIPTION
## 背景

这是对 #1072 以及 v0.2.35 快照轮询实现的正确性补强。

Graph 的 SSE 实时事件可能漏送；同时，面板切换线程时存在短暂窗口，旧线程的投影可能被画到新线程下。同步状态本身也不应决定是否停止可靠性兜底。

## 修改

- 保留 5 秒持久化快照轮询，并与 SSE 实时更新并行工作。
- 非终态运行、活跃规划草稿或活跃 Graph 来源轮次始终允许静默快照回补。
- 刷新保持 single-flight，隐藏面板后停止。
- `syncStatus` 仅用于连接状态展示，不再参与轮询决策。
- 增加线程 ownership render gate，防止把线程 A 的 Graph 投影显示在线程 B。
- 新增独立 thread observer 与 hook 测试。

## 验证

- graph-store：22 pass
- graph-thread-observer：4 pass
- use-graph-thread-observer：5 pass
- use-graph-parent-observer：2 pass
- GraphModePanel：16 pass
- chat-store-thread-actions：54 pass
- 合计：103 pass
- `npm run typecheck`：通过
- `git diff --check`：通过

Refs #1072
