### PR TITLE
fix(office): soft-fail WPS schema validate on intake

### DIFF
--- a/src/main/services/office-document-service.test.ts
+++ b/src/main/services/office-document-service.test.ts
@@ -6,7 +6,10 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ZipFile } from 'yazl'
 import { MAX_RUNTIME_DOCUMENT_SOURCE_BYTES } from '../../shared/office-document'
-import { readLocalOfficeDocument } from './office-document-service'
+import {
+  isBenignOoxmlSchemaFailure,
+  readLocalOfficeDocument
+} from './office-document-service'
 
 const roots: string[] = []
 
@@ -140,5 +143,114 @@ describe('Office document intake', () => {
 
     expect(result).toMatchObject({ ok: false, code: 'file_too_large' })
     expect(runOfficeCli).not.toHaveBeenCalled()
+  })
+
+  it('soft-fails WPS undeclared schema attributes and continues text extraction (#1122)', async () => {
+    const filePath = await ooxmlFixture('xlsx')
+    const wpsSchemaFailure = JSON.stringify({
+      success: false,
+      data: {
+        count: 1,
+        errors: [{
+          type: 'Schema',
+          description:
+            "The'http://www.wps.cn/officeDocument/2017/etCustomData:filterBottomFollowUsedRange' attribute is not declared.",
+          path: '/x:worksheet[1]/x:autoFilter[1]',
+          part: '/xl/worksheets/sheet1.xml'
+        }]
+      }
+    })
+    const runOfficeCli = vi.fn(async (args: string[]) => {
+      if (args[0] === 'validate') {
+        return { stdout: wpsSchemaFailure, stderr: '', exitCode: 1 }
+      }
+      if (args[2] === 'stats') return { stdout: '{"sheetCount":1}', stderr: '', exitCode: 0 }
+      if (args[2] === 'html') return { stdout: '<html><body>WPS</body></html>', stderr: '', exitCode: 0 }
+      return { stdout: 'Sheet1\\nA1 = ok', stderr: '', exitCode: 0 }
+    })
+
+    const result = await readLocalOfficeDocument({ path: filePath }, {
+      runOfficeCli,
+      renderHtml: vi.fn(async () => ({
+        dataBase64: Buffer.from('p').toString('base64'),
+        mimeType: 'image/webp' as const,
+        byteSize: 1
+      }))
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      format: 'xlsx',
+      documentText: expect.stringContaining('A1 = ok'),
+      validationWarning: expect.stringContaining('filterBottomFollowUsedRange')
+    })
+    expect(runOfficeCli.mock.calls.map(([args]) => args[0])).toEqual([
+      'validate',
+      'view',
+      'view',
+      'view'
+    ])
+  })
+
+  it('still rejects non-schema OfficeCLI validate failures', async () => {
+    const filePath = await ooxmlFixture('xlsx')
+    const runOfficeCli = vi.fn(async (args: string[]) => {
+      if (args[0] === 'validate') {
+        return {
+          stdout: JSON.stringify({
+            success: false,
+            data: {
+              count: 1,
+              errors: [{ type: 'Package', description: 'Missing required part /xl/workbook.xml' }]
+            }
+          }),
+          stderr: '',
+          exitCode: 1
+        }
+      }
+      return { stdout: 'should-not-run', stderr: '', exitCode: 0 }
+    })
+
+    const result = await readLocalOfficeDocument({ path: filePath }, {
+      runOfficeCli,
+      renderHtml: vi.fn()
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'office_document_failed',
+      message: expect.stringContaining('Office document validation failed')
+    })
+    expect(runOfficeCli).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('isBenignOoxmlSchemaFailure', () => {
+  it('accepts Schema undeclared-attribute errors from WPS packages', () => {
+    expect(isBenignOoxmlSchemaFailure({
+      exitCode: 1,
+      stdout: JSON.stringify({
+        success: false,
+        data: {
+          errors: [{
+            type: 'Schema',
+            description:
+              "The'http://www.wps.cn/officeDocument/2017/etCustomData:filterBottomFollowUsedRange' attribute is not declared."
+          }]
+        }
+      }),
+      stderr: ''
+    })).toBe(true)
+  })
+
+  it('rejects package-structure validate failures', () => {
+    expect(isBenignOoxmlSchemaFailure({
+      exitCode: 1,
+      stdout: JSON.stringify({
+        success: false,
+        data: { errors: [{ type: 'Package', description: 'Corrupt ZIP central directory' }] }
+      }),
+      stderr: ''
+    })).toBe(false)
   })
 })

--- a/src/main/services/office-document-service.ts
+++ b/src/main/services/office-document-service.ts
@@ -84,7 +84,16 @@ export async function readLocalOfficeDocument(
       ))
 
     const validation = await run(['validate', filePath, '--json'])
-    assertOfficeCliSuccess(validation, 'Office document validation failed')
+    let validationWarning: string | undefined
+    if (validation.exitCode !== 0) {
+      if (!isBenignOoxmlSchemaFailure(validation)) {
+        assertOfficeCliSuccess(validation, 'Office document validation failed')
+      }
+      // Vendor extensions (notably WPS etCustomData attrs) fail strict OpenXML
+      // schema checks but still extract cleanly. Keep intake open and surface a
+      // warning instead of forcing a local tool-reference fallback (#1122).
+      validationWarning = summarizeOfficeCliFailure(validation, 'Office document validation warning')
+    }
 
     const semanticArgs = semanticViewArgs(filePath, format)
     const semantic = await run(semanticArgs)
@@ -130,7 +139,8 @@ export async function readLocalOfficeDocument(
       ...(pageCount ? { pageCount } : {}),
       truncated,
       ...(visualPreview ? { visualPreview } : {}),
-      ...(previewUnavailableReason ? { previewUnavailableReason } : {})
+      ...(previewUnavailableReason ? { previewUnavailableReason } : {}),
+      ...(validationWarning ? { validationWarning } : {})
     }
   } catch (error) {
     return { ok: false, code: 'office_document_failed', message: boundedErrorMessage(error) }
@@ -145,8 +155,57 @@ function semanticViewArgs(filePath: string, format: OfficeDocumentFormat): strin
 
 function assertOfficeCliSuccess(result: OfficeCliResult, fallback: string): void {
   if (result.exitCode === 0) return
+  throw new Error(summarizeOfficeCliFailure(result, fallback))
+}
+
+function summarizeOfficeCliFailure(result: OfficeCliResult, fallback: string): string {
   const detail = result.stderr.trim() || result.stdout.trim()
-  throw new Error(detail ? `${fallback}: ${detail}` : fallback)
+  return detail ? `${fallback}: ${detail}` : fallback
+}
+
+/**
+ * Intake-only: strict OpenXML schema rejects common vendor extensions (WPS
+ * etCustomData attributes, undeclared Ignorable attrs). Those documents still
+ * yield usable text via `view`. Reject anything that is not a Schema / undeclared
+ * markup failure so corrupted packages stay blocked.
+ */
+export function isBenignOoxmlSchemaFailure(result: OfficeCliResult): boolean {
+  if (result.exitCode === 0) return false
+  const payload = result.stdout.trim() || result.stderr.trim()
+  if (!payload) return false
+  const errors = extractOfficeValidateErrors(payload)
+  if (!errors || errors.length === 0) {
+    // Fallback when officecli prints a flat message without --json structure.
+    return /not declared|undeclared|schema/i.test(payload) &&
+      /wps\.cn|etCustomData|officeDocument\/2017/i.test(payload)
+  }
+  return errors.every((error) => isBenignOoxmlSchemaError(error))
+}
+
+function extractOfficeValidateErrors(payload: string): Array<Record<string, unknown>> | null {
+  try {
+    const parsed = JSON.parse(payload) as unknown
+    if (!parsed || typeof parsed !== 'object') return null
+    const root = parsed as Record<string, unknown>
+    const data = root.data && typeof root.data === 'object'
+      ? root.data as Record<string, unknown>
+      : root
+    const errors = data.errors
+    if (!Array.isArray(errors)) return null
+    return errors.filter((entry): entry is Record<string, unknown> =>
+      Boolean(entry) && typeof entry === 'object'
+    )
+  } catch {
+    return null
+  }
+}
+
+function isBenignOoxmlSchemaError(error: Record<string, unknown>): boolean {
+  const type = typeof error.type === 'string' ? error.type : ''
+  const description = typeof error.description === 'string' ? error.description : ''
+  const combined = `${type} ${description}`
+  if (!/schema/i.test(type) && !/schema/i.test(description)) return false
+  return /not declared|undeclared|wps\.cn|etCustomData|officeDocument\/2017/i.test(combined)
 }
 
 async function runOfficeCli(

--- a/src/shared/office-document.ts
+++ b/src/shared/office-document.ts
@@ -29,6 +29,8 @@ export type LocalOfficeDocumentReadResult =
       truncated: boolean
       visualPreview?: OfficeDocumentVisualPreview
       previewUnavailableReason?: string
+      /** Soft OOXML schema issues (e.g. WPS vendor attrs) that did not block intake. */
+      validationWarning?: string
     }
   | { ok: false; code?: string; message: string }
 


### PR DESCRIPTION
## Summary
- Soft-fail OfficeCLI OpenXML schema errors caused by vendor extensions (WPS `etCustomData` / undeclared attributes) during drag-drop intake.
- Continue text extraction when only Schema/undeclared markup fails; keep package-type and extract failures hard.
- Leave `office_edit` post-write validation strict.

## Changes
- `readLocalOfficeDocument` records `validationWarning` instead of rejecting benign schema failures.
- Unit coverage for the #1122 WPS validate payload and non-schema package failures.

## Tests
- [x] `npx vitest run src/main/services/office-document-service.test.ts`
- [x] `git diff --check`

Fixes #1122

Made with [Cursor](https://cursor.com)