### PR TITLE
feat(mcp): add Parallel Search to marketplace

### DIFF
--- a/src/renderer/src/components/PluginMarketplaceView.test.ts
+++ b/src/renderer/src/components/PluginMarketplaceView.test.ts
@@ -28,6 +28,7 @@ describe('PluginMarketplaceView MCP config helpers', () => {
       'sequential-thinking',
       'memory',
       'brave-search',
+      'parallel-search',
       'vercel'
     ]))
     expect(recommendedMarketplaceItemIds()).not.toContain('google-workspace')
@@ -61,6 +62,39 @@ describe('PluginMarketplaceView MCP config helpers', () => {
           trustScope: 'user'
         })
       }
+    })
+  })
+
+  it('builds the Parallel Search remote MCP config without secrets', () => {
+    const config = buildRemoteMcpConfig({
+      'parallel-search': 'https://search.parallel.ai/mcp'
+    })
+
+    expect(config).toEqual({
+      servers: {
+        'parallel-search': {
+          enabled: true,
+          transport: 'streamable-http',
+          url: 'https://search.parallel.ai/mcp',
+          headers: {},
+          env: {},
+          trustScope: 'user',
+          timeoutMs: 30_000
+        }
+      }
+    })
+    expect(auditMarketplaceInstall({
+      id: 'parallel-search',
+      kind: 'mcp',
+      title: 'Parallel Search',
+      description: 'Search the live web and fetch clean Markdown.',
+      group: 'recommended',
+      mcpConfig: () => config,
+      supplyChain: { source: 'remote-mcp', permissions: ['network'] }
+    }, '/workspace')).toEqual({
+      ok: true,
+      permissions: ['network'],
+      errors: []
     })
   })
 

--- a/src/renderer/src/components/PluginMarketplaceView.tsx
+++ b/src/renderer/src/components/PluginMarketplaceView.tsx
@@ -809,6 +809,18 @@ const RECOMMENDED_ITEMS: MarketplaceItem[] = [
     supplyChain: { source: 'mcp', packageName: '@modelcontextprotocol/server-brave-search', version: '0.6.2', permissions: ['command', 'network', 'secret'] }
   },
   {
+    id: 'parallel-search',
+    kind: 'mcp',
+    titleKey: 'pluginMcpParallelSearchTitle',
+    descriptionKey: 'pluginMcpParallelSearchDesc',
+    group: 'recommended',
+    mcpConfig: () =>
+      buildRemoteMcpConfig({
+        'parallel-search': 'https://search.parallel.ai/mcp'
+      }),
+    supplyChain: { source: 'remote-mcp', permissions: ['network'] }
+  },
+  {
     id: 'code-review',
     kind: 'skill',
     titleKey: 'pluginSkillReviewTitle',

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -1510,6 +1510,8 @@
   "pluginMcpMemoryDesc": "Keep reusable project facts and preferences available across tasks.",
   "pluginMcpBraveSearchTitle": "Brave Search",
   "pluginMcpBraveSearchDesc": "Search the web through Brave Search. Requires your own API key.",
+  "pluginMcpParallelSearchTitle": "Parallel Search",
+  "pluginMcpParallelSearchDesc": "Search the live web and fetch clean Markdown with no account or API key required.",
   "pluginMcpVercelTitle": "Vercel",
   "pluginMcpVercelDesc": "Manage Vercel projects, deployments, logs, and docs through the official remote MCP server.",
   "pluginMcpGoogleWorkspaceTitle": "Google Workspace",

--- a/src/renderer/src/locales/hi/common.json
+++ b/src/renderer/src/locales/hi/common.json
@@ -1510,6 +1510,8 @@
   "pluginMcpMemoryDesc": "पुन: प्रयोज्य परियोजना तथ्यों और प्राथमिकताओं को सभी कार्यों में उपलब्ध रखें।",
   "pluginMcpBraveSearchTitle": "बहादुर खोज",
   "pluginMcpBraveSearchDesc": "ब्रेव सर्च के माध्यम से वेब पर खोजें। आपकी अपनी API कुंजी की आवश्यकता है.",
+  "pluginMcpParallelSearchTitle": "Parallel Search",
+  "pluginMcpParallelSearchDesc": "लाइव वेब पर खोजें और साफ़ Markdown प्राप्त करें—किसी खाते या API कुंजी की आवश्यकता नहीं।",
   "pluginMcpVercelTitle": "वर्सेल",
   "pluginMcpVercelDesc": "आधिकारिक रिमोट एमसीपी सर्वर के माध्यम से वर्सेल प्रोजेक्ट्स, परिनियोजन, लॉग और दस्तावेज़ प्रबंधित करें।",
   "pluginMcpGoogleWorkspaceTitle": "गूगल कार्यक्षेत्र",

--- a/src/renderer/src/locales/ja/common.json
+++ b/src/renderer/src/locales/ja/common.json
@@ -1510,6 +1510,8 @@
   "pluginMcpMemoryDesc": "再利用可能なプロジェクトの事実と設定をタスク間で利用できるようにします。",
   "pluginMcpBraveSearchTitle": "ブレイブサーチ",
   "pluginMcpBraveSearchDesc": "Brave Search でウェブを検索します。独自の API キーが必要です。",
+  "pluginMcpParallelSearchTitle": "Parallel Search",
+  "pluginMcpParallelSearchDesc": "アカウントや API キーなしで、最新のウェブを検索し、整形された Markdown を取得します。",
   "pluginMcpVercelTitle": "ヴェルセル",
   "pluginMcpVercelDesc": "公式リモート MCP サーバーを通じて Vercel プロジェクト、デプロイメント、ログ、ドキュメントを管理します。",
   "pluginMcpGoogleWorkspaceTitle": "Google ワークスペース",

--- a/src/renderer/src/locales/ko/common.json
+++ b/src/renderer/src/locales/ko/common.json
@@ -1510,6 +1510,8 @@
   "pluginMcpMemoryDesc": "작업 전반에 걸쳐 재사용 가능한 프로젝트 정보와 기본 설정을 유지하세요.",
   "pluginMcpBraveSearchTitle": "용감한 검색",
   "pluginMcpBraveSearchDesc": "Brave Search를 통해 웹을 검색해보세요. 자체 API 키가 필요합니다.",
+  "pluginMcpParallelSearchTitle": "Parallel Search",
+  "pluginMcpParallelSearchDesc": "계정이나 API 키 없이 실시간 웹을 검색하고 정리된 Markdown을 가져옵니다.",
   "pluginMcpVercelTitle": "베르셀",
   "pluginMcpVercelDesc": "공식 원격 MCP 서버를 통해 Vercel 프로젝트, 배포, 로그 및 문서를 관리하세요.",
   "pluginMcpGoogleWorkspaceTitle": "Google 작업공간",

--- a/src/renderer/src/locales/ru/common.json
+++ b/src/renderer/src/locales/ru/common.json
@@ -1510,6 +1510,8 @@
   "pluginMcpMemoryDesc": "Сохраняйте повторно используемые факты и настройки проекта доступными для разных задач.",
   "pluginMcpBraveSearchTitle": "Смелый поиск",
   "pluginMcpBraveSearchDesc": "Выполняйте поиск в Интернете с помощью Brave Search. Требуется собственный ключ API.",
+  "pluginMcpParallelSearchTitle": "Parallel Search",
+  "pluginMcpParallelSearchDesc": "Ищите актуальную информацию в интернете и извлекайте чистый Markdown без учётной записи или API-ключа.",
   "pluginMcpVercelTitle": "Версель",
   "pluginMcpVercelDesc": "Управляйте проектами Vercel, развертываниями, журналами и документами через официальный удаленный сервер MCP.",
   "pluginMcpGoogleWorkspaceTitle": "Google Рабочая область",

--- a/src/renderer/src/locales/th/common.json
+++ b/src/renderer/src/locales/th/common.json
@@ -1510,6 +1510,8 @@
   "pluginMcpMemoryDesc": "เก็บข้อเท็จจริงและการตั้งค่าของโครงการที่นำมาใช้ซ้ำได้ในงานต่างๆ",
   "pluginMcpBraveSearchTitle": "การค้นหาที่กล้าหาญ",
   "pluginMcpBraveSearchDesc": "ค้นหาเว็บผ่าน Brave Search ต้องใช้คีย์ API ของคุณเอง",
+  "pluginMcpParallelSearchTitle": "Parallel Search",
+  "pluginMcpParallelSearchDesc": "ค้นหาเว็บแบบเรียลไทม์และดึง Markdown ที่สะอาด โดยไม่ต้องมีบัญชีหรือคีย์ API",
   "pluginMcpVercelTitle": "เวอร์เซล",
   "pluginMcpVercelDesc": "จัดการโปรเจ็กต์ Vercel การปรับใช้ บันทึก และเอกสารผ่านเซิร์ฟเวอร์ MCP ระยะไกลอย่างเป็นทางการ",
   "pluginMcpGoogleWorkspaceTitle": "Google เวิร์คสเปซ",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -1510,6 +1510,8 @@
   "pluginMcpMemoryDesc": "在任务之间保留可复用的项目事实和偏好。",
   "pluginMcpBraveSearchTitle": "Brave Search",
   "pluginMcpBraveSearchDesc": "通过 Brave Search 搜索网页，需要使用你自己的 API Key。",
+  "pluginMcpParallelSearchTitle": "Parallel Search",
+  "pluginMcpParallelSearchDesc": "搜索实时网页并提取整洁的 Markdown，无需账号或 API Key。",
   "pluginMcpVercelTitle": "Vercel",
   "pluginMcpVercelDesc": "通过官方远程 MCP 管理 Vercel 项目、部署、日志和文档。",
   "pluginMcpGoogleWorkspaceTitle": "Google Workspace",


### PR DESCRIPTION
## Summary / 概要

- Adds Parallel Search as an optional recommended remote MCP server in Kun's existing plugin marketplace.

## Why / 背景

- Gives users a native way to add live web search and URL fetching without manually editing MCP JSON or supplying an account or API key.

## Changes / 变更

- Registers `https://search.parallel.ai/mcp` through the existing secure remote-MCP configuration path with network-only supply-chain permissions.
- Adds focused marketplace coverage and localized card copy for all seven active application locales.
- Preserves Brave Search and every existing marketplace item, default, and runtime behavior.

## Media / 截图或录屏

- Not attached. This is a data-only addition to the existing marketplace card layout and interaction path.

## Tests / 测试

- `PluginMarketplaceView.test.ts` (32 tests passed)
- Parallel Search locale-key presence check (7/7 locales)

## Validation / 验证

- [x] I agree that this contribution is submitted under the [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md). / 我同意本贡献遵循 [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md) 提交。
- [ ] `npm run test`
- [ ] `npm run typecheck`
- [x] `npm run build`
- [ ] `npm run dev` (if runtime or UI behavior changed / 如果运行时或界面行为有变化)
- [ ] UI change: video or GIF attached / 界面变更：已附上视频或 GIF
- [x] Logic change: unit tests added or updated / 逻辑变更：已新增或更新单元测试

## Notes / 备注

- `npm run typecheck` currently reports errors in existing provider settings and credential-readiness tests outside this change.
- The combined locale test reaches existing `settings.json` parity failures in five locales after the marketplace tests pass. The two new `common.json` keys are present in all seven locales.
- The full test command completed extension tests but did not exit after the Kun runtime suite became idle; the focused marketplace suite passes.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.