### PR TITLE
fix(approval): bind consent to ensured runtime token

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2770,15 +2770,34 @@ app.whenReady().then(async () => {
       credentialMigration?.invalidateRuntime(dataDir)
       return { reset: true as const, ...result }
     },
-    runtimeRequest: async (path, method, body, headers) => {
+    runtimeRequest: async (path, method, body, headers, options) => {
       const settings = await store.load()
-      const result = await runtimeRequest(settings, path, { method, body, headers })
+      // Protected approval mints consent against the post-ensure token, then
+      // POSTs with skipEnsure so Authorization cannot rotate under the consent.
+      const ensureForRequest = options?.skipEnsure
+        ? async (current: AppSettingsV1) => current
+        : ensureRuntime
+      const result = await runtimeRequestViaHost(
+        settings,
+        path,
+        { method, body, headers },
+        ensureForRequest
+      ).catch((e) => {
+        const message = e instanceof Error ? e.message : String(e)
+        logError('runtime-request', `HTTP request to ${path} failed`, { message })
+        const parsed = parseRuntimeErrorBody(message, message)
+        if (parsed.code !== 'unknown' || parsed.message !== message) {
+          return runtimeFailure(parsed.code, parsed.message, 0, parsed.details)
+        }
+        return runtimeFailure('fetch_failed', message)
+      })
       const cleanup = result.ok
         ? browserUseCleanupForRuntimeRequest({ path, method, body })
         : undefined
       if (cleanup) await browserUseManager.clear(cleanup.threadId, cleanup.reason)
       return result
     },
+    ensureRuntime: async (settings) => ensureRuntime(settings),
     getRuntimeAuthToken,
     getRuntimeSettingsSyncStatus: () => runtimeSettingsSyncStatus,
     restartRuntime: async () => {

--- a/src/main/ipc/register-app-ipc-handlers.test.ts
+++ b/src/main/ipc/register-app-ipc-handlers.test.ts
@@ -128,6 +128,7 @@ function registerOptions(overrides: Partial<Parameters<typeof import('./register
       movedItems: ['secret.key']
     })),
     runtimeRequest: vi.fn() as never,
+    ensureRuntime: vi.fn(async (current: AppSettingsV1) => current),
     getRuntimeAuthToken: (current: AppSettingsV1) => current.agents.kun.runtimeToken.trim(),
     getRuntimeSettingsSyncStatus: () => ({
       state: 'idle' as const,
@@ -519,6 +520,159 @@ describe('registerAppIpcHandlers', () => {
       approvalId: 'approval-1',
       decision: 'allow'
     })).toBe(true)
+  })
+
+  it('signs protected approval consent with the same post-ensure runtime token used for Authorization', async () => {
+    // After confirmation: ensure may rotate token-A → token-B, then consent and
+    // Authorization must both bind to post-ensure token-B (#1084).
+    const current = settings()
+    const live = { token: 'token-A' }
+    const getRuntimeAuthToken = vi.fn(() => live.token)
+    const mainFrame = { processId: 10, routingId: 20 }
+    const contents = { id: 7, mainFrame }
+    const mainWindow = { isDestroyed: () => false, webContents: contents }
+    const captured: {
+      consentHeader?: string
+      authorizationHeader?: string
+      skipEnsure?: boolean
+    } = {}
+
+    const ensureRuntime = vi.fn(async (loaded: AppSettingsV1) => {
+      live.token = 'token-B'
+      return loaded
+    })
+    const runtimeRequest = vi.fn(async (
+      _path: string,
+      _method?: string,
+      _body?: string,
+      headers?: Record<string, string>,
+      options?: { skipEnsure?: boolean }
+    ) => {
+      captured.consentHeader = headers?.[KUN_APPROVAL_CONSENT_HEADER]
+      captured.authorizationHeader = headers?.Authorization
+      captured.skipEnsure = options?.skipEnsure
+      return { ok: true, status: 200, body: '{}' }
+    })
+
+    registerAppIpcHandlers(registerOptions({
+      store: { load: vi.fn(async () => current) } as never,
+      getMainWindow: () => mainWindow as never,
+      getRuntimeAuthToken,
+      ensureRuntime,
+      runtimeRequest
+    }))
+    const handler = handlers.get('approval:decide')!
+    const payload = { approvalId: 'approval-rotate', decision: 'allow' as const, source: 'user' as const }
+
+    electronMock.showMessageBox.mockResolvedValueOnce({ response: 0 })
+    await expect(handler({ sender: contents, senderFrame: mainFrame }, payload))
+      .resolves.toMatchObject({ confirmed: true })
+
+    expect(ensureRuntime).toHaveBeenCalledOnce()
+    expect(ensureRuntime.mock.invocationCallOrder[0]!).toBeLessThan(
+      runtimeRequest.mock.invocationCallOrder[0]!
+    )
+    expect(captured.skipEnsure).toBe(true)
+    expect(captured.consentHeader).toMatch(/^v1\./)
+    expect(captured.authorizationHeader).toBe('Bearer token-B')
+
+    // Invariant: consent HMAC key === Authorization bearer key (both post-ensure B).
+    const validWithAuthorizationKey = new ApprovalConsentVerifier('token-B').verifyAndConsume({
+      token: captured.consentHeader!,
+      approvalId: 'approval-rotate',
+      decision: 'allow'
+    })
+    expect(validWithAuthorizationKey).toBe(true)
+    // Pre-ensure token-A must not verify the consent.
+    expect(new ApprovalConsentVerifier('token-A').verifyAndConsume({
+      token: captured.consentHeader!,
+      approvalId: 'approval-rotate',
+      decision: 'allow'
+    })).toBe(false)
+  })
+
+  it('can mint protected approval consent after ensure supplies a cold-start runtime token', async () => {
+    // Cold start: no token until ensureRuntime attaches. Consent must run after
+    // ensure so the user is not failed after confirming the native dialog.
+    const current = settings()
+    expect(current.agents.kun.runtimeToken).toBe('')
+    const live = { token: '' }
+    const getRuntimeAuthToken = vi.fn(() => live.token)
+    const mainFrame = { processId: 11, routingId: 21 }
+    const contents = { id: 8, mainFrame }
+    const mainWindow = { isDestroyed: () => false, webContents: contents }
+
+    const ensureRuntime = vi.fn(async (loaded: AppSettingsV1) => {
+      live.token = 'token-after-ensure'
+      return loaded
+    })
+    const runtimeRequest = vi.fn(async (
+      _path: string,
+      _method?: string,
+      _body?: string,
+      headers?: Record<string, string>,
+      options?: { skipEnsure?: boolean }
+    ) => {
+      expect(options?.skipEnsure).toBe(true)
+      expect(headers?.Authorization).toBe('Bearer token-after-ensure')
+      expect(headers?.[KUN_APPROVAL_CONSENT_HEADER]).toMatch(/^v1\./)
+      expect(new ApprovalConsentVerifier('token-after-ensure').verifyAndConsume({
+        token: headers![KUN_APPROVAL_CONSENT_HEADER]!,
+        approvalId: 'approval-cold',
+        decision: 'allow'
+      })).toBe(true)
+      return { ok: true, status: 200, body: '{}' }
+    })
+
+    registerAppIpcHandlers(registerOptions({
+      store: { load: vi.fn(async () => current) } as never,
+      getMainWindow: () => mainWindow as never,
+      getRuntimeAuthToken,
+      ensureRuntime,
+      runtimeRequest
+    }))
+    const handler = handlers.get('approval:decide')!
+    electronMock.showMessageBox.mockResolvedValueOnce({ response: 0 })
+
+    await expect(handler({ sender: contents, senderFrame: mainFrame }, {
+      approvalId: 'approval-cold',
+      decision: 'allow',
+      source: 'user'
+    })).resolves.toMatchObject({ confirmed: true })
+    expect(ensureRuntime).toHaveBeenCalledOnce()
+    expect(runtimeRequest).toHaveBeenCalledOnce()
+  })
+
+  it('does not submit protected approval when ensureRuntime fails after confirmation', async () => {
+    const current = settings()
+    const live = { token: 'token-A' }
+    const getRuntimeAuthToken = vi.fn(() => live.token)
+    const mainFrame = { processId: 12, routingId: 22 }
+    const contents = { id: 9, mainFrame }
+    const mainWindow = { isDestroyed: () => false, webContents: contents }
+    const ensureRuntime = vi.fn(async () => {
+      throw new Error('runtime ensure failed')
+    })
+    const runtimeRequest = vi.fn()
+
+    registerAppIpcHandlers(registerOptions({
+      store: { load: vi.fn(async () => current) } as never,
+      getMainWindow: () => mainWindow as never,
+      getRuntimeAuthToken,
+      ensureRuntime,
+      runtimeRequest
+    }))
+    const handler = handlers.get('approval:decide')!
+    electronMock.showMessageBox.mockResolvedValueOnce({ response: 0 })
+
+    await expect(handler({ sender: contents, senderFrame: mainFrame }, {
+      approvalId: 'approval-ensure-fail',
+      decision: 'allow',
+      source: 'user'
+    })).rejects.toThrow(/runtime ensure failed/)
+    expect(ensureRuntime).toHaveBeenCalledOnce()
+    expect(runtimeRequest).not.toHaveBeenCalled()
+    expect(getRuntimeAuthToken).not.toHaveBeenCalled()
   })
 
   it('reveals the approval parent and records only a redacted native-dialog reference', async () => {

--- a/src/main/ipc/register-app-ipc-handlers.ts
+++ b/src/main/ipc/register-app-ipc-handlers.ts
@@ -343,8 +343,14 @@ type RegisterAppIpcHandlersOptions = {
     path: string,
     method?: string,
     body?: string,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
+    options?: { skipEnsure?: boolean }
   ) => Promise<RuntimeRequestResult>
+  /**
+   * Attach/start the live Kun runtime before protected operations that must
+   * bind consent to the post-ensure Authorization token (#1084).
+   */
+  ensureRuntime: (settings: AppSettingsV1) => Promise<AppSettingsV1 | void>
   getRuntimeAuthToken: (settings: AppSettingsV1) => string
   getRuntimeSettingsSyncStatus: () => KunRuntimeSettingsSyncStatusPayload
   restartRuntime: () => Promise<void>
@@ -633,6 +639,7 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
     saveSettingsPatch,
     resetUnreadableCredentials,
     runtimeRequest,
+    ensureRuntime,
     getRuntimeAuthToken,
     getRuntimeSettingsSyncStatus,
     restartRuntime,
@@ -1076,9 +1083,18 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
       }
     }
 
+    // #1084: ensure/attach the live runtime first, then mint consent with the
+    // exact token that Authorization will use. Do not sign with a pre-ensure
+    // settings token and do not let a second ensure rotate the token between
+    // consent creation and the authenticated POST.
     const settings = await store.load()
+    const ensuredSettings = (await ensureRuntime(settings)) ?? settings
+    const runtimeToken = getRuntimeAuthToken(ensuredSettings)
+    if (!runtimeToken) {
+      throw new Error('Kun runtime token is required for protected approval.')
+    }
     const consentToken = createApprovalConsentToken({
-      runtimeToken: getRuntimeAuthToken(settings),
+      runtimeToken,
       approvalId: request.approvalId,
       decision: request.decision,
       expiresAt: Date.now() + 30_000
@@ -1087,7 +1103,13 @@ export function registerAppIpcHandlers(options: RegisterAppIpcHandlersOptions): 
       `/v1/approvals/${encodeURIComponent(request.approvalId)}`,
       'POST',
       JSON.stringify({ decision: request.decision }),
-      { [KUN_APPROVAL_CONSENT_HEADER]: consentToken }
+      {
+        [KUN_APPROVAL_CONSENT_HEADER]: consentToken,
+        // Pin Authorization to the same post-ensure token used for the HMAC so
+        // a concurrent discovery refresh cannot desync consent and bearer auth.
+        Authorization: `Bearer ${runtimeToken}`
+      },
+      { skipEnsure: true }
     )
     return { confirmed: true as const, response }
   })

