### PR TITLE
fix(runtime): reject recycled PID lock owners

### DIFF
--- a/kun/src/cli/gui-settings-bridge.test.ts
+++ b/kun/src/cli/gui-settings-bridge.test.ts
@@ -221,7 +221,7 @@ describe('GUI settings bridge', () => {
       schemaVersion: 1,
       pid: process.pid,
       token: 'legacy-runtime-owner',
-      startedAt: '2026-08-05T00:00:00.000Z'
+      startedAt: new Date().toISOString()
     }))
 
     await expect(syncGuiProviderCatalogToConfig(fixture.dataDir, settings!))

--- a/kun/src/server/runtime-data-dir-lease.test.ts
+++ b/kun/src/server/runtime-data-dir-lease.test.ts
@@ -58,7 +58,7 @@ describe('Runtime data directory lease', () => {
       schemaVersion: 1,
       pid: process.pid,
       token: 'legacy-migration-lock',
-      startedAt: '2026-08-05T00:00:00.000Z',
+      startedAt: new Date().toISOString(),
       dataDir
     }))
 

--- a/kun/src/server/runtime-data-dir-lease.ts
+++ b/kun/src/server/runtime-data-dir-lease.ts
@@ -8,6 +8,12 @@ import {
   reclaimLockFileIfUnchanged,
   runtimeDataDirOwnerPath
 } from './runtime-data-dir-migration-lock.js'
+import {
+  isValidRuntimeProcessIdentity,
+  runtimeProcessIdentity,
+  runtimeProcessIsAlive,
+  type RuntimeProcessIsAlive
+} from './runtime-process-identity.js'
 
 export { RUNTIME_DATA_DIR_OWNER_FILE } from './runtime-data-dir-migration-lock.js'
 
