### PR TITLE
fix(models): preserve custom provider display names

### DIFF
--- a/src/main/main-ready-ipc.ts
+++ b/src/main/main-ready-ipc.ts
@@ -211,9 +211,18 @@ export function registerMainIpc(services: MainServices): void {
         const shared = await runtimeRequest(settings, '/v1/model-connections', { method: 'GET' })
         if (shared.ok) {
           try {
+            const providerSettings = getModelProviderSettings(settings)
+            const configuredProviderLabels = new Map(
+              providerSettings.providers.flatMap((provider) => {
+                const providerId = provider.id.trim().toLowerCase()
+                const label = provider.name.trim()
+                return providerId && label ? [[providerId, label]] : []
+              })
+            )
             const live = modelListFromSharedConnections(
               JSON.parse(shared.body) as unknown,
-              getModelProviderSettings(settings).localGateway.name
+              providerSettings.localGateway.name,
+              configuredProviderLabels
             )
             if (live) return live
           } catch {

--- a/src/main/upstream-models.test.ts
+++ b/src/main/upstream-models.test.ts
@@ -77,6 +77,64 @@ function settings(dataDir: string, model = 'settings-model'): AppSettingsV1 {
 }
 
 describe('upstream model picker list', () => {
+  it('uses the latest configured name for a live custom provider', () => {
+    const result = modelListFromSharedConnections({
+      schemaVersion: 1,
+      providers: [{
+        id: 'custom-provider-10',
+        name: 'custom-provider-10',
+        configured: true,
+        credentialStatus: 'ready',
+        models: ['custom-model'],
+        modelCapabilities: {
+          'custom-model': {
+            inputModalities: ['text', 'image'],
+            outputModalities: ['text'],
+            supportsToolCalling: true,
+            messageParts: ['text', 'image_url']
+          }
+        }
+      }]
+    }, 'Kun API', new Map([['custom-provider-10', 'My Gateway']]))
+
+    expect(result).toMatchObject({
+      ok: true,
+      modelGroups: [expect.objectContaining({
+        providerId: 'custom-provider-10',
+        label: 'My Gateway',
+        modelIds: ['custom-model'],
+        modelProfiles: {
+          'custom-model': expect.objectContaining({
+            inputModalities: ['text', 'image'],
+            supportsToolCalling: true
+          })
+        }
+      })]
+    })
+  })
+
+  it('preserves the live label when no configured provider name matches', () => {
+    const result = modelListFromSharedConnections({
+      schemaVersion: 1,
+      providers: [{
+        id: 'runtime-only',
+        name: 'Runtime Only',
+        configured: true,
+        credentialStatus: 'ready',
+        models: ['runtime-model']
+      }]
+    }, 'Kun API', new Map([['other-provider', 'Other Provider']]))
+
+    expect(result).toMatchObject({
+      ok: true,
+      modelGroups: [expect.objectContaining({
+        providerId: 'runtime-only',
+        label: 'Runtime Only',
+        modelIds: ['runtime-model']
+      })]
+    })
+  })
+
   it('preserves Codex preset identity and Fast service-tier capability from the live registry', () => {
     const result = modelListFromSharedConnections({
       schemaVersion: 1,

--- a/src/main/upstream-models.ts
+++ b/src/main/upstream-models.ts
@@ -82,7 +82,8 @@ export async function fetchUpstreamModelIds(
  */
 export function modelListFromSharedConnections(
   value: unknown,
-  localGatewayName = 'Kun API'
+  localGatewayName = 'Kun API',
+  configuredProviderLabels: ReadonlyMap<string, string> = new Map()
 ): FetchUpstreamModelsResult | null {
   const root = objectValue(value)
   if (root.schemaVersion !== 1 || !Array.isArray(root.providers)) return null
@@ -94,6 +95,7 @@ export function modelListFromSharedConnections(
       profile.configured !== true ||
       credentialUnavailable ||
       typeof profile.id !== 'string' ||
+      !profile.id.trim() ||
       !Array.isArray(profile.models)
     ) {
       return []
@@ -135,12 +137,15 @@ export function modelListFromSharedConnections(
         ...(capability.responsesMode === 'lite' ? { responsesMode: 'lite' as const } : {})
       } satisfies ModelProviderModelProfileV1]]
     }))
+    const providerId = profile.id.trim()
+    const configuredLabel = configuredProviderLabels.get(providerId.toLowerCase())?.trim()
     return [{
-      providerId: profile.id,
+      providerId,
       ...(typeof profile.presetSource === 'string' && profile.presetSource.trim()
         ? { presetSource: profile.presetSource.trim() }
         : {}),
-      label: typeof profile.name === 'string' && profile.name.trim() ? profile.name.trim() : profile.id,
+      label: configuredLabel ||
+        (typeof profile.name === 'string' && profile.name.trim() ? profile.name.trim() : providerId),
       modelIds,
       modelProfiles,
       ...(typeof profile.accountId === 'string' && profile.accountId.trim()


### PR DESCRIPTION
## Summary

Fixes the composer model picker showing a stale autogenerated custom-provider ID after a provider is renamed in Settings.

## Changes

- Overlay current configured provider display names onto matching live registry groups.
- Keep the live registry authoritative for availability, models, credentials, and capabilities.
- Add coverage for renamed custom providers and unmatched live providers.

## Tests

- `npx vitest run src/main/upstream-models.test.ts`
- `npm run typecheck`
- `npm run lint` (26 existing warnings)
- `npm run check:file-lines`
- `npm run build`

Fixes #1174