--- a/src/main/runtime/kun-adapter.test.ts
+++ b/src/main/runtime/kun-adapter.test.ts
@@ -146,6 +146,57 @@ describe('runtimeRequestViaHost', () => {
     expect(seenAuthorization).toBe('Bearer usage-token')
   })
 
+  it('lets caller-pinned Authorization override settings runtimeToken (#1084 contract)', async () => {
+    // Protected approval mints consent with the post-ensure live token and pins
+    // Authorization on the POST so runtimeAuthHeaders(settings) cannot reintroduce
+    // a stale settings token (token-A) after ensure resolved token-B.
+    let seenAuthorization = ''
+    let postCount = 0
+    let ensureCalls = 0
+    const port = await listen((req, res) => {
+      if ((req.method ?? 'GET').toUpperCase() === 'POST') {
+        postCount += 1
+        seenAuthorization = req.headers.authorization ?? ''
+      }
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ ok: true }))
+    })
+
+    const base = settingsForPort(port)
+    const settings: AppSettingsV1 = {
+      ...base,
+      agents: {
+        kun: {
+          ...base.agents.kun,
+          runtimeToken: 'token-A'
+        }
+      }
+    }
+
+    const response = await runtimeRequestViaHost(
+      settings,
+      '/v1/approvals/approval-1',
+      {
+        method: 'POST',
+        body: JSON.stringify({ decision: 'allow' }),
+        headers: {
+          Authorization: 'Bearer token-B'
+        }
+      },
+      async (current) => {
+        // Stub ensure: do not rotate the settings token.
+        ensureCalls += 1
+        return current
+      }
+    )
+
+    expect(response.ok).toBe(true)
+    expect(response.status).toBe(200)
+    expect(ensureCalls).toBe(1)
+    expect(postCount).toBe(1)
+    expect(seenAuthorization).toBe('Bearer token-B')
+  })
+
   it('uses settings returned by ensureRuntime when the managed port changes', async () => {
     let seenUrl = ''
     const port = await listen((req, res) => {


### PR DESCRIPTION
## 背景

受保护审批在 `ensureRuntime` 之前使用旧 token 签名 consent，随后请求却可能使用 ensure 后的新 token 作为 Authorization，导致用户点击允许后仍然鉴权失败。cold-start 时则会在用户确认后直接报 token 缺失。

## 修改

- 原生人工确认后，先 `ensureRuntime`。
- 从 live runtime 获取 token，再用同一 token 签名 consent。
- POST 请求固定使用相同的 `Authorization: Bearer <token>`。
- 请求支持 `skipEnsure`，避免签名后再次 ensure 导致 token 分叉。
- ensure 失败时不发送审批请求，并保持 fail-closed。
- renderer 不接触原始 runtime token。

## 验证

- register-app-ipc-handlers：41/41
- kun-adapter：11/11
- approval-consent：2/2
- token rotation、cold-start、ensure failure 回归均通过
- `npm run typecheck`：通过
- `git diff --check`：通过

Fixes #1084
