### PR TITLE
fix(runtime): restore SQLite thread page counts

### DIFF
--- a/kun/src/adapters/hybrid/hybrid-thread-store.test.ts
+++ b/kun/src/adapters/hybrid/hybrid-thread-store.test.ts
@@ -131,6 +131,41 @@ describe('HybridThreadStore filesystem surface fallback', () => {
   })
 })
 
+describe('HybridThreadStore SQLite pagination', () => {
+  it('uses the index count for filtered pages without scanning JSONL', async () => {
+    const { store } = await createStore()
+    const records = [
+      createThreadRecord({ id: 'thread_alpha', title: 'Alpha', workspace: '/tmp/a', model: 'test-model' }),
+      createThreadRecord({ id: 'thread_beta', title: 'Beta', workspace: '/tmp/a', model: 'test-model' }),
+      createThreadRecord({ id: 'thread_other', title: 'Alpha other', workspace: '/tmp/b', model: 'test-model' })
+    ]
+    await Promise.all(records.map((record) => store.upsert(record)))
+    const source = store as unknown as { listFromFilesystem(): Promise<unknown[]> }
+    const filesystemScan = vi.spyOn(source, 'listFromFilesystem')
+
+    try {
+      const first = await store.listPage({
+        workspace: '/tmp/a', search: 'a', includeArchived: true, limit: 1
+      })
+      expect(first).toMatchObject({ total: 2, hasMore: true })
+      expect(first.threads).toHaveLength(1)
+      expect(first.nextCursor).toEqual(expect.any(String))
+
+      const second = await store.listPage({
+        workspace: '/tmp/a', search: 'a', includeArchived: true,
+        limit: 1, cursor: first.nextCursor
+      })
+      expect(second).toMatchObject({ hasMore: false })
+      expect(second.threads).toHaveLength(1)
+      expect(second).not.toHaveProperty('total')
+      expect(filesystemScan).not.toHaveBeenCalled()
+    } finally {
+      filesystemScan.mockRestore()
+      store.close()
+    }
+  })
+})
+
 function legacyWorkThread(id: string, title: string): ThreadRecord {
   const turnId = `${id}_turn`
   const prompt = '[写作上下文]\n交互约定: 需要更多信息时通常直接用普通文本向用户提问。仅当当前激活的专用工作流明确要求结构化确认（例如 PPT 视觉评审）时，调用该工作流提供的确认工具；其他写作任务不要滥用结构化交互。\n\n润色当前文件'

--- a/kun/src/adapters/hybrid/hybrid-thread-store.ts
+++ b/kun/src/adapters/hybrid/hybrid-thread-store.ts
@@ -491,6 +491,7 @@ export class HybridThreadStore implements ThreadStore {
   private queryThreadRows(options: ThreadStoreListOptions): ThreadRow[] {
     return this.index?.query(options) ?? []
   }
+  private indexCount(options: ThreadStoreListOptions): number | undefined { return this.index?.count(options) }
 
   private findRow(threadId: string): ThreadRow | null {
     return this.index?.find(threadId) ?? null


### PR DESCRIPTION
## Summary

Restore the SQLite-backed thread list pagination path instead of falling back to a full JSONL directory scan on every page request.

## Root cause

`hybrid-thread-list-page.ts` called `source.indexCount(options)`, but `HybridThreadStore` did not implement that structural method even though `HybridThreadIndexRepository.count()` already existed.

## Changes

- delegate filtered page counts from `HybridThreadStore` to the SQLite index repository
- add a real SQLite regression test covering workspace/search filters, total count, cursor pagination, and absence of filesystem fallback

## Tests

- Electron-ABI Vitest: `src/adapters/hybrid/hybrid-thread-store.test.ts` (4 passed)
- `npm --prefix kun run typecheck`
- `npm run build:kun`
- `npm run typecheck`
- targeted ESLint
- `npm run check:file-lines`
- `git diff --check`

Fixes #1187