@@ -16,6 +22,7 @@ type RuntimeDataDirOwner = {
   pid: number
   token: string
   startedAt: string
+  processIdentity?: string
 }
 
 export type RuntimeDataDirLease = {
@@ -96,15 +103,6 @@ function isErrno(error: unknown, code: string): boolean {
     (error as NodeJS.ErrnoException).code === code
 }
 
-function defaultProcessIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return !isErrno(error, 'ESRCH')
-  }
-}
-
 function parseOwner(raw: string): RuntimeDataDirOwner | null {
   try {
     const parsed = JSON.parse(raw) as Partial<RuntimeDataDirOwner>
@@ -113,7 +111,8 @@ function parseOwner(raw: string): RuntimeDataDirOwner | null {
       (parsed.pid ?? 0) > 0 &&
       typeof parsed.token === 'string' &&
       parsed.token.length > 0 &&
-      typeof parsed.startedAt === 'string'
+      typeof parsed.startedAt === 'string' &&
+      isValidRuntimeProcessIdentity(parsed.processIdentity)
       ? parsed as RuntimeDataDirOwner
       : null
   } catch {
@@ -144,7 +143,7 @@ async function writeOwnerExclusively(path: string, owner: RuntimeDataDirOwner): 
 type RuntimeDataDirLeaseOptions = {
   pid?: number
   now?: () => Date
-  processIsAlive?: (pid: number) => boolean
+  processIsAlive?: RuntimeProcessIsAlive
   beforeStaleReclaim?: (path: string, expectedRaw: string) => void | Promise<void>
 }
 
@@ -155,7 +154,7 @@ async function acquireRuntimeDataDirWriterLease(
 ): Promise<RuntimeDataDirLease> {
   const pid = options.pid ?? process.pid
   const now = options.now ?? (() => new Date())
-  const processIsAlive = options.processIsAlive ?? defaultProcessIsAlive
+  const processIsAlive = options.processIsAlive ?? runtimeProcessIsAlive
   const path = runtimeDataDirOwnerPath(dataDir)
   const writerClaim = await acquireRuntimeDataDirWriterClaim(dataDir, claimKind, {
     pid,
@@ -166,11 +165,13 @@ async function acquireRuntimeDataDirWriterLease(
   // Check both sides of owner-file creation. If a migration wins between the
   // checks, this contender removes only its token-matched owner record and
   // exits before constructing any persistent Runtime stores.
+  const processIdentity = runtimeProcessIdentity(pid)
   const owner: RuntimeDataDirOwner = {
     schemaVersion: 1,
     pid,
     token: randomUUID(),
-    startedAt: now().toISOString()
+    startedAt: now().toISOString(),
+    ...(processIdentity ? { processIdentity } : {})
   }
   let ownerCreated = false
   let dataDirCreated = false
@@ -203,7 +204,7 @@ async function acquireRuntimeDataDirWriterLease(
       if (!existing) {
         throw new Error(`Kun Runtime data directory owner record is invalid: ${path}`)
       }
-      if (processIsAlive(existing.pid)) {
+      if (processIsAlive(existing.pid, existing)) {
         throw new Error(
           `Kun Runtime data directory is already owned by active process ${existing.pid}: ${dataDir}`
         )

--- a/kun/src/server/runtime-data-dir-migration-lock.test.ts
+++ b/kun/src/server/runtime-data-dir-migration-lock.test.ts
@@ -89,6 +89,41 @@ describe('Runtime data migration lock', () => {
     ))
   })
 
+  it('reclaims a writer claim after its PID is reused by another process', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-runtime-migration-lock-'))
+    roots.push(root)
+    const dataDir = join(root, 'runtime')
+    const claimsPath = runtimeDataDirClaimsPath(dataDir)
+    const token = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const stalePath = join(claimsPath, `claim-701-${token}.json`)
+    await mkdir(claimsPath, { recursive: true })
+    await writeFile(stalePath, JSON.stringify({
+      schemaVersion: 1,
+      kind: 'runtime',
+      pid: 701,
+      token,
+      startedAt: '2026-08-16T00:00:00.000Z',
+      processIdentity: 'win32-v1:original-process',
+      dataDir
+    }))
+    let inspectedIdentity: string | undefined
+
+    const lock = await acquireRuntimeDataDirMigrationLock(dataDir, {
+      pid: 702,
+      processIsAlive: (pid, record) => {
+        if (pid === 701) {
+          inspectedIdentity = record?.processIdentity
+          return record?.processIdentity === 'win32-v1:reused-process'
+        }
+        return pid === 702
+      }
+    })
+
+    expect(inspectedIdentity).toBe('win32-v1:original-process')
+    await expect(readFile(stalePath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    await lock.release()
+  })
+
   it('fails closed on unknown or non-regular claim entries', async () => {
     const root = await mkdtemp(join(tmpdir(), 'kun-runtime-migration-lock-'))
     roots.push(root)

--- a/kun/src/server/runtime-data-dir-migration-lock.ts
+++ b/kun/src/server/runtime-data-dir-migration-lock.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from 'node:crypto'
 import { link, mkdir, open, readFile, readdir, rename, rm, unlink } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
+import {
+  isValidRuntimeProcessIdentity,
+  runtimeProcessIdentity,
+  runtimeProcessIsAlive,
+  type RuntimeProcessIsAlive
+} from './runtime-process-identity.js'
 
 export const RUNTIME_DATA_DIR_MIGRATION_LOCK_SUFFIX = '.kun-runtime-migration.lock'
 export const RUNTIME_DATA_DIR_OWNER_FILE = '.kun-runtime-owner.json'
@@ -14,6 +20,7 @@ type RuntimeDataDirWriterClaimRecord = {
   pid: number
   token: string
   startedAt: string
+  processIdentity?: string
   dataDir: string
 }
 
@@ -27,6 +34,7 @@ type RuntimeDataDirMigrationLockOwner = {
   pid: number
   token: string
   startedAt: string
+  processIdentity?: string
   dataDir: string
 }
 
@@ -35,6 +43,7 @@ type RuntimeDataDirOwner = {
   pid: number
   token: string
   startedAt: string
+  processIdentity?: string
 }
 
 function isErrno(error: unknown, code: string): boolean {
@@ -42,15 +51,6 @@ function isErrno(error: unknown, code: string): boolean {
     error !== null &&
     'code' in error &&
     (error as NodeJS.ErrnoException).code === code
-}
-
-function defaultProcessIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return !isErrno(error, 'ESRCH')
-  }
 }
 
 function parseOwner(raw: string): RuntimeDataDirMigrationLockOwner | null {
@@ -62,6 +62,7 @@ function parseOwner(raw: string): RuntimeDataDirMigrationLockOwner | null {
       typeof parsed.token === 'string' &&
       parsed.token.length > 0 &&
       typeof parsed.startedAt === 'string' &&
+      isValidRuntimeProcessIdentity(parsed.processIdentity) &&
       typeof parsed.dataDir === 'string' &&
       parsed.dataDir.length > 0
       ? parsed as RuntimeDataDirMigrationLockOwner
@@ -79,7 +80,8 @@ function parseRuntimeOwner(raw: string): RuntimeDataDirOwner | null {
       (parsed.pid ?? 0) > 0 &&
       typeof parsed.token === 'string' &&
       parsed.token.length > 0 &&
-      typeof parsed.startedAt === 'string'
+      typeof parsed.startedAt === 'string' &&
+      isValidRuntimeProcessIdentity(parsed.processIdentity)
       ? parsed as RuntimeDataDirOwner
       : null
   } catch {
@@ -102,6 +104,7 @@ function parseWriterClaim(raw: string): RuntimeDataDirWriterClaimRecord | null {
       typeof parsed.token === 'string' &&
       parsed.token.length > 0 &&
       typeof parsed.startedAt === 'string' &&
+      isValidRuntimeProcessIdentity(parsed.processIdentity) &&
       typeof parsed.dataDir === 'string' &&
       parsed.dataDir.length > 0
       ? parsed as RuntimeDataDirWriterClaimRecord
@@ -165,23 +168,25 @@ export async function acquireRuntimeDataDirWriterClaim(
   options: {
     pid?: number
     now?: () => Date
-    processIsAlive?: (pid: number) => boolean
+    processIsAlive?: RuntimeProcessIsAlive
     afterClaimCreated?: (path: string) => void | Promise<void>
   } = {}
 ): Promise<RuntimeDataDirWriterClaim> {
   const pid = options.pid ?? process.pid
   const now = options.now ?? (() => new Date())
-  const processIsAlive = options.processIsAlive ?? defaultProcessIsAlive
+  const processIsAlive = options.processIsAlive ?? runtimeProcessIsAlive
   const canonicalDataDir = resolve(dataDir)
   const claimsPath = runtimeDataDirClaimsPath(canonicalDataDir)
   const token = randomUUID()
   const path = join(claimsPath, writerClaimFilename(pid, token))
+  const processIdentity = runtimeProcessIdentity(pid)
   const record: RuntimeDataDirWriterClaimRecord = {
     schemaVersion: 1,
     kind,
     pid,
     token,
     startedAt: now().toISOString(),
+    ...(processIdentity ? { processIdentity } : {}),
     dataDir: canonicalDataDir
   }
   await mkdir(claimsPath, { recursive: true, mode: 0o700 })
@@ -229,7 +234,7 @@ export async function acquireRuntimeDataDirWriterClaim(
         }
         throw new Error(`Kun Runtime writer claim is invalid: ${contenderPath}`)
       }
-      if (processIsAlive(contender.pid)) {
+      if (processIsAlive(contender.pid, contender)) {
         if (writerClaimsConflict(kind, contender.kind)) {
           throw new Error(claimConflictMessage(contender, dataDir))
         }
@@ -328,12 +333,12 @@ export async function assertRuntimeDataDirMigrationInactive(
   dataDir: string,
   options: {
     pid?: number
-    processIsAlive?: (pid: number) => boolean
+    processIsAlive?: RuntimeProcessIsAlive
     beforeStaleReclaim?: (path: string, expectedRaw: string) => void | Promise<void>
   } = {}
 ): Promise<void> {
   const pid = options.pid ?? process.pid
-  const processIsAlive = options.processIsAlive ?? defaultProcessIsAlive
+  const processIsAlive = options.processIsAlive ?? runtimeProcessIsAlive
   const path = runtimeDataDirMigrationLockPath(dataDir)
   for (;;) {
     let raw: string
@@ -349,7 +354,7 @@ export async function assertRuntimeDataDirMigrationInactive(
     if (!owner) {
       throw new Error(`Kun Runtime migration lock is invalid: ${path}`)
     }
-    if (processIsAlive(owner.pid)) {
+    if (processIsAlive(owner.pid, owner)) {
       throw new Error(
         `Kun Runtime data migration is active in process ${owner.pid}: ${dataDir}`
       )
@@ -365,12 +370,12 @@ export async function assertRuntimeDataDirLeaseInactive(
   dataDir: string,
   options: {
     pid?: number
-    processIsAlive?: (pid: number) => boolean
+    processIsAlive?: RuntimeProcessIsAlive
     beforeStaleReclaim?: (path: string, expectedRaw: string) => void | Promise<void>
   } = {}
 ): Promise<void> {
   const pid = options.pid ?? process.pid
-  const processIsAlive = options.processIsAlive ?? defaultProcessIsAlive
+  const processIsAlive = options.processIsAlive ?? runtimeProcessIsAlive
   const path = runtimeDataDirOwnerPath(dataDir)
   for (;;) {
     let raw: string
@@ -384,7 +389,7 @@ export async function assertRuntimeDataDirLeaseInactive(
     }
     const owner = parseRuntimeOwner(raw)
     if (!owner) throw new Error(`Kun Runtime data directory owner record is invalid: ${path}`)
-    if (processIsAlive(owner.pid)) {
+    if (processIsAlive(owner.pid, owner)) {
       throw new Error(
         `Kun Runtime data directory is already owned by active process ${owner.pid}: ${dataDir}`
       )
@@ -408,13 +413,13 @@ export async function acquireRuntimeDataDirMigrationLock(
   options: {
     pid?: number
     now?: () => Date
-    processIsAlive?: (pid: number) => boolean
+    processIsAlive?: RuntimeProcessIsAlive
     beforeStaleReclaim?: (path: string, expectedRaw: string) => void | Promise<void>
   } = {}
 ): Promise<RuntimeDataDirMigrationLock> {
   const pid = options.pid ?? process.pid
   const now = options.now ?? (() => new Date())
-  const processIsAlive = options.processIsAlive ?? defaultProcessIsAlive
+  const processIsAlive = options.processIsAlive ?? runtimeProcessIsAlive
   const path = runtimeDataDirMigrationLockPath(dataDir)
   await mkdir(dirname(path), { recursive: true, mode: 0o700 })
   const writerClaim = await acquireRuntimeDataDirWriterClaim(dataDir, 'migration', {
@@ -432,11 +437,13 @@ export async function acquireRuntimeDataDirMigrationLock(
     await writerClaim.release().catch(() => undefined)
     throw error
   }
+  const processIdentity = runtimeProcessIdentity(pid)
   const owner: RuntimeDataDirMigrationLockOwner = {
     schemaVersion: 1,
     pid,
     token: randomUUID(),
     startedAt: now().toISOString(),
+    ...(processIdentity ? { processIdentity } : {}),
     dataDir: resolve(dataDir)
   }
   try {

--- a/kun/src/server/runtime-process-identity.test.ts
+++ b/kun/src/server/runtime-process-identity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  inspectRuntimeProcess,
+  runtimeProcessInspectionMatchesRecord,
+  runtimeProcessIsAlive
+} from './runtime-process-identity.js'
+
+describe('runtime process identity', () => {
+  it('reads a stable identity for the current process', () => {
+    const inspection = inspectRuntimeProcess(process.pid)
+    expect(inspection?.identity).toMatch(/-v1:/u)
+    const startedAt = new Date().toISOString()
+    expect(runtimeProcessIsAlive(process.pid, {
+      startedAt,
+      processIdentity: inspection?.identity
+    })).toBe(true)
+    expect(runtimeProcessIsAlive(process.pid, {
+      startedAt,
+      processIdentity: `${inspection?.identity}:reused`
+    })).toBe(false)
+  })
+
+  it('rejects a live PID whose process birth identity changed', () => {
+    expect(runtimeProcessInspectionMatchesRecord(
+      { startedAt: '2026-08-16T00:00:00.000Z', processIdentity: 'win32-v1:old' },
+      { identity: 'win32-v1:reused', startedAtMs: Date.parse('2026-08-16T00:01:00.000Z') }
+    )).toBe(false)
+  })
+
+  it('recovers legacy records when the current process started later', () => {
+    const record = { startedAt: '2026-08-16T00:00:00.000Z' }
+    expect(runtimeProcessInspectionMatchesRecord(record, {
+      startedAtMs: Date.parse('2026-08-16T00:01:00.000Z')
+    })).toBe(false)
+    expect(runtimeProcessInspectionMatchesRecord(record, {
+      startedAtMs: Date.parse('2026-08-15T23:59:00.000Z')
+    })).toBe(true)
+  })
+
+  it('fails closed when process birth identity cannot be inspected', () => {
+    expect(runtimeProcessInspectionMatchesRecord({
+      startedAt: '2026-08-16T00:00:00.000Z',
+      processIdentity: 'win32-v1:owner'
+    }, undefined)).toBe(true)
+  })
+})

--- a/kun/src/server/runtime-process-identity.ts
+++ b/kun/src/server/runtime-process-identity.ts
@@ -1,0 +1,154 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type RuntimeProcessRecordIdentity = {
+  startedAt: string
+  processIdentity?: string
+}
+
+export type RuntimeProcessIsAlive = (
+  pid: number,
+  record?: RuntimeProcessRecordIdentity
+) => boolean
+
+export type RuntimeProcessInspection = {
+  identity?: string
+  startedAtMs?: number
+}
+
+export function isValidRuntimeProcessIdentity(value: unknown): value is string | undefined {
+  return value === undefined || (
+    typeof value === 'string' && value.length > 0 && value.length <= 512
+  )
+}
+
+const PROCESS_INSPECTION_TIMEOUT_MS = 3_000
+const PROCESS_INSPECTION_MAX_BUFFER = 16 * 1024
+let cachedCurrentProcessInspection: RuntimeProcessInspection | undefined
+
+function errnoCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as NodeJS.ErrnoException).code)
+    : undefined
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // EPERM means the process exists but cannot be signalled. Unknown errors
+    // also fail closed instead of reclaiming a potentially live owner.
+    return errnoCode(error) !== 'ESRCH'
+  }
+}
+
+function boundedExec(executable: string, args: string[]): string {
+  return execFileSync(executable, args, {
+    encoding: 'utf8',
+    timeout: PROCESS_INSPECTION_TIMEOUT_MS,
+    maxBuffer: PROCESS_INSPECTION_MAX_BUFFER,
+    windowsHide: true,
+    env: { ...process.env, LANG: 'C', LC_ALL: 'C' }
+  }).trim()
+}
+
+function inspectWindowsProcess(pid: number): RuntimeProcessInspection | undefined {
+  const systemRoot = process.env.SystemRoot?.trim()
+  const powershell = systemRoot
+    ? join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+    : 'powershell.exe'
+  const command = [
+    `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction Stop`,
+    'if ($null -eq $p) { exit 3 }',
+    `[Console]::Out.Write($p.CreationDate.ToUniversalTime().ToString('O'))`
+  ].join('; ')
+  const startedAt = boundedExec(powershell, [
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-Command',
+    command
+  ])
+  const startedAtMs = Date.parse(startedAt)
+  if (!startedAt || !Number.isFinite(startedAtMs)) return undefined
+  return { identity: `win32-v1:${startedAt}`, startedAtMs }
+}
+
+function inspectProcProcess(pid: number): RuntimeProcessInspection | undefined {
+  const stat = readFileSync(`/proc/${pid}/stat`, 'utf8')
+  const commandEnd = stat.lastIndexOf(')')
+  if (commandEnd < 0) return undefined
+  const fields = stat.slice(commandEnd + 1).trim().split(/\s+/u)
+  const startTicks = fields[19]
+  if (!startTicks || !/^\d+$/u.test(startTicks)) return undefined
+  const bootId = readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim()
+  if (!bootId) return undefined
+  let startedAtMs: number | undefined
+  try {
+    startedAtMs = inspectPosixStartedAt(pid)
+  } catch {
+    // The opaque boot/tick identity is still authoritative for new records.
+  }
+  return {
+    identity: `linux-v1:${bootId}:${startTicks}`,
+    ...(startedAtMs === undefined ? {} : { startedAtMs })
+  }
+}
+
+function inspectPosixStartedAt(pid: number): number | undefined {
+  const value = boundedExec('/bin/ps', ['-o', 'lstart=', '-p', String(pid)])
+  const startedAtMs = Date.parse(value)
+  return Number.isFinite(startedAtMs) ? startedAtMs : undefined
+}
+
+function inspectPosixProcess(pid: number): RuntimeProcessInspection | undefined {
+  const startedAt = boundedExec('/bin/ps', ['-o', 'lstart=', '-p', String(pid)])
+  const startedAtMs = Date.parse(startedAt)
+  if (!startedAt || !Number.isFinite(startedAtMs)) return undefined
+  return { identity: `${process.platform}-v1:${startedAt}`, startedAtMs }
+}
+
+export function inspectRuntimeProcess(pid: number): RuntimeProcessInspection | undefined {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return undefined
+  if (pid === process.pid && cachedCurrentProcessInspection) {
+    return cachedCurrentProcessInspection
+  }
+  let inspection: RuntimeProcessInspection | undefined
+  try {
+    if (process.platform === 'win32') inspection = inspectWindowsProcess(pid)
+    else if (process.platform === 'linux') inspection = inspectProcProcess(pid)
+    else inspection = inspectPosixProcess(pid)
+  } catch {
+    inspection = undefined
+  }
+  if (pid === process.pid && inspection) cachedCurrentProcessInspection = inspection
+  return inspection
+}
+
+export function runtimeProcessIdentity(pid = process.pid): string | undefined {
+  return inspectRuntimeProcess(pid)?.identity
+}
+
+export function runtimeProcessInspectionMatchesRecord(
+  record: RuntimeProcessRecordIdentity | undefined,
+  inspection: RuntimeProcessInspection | undefined
+): boolean {
+  if (!record || !inspection) return true
+  if (record.processIdentity) {
+    return inspection.identity === undefined || inspection.identity === record.processIdentity
+  }
+  const recordedAtMs = Date.parse(record.startedAt)
+  if (!Number.isFinite(recordedAtMs) || inspection.startedAtMs === undefined) return true
+  // A process that started after the record was written cannot be its owner.
+  return inspection.startedAtMs <= recordedAtMs
+}
+
+export const runtimeProcessIsAlive: RuntimeProcessIsAlive = (pid, record) => {
+  if (!processExists(pid)) return false
+  const inspection = inspectRuntimeProcess(pid)
+  if (!inspection) return processExists(pid)
+  return runtimeProcessInspectionMatchesRecord(record, inspection)
+}

--- a/src/main/runtime-data-dir-migration-lock.test.ts
+++ b/src/main/runtime-data-dir-migration-lock.test.ts
@@ -227,6 +227,41 @@ describe('canonical Runtime migration startup lock', () => {
     })).toThrow(/claim is not a regular file/)
   })
 
+  it('reclaims a common writer claim after its PID is reused', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kun-main-migration-lock-'))
+    roots.push(root)
+    const dataDir = join(root, '.kun', 'data')
+    const claimsPath = runtimeDataDirClaimsPath(dataDir)
+    const token = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const stalePath = join(claimsPath, `claim-561-${token}.json`)
+    await mkdir(claimsPath, { recursive: true })
+    await writeFile(stalePath, JSON.stringify({
+      schemaVersion: 1,
+      kind: 'runtime',
+      pid: 561,
+      token,
+      startedAt: '2026-08-16T00:00:00.000Z',
+      processIdentity: 'win32-v1:original-process',
+      dataDir
+    }))
+    let inspectedIdentity: string | undefined
+
+    const migration = acquireCanonicalRuntimeMigrationLock([dataDir], {
+      pid: 562,
+      processIsAlive: (pid, record) => {
+        if (pid === 561) {
+          inspectedIdentity = record?.processIdentity
+          return record?.processIdentity === 'win32-v1:reused-process'
+        }
+        return pid === 562
+      }
+    })
+
+    expect(inspectedIdentity).toBe('win32-v1:original-process')
+    await expect(readFile(stalePath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    migration.release()
+  })
+
   it('preserves a replacement lock observed during stale reclamation', async () => {
     const root = await mkdtemp(join(tmpdir(), 'kun-main-migration-lock-'))
     roots.push(root)

--- a/src/main/runtime-data-dir-migration-lock.ts
+++ b/src/main/runtime-data-dir-migration-lock.ts
@@ -18,12 +18,19 @@ import {
   runtimeDataDirMigrationLockPath,
   runtimeDataDirOwnerPath
 } from '../../kun/src/server/runtime-data-dir-migration-lock.js'
+import {
+  isValidRuntimeProcessIdentity,
+  runtimeProcessIdentity,
+  runtimeProcessIsAlive,
+  type RuntimeProcessIsAlive
+} from '../../kun/src/server/runtime-process-identity.js'
 
 type MigrationLockOwner = {
   schemaVersion: 1
   pid: number
   token: string
   startedAt: string
+  processIdentity?: string
   dataDir: string
 }
 
@@ -32,6 +39,7 @@ type RuntimeDataDirOwner = {
   pid: number
   token: string
   startedAt: string
+  processIdentity?: string
 }
 
 type RuntimeDataDirWriterClaim = {
@@ -40,6 +48,7 @@ type RuntimeDataDirWriterClaim = {
   pid: number
   token: string
   startedAt: string
+  processIdentity?: string
   dataDir: string
 }
 
@@ -61,15 +70,6 @@ function errnoCode(error: unknown): string | undefined {
     : undefined
 }
 
-function processIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return errnoCode(error) !== 'ESRCH'
-  }
-}
-
 function parseOwner(raw: string): MigrationLockOwner | null {
   try {
     const value = JSON.parse(raw) as Partial<MigrationLockOwner>
@@ -79,6 +79,7 @@ function parseOwner(raw: string): MigrationLockOwner | null {
       typeof value.token === 'string' &&
       value.token.length > 0 &&
       typeof value.startedAt === 'string' &&
+      isValidRuntimeProcessIdentity(value.processIdentity) &&
       typeof value.dataDir === 'string' &&
       value.dataDir.length > 0
       ? value as MigrationLockOwner
@@ -96,7 +97,8 @@ function parseRuntimeOwner(raw: string): RuntimeDataDirOwner | null {
       (value.pid ?? 0) > 0 &&
       typeof value.token === 'string' &&
       value.token.length > 0 &&
-      typeof value.startedAt === 'string'
+      typeof value.startedAt === 'string' &&
+      isValidRuntimeProcessIdentity(value.processIdentity)
       ? value as RuntimeDataDirOwner
       : null
   } catch {
@@ -119,6 +121,7 @@ function parseWriterClaim(raw: string): RuntimeDataDirWriterClaim | null {
       typeof value.token === 'string' &&
       value.token.length > 0 &&
       typeof value.startedAt === 'string' &&
+      isValidRuntimeProcessIdentity(value.processIdentity) &&
       typeof value.dataDir === 'string' &&
       value.dataDir.length > 0
       ? value as RuntimeDataDirWriterClaim
@@ -144,7 +147,7 @@ function acquireWriterClaimSync(
   input: {
     pid: number
     now: () => Date
-    processIsAlive: (pid: number) => boolean
+    processIsAlive: RuntimeProcessIsAlive
   }
 ): { path: string; owner: RuntimeDataDirWriterClaim } {
   const canonicalDataDir = resolve(dataDir)
@@ -152,12 +155,14 @@ function acquireWriterClaimSync(
   mkdirSync(claimsPath, { recursive: true, mode: 0o700 })
   const token = randomUUID()
   const path = join(claimsPath, writerClaimFilename(input.pid, token))
+  const processIdentity = runtimeProcessIdentity(input.pid)
   const owner: RuntimeDataDirWriterClaim = {
     schemaVersion: 1,
     kind: 'migration',
     pid: input.pid,
     token,
     startedAt: input.now().toISOString(),
+    ...(processIdentity ? { processIdentity } : {}),
     dataDir: canonicalDataDir
   }
   let handle: number | undefined
@@ -199,7 +204,7 @@ function acquireWriterClaimSync(
         }
         throw new Error(`Kun Runtime writer claim is invalid: ${contenderPath}`)
       }
-      if (input.processIsAlive(contender.pid)) {
+      if (input.processIsAlive(contender.pid, contender)) {
         throw new Error(
           contender.kind === 'migration'
             ? `Kun Runtime data migration is already active in process ${contender.pid}`
@@ -283,7 +288,7 @@ function assertRuntimeDataDirLeaseInactiveSync(
   dataDir: string,
   input: {
     pid: number
-    processIsAlive: (pid: number) => boolean
+    processIsAlive: RuntimeProcessIsAlive
     beforeReclaim?: (path: string, expectedRaw: string) => void
   }
 ): void {
@@ -298,7 +303,7 @@ function assertRuntimeDataDirLeaseInactiveSync(
     }
     const owner = parseRuntimeOwner(raw)
     if (!owner) throw new Error(`Kun Runtime data directory owner record is invalid: ${path}`)
-    if (input.processIsAlive(owner.pid)) {
+    if (input.processIsAlive(owner.pid, owner)) {
       throw new Error(
         `Kun Runtime data directory is already owned by active process ${owner.pid}: ${dataDir}`
       )
@@ -316,14 +321,14 @@ export function acquireCanonicalRuntimeMigrationLock(
   options: {
     pid?: number
     now?: () => Date
-    processIsAlive?: (pid: number) => boolean
+    processIsAlive?: RuntimeProcessIsAlive
     beforeStaleReclaim?: (path: string, expectedRaw: string) => void
     unlinkLock?: (path: string) => void
   } = {}
 ): CanonicalRuntimeMigrationLock {
   const pid = options.pid ?? process.pid
   const now = options.now ?? (() => new Date())
-  const isAlive = options.processIsAlive ?? processIsAlive
+  const isAlive = options.processIsAlive ?? runtimeProcessIsAlive
   const unlinkLock = options.unlinkLock ?? unlinkSync
   const canonicalDirs = [...new Set(dataDirs.map((path) => resolve(path)))].sort()
   const owned: Array<{ path: string; owner: MigrationLockOwner }> = []
@@ -342,11 +347,13 @@ export function acquireCanonicalRuntimeMigrationLock(
         processIsAlive: isAlive,
         beforeReclaim: options.beforeStaleReclaim
       })
+      const processIdentity = runtimeProcessIdentity(pid)
       const owner: MigrationLockOwner = {
         schemaVersion: 1,
         pid,
         token: randomUUID(),
         startedAt: now().toISOString(),
+        ...(processIdentity ? { processIdentity } : {}),
         dataDir
       }
       for (;;) {
@@ -382,7 +389,7 @@ export function acquireCanonicalRuntimeMigrationLock(
         }
         const current = parseOwner(currentRaw)
         if (!current) throw new Error(`Kun Runtime migration lock is invalid: ${path}`)
-        if (isAlive(current.pid)) {
+        if (isAlive(current.pid, current)) {
           throw new Error(
             `Kun Runtime data migration is already active in process ${current.pid}`
           )


### PR DESCRIPTION
## Summary

Prevent stale Runtime writer claims, owner files, and migration locks from blocking startup after the operating system reuses a PID.

## Root cause

Lock liveness only called `process.kill(pid, 0)`. A recycled PID therefore made an abandoned record look live even though the process behind that PID was unrelated.

## Changes

- record an optional, stable process birth identity while retaining schema version 1 compatibility
- inspect Windows process creation time through bounded CIM/PowerShell execution
- use Linux boot ID plus `/proc/<pid>/stat` start ticks and POSIX start time on other platforms
- compare legacy records without identity by checking whether the current process started after the record
- fail closed when process identity cannot be inspected
- apply the same logic to async Kun claims, Runtime owners, and synchronous Electron migration locks
- add pure identity and async/sync lock recovery regression tests

## Tests

- `npm --prefix kun test -- src/server/runtime-process-identity.test.ts src/server/runtime-data-dir-migration-lock.test.ts src/server/runtime-data-dir-lease.test.ts`
- `npx vitest run src/main/runtime-data-dir-migration-lock.test.ts`
- `npm run build:kun`
- `npm run typecheck`
- targeted ESLint
- `npm run check:file-lines`
- `git diff --check`

Fixes #1186