### PR TITLE
fix(runtime): avoid Windows process owner scan timeout

### DIFF
--- a/src/main/runtime/kun-serve-process-cleanup.test.ts
+++ b/src/main/runtime/kun-serve-process-cleanup.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  WINDOWS_CURRENT_USER_PROCESS_SCRIPT,
+  PROCESS_TABLE_TIMEOUT_MS,
+  WINDOWS_PROCESS_CANDIDATE_SCRIPT,
   clearHistoricalKunServeProcesses,
+  inspectCurrentUserProcess,
   listCurrentUserProcesses,
   looksLikeKunServeCommand,
   looksLikeKunServeProcess,
   parseUnixProcessSnapshot,
   parseWindowsProcessSnapshot,
+  windowsCurrentUserProcessScript,
   type KunServeProcessSnapshot
 } from './kun-serve-process-cleanup'
 
@@ -48,7 +51,7 @@ describe('Kun serve process snapshot parsing', () => {
     ]))).toEqual([{ pid: 203, parentPid: 10, command: 'kun-runtime' }])
   })
 
-  it('uses UID-filtered ps on Unix and candidate-filtered CIM on Windows', async () => {
+  it('uses UID-filtered ps on Unix and owner-free candidate CIM on Windows', async () => {
     const unixRun = vi.fn(async () => ({ stdout: '' }))
     await listCurrentUserProcesses({
       platform: 'linux',
@@ -58,25 +61,130 @@ describe('Kun serve process snapshot parsing', () => {
     expect(unixRun).toHaveBeenCalledWith(
       'ps',
       ['-axww', '-o', 'pid=', '-o', 'ppid=', '-o', 'uid=', '-o', 'command='],
-      expect.objectContaining({ windowsHide: true })
+      expect.objectContaining({ windowsHide: true, timeout: 1_800_000 })
     )
 
     const windowsRun = vi.fn(async () => ({ stdout: '[]' }))
     await listCurrentUserProcesses({ platform: 'win32', run: windowsRun })
     expect(windowsRun).toHaveBeenCalledWith(
       'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_CURRENT_USER_PROCESS_SCRIPT],
-      expect.objectContaining({ windowsHide: true })
+      ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_PROCESS_CANDIDATE_SCRIPT],
+      expect.objectContaining({ windowsHide: true, timeout: 1_800_000 })
     )
-    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain('-Filter')
-    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain("Name = 'node.exe'")
-    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain("Name = 'electron.exe'")
-    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain("Name LIKE 'kun%.exe'")
-    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).not.toContain(
-      'Get-CimInstance Win32_Process | ForEach-Object'
+    expect(PROCESS_TABLE_TIMEOUT_MS).toBe(1_800_000)
+    expect(WINDOWS_PROCESS_CANDIDATE_SCRIPT).toContain('-Filter')
+    expect(WINDOWS_PROCESS_CANDIDATE_SCRIPT).toContain("Name = 'node.exe'")
+    expect(WINDOWS_PROCESS_CANDIDATE_SCRIPT).toContain("Name = 'electron.exe'")
+    expect(WINDOWS_PROCESS_CANDIDATE_SCRIPT).toContain("Name LIKE 'kun%.exe'")
+    expect(WINDOWS_PROCESS_CANDIDATE_SCRIPT).not.toContain('GetOwnerSid')
+    expect(WINDOWS_PROCESS_CANDIDATE_SCRIPT).not.toContain('$currentSid')
+  })
+
+  it('verifies current-user ownership through an exact Windows PID query', async () => {
+    const snapshot = {
+      ProcessId: 204,
+      ParentProcessId: 10,
+      ExecutablePath: 'C:\\Program Files\\nodejs\\node.exe',
+      CommandLine: 'node C:\\Kun\\serve-entry.js serve'
+    }
+    const windowsRun = vi.fn(async () => ({ stdout: JSON.stringify(snapshot) }))
+
+    await expect(inspectCurrentUserProcess(204, {
+      platform: 'win32',
+      run: windowsRun
+    })).resolves.toEqual({
+      pid: 204,
+      parentPid: 10,
+      executable: 'C:\\Program Files\\nodejs\\node.exe',
+      command: 'node C:\\Kun\\serve-entry.js serve'
+    })
+
+    const script = windowsCurrentUserProcessScript(204)
+    expect(script).toContain('ProcessId = 204')
+    expect(script).toContain('GetOwnerSid')
+    expect(script).toContain('$currentSid')
+    expect(windowsRun).toHaveBeenCalledWith(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      expect.objectContaining({ timeout: 1_800_000 })
     )
-    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain('GetOwnerSid')
-    expect(WINDOWS_CURRENT_USER_PROCESS_SCRIPT).toContain('$currentSid')
+  })
+
+  it('re-verifies an exact Unix PID with the current UID', async () => {
+    const unixRun = vi.fn(async () => ({
+      stdout: '  205    1  501 /usr/local/bin/node /Kun/serve-entry.js serve\n'
+    }))
+
+    await expect(inspectCurrentUserProcess(205, {
+      platform: 'linux',
+      currentUid: 501,
+      run: unixRun
+    })).resolves.toEqual({
+      pid: 205,
+      parentPid: 1,
+      command: '/usr/local/bin/node /Kun/serve-entry.js serve'
+    })
+    expect(unixRun).toHaveBeenCalledWith(
+      'ps',
+      ['-p', '205', '-o', 'pid=', '-o', 'ppid=', '-o', 'uid=', '-o', 'command='],
+      expect.objectContaining({ timeout: 1_800_000 })
+    )
+  })
+
+  it('does not query owners for unrelated processes in a Node-heavy Windows snapshot', async () => {
+    const unrelated = Array.from({ length: 37 }, (_, index) => ({
+      ProcessId: 1_000 + index,
+      ParentProcessId: 10,
+      ExecutablePath: 'C:\\Program Files\\nodejs\\node.exe',
+      CommandLine: `node C:\\tools\\mcp-${index}.js`
+    }))
+    const kun = {
+      ProcessId: 2_000,
+      ParentProcessId: 10,
+      ExecutablePath: 'C:\\Program Files\\nodejs\\node.exe',
+      CommandLine: 'node C:\\Kun\\serve-entry.js serve --port 18899'
+    }
+    const windowsRun = vi.fn(async (_command: string, args: string[]) => {
+      const script = args[3] ?? ''
+      if (script === WINDOWS_PROCESS_CANDIDATE_SCRIPT) {
+        return { stdout: JSON.stringify([...unrelated, kun]) }
+      }
+      if (script.includes('ProcessId = 2000')) return { stdout: JSON.stringify(kun) }
+      throw new Error(`unexpected owner query: ${script}`)
+    })
+
+    await expect(listCurrentUserProcesses({
+      platform: 'win32',
+      run: windowsRun
+    })).resolves.toEqual([{
+      pid: 2_000,
+      parentPid: 10,
+      executable: 'C:\\Program Files\\nodejs\\node.exe',
+      command: 'node C:\\Kun\\serve-entry.js serve --port 18899'
+    }])
+
+    const ownerQueries = windowsRun.mock.calls
+      .map((call) => call[1][3] ?? '')
+      .filter((script) => script.includes('GetOwnerSid'))
+    expect(ownerQueries).toHaveLength(1)
+    expect(ownerQueries[0]).toContain('ProcessId = 2000')
+  })
+
+  it('drops a strict Windows candidate when exact-PID ownership cannot be verified', async () => {
+    const kun = {
+      ProcessId: 2_001,
+      ParentProcessId: 10,
+      ExecutablePath: 'C:\\Program Files\\nodejs\\node.exe',
+      CommandLine: 'node C:\\Kun\\serve-entry.js serve'
+    }
+    const windowsRun = vi.fn(async (_command: string, args: string[]) => ({
+      stdout: args[3] === WINDOWS_PROCESS_CANDIDATE_SCRIPT ? JSON.stringify(kun) : ''
+    }))
+
+    await expect(listCurrentUserProcesses({
+      platform: 'win32',
+      run: windowsRun
+    })).resolves.toEqual([])
   })
 })
 
@@ -145,13 +253,14 @@ describe('historical Kun serve cleanup', () => {
   })
 
   it('fails closed when a matched PID changes identity before signaling', async () => {
-    let reads = 0
-    const listProcesses = vi.fn(async () => {
-      reads += 1
-      return reads === 1
-        ? [{ pid: 401, parentPid: 1, command: 'kun-runtime' }]
-        : [{ pid: 401, parentPid: 1, command: '/usr/bin/node unrelated.js' }]
-    })
+    const listProcesses = vi.fn(async () => [
+      { pid: 401, parentPid: 1, command: 'kun-runtime' }
+    ])
+    const inspectProcess = vi.fn(async () => ({
+      pid: 401,
+      parentPid: 1,
+      command: '/usr/bin/node unrelated.js'
+    }))
     const waitForExit = vi.fn(async () => false)
     const terminate = vi.fn(async (_pid: number, verify: () => Promise<boolean>) => {
       expect(await verify()).toBe(false)
@@ -161,9 +270,13 @@ describe('historical Kun serve cleanup', () => {
     await expect(clearHistoricalKunServeProcesses({
       currentPid: 999,
       listProcesses,
+      inspectProcess,
       waitForExit,
       terminate,
       log: vi.fn(async () => undefined)
     })).rejects.toThrow(/401.*replacement was not started/i)
+
+    expect(terminate).toHaveBeenCalledOnce()
+    expect(inspectProcess).toHaveBeenCalledWith(401)
   })
 })

--- a/src/main/runtime/kun-serve-process-cleanup.ts
+++ b/src/main/runtime/kun-serve-process-cleanup.ts
@@ -36,30 +36,48 @@ type ProcessListOptions = {
 type CleanupOptions = {
   currentPid?: number
   listProcesses?: () => Promise<KunServeProcessSnapshot[]>
+  inspectProcess?: (pid: number) => Promise<KunServeProcessSnapshot | null>
   terminate?: typeof terminateVerifiedPid
   waitForExit?: typeof waitForPidExit
   log?: (line: string) => Promise<void>
 }
 
-const PROCESS_TABLE_TIMEOUT_MS = 15_000
+export const PROCESS_TABLE_TIMEOUT_MS = 30 * 60_000
 const PROCESS_TABLE_MAX_BUFFER = 16 * 1024 * 1024
 
-export const WINDOWS_CURRENT_USER_PROCESS_SCRIPT = [
-  '$currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value',
+export const WINDOWS_PROCESS_CANDIDATE_SCRIPT = [
   "$candidates = Get-CimInstance Win32_Process -Filter \"Name = 'node.exe' OR Name = 'electron.exe' OR Name LIKE 'kun%.exe'\"",
   '$items = $candidates | ForEach-Object {',
-  '  $owner = Invoke-CimMethod -InputObject $_ -MethodName GetOwnerSid -ErrorAction SilentlyContinue',
-  '  if ($owner.Sid -eq $currentSid) {',
-  '    [pscustomobject]@{',
-  '      ProcessId = $_.ProcessId',
-  '      ParentProcessId = $_.ParentProcessId',
-  '      ExecutablePath = $_.ExecutablePath',
-  '      CommandLine = $_.CommandLine',
-  '    }',
+  '  [pscustomobject]@{',
+  '    ProcessId = $_.ProcessId',
+  '    ParentProcessId = $_.ParentProcessId',
+  '    ExecutablePath = $_.ExecutablePath',
+  '    CommandLine = $_.CommandLine',
   '  }',
   '}',
   '@($items) | ConvertTo-Json -Compress'
 ].join('\n')
+
+export function windowsCurrentUserProcessScript(pid: number): string {
+  if (!validPid(pid)) throw new Error(`Invalid process ID: ${pid}`)
+  return [
+    '$currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value',
+    `$candidate = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"`,
+    '$items = @()',
+    'if ($null -ne $candidate) {',
+    '  $owner = Invoke-CimMethod -InputObject $candidate -MethodName GetOwnerSid -ErrorAction SilentlyContinue',
+    '  if ($owner.Sid -eq $currentSid) {',
+    '    $items += [pscustomobject]@{',
+    '      ProcessId = $candidate.ProcessId',
+    '      ParentProcessId = $candidate.ParentProcessId',
+    '      ExecutablePath = $candidate.ExecutablePath',
+    '      CommandLine = $candidate.CommandLine',
+    '    }',
+    '  }',
+    '}',
+    '@($items) | ConvertTo-Json -Compress'
+  ].join('\n')
+}
 
 const defaultRun: ProcessTableRunner = async (command, args, options) => {
   const result = await execFileAsync(command, args, options)
@@ -74,10 +92,17 @@ export async function listCurrentUserProcesses(
   if (platform === 'win32') {
     const { stdout } = await run(
       'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_CURRENT_USER_PROCESS_SCRIPT],
+      ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_PROCESS_CANDIDATE_SCRIPT],
       processTableCommandOptions()
     )
-    return parseWindowsProcessSnapshot(stdout)
+    const candidates = parseWindowsProcessSnapshot(stdout)
+      .filter((entry) => looksLikeKunServeProcess(entry))
+    const verified: KunServeProcessSnapshot[] = []
+    for (const candidate of candidates) {
+      const current = await inspectCurrentUserProcess(candidate.pid, { platform, run })
+      if (current && looksLikeKunServeProcess(current)) verified.push(current)
+    }
+    return verified
   }
 
   const currentUid = options.currentUid ?? process.getuid?.()
@@ -90,6 +115,35 @@ export async function listCurrentUserProcesses(
     processTableCommandOptions()
   )
   return parseUnixProcessSnapshot(stdout, currentUid as number)
+}
+
+export async function inspectCurrentUserProcess(
+  pid: number,
+  options: ProcessListOptions = {}
+): Promise<KunServeProcessSnapshot | null> {
+  if (!validPid(pid)) return null
+  const platform = options.platform ?? process.platform
+  const run = options.run ?? defaultRun
+  if (platform === 'win32') {
+    const { stdout } = await run(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', windowsCurrentUserProcessScript(pid)],
+      processTableCommandOptions()
+    )
+    return parseWindowsProcessSnapshot(stdout).find((entry) => entry.pid === pid) ?? null
+  }
+
+  const currentUid = options.currentUid ?? process.getuid?.()
+  if (!Number.isInteger(currentUid) || (currentUid ?? -1) < 0) {
+    throw new Error('Cannot verify the current Unix user while inspecting a Kun serve process.')
+  }
+  const { stdout } = await run(
+    'ps',
+    ['-p', String(pid), '-o', 'pid=', '-o', 'ppid=', '-o', 'uid=', '-o', 'command='],
+    processTableCommandOptions()
+  )
+  return parseUnixProcessSnapshot(stdout, currentUid as number)
+    .find((entry) => entry.pid === pid) ?? null
 }
 
 function processTableCommandOptions(): {
@@ -184,6 +238,9 @@ export async function clearHistoricalKunServeProcesses(
 ): Promise<KunServeCleanupReport> {
   const currentPid = options.currentPid ?? process.pid
   const listProcesses = options.listProcesses ?? (() => listCurrentUserProcesses())
+  const inspectProcess = options.inspectProcess ?? (options.listProcesses
+    ? async (pid: number) => (await listProcesses()).find((entry) => entry.pid === pid) ?? null
+    : (pid: number) => inspectCurrentUserProcess(pid))
   const terminate = options.terminate ?? terminateVerifiedPid
   const waitForExit = options.waitForExit ?? waitForPidExit
   const log = options.log ?? ((line) => appendManagedLogLine('kun', line))
@@ -210,7 +267,7 @@ export async function clearHistoricalKunServeProcesses(
     }
     await log(formatKunLogLine('lifecycle', match.pid, 'terminating historical kun serve process'))
     const terminated = await terminate(match.pid, async () => {
-      const current = (await listProcesses()).find((entry) => entry.pid === match.pid)
+      const current = await inspectProcess(match.pid)
       return Boolean(current && looksLikeKunServeProcess(current, currentPid))
     }, waitForExit)
     if (terminated) {


### PR DESCRIPTION
## Summary

Fix Windows desktop startup failures when a machine runs many Node or Electron processes.

Fixes #1172

## Root cause

The startup scanner filtered `Win32_Process` by image name, but still invoked `GetOwnerSid` serially for every `node.exe`, `electron.exe`, and `kun*.exe` candidate. Node-heavy development machines could therefore exceed the fixed 15-second process command timeout before the main window was created.

## Changes

- split Windows discovery into an owner-free candidate metadata snapshot and exact-PID current-user verification
- apply the existing strict Kun serve matcher before any SID lookup
- reuse exact-PID SID/command verification immediately before termination instead of rescanning the whole process table
- use targeted `ps -p` UID verification on Unix
- raise the absolute process-inspection timeout to 30 minutes (`1,800,000` ms)
- add Node-heavy, ownership failure, PID identity change, timeout, and cross-platform regression coverage

## Impact

Unrelated Node and Electron processes no longer add `GetOwnerSid` latency. Only actual Kun serve candidates are owner-verified, while the existing SID/UID boundary, strict command matching, PID re-verification, and fail-closed replacement behavior remain intact.

## Tests

- `npx vitest run src/main/runtime/kun-serve-process-cleanup.test.ts src/main/main-runtime-startup.replacement.test.ts` — 30 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run lint` — passed with 26 existing warnings
- `npm run check:file-lines` — passed
- `npm run test` — 4503 passed; 2 unrelated local failures because `node-pty` and `better-sqlite3` are installed for Electron ABI 127 while the local Node 25 runtime requires ABI 141