### PR TITLE
fix(runtime): fence JSONL compaction against concurrent appends

### DIFF
--- a/kun/src/adapters/file/atomic-write.ts
+++ b/kun/src/adapters/file/atomic-write.ts
@@ -3,6 +3,7 @@ import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
 export type AtomicWriteFileOptions = {
+  allowDirectWriteFallback?: boolean
   renameRetry?: {
     attempts?: number
     baseDelayMs?: number
@@ -23,9 +24,9 @@ export async function atomicWriteFile(
   try {
     await writeFile(tmp, contents, { encoding: 'utf-8', mode: 0o600 })
     try {
-      await renameWithRetry(tmp, path, options.renameRetry)
+      await renameFileWithRetry(tmp, path, options.renameRetry)
     } catch (error) {
-      if (!shouldFallbackToDirectWrite(error)) {
+      if (options.allowDirectWriteFallback === false || !shouldFallbackToDirectWrite(error)) {
         throw error
       }
       await writeFile(path, contents, { encoding: 'utf-8', mode: 0o600 })
@@ -61,10 +62,10 @@ function describeAtomicWriteError(path: string, error: unknown): unknown {
   return prefixed
 }
 
-async function renameWithRetry(
+export async function renameFileWithRetry(
   from: string,
   to: string,
-  options: NonNullable<AtomicWriteFileOptions['renameRetry']> | undefined
+  options?: NonNullable<AtomicWriteFileOptions['renameRetry']>
 ): Promise<void> {
   const attempts = Math.max(1, Math.floor(options?.attempts ?? DEFAULT_RENAME_RETRY_ATTEMPTS))
   const baseDelayMs = Math.max(0, Math.floor(options?.baseDelayMs ?? DEFAULT_RENAME_RETRY_BASE_DELAY_MS))

--- a/kun/src/adapters/file/file-session-jsonl.ts
+++ b/kun/src/adapters/file/file-session-jsonl.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from 'node:crypto'
 import { createReadStream, createWriteStream } from 'node:fs'
-import { rename, rm, type FileHandle } from 'node:fs/promises'
+import { rm, type FileHandle } from 'node:fs/promises'
 import type { RuntimeEvent } from '../../contracts/events.js'
 import { isPublicTurnItem, type TurnItem } from '../../contracts/items.js'
 import type { ItemHistoryPage, ItemHistoryPageOptions } from '../../ports/session-store.js'
 import { buildPublicItemHistoryPage, timelineSafeItem } from '../../services/item-history-page.js'
 import { yieldToEventLoop } from '../hybrid/hybrid-thread-support.js'
+import { renameFileWithRetry } from './atomic-write.js'
 
 const MS_PER_DAY = 86_400_000
 const DEFAULT_ITEM_HISTORY_MAX_RECORD_BYTES = 16 * 1024 * 1024
@@ -34,7 +35,12 @@ export function compactUsageEvents(
  */
 export async function compactUsageEventsJsonlFile(
   path: string,
-  options: { nowIso: string; retentionDays: number; maxRecordBytes: number }
+  options: {
+    nowIso: string
+    retentionDays: number
+    maxRecordBytes: number
+    commitReplacement?: (replace: () => Promise<void>) => Promise<boolean>
+  }
 ): Promise<boolean> {
   const cutoffMs = Date.parse(options.nowIso) - options.retentionDays * MS_PER_DAY
   if (!Number.isFinite(cutoffMs)) return false
@@ -57,11 +63,17 @@ export async function compactUsageEventsJsonlFile(
       maxRecordBytes: options.maxRecordBytes,
       keepLine: (event, index) => event.kind !== 'usage' || keepUsageIndexes.has(index)
     })
-    await rename(tmp, path)
+    const replace = async (): Promise<void> => renameFileWithRetry(tmp, path)
+    if (options.commitReplacement) {
+      const committed = await options.commitReplacement(replace)
+      return committed
+    }
+    await replace()
     return true
-  } catch (error) {
+  } finally {
+    // A stale snapshot deliberately declines replacement. Always remove its
+    // prepared rewrite; after a successful rename this is a harmless no-op.
     await rm(tmp, { force: true }).catch(() => undefined)
-    throw error
   }
 }
 
@@ -225,7 +237,12 @@ export async function readLatestItemsFromJsonl(
     maxRecordBytes?: number
     rejectMalformed?: boolean
   } = {}
-): Promise<{ items: TurnItem[]; rawCount: number; malformedCount: number }> {
+): Promise<{
+  items: TurnItem[]
+  rawCount: number
+  malformedCount: number
+  incompleteTrailingRecord: boolean
+}> {
   const maxRecordBytes = Math.max(
     1,
     Math.floor(options.maxRecordBytes ?? DEFAULT_ITEM_HISTORY_MAX_RECORD_BYTES)
@@ -235,9 +252,10 @@ export async function readLatestItemsFromJsonl(
   let remainder = ''
   let rawCount = 0
   let malformedCount = 0
+  let incompleteTrailingRecord = false
   let linesSinceYield = 0
 
-  const acceptLine = async (line: string): Promise<void> => {
+  const acceptLine = async (line: string, trailing = false): Promise<void> => {
     if (!line.trim()) return
     if (Buffer.byteLength(line, 'utf-8') > maxRecordBytes) {
       throw new Error(`item history record exceeds ${maxRecordBytes} bytes`)
@@ -252,7 +270,8 @@ export async function readLatestItemsFromJsonl(
       if (!latestById.has(item.id)) firstSeenIds.push(item.id)
       latestById.set(item.id, item)
     } catch {
-      malformedCount += 1
+      if (trailing) incompleteTrailingRecord = true
+      else malformedCount += 1
     }
     linesSinceYield += 1
     if (linesSinceYield >= YIELD_EVERY_LINES) {
@@ -278,18 +297,20 @@ export async function readLatestItemsFromJsonl(
         throw new Error(`item history record exceeds ${maxRecordBytes} bytes`)
       }
     }
-    await acceptLine(remainder)
+    await acceptLine(remainder, true)
   } catch (error) {
     if ((error as { code?: string }).code !== 'ENOENT') throw error
   }
 
-  if (options.rejectMalformed && malformedCount > 0) {
-    throw new Error(`item history contains ${malformedCount} malformed record(s)`)
+  const rejectedRecords = malformedCount + (incompleteTrailingRecord ? 1 : 0)
+  if (options.rejectMalformed && rejectedRecords > 0) {
+    throw new Error(`item history contains ${rejectedRecords} malformed record(s)`)
   }
   return {
     items: firstSeenIds.map((id) => latestById.get(id)!),
     rawCount,
-    malformedCount
+    malformedCount,
+    incompleteTrailingRecord
   }
 }
 

--- a/kun/src/adapters/file/file-session-store.ordering.test.ts
+++ b/kun/src/adapters/file/file-session-store.ordering.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { makeAssistantTextItem, makeToolCallItem, makeToolResultItem, makeUserItem } from '../../domain/item.js'
-import { FileSessionStore } from './file-session-store.js'
+import { FileSessionStore, readLatestItemsFromJsonl } from './file-session-store.js'
 
 const roots: string[] = []
 
@@ -141,6 +141,32 @@ describe('FileSessionStore item ordering', () => {
     await expect(store.compactItems(threadId, { force: true }))
       .rejects.toThrow('malformed record')
     expect(await readFile(path, 'utf-8')).toBe(before)
+  })
+
+  it('distinguishes an unterminated trailing write from a malformed completed row', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-session-incomplete-tail-'))
+    roots.push(root)
+    const path = join(root, 'messages.jsonl')
+    const item = makeUserItem({
+      id: 'user_1',
+      threadId: 'thread_incomplete_tail',
+      turnId: 'turn_1',
+      text: 'valid'
+    })
+    await appendFile(path, `${JSON.stringify(item)}\n{"id":`)
+
+    await expect(readLatestItemsFromJsonl(path)).resolves.toMatchObject({
+      items: [expect.objectContaining({ id: 'user_1' })],
+      rawCount: 1,
+      malformedCount: 0,
+      incompleteTrailingRecord: true
+    })
+
+    await appendFile(path, '}\n{broken-json\n')
+    await expect(readLatestItemsFromJsonl(path)).resolves.toMatchObject({
+      malformedCount: 2,
+      incompleteTrailingRecord: false
+    })
   })
 
   it('does not retain a Session item array that exceeds its byte admission limit', async () => {

--- a/kun/src/adapters/file/file-session-store.ts
+++ b/kun/src/adapters/file/file-session-store.ts
@@ -46,6 +46,7 @@ const DEFAULT_ITEMS_CACHE_MAX_BYTES = 16 * 1024 * 1024
 const DEFAULT_ITEM_HISTORY_COMPACTION_MIN_BYTES = 4 * 1024 * 1024
 const HIGHEST_SEQ_CACHE_MAX_THREADS = 256
 const ITEM_HISTORY_REVISION_MAX_THREADS = 512
+const EVENT_HISTORY_REVISION_MAX_THREADS = 512
 // A valid model tool argument may contain 1 MiB of JSON, whose escaping can
 // nearly double the persisted item event. Unresolved `__raw` strings are
 // summarized before persistence, while replay remains bounded for valid calls.
@@ -71,6 +72,8 @@ export class FileSessionStore implements SessionStore {
   /** Opaque revisions used to fence stale read-compute-rewrite snapshots. */
   private readonly itemHistoryRevisions = new Map<string, number>()
   private nextItemHistoryRevision = 0
+  private readonly eventHistoryRevisions = new Map<string, number>()
+  private nextEventHistoryRevision = 0
   private readonly highestSeqCache = new Map<string, { seq: number; size: number; mtimeMs: number }>()
   private readonly writeQueues = new Map<string, Promise<unknown>>()
   private readonly compactionScheduler: SessionCompactionScheduler
@@ -136,6 +139,7 @@ export class FileSessionStore implements SessionStore {
       await this.ensureDir(this.threadDir(threadId))
       const path = this.eventsPath(threadId)
       await appendFile(path, `${JSON.stringify(event)}\n`, { encoding: 'utf-8', mode: 0o600 })
+      this.bumpEventHistoryRevision(threadId)
       const info = await stat(path)
       this.cacheHighestSeq(threadId, event.seq, info, { preserveHigher: true })
     })
@@ -232,21 +236,18 @@ export class FileSessionStore implements SessionStore {
     }
     // Scan unlocked so appendItem/updateItem are not queued behind a 350MB parse.
     const revisionBefore = this.itemHistoryRevision(threadId)
-    const parsed = await readLatestItemsFromJsonl(path, { rejectMalformed: true })
+    const parsed = await readLatestItemsFromJsonl(path)
     const contents = parsed.items.map((item) => JSON.stringify(item)).join('\n')
     const output = contents ? `${contents}\n` : ''
     const afterBytes = Buffer.byteLength(output, 'utf-8')
-    if (afterBytes >= info.size) {
-      this.cacheItems(threadId, parsed.items)
-      return {
-        compacted: false,
-        beforeBytes: info.size,
-        afterBytes: info.size,
-        itemCount: parsed.items.length
-      }
-    }
     return this.withThreadWrite(threadId, async () => {
-      if (this.itemHistoryRevision(threadId) !== revisionBefore) {
+      const currentInfo = await stat(path).catch(() => null)
+      if (
+        this.itemHistoryRevision(threadId) !== revisionBefore ||
+        !currentInfo ||
+        currentInfo.size !== info.size ||
+        currentInfo.mtimeMs !== info.mtimeMs
+      ) {
         // A concurrent append invalidated the snapshot; coalesce another pass.
         this.scheduleItemHistoryCompaction(threadId)
         return {
@@ -256,7 +257,20 @@ export class FileSessionStore implements SessionStore {
           itemCount: parsed.items.length
         }
       }
-      await this.atomicWrite(path, output)
+      const malformedCount = parsed.malformedCount + (parsed.incompleteTrailingRecord ? 1 : 0)
+      if (malformedCount > 0) {
+        throw new Error(`item history contains ${malformedCount} malformed record(s)`)
+      }
+      if (afterBytes >= currentInfo.size) {
+        this.cacheItems(threadId, parsed.items)
+        return {
+          compacted: false,
+          beforeBytes: currentInfo.size,
+          afterBytes: currentInfo.size,
+          itemCount: parsed.items.length
+        }
+      }
+      await atomicWriteFile(path, output, { allowDirectWriteFallback: false })
       this.bumpItemsVersion(threadId)
       this.cacheItems(threadId, parsed.items)
       this.bumpItemHistoryRevision(threadId)
@@ -452,6 +466,7 @@ export class FileSessionStore implements SessionStore {
     this.itemsCacheBytes.clear()
     this.itemsCacheVersion.clear()
     this.itemHistoryRevisions.clear()
+    this.eventHistoryRevisions.clear()
     this.highestSeqCache.clear()
   }
 
@@ -459,6 +474,7 @@ export class FileSessionStore implements SessionStore {
     this.removeCachedItems(threadId)
     this.itemsCacheVersion.delete(threadId)
     this.itemHistoryRevisions.delete(threadId)
+    this.eventHistoryRevisions.delete(threadId)
     this.highestSeqCache.delete(threadId)
   }
 
@@ -496,6 +512,26 @@ export class FileSessionStore implements SessionStore {
       this.itemHistoryRevisions.delete(oldest)
     }
     return this.nextItemHistoryRevision
+  }
+
+  private eventHistoryRevision(threadId: string): number {
+    const revision = this.eventHistoryRevisions.get(threadId)
+    if (revision === undefined) return this.bumpEventHistoryRevision(threadId)
+    this.eventHistoryRevisions.delete(threadId)
+    this.eventHistoryRevisions.set(threadId, revision)
+    return revision
+  }
+
+  private bumpEventHistoryRevision(threadId: string): number {
+    this.nextEventHistoryRevision += 1
+    this.eventHistoryRevisions.delete(threadId)
+    this.eventHistoryRevisions.set(threadId, this.nextEventHistoryRevision)
+    while (this.eventHistoryRevisions.size > EVENT_HISTORY_REVISION_MAX_THREADS) {
+      const oldest = this.eventHistoryRevisions.keys().next().value
+      if (oldest === undefined) break
+      this.eventHistoryRevisions.delete(oldest)
+    }
+    return this.nextEventHistoryRevision
   }
 
   private cacheItems(threadId: string, items: TurnItem[]): void {
@@ -618,11 +654,29 @@ export class FileSessionStore implements SessionStore {
     const path = this.eventsPath(threadId)
     const info = await stat(path).catch(() => null)
     if (!info || info.size <= this.usageEventCompaction.maxBytes) return
+    const revisionBefore = this.eventHistoryRevision(threadId)
+    let conflicted = false
     const compacted = await compactUsageEventsJsonlFile(path, {
       nowIso: this.usageEventCompaction.nowIso(),
       retentionDays: this.usageEventCompaction.retentionDays,
-      maxRecordBytes: DEFAULT_EVENT_REPLAY_MAX_RECORD_BYTES
+      maxRecordBytes: DEFAULT_EVENT_REPLAY_MAX_RECORD_BYTES,
+      commitReplacement: (replace) => this.withThreadWrite(threadId, async () => {
+        const currentInfo = await stat(path).catch(() => null)
+        if (
+          this.eventHistoryRevision(threadId) !== revisionBefore ||
+          !currentInfo ||
+          currentInfo.size !== info.size ||
+          currentInfo.mtimeMs !== info.mtimeMs
+        ) {
+          conflicted = true
+          return false
+        }
+        await replace()
+        this.bumpEventHistoryRevision(threadId)
+        return true
+      })
     })
+    if (conflicted) this.scheduleUsageEventCompaction(threadId)
     if (!compacted) return
     // Size/mtime changed; drop the stale high-water cache entry so the next
     // highestSeq() rescans against the rewritten file.

--- a/kun/src/adapters/session-event-query.test.ts
+++ b/kun/src/adapters/session-event-query.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises'
+import { appendFile, mkdtemp, readdir, rm, writeFile, readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -144,12 +144,49 @@ describe('compactUsageEventsJsonlFile', () => {
     await expect(compactUsageEventsJsonlFile(path, {
       nowIso: '2026-06-03T00:00:00.000Z',
       retentionDays: 30,
-      maxRecordBytes: 1024 * 1024
+      maxRecordBytes: 1024 * 1024,
+      commitReplacement: async (replace) => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        expect((await readdir(root)).some((name) => name.endsWith('.tmp'))).toBe(true)
+        await replace()
+        return true
+      }
     })).resolves.toBe(true)
 
     const rewritten = (await readFile(path, 'utf8')).trim().split('\n').map((line) => JSON.parse(line))
     // Keep the heartbeat, the latest pre-cutoff usage anchor, and the latest usage.
     expect(rewritten.map((event) => event.seq)).toEqual([1, 3, 4])
+  })
+
+  it('discards its temporary rewrite when a concurrent append invalidates the snapshot', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-usage-compact-conflict-'))
+    roots.push(root)
+    const path = join(root, 'events.jsonl')
+    const lines = [
+      { kind: 'usage', seq: 1, timestamp: '2024-01-01T00:00:00.000Z', threadId: 'thr' },
+      { kind: 'usage', seq: 2, timestamp: '2024-01-02T00:00:00.000Z', threadId: 'thr' },
+      { kind: 'heartbeat', seq: 3, timestamp: '2026-01-01T00:00:00.000Z', threadId: 'thr' }
+    ]
+    await writeFile(path, `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`, 'utf8')
+
+    await expect(compactUsageEventsJsonlFile(path, {
+      nowIso: '2026-06-03T00:00:00.000Z',
+      retentionDays: 30,
+      maxRecordBytes: 1024 * 1024,
+      commitReplacement: async () => {
+        await appendFile(path, `${JSON.stringify({
+          kind: 'heartbeat',
+          seq: 4,
+          timestamp: '2026-01-01T00:00:01.000Z',
+          threadId: 'thr'
+        })}\n`)
+        return false
+      }
+    })).resolves.toBe(false)
+
+    const preserved = (await readFile(path, 'utf8')).trim().split('\n').map((line) => JSON.parse(line))
+    expect(preserved.map((event) => event.seq)).toEqual([1, 2, 3, 4])
+    expect((await readdir(root)).filter((name) => name.endsWith('.tmp'))).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

Fix Windows JSONL compaction races without blocking live thread writes.

## Root cause

The Service Manager owns the normal file store, but background compaction scanned active JSONL files outside the per-thread write queue and later replaced them without proving that the snapshot was still current. Item compaction could also classify an in-progress unterminated tail as permanent corruption. On Windows, usage compaction used a single rename attempt.

## Changes

- fence item and usage compaction with per-thread revisions plus size/mtime validation
- prepare large rewrites outside the short write lock, then commit only a still-current snapshot
- distinguish an incomplete trailing JSONL record from completed malformed records
- retry transient Windows rename failures and keep history compaction atomic
- discard stale temporary rewrites and reschedule compaction after conflicts
- add regression coverage for concurrent usage appends and incomplete item tails

## Tests

- `npm --prefix kun test -- src/adapters/session-event-query.test.ts src/adapters/file/file-session-store.ordering.test.ts src/adapters/file/session-compaction-scheduler.test.ts`
- `npm --prefix kun run typecheck`
- `npm run typecheck`
- `npm run build:kun`
- targeted ESLint
- `npm run check:file-lines`
- `git diff --check`

Fixes #1185