### PR TITLE
fix(runtime): prevent Windows startup process scan timeout

### DIFF
--- a/src/main/runtime/kun-serve-process-cleanup.test.ts
+++ b/src/main/runtime/kun-serve-process-cleanup.test.ts
@@ -48,7 +48,7 @@ describe('Kun serve process snapshot parsing', () => {
     ]))).toEqual([{ pid: 203, parentPid: 10, command: 'kun-runtime' }])
   })
 
-  it('uses UID-filtered ps on Unix and SID-filtered CIM on Windows', async () => {
+  it('uses UID-filtered ps on Unix and candidate-filtered CIM on Windows', async () => {
     const unixRun = vi.fn(async () => ({ stdout: '' }))
     await listCurrentUserProcesses({
       platform: 'linux',
@@ -67,6 +67,13 @@ describe('Kun serve process snapshot parsing', () => {
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_CURRENT_USER_PROCESS_SCRIPT],
       expect.objectContaining({ windowsHide: true })
+    )
+    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain('-Filter')
+    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain("Name = 'node.exe'")
+    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain("Name = 'electron.exe'")
+    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain("Name LIKE 'kun%.exe'")
+    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).not.toContain(
+      'Get-CimInstance Win32_Process | ForEach-Object'
     )
     expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain('GetOwnerSid')
     expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain('$currentSid')

--- a/src/main/runtime/kun-serve-process-cleanup.ts
+++ b/src/main/runtime/kun-serve-process-cleanup.ts
@@ -46,7 +46,8 @@ const PROCESS_TABLE_MAX_BUFFER = 16 * 1024 * 1024
 
 export const WINDOWS_CURRENT_USER_PROCESS_SCRIPT = [
   '$currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value',
-  '$items = Get-CimInstance Win32_Process | ForEach-Object {',
+  "$candidates = Get-CimInstance Win32_Process -Filter \"Name = 'node.exe' OR Name = 'electron.exe' OR Name LIKE 'kun%.exe'\"",
+  '$items = $candidates | ForEach-Object {',
   '  $owner = Invoke-CimMethod -InputObject $_ -MethodName GetOwnerSid -ErrorAction SilentlyContinue',
   '  if ($owner.Sid -eq $currentSid) {',
   '    [pscustomobject]@{',


### PR DESCRIPTION
## Summary

Fix Windows packaged-app startup failures caused by the historical Kun process scan timing out before main-window creation.

## Changes

- Filter `Win32_Process` in CIM before invoking `GetOwnerSid`, limiting owner lookups to `node.exe`, `electron.exe`, and `kun*.exe` candidates.
- Preserve the existing current-user SID boundary and verified PID termination behavior.
- Add regression assertions that prevent the expensive unfiltered process-table pipeline from returning.

## Impact

Windows users with large process tables no longer pay one CIM owner lookup per system process during startup, avoiding the 15-second command timeout reported in 0.3.0.

## Tests

- `npx vitest run src/main/runtime/kun-serve-process-cleanup.test.ts src/main/main-runtime-startup.replacement.test.ts`
- `npm run typecheck`
- `npx vitest run`
- `npm run build`
- `npm run lint`
- `npm run check:file-lines`

`npm test` additionally ran 563 Kun test files / 4502 tests; 3 native-module ABI checks failed locally because `node-pty` and `better-sqlite3` were installed for different Node/Electron ABIs. The changed main-process tests and the root suite pass.

Fixes #1163
