### PR TITLE
fix(graph): deduplicate supervision resolution events

### DIFF
--- a/kun/src/graph/graph-reducer.test.ts
+++ b/kun/src/graph/graph-reducer.test.ts
@@ -295,4 +295,110 @@ describe('GraphRun deterministic reducer', () => {
       }
     }))).toThrow(/steering transition expected/)
   })
+
+  it('replays historical duplicate supervision_obligation_resolved without rewriting first resolve (#1082)', () => {
+    // Pre-fix journals may contain multiple resolved events for one obligation.
+    // The reducer must not throw, must keep the first resolvedAt/updatedAt, and
+    // must still advance lastEventSeq so replay/hydration stays consistent.
+    const obligationBase = {
+      version: GRAPH_CONTRACT_VERSION,
+      id: 'graph_obligation_hist_dup',
+      kind: 'help' as const,
+      reason: 'help' as const,
+      graphRevision: 1,
+      nodeIds: [] as string[],
+      attemptIds: [] as string[],
+      digest: 'historical duplicate resolve subject',
+      deliveryAttempts: 1,
+      noProgressCount: 0,
+      lastProgressSeq: 1,
+      createdAt: TEST_GRAPH_NOW
+    }
+    const firstResolvedAt = '2026-07-26T00:00:02.000Z'
+    const secondResolvedAt = '2026-07-26T00:00:09.000Z'
+    const otherObligation = {
+      version: GRAPH_CONTRACT_VERSION,
+      id: 'graph_obligation_other',
+      kind: 'conflict' as const,
+      reason: 'conflict' as const,
+      graphRevision: 1,
+      nodeIds: [] as string[],
+      attemptIds: [] as string[],
+      digest: 'unrelated obligation must stay pending',
+      state: 'pending' as const,
+      deliveryAttempts: 0,
+      noProgressCount: 0,
+      lastProgressSeq: 1,
+      createdAt: TEST_GRAPH_NOW,
+      updatedAt: TEST_GRAPH_NOW
+    }
+
+    let state = applyGraphEvent(undefined, testGraphEnvelope(1, created()))
+    state = applyGraphEvent(state, testGraphEnvelope(2, {
+      type: 'supervision_obligation_opened',
+      payload: {
+        obligation: {
+          ...obligationBase,
+          state: 'pending',
+          updatedAt: TEST_GRAPH_NOW
+        }
+      }
+    }))
+    state = applyGraphEvent(state, testGraphEnvelope(3, {
+      type: 'supervision_obligation_opened',
+      payload: { obligation: otherObligation }
+    }))
+    state = applyGraphEvent(state, testGraphEnvelope(4, {
+      type: 'supervision_obligation_resolved',
+      payload: {
+        obligation: {
+          ...obligationBase,
+          state: 'resolved',
+          updatedAt: firstResolvedAt,
+          resolvedAt: firstResolvedAt
+        }
+      }
+    }, {
+      eventId: 'graph_event_resolved_first',
+      timestamp: firstResolvedAt
+    }))
+    expect(state.supervisionObligations.find((entry) => entry.id === obligationBase.id)).toMatchObject({
+      state: 'resolved',
+      resolvedAt: firstResolvedAt,
+      updatedAt: firstResolvedAt
+    })
+    expect(state.lastEventSeq).toBe(4)
+
+    // Second historical resolved with different eventId / graphSeq / timestamp.
+    state = applyGraphEvent(state, testGraphEnvelope(5, {
+      type: 'supervision_obligation_resolved',
+      payload: {
+        obligation: {
+          ...obligationBase,
+          state: 'resolved',
+          updatedAt: secondResolvedAt,
+          resolvedAt: secondResolvedAt,
+          deliveryAttempts: 99
+        }
+      }
+    }, {
+      eventId: 'graph_event_resolved_duplicate',
+      timestamp: secondResolvedAt
+    }))
+
+    const primary = state.supervisionObligations.find((entry) => entry.id === obligationBase.id)!
+    const secondary = state.supervisionObligations.find((entry) => entry.id === otherObligation.id)!
+    expect(primary).toMatchObject({
+      state: 'resolved',
+      resolvedAt: firstResolvedAt,
+      updatedAt: firstResolvedAt,
+      deliveryAttempts: 1
+    })
+    expect(secondary).toMatchObject({
+      id: otherObligation.id,
+      state: 'pending'
+    })
+    expect(state.lastEventSeq).toBe(5)
+    expect(state.updatedAt).toBe(secondResolvedAt)
+  })
 })

--- a/kun/src/graph/graph-reducer.ts
+++ b/kun/src/graph/graph-reducer.ts
@@ -317,7 +317,19 @@ export function applyGraphEvent(
         awaiting_action: ['awaiting_action', 'delivering', 'retry_scheduled', 'resolved', 'needs_attention'],
         retry_scheduled: ['retry_scheduled', 'pending', 'delivering', 'resolved', 'needs_attention'],
         needs_attention: ['needs_attention', 'pending', 'delivering', 'resolved'],
-        resolved: ['resolved']
+        // resolved is terminal for the obligation lifecycle. New writers must not
+        // append resolved→resolved (manager guard + stable idempotency key +
+        // store queue). The no-op branch below exists only so already-persisted
+        // pre-fix journals that contain duplicate resolved events can still
+        // replay without throwing.
+        resolved: []
+      }
+      if (previous.state === 'resolved' && obligation.state === 'resolved') {
+        // Compatibility no-op for historical #1082 journals: keep the first
+        // resolvedAt/updatedAt projection. The reducer does not prevent durable
+        // append — persistence happens outside reduce; lastEventSeq still advances
+        // after this switch when the envelope is applied.
+        break
       }
       if (!transitions[previous.state].includes(obligation.state)) {
         throw new GraphReducerError(

--- a/kun/src/graph/graph-supervision-obligation-manager.ts
+++ b/kun/src/graph/graph-supervision-obligation-manager.ts
@@ -68,8 +68,12 @@ export class GraphSupervisionObligationManager {
     const claimed: GraphSupervisionObligationV1[] = []
     for (const obligationId of obligationIds) {
       const result = await this.update(runId, obligationId, (run, current) => {
-        if (!graphSupervisionObligationIsActionable(run, current)) return resolved(current, this.options.nowIso())
-        if (current.state === 'needs_attention' || current.state === 'resolved') return null
+        // Terminal / already-settled obligations must no-op. Never re-emit resolved
+        // for a non-actionable obligation that is already resolved (#1082).
+        if (current.state === 'resolved' || current.state === 'needs_attention') return null
+        if (!graphSupervisionObligationIsActionable(run, current)) {
+          return resolved(current, this.options.nowIso())
+        }
         if (current.state === 'delivering' && future(current.leaseUntil, this.options.nowMs())) return null
         if ((current.state === 'retry_scheduled' || current.state === 'awaiting_action') && future(current.nextWakeAt, this.options.nowMs())) return null
         if (current.state === 'awaiting_action' && this.options.isLeadTurnActive?.(run)) return null
@@ -87,7 +91,10 @@ export class GraphSupervisionObligationManager {
   async recordDelivered(runId: string, obligations: readonly GraphSupervisionObligationV1[], delivery: Extract<GraphLeadDeliveryResult, { status: 'delivered' }>): Promise<void> {
     for (const obligation of obligations) {
       await this.update(runId, obligation.id, (run, current) => {
-        if (!graphSupervisionObligationIsActionable(run, current) || isTerminal(run.status)) return resolved(current, this.options.nowIso())
+        if (current.state === 'resolved' || current.state === 'needs_attention') return null
+        if (!graphSupervisionObligationIsActionable(run, current) || isTerminal(run.status)) {
+          return resolved(current, this.options.nowIso())
+        }
         const next = {
           ...current, state: 'awaiting_action' as const,
           lastDeliveredSeq: Math.max(current.lastDeliveredSeq ?? 0, delivery.deliveredSeq),
@@ -105,7 +112,10 @@ export class GraphSupervisionObligationManager {
   async scheduleRetry(runId: string, obligations: readonly GraphSupervisionObligationV1[], error: string): Promise<void> {
     for (const obligation of obligations) {
       await this.update(runId, obligation.id, (run, current) => {
-        if (!graphSupervisionObligationIsActionable(run, current)) return resolved(current, this.options.nowIso())
+        if (current.state === 'resolved' || current.state === 'needs_attention') return null
+        if (!graphSupervisionObligationIsActionable(run, current)) {
+          return resolved(current, this.options.nowIso())
+        }
         const next = {
           ...current, state: 'retry_scheduled' as const,
           nextWakeAt: this.timestampAfter(graphSupervisionRetryDelayMs(Math.max(0, current.deliveryAttempts - 1))),
@@ -124,7 +134,11 @@ export class GraphSupervisionObligationManager {
       const current = before?.supervisionObligations.find((entry) => entry.id === obligationId)
       const latestProgress = current ? graphLatestSemanticProgressSeq(await this.options.store.events(runId, current.lastProgressSeq), current.lastProgressSeq) : undefined
       const result = await this.update(runId, obligationId, (run, obligation) => {
-        if (!graphSupervisionObligationIsActionable(run, obligation)) return resolved(obligation, this.options.nowIso())
+        // Already terminal lifecycle states are durable no-ops (#1082).
+        if (obligation.state === 'resolved' || obligation.state === 'needs_attention') return null
+        if (!graphSupervisionObligationIsActionable(run, obligation)) {
+          return resolved(obligation, this.options.nowIso())
+        }
         if (obligation.state !== 'awaiting_action') return null
         if (latestProgress !== undefined && latestProgress > obligation.lastProgressSeq) {
           const next = { ...obligation, state: 'retry_scheduled' as const, noProgressCount: 0, lastProgressSeq: latestProgress, nextWakeAt: this.timestampAfter(graphSupervisionRetryDelayMs(0)), updatedAt: this.options.nowIso() }
@@ -174,11 +188,24 @@ export class GraphSupervisionObligationManager {
       if (!current) return null
       const next = update(run, current)
       if (!next) return { run, obligation: current, changed: false }
+      // Semantic no-op: do not append resolved→resolved noise even if a caller
+      // forgets the early return (defense in depth for #1082).
+      if (current.state === 'resolved' && next.state === 'resolved') {
+        return { run, obligation: current, changed: false }
+      }
       try {
+        // Resolve transitions use a stable per-obligation key so concurrent
+        // force-resolve paths collapse to one durable event. Other operations
+        // keep seq-scoped keys for legitimate multi-step progress.
+        const idempotencyKey = stableIdempotencyKey ?? (
+          next.state === 'resolved'
+            ? `supervision-obligation:${obligationId}:resolved`
+            : ['supervision-obligation', obligationId, operation, String(run.lastEventSeq)].join(':').slice(0, 256)
+        )
         const appended = await this.options.store.append(run.id, {
           expectedSeq: run.lastEventSeq, graphRevision: run.currentRevision,
           commandId: this.options.nextId('graph_supervision'),
-          idempotencyKey: stableIdempotencyKey ?? ['supervision-obligation', obligationId, operation, String(run.lastEventSeq)].join(':').slice(0, 256),
+          idempotencyKey,
           event: { type: obligationEventType(next.state), payload: { obligation: next } }
         })
         const obligation = appended.state.supervisionObligations.find((entry) => entry.id === obligationId)!

--- a/kun/src/graph/graph-supervisor-obligation.test.ts
+++ b/kun/src/graph/graph-supervisor-obligation.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../contracts/graph.js'
 import { FileGraphRunStore } from './graph-run-store.js'
 import { GraphSupervisor } from './graph-supervisor.js'
+import { GraphSupervisionObligationManager } from './graph-supervision-obligation-manager.js'
 import {
   graphSupervisionObligationForSignal,
   graphSupervisionObligationIsActionable
@@ -623,5 +624,212 @@ describe('GraphSupervisor durable supervision obligations', () => {
     expect(onlyObligation(run).state).toBe('needs_attention')
     expectDurableLiveness(run, harness.nowMs())
     await supervisor.stop()
+  })
+
+  it('emits at most one supervision_obligation_resolved per obligation after terminal force-resolve and rearm flush (#1082)', async () => {
+    // Production race while still delivering:
+    // claim → delivering (actionable), leadTurn parks with !executionActive,
+    // recordDelivered force-resolves because the run became terminal / non-actionable,
+    // then rearmAfterNoProgress maps !actionable to another resolved projection.
+    const harness = await persistentHarness()
+    await transitionRunToRunning(harness)
+    const supervisor = supervisorFor(harness, {
+      leadTurn: async ({ run: latest }) => {
+        // Become terminal mid-delivery so recordDelivered takes the force-resolve branch.
+        await harness.store.append(latest.id, {
+          expectedSeq: latest.lastEventSeq,
+          graphRevision: latest.currentRevision,
+          commandId: 'command_terminal_mid_delivery',
+          idempotencyKey: 'obligation-test:terminal-mid-delivery',
+          timestamp: harness.nowIso(),
+          event: {
+            type: 'run_status_changed',
+            payload: {
+              from: 'running',
+              to: 'cancelled',
+              reason: 'owning source turn ended with status failed'
+            }
+          }
+        })
+        return {
+          status: 'delivered' as const,
+          sourceTurnId: latest.sourceTurnId,
+          deliveredSeq: latest.lastEventSeq,
+          executionActive: false,
+          parkedWithPendingSupervision: true
+        }
+      },
+      isLeadTurnActive: () => false
+    })
+
+    await supervisor.signal(HELP_SIGNAL)
+    let run = (await harness.store.get(HELP_SIGNAL.runId))!
+    const obligationId = onlyObligation(run).id
+
+    await supervisor.flush(HELP_SIGNAL.runId)
+    // Stale queued flushes / sweep after terminal must not double-resolve.
+    await supervisor.flush(HELP_SIGNAL.runId)
+    await supervisor.sweepObligations()
+    await supervisor.sweepObligations()
+    await supervisor.sweepObligations()
+
+    run = (await harness.store.get(HELP_SIGNAL.runId))!
+    expect(onlyObligation(run)).toMatchObject({
+      id: obligationId,
+      state: 'resolved'
+    })
+    const resolvedEvents = (await harness.store.events(HELP_SIGNAL.runId, 0))
+      .filter((envelope) => envelope.event.type === 'supervision_obligation_resolved')
+    expect(resolvedEvents).toHaveLength(1)
+    expect(
+      resolvedEvents.filter((envelope) =>
+        envelope.event.type === 'supervision_obligation_resolved' &&
+        envelope.event.payload.obligation.id === obligationId)
+    ).toHaveLength(1)
+    await supervisor.stop()
+  })
+
+  it('does not re-open a resolved obligation via rearmAfterNoProgress (#1082)', async () => {
+    const harness = await persistentHarness()
+    await transitionRunToRunning(harness)
+    const manager = new GraphSupervisionObligationManager({
+      store: harness.store,
+      nowIso: harness.nowIso,
+      nowMs: harness.nowMs,
+      nextId: harness.nextId,
+      isLeadTurnActive: () => false
+    })
+    await manager.persistSignal(HELP_SIGNAL, true)
+    let run = (await harness.store.get(HELP_SIGNAL.runId))!
+    const obligationId = onlyObligation(run).id
+    // First durable resolve.
+    await manager.resolve(HELP_SIGNAL.runId, [onlyObligation(run)])
+    run = (await harness.store.get(HELP_SIGNAL.runId))!
+    expect(onlyObligation(run).state).toBe('resolved')
+    const resolvedCount = (await durableEventTypes(harness.store))
+      .filter((type) => type === 'supervision_obligation_resolved').length
+    expect(resolvedCount).toBe(1)
+
+    // Subsequent rearm / claim force-resolve paths must not re-emit or reopen.
+    await manager.rearmAfterNoProgress(HELP_SIGNAL.runId, [obligationId])
+    await manager.rearmAfterNoProgress(HELP_SIGNAL.runId, [obligationId])
+    await manager.claim(HELP_SIGNAL.runId, [obligationId])
+    await manager.recordDelivered(
+      HELP_SIGNAL.runId,
+      [onlyObligation((await harness.store.get(HELP_SIGNAL.runId))!)],
+      {
+        status: 'delivered',
+        sourceTurnId: 'turn_obligation',
+        deliveredSeq: 1,
+        executionActive: false
+      }
+    )
+    run = (await harness.store.get(HELP_SIGNAL.runId))!
+    expect(onlyObligation(run).state).toBe('resolved')
+    expect(['awaiting_action', 'retry_scheduled', 'pending', 'delivering'])
+      .not.toContain(onlyObligation(run).state)
+    const after = (await durableEventTypes(harness.store))
+      .filter((type) => type === 'supervision_obligation_resolved').length
+    expect(after).toBe(1)
+  })
+
+  it('keeps multi-obligation resolved counts independent under repeated sweeps (#1082)', async () => {
+    const harness = await persistentHarness()
+    await transitionRunToRunning(harness)
+    const supervisor = supervisorFor(harness, {
+      leadTurn: async ({ run: latest }) => {
+        await harness.store.append(latest.id, {
+          expectedSeq: latest.lastEventSeq,
+          graphRevision: latest.currentRevision,
+          commandId: harness.nextId('command_terminal_multi'),
+          idempotencyKey: `obligation-test:terminal-multi:${latest.lastEventSeq}`,
+          timestamp: harness.nowIso(),
+          event: {
+            type: 'run_status_changed',
+            payload: { from: latest.status, to: 'cancelled', reason: 'terminal' }
+          }
+        })
+        return {
+          status: 'delivered' as const,
+          sourceTurnId: latest.sourceTurnId,
+          deliveredSeq: latest.lastEventSeq,
+          executionActive: false,
+          parkedWithPendingSupervision: true
+        }
+      },
+      isLeadTurnActive: () => false
+    })
+
+    await supervisor.signal({
+      runId: HELP_SIGNAL.runId,
+      reason: 'help',
+      nodeIds: [],
+      digest: 'First durable supervision obligation.'
+    })
+    await supervisor.signal({
+      runId: HELP_SIGNAL.runId,
+      reason: 'conflict',
+      nodeIds: [],
+      digest: 'Second durable supervision obligation with distinct subject.'
+    })
+    let run = (await harness.store.get(HELP_SIGNAL.runId))!
+    expect(run.supervisionObligations.length).toBeGreaterThanOrEqual(2)
+    const obligationIds = run.supervisionObligations.map((entry) => entry.id)
+    expect(new Set(obligationIds).size).toBe(obligationIds.length)
+
+    await supervisor.flush(HELP_SIGNAL.runId)
+    for (let i = 0; i < 5; i += 1) await supervisor.sweepObligations()
+    await supervisor.flush(HELP_SIGNAL.runId)
+
+    run = (await harness.store.get(HELP_SIGNAL.runId))!
+    for (const obligation of run.supervisionObligations) {
+      expect(obligation.state).toBe('resolved')
+    }
+    const resolvedEvents = (await harness.store.events(HELP_SIGNAL.runId, 0))
+      .filter((envelope) => envelope.event.type === 'supervision_obligation_resolved')
+    expect(resolvedEvents).toHaveLength(run.supervisionObligations.length)
+    for (const id of obligationIds) {
+      expect(
+        resolvedEvents.filter((envelope) =>
+          envelope.event.type === 'supervision_obligation_resolved' &&
+          envelope.event.payload.obligation.id === id)
+      ).toHaveLength(1)
+    }
+    await supervisor.stop()
+  })
+
+  it('collapses concurrent manager.resolve writers to one durable resolved event (#1082)', async () => {
+    // Stable per-obligation resolve idempotency key + FileGraphRunStore append
+    // serialization must fold concurrent resolve() calls into a single durable
+    // supervision_obligation_resolved event.
+    const harness = await persistentHarness()
+    await transitionRunToRunning(harness)
+    const manager = new GraphSupervisionObligationManager({
+      store: harness.store,
+      nowIso: harness.nowIso,
+      nowMs: harness.nowMs,
+      nextId: harness.nextId,
+      isLeadTurnActive: () => false
+    })
+    await manager.persistSignal(HELP_SIGNAL, true)
+    let run = (await harness.store.get(HELP_SIGNAL.runId))!
+    const obligation = onlyObligation(run)
+    expect(obligation.state).not.toBe('resolved')
+
+    await Promise.all([
+      manager.resolve(HELP_SIGNAL.runId, [obligation]),
+      manager.resolve(HELP_SIGNAL.runId, [obligation])
+    ])
+
+    run = (await harness.store.get(HELP_SIGNAL.runId))!
+    expect(onlyObligation(run).state).toBe('resolved')
+    const resolvedEvents = (await harness.store.events(HELP_SIGNAL.runId, 0))
+      .filter((envelope) => envelope.event.type === 'supervision_obligation_resolved')
+    expect(resolvedEvents).toHaveLength(1)
+    expect(
+      resolvedEvents.filter((envelope) =>
+        envelope.event.type === 'supervision_obligation_resolved' &&
+        envelope.event.payload.obligation.id === obligation.id)
+    ).toHaveLength(1)
   })
 })

--- a/kun/src/graph/graph-supervisor.ts
+++ b/kun/src/graph/graph-supervisor.ts
@@ -243,8 +243,19 @@ export class GraphSupervisor implements GraphSupervisionPort {
         if (delivery.status === 'delivered') {
           await this.acknowledgeLeadSteering(runId, deliveredSteeringIds)
           await this.obligations.recordDelivered(runId, obligations, delivery)
+          // Only rearm obligations that remained awaiting_action after delivery.
+          // Terminal force-resolve in recordDelivered must not immediately feed
+          // rearmAfterNoProgress and re-emit supervision_obligation_resolved (#1082).
           if (delivery.parkedWithPendingSupervision || !delivery.executionActive) {
-            await this.rearmAfterNoProgress(runId, obligations.map((entry) => entry.id))
+            const afterDelivery = await this.options.store.get(runId)
+            const stillAwaiting = (afterDelivery?.supervisionObligations ?? [])
+              .filter((entry) =>
+                obligations.some((claimed) => claimed.id === entry.id) &&
+                entry.state === 'awaiting_action')
+              .map((entry) => entry.id)
+            if (stillAwaiting.length > 0) {
+              await this.rearmAfterNoProgress(runId, stillAwaiting)
+            }
           }
           return
         }


### PR DESCRIPTION
## 背景

#1082 中，已经 resolved 的 supervision obligation 会被重复 resolve；变化的 idempotency key 又会把这些语义相同的操作写成数千条持久事件。

## 根因与修改

- 在 actionability 判断之前先拦截 `resolved` / `needs_attention`。
- resolved obligation 的 claim、delivery、retry、rearm 均成为 no-op。
- resolution 使用稳定 idempotency key。
- delivery 完成后，仅对仍处于 `awaiting_action` 的 obligation rearm。
- reducer 将历史 `resolved -> resolved` 事件作为兼容性 no-op，同时保持序列推进。
- terminal run 的重复 sweep 不再追加同义事件。
- 增加真实 `FileGraphRunStore` 下的并发 resolve 测试。

## 验证

- graph-supervisor-obligation：14/14
- graph-reducer：6/6
- supervisor / delivery / manual-wake：15/15
- supervision-liveness：3/3
- `npm run typecheck`：通过
- `git diff --check`：通过

Fixes #1082
