### PR TITLE
fix(runtime): recover shared Kun when discovery PID is dead

### DIFF
--- a/src/main/kun-runtime-supervisor.test.ts
+++ b/src/main/kun-runtime-supervisor.test.ts
@@ -184,6 +184,26 @@ describe('KunRuntimeSupervisor', () => {
     expect(h.statuses.map((status) => status.state)).toEqual(['restarting', 'running'])
   })
 
+  it('takes the missing/ensure path when health clears a stale childRunning cache (#1116)', async () => {
+    let childRunning = true
+    const h = harness({
+      childRunning: true,
+      watchdogFailureThreshold: 3
+    })
+    h.deps.isChildRunning = () => childRunning
+    h.checkHealth.mockImplementation(async () => {
+      childRunning = false
+      return false
+    })
+    h.supervisor.setManagedRuntimeExpected(true)
+
+    await h.supervisor.watchdogTick()
+
+    expect(h.ensureRuntime).toHaveBeenCalledOnce()
+    expect(h.restartRuntime).not.toHaveBeenCalled()
+    expect(h.statuses.map((status) => status.state)).toEqual(['restarting', 'running'])
+  })
+
   it('does not recover or restart after shutdown begins', async () => {
     const h = harness({ stopped: true })
     h.supervisor.setManagedRuntimeExpected(true)

--- a/src/main/kun-runtime-supervisor.ts
+++ b/src/main/kun-runtime-supervisor.ts
@@ -247,12 +247,16 @@ export class KunRuntimeSupervisor<Settings> {
       const settings = await this.deps.loadSettings()
       if (!this.managedRuntimeExpected || !this.deps.canAutoRestart(settings)) return
 
-      const childRunning = this.deps.isChildRunning()
+      let childRunning = this.deps.isChildRunning()
       if (childRunning && await this.deps.checkHealth(settings, 5_000)) {
         this.noteHealthy('watchdog')
         return
       }
 
+      // checkHealth refreshes discovery; a dead shared-runtime PID may have been
+      // cleared from the adapter cache. Re-read before counting unresponsive
+      // failures so recovery can take the missing/ensure path (#1116).
+      childRunning = this.deps.isChildRunning()
       if (!childRunning) {
         await this.recoverFromWatchdog('missing')
         return

--- a/src/main/runtime/kun-adapter.test.ts
+++ b/src/main/runtime/kun-adapter.test.ts
@@ -23,7 +23,8 @@ import {
   resolveRuntimeRequestTimeoutMs,
   runtimeAuthHeaders,
   runtimeRequestViaHost,
-  runtimeRequestViaLease
+  runtimeRequestViaLease,
+  setResolvedKunRuntimeConnectionForTests
 } from './kun-adapter'
 import { buildRuntimeCapabilityManifest } from '../../../kun/src/contracts/capabilities.js'
 import { modelCapabilitiesForModel } from '../../../kun/src/loop/model-context-profile.js'
@@ -479,5 +480,50 @@ describe('kunRuntimeAdapter.resolveConnection', () => {
       await kunRuntimeAdapter.stopAndWait()
       await rm(root, { recursive: true, force: true })
     }
+  })
+})
+
+describe('kunRuntimeAdapter.isChildRunning dead-PID recovery', () => {
+  afterEach(async () => {
+    setResolvedKunRuntimeConnectionForTests(null)
+    await kunRuntimeAdapter.stopAndWait()
+  })
+
+  it('clears a cached discovery record whose PID is no longer alive (#1116)', () => {
+    setResolvedKunRuntimeConnectionForTests({
+      version: 1,
+      instanceId: 'dead-shared-runtime',
+      pid: 2_147_483_647,
+      startedAt: '2026-08-07T00:00:00.000Z',
+      host: '127.0.0.1',
+      port: 44793,
+      baseUrl: 'http://127.0.0.1:44793',
+      runtimeToken: 'stale-token',
+      insecure: false,
+      serviceVersion: '0.0.0-test',
+      launchMode: 'shared'
+    })
+
+    expect(kunRuntimeAdapter.isChildRunning()).toBe(false)
+    expect(kunRuntimeAdapter.getBaseUrl(settingsForPort(18788))).toBe('http://127.0.0.1:18788')
+  })
+
+  it('keeps reporting running while the cached discovery PID is alive', () => {
+    setResolvedKunRuntimeConnectionForTests({
+      version: 1,
+      instanceId: 'live-shared-runtime',
+      pid: process.pid,
+      startedAt: '2026-08-07T00:00:00.000Z',
+      host: '127.0.0.1',
+      port: 44793,
+      baseUrl: 'http://127.0.0.1:44793',
+      runtimeToken: 'live-token',
+      insecure: false,
+      serviceVersion: '0.0.0-test',
+      launchMode: 'shared'
+    })
+
+    expect(kunRuntimeAdapter.isChildRunning()).toBe(true)
+    expect(kunRuntimeAdapter.getBaseUrl(settingsForPort(18788))).toBe('http://127.0.0.1:44793')
   })
 })

--- a/src/main/runtime/kun-adapter.ts
+++ b/src/main/runtime/kun-adapter.ts
@@ -68,7 +68,14 @@ export const kunRuntimeAdapter = {
   },
 
   isChildRunning(): boolean {
-    return Boolean(resolvedConnection) || isKunChildRunning()
+    if (resolvedConnection) {
+      // Shared runtimes are detached; a cached discovery record can outlive the
+      // process. Treat a dead PID as "not running" so watchdog recovery takes the
+      // missing/ensure fast path instead of waiting out unresponsive retries (#1116).
+      if (processIsAlive(resolvedConnection.pid)) return true
+      resolvedConnection = null
+    }
+    return isKunChildRunning()
   },
 
   getBaseUrl(settings: AppSettingsV1): string {
@@ -165,6 +172,23 @@ function sharedRuntimeScope(dataDir: string): {
 
 function expandDataDir(value: string): string {
   return value.replace(/^~(?=$|[\\/])/, homedir())
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // EPERM means the process exists but we cannot signal it.
+    return (error as NodeJS.ErrnoException)?.code === 'EPERM'
+  }
+}
+
+/** Test-only: inject a cached discovery record for dead-PID recovery coverage. */
+export function setResolvedKunRuntimeConnectionForTests(
+  connection: RuntimeDiscoveryRecord | null
+): void {
+  resolvedConnection = connection
 }
 
 export type RuntimeRequestInit = {


### PR DESCRIPTION
## Summary
- Harden Ubuntu/shared-runtime recovery when the detached Kun process dies but Main still caches its ephemeral discovery endpoint.
- Clear dead discovery PIDs from the adapter cache and re-check `isChildRunning` after health probes so watchdog takes the missing/`ensureRuntime` path instead of waiting out unresponsive retries.

## Changes
- `kunRuntimeAdapter.isChildRunning()` verifies discovery PID liveness and drops stale cache entries.
- Watchdog re-reads `isChildRunning` after a failed health probe (which refreshes discovery).
- Unit coverage for dead/live PID cache behavior and missing-path recovery.

## Notes
Startup Chromium/GLib noise and composer ↑ history are out of scope. If long edit chains still kill the runtime after this lands, please attach `runtime.log` and any OOM evidence from `dmesg`/journalctl.

## Tests
- [x] `npx vitest run src/main/runtime/kun-adapter.test.ts src/main/kun-runtime-supervisor.test.ts` (39 passed)
- [x] `git diff --check`

Fixes #1116

Made with [Cursor](https://cursor.com)