### PR TITLE
fix(windows): skip unsupported POSIX chmod

### DIFF
--- a/kun/src/artifacts/artifact-store.ts
+++ b/kun/src/artifacts/artifact-store.ts
@@ -10,10 +10,11 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { chmod, mkdir, readFile, readdir, rename, rm, writeFile, stat as fsStat, open as fsOpen } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rename, rm, writeFile, stat as fsStat, open as fsOpen } from 'node:fs/promises'
 import { join } from 'node:path'
 import { StringDecoder } from 'node:string_decoder'
 import { artifactId, summarizeForModel, type ArtifactSummary } from './artifact-summary.js'
+import { applyPosixMode } from '../security/posix-permissions.js'
 
 export type ArtifactSourceKind = 'mcp' | 'web' | 'bash' | 'attachment' | 'remote-log' | 'tool' | 'other'
 
@@ -286,7 +287,7 @@ export class FileArtifactStore implements ArtifactStore {
   private async ensureDir(): Promise<void> {
     if (!this.ready) {
       this.ready = mkdir(this.dir, { recursive: true, mode: 0o700 })
-        .then(async () => { await chmod(this.dir, 0o700) })
+        .then(async () => { await applyPosixMode(this.dir, 0o700) })
     }
     return this.ready
   }

--- a/kun/src/attachments/attachment-store.ts
+++ b/kun/src/attachments/attachment-store.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { chmod, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { z } from 'zod'
 import type { AttachmentsCapabilityConfig } from '../contracts/capabilities.js'
@@ -10,6 +10,7 @@ import type {
   AttachmentVisualPreview
 } from '../contracts/attachments.js'
 import { AttachmentMetadata as AttachmentMetadataSchema } from '../contracts/attachments.js'
+import { applyPosixMode } from '../security/posix-permissions.js'
 
 const ATTACHMENT_ID_PATTERN = /^att_[0-9a-f]{24}$/
 const PendingAttachmentLeaseSchema = z.object({
@@ -422,7 +423,7 @@ export class FileAttachmentStore implements AttachmentStore {
 
   private async ensureRoot(): Promise<void> {
     await mkdir(this.options.rootDir, { recursive: true, mode: 0o700 })
-    await chmod(this.options.rootDir, 0o700)
+    await applyPosixMode(this.options.rootDir, 0o700)
   }
 }
 

--- a/kun/src/delegation/delegation-runtime-contracts.ts
+++ b/kun/src/delegation/delegation-runtime-contracts.ts
@@ -1,7 +1,8 @@
-import { chmod, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 import { z } from 'zod'
+import { applyPosixMode } from '../security/posix-permissions.js'
 import {
   ModelReasoningEffort,
   SubagentProfileConfig,
@@ -470,7 +471,7 @@ export class FileDelegationStore {
 
   private async ensureRoot(): Promise<void> {
     await mkdir(this.rootDir, { recursive: true, mode: 0o700 })
-    await chmod(this.rootDir, 0o700)
+    await applyPosixMode(this.rootDir, 0o700)
   }
 }
 

--- a/kun/src/memory/memory-store.ts
+++ b/kun/src/memory/memory-store.ts
@@ -1,7 +1,8 @@
-import { chmod, mkdir, readFile, readdir, rm } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import type { MemoryCapabilityConfig } from '../contracts/capabilities.js'
 import { atomicWriteFile } from '../adapters/file/atomic-write.js'
+import { applyPosixMode } from '../security/posix-permissions.js'
 import {
   MemoryDiagnostics,
   MemoryRecord,
@@ -220,7 +221,7 @@ export class FileMemoryStore implements MemoryStore {
 
   private async ensureRoot(): Promise<void> {
     await mkdir(this.options.rootDir, { recursive: true, mode: 0o700 })
-    await chmod(this.options.rootDir, 0o700)
+    await applyPosixMode(this.options.rootDir, 0o700)
   }
 
   private now(): string {

--- a/kun/src/security/posix-permissions.test.ts
+++ b/kun/src/security/posix-permissions.test.ts
@@ -1,0 +1,27 @@
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import {
+  applyPosixMode,
+  applyPosixModeSync,
+  shouldApplyPosixMode
+} from './posix-permissions.js'
+
+describe('POSIX permission compatibility', () => {
+  it('classifies Windows as non-POSIX without weakening Unix platforms', () => {
+    expect(shouldApplyPosixMode('win32')).toBe(false)
+    expect(shouldApplyPosixMode('darwin')).toBe(true)
+    expect(shouldApplyPosixMode('linux')).toBe(true)
+  })
+
+  it('skips chmod on Windows and preserves errors on POSIX', async () => {
+    const missing = join(tmpdir(), `kun-missing-permissions-${process.pid}`)
+    if (process.platform === 'win32') {
+      await expect(applyPosixMode(missing, 0o700)).resolves.toBeUndefined()
+      expect(() => applyPosixModeSync(missing, 0o700)).not.toThrow()
+      return
+    }
+    await expect(applyPosixMode(missing, 0o700)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(() => applyPosixModeSync(missing, 0o700)).toThrow(expect.objectContaining({ code: 'ENOENT' }))
+  })
+})

--- a/kun/src/security/posix-permissions.ts
+++ b/kun/src/security/posix-permissions.ts
@@ -1,0 +1,17 @@
+import { chmodSync } from 'node:fs'
+import { chmod } from 'node:fs/promises'
+
+export function shouldApplyPosixMode(platform: NodeJS.Platform = process.platform): boolean {
+  return platform !== 'win32'
+}
+
+/** Windows ACLs do not implement POSIX modes; permission hardening is non-applicable there. */
+export async function applyPosixMode(path: string, mode: number): Promise<void> {
+  if (!shouldApplyPosixMode()) return
+  await chmod(path, mode)
+}
+
+export function applyPosixModeSync(path: string, mode: number): void {
+  if (!shouldApplyPosixMode()) return
+  chmodSync(path, mode)
+}

--- a/kun/src/services/background-shell-output.ts
+++ b/kun/src/services/background-shell-output.ts
@@ -1,6 +1,7 @@
-import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { createWriteStream, type WriteStream } from 'node:fs'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { applyPosixMode } from '../security/posix-permissions.js'
 
 /** Shared per-thread folder for all background shell logs (alongside messages.jsonl). */
 export const BACKGROUND_SHELL_OUTPUT_SUBDIR = 'background-shells'
@@ -105,7 +106,7 @@ export class BackgroundShellOutputWriter {
   async open(): Promise<void> {
     await this.ensureOutputDir()
     await writeFile(this.paths.outputFilePath, '', { encoding: 'utf-8', mode: 0o600 })
-    await chmod(this.paths.outputFilePath, 0o600)
+    await applyPosixMode(this.paths.outputFilePath, 0o600)
     this.stream = createWriteStream(this.paths.outputFilePath, { flags: 'a', mode: 0o600 })
   }
 
@@ -132,7 +133,7 @@ export class BackgroundShellOutputWriter {
     if (!this.stream) {
       await this.ensureOutputDir()
       await writeFile(this.paths.outputFilePath, '', { encoding: 'utf-8', mode: 0o600 })
-      await chmod(this.paths.outputFilePath, 0o600)
+      await applyPosixMode(this.paths.outputFilePath, 0o600)
       return
     }
     const stream = this.stream
@@ -166,6 +167,6 @@ export class BackgroundShellOutputWriter {
 
   private async ensureOutputDir(): Promise<void> {
     await mkdir(this.paths.outputDir, { recursive: true, mode: 0o700 })
-    await chmod(this.paths.outputDir, 0o700)
+    await applyPosixMode(this.paths.outputDir, 0o700)
   }
 }

--- a/kun/src/services/model-request-trace-store.ts
+++ b/kun/src/services/model-request-trace-store.ts
@@ -1,7 +1,8 @@
 import { createReadStream } from 'node:fs'
-import { appendFile, chmod, mkdir, rm } from 'node:fs/promises'
+import { appendFile, mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createInterface } from 'node:readline'
+import { applyPosixMode } from '../security/posix-permissions.js'
 import {
   MODEL_REQUEST_TRACE_SCHEMA_VERSION,
   ModelRequestTraceRecordSchema,
@@ -41,7 +42,7 @@ export class ModelRequestTraceStore {
           await this.ensureReady()
           const path = this.pathForThread(threadId)
           await appendFile(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8', mode: 0o600 })
-          await chmod(path, 0o600)
+          await applyPosixMode(path, 0o600)
           this.rememberRecent(threadId, record)
         } catch (error) {
           this.rememberWarning(classifyTracePersistenceError(error))
@@ -139,7 +140,7 @@ export class ModelRequestTraceStore {
 
   private async ensureReady(): Promise<void> {
     this.ready ??= mkdir(this.root, { recursive: true, mode: 0o700 })
-      .then(async () => { await chmod(this.root, 0o700) })
+      .then(async () => { await applyPosixMode(this.root, 0o700) })
     await this.ready
   }
 

--- a/kun/src/telemetry/agent-observability.ts
+++ b/kun/src/telemetry/agent-observability.ts
@@ -1,11 +1,12 @@
 import { createHash } from 'node:crypto'
-import { appendFile, chmod, mkdir } from 'node:fs/promises'
+import { appendFile, mkdir } from 'node:fs/promises'
 import { dirname, isAbsolute, join } from 'node:path'
 import type { RuntimeEvent } from '../contracts/events.js'
 import type { UsageSnapshot } from '../contracts/usage.js'
 import type { ObservabilityConfig } from '../config/kun-config.js'
 import type { RuntimeEventObserver } from '../services/runtime-event-recorder.js'
 import { OtlpHttpJsonAgentObservabilitySink } from './otlp-http-json-sink.js'
+import { applyPosixMode } from '../security/posix-permissions.js'
 
 export type AgentObservabilityAttributeValue = string | number | boolean | string[]
 
@@ -59,11 +60,11 @@ export class JsonlAgentObservabilitySink implements AgentObservabilitySink {
 
   async emit(span: AgentObservabilitySpan): Promise<void> {
     this.ready ??= mkdir(dirname(this.outputPath), { recursive: true, mode: 0o700 })
-      .then(async () => { await chmod(dirname(this.outputPath), 0o700) })
+      .then(async () => { await applyPosixMode(dirname(this.outputPath), 0o700) })
     await this.ready
     await appendFile(this.outputPath, JSON.stringify({ span }) + '\n', { encoding: 'utf8', mode: 0o600 })
     if (!this.hardened) {
-      await chmod(this.outputPath, 0o600)
+      await applyPosixMode(this.outputPath, 0o600)
       this.hardened = true
     }
   }

--- a/src/main/browser-use/browser-use-audit-log.ts
+++ b/src/main/browser-use/browser-use-audit-log.ts
@@ -1,12 +1,12 @@
 import {
   appendFile,
-  chmod,
   mkdir,
   rename,
   stat,
   unlink
 } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { applyPosixMode } from '../../../kun/src/security/posix-permissions.js'
 
 export const BROWSER_USE_AUDIT_MAX_FILE_BYTES = 5 * 1024 * 1024
 export const BROWSER_USE_AUDIT_MAX_ARCHIVES = 2
@@ -38,7 +38,7 @@ export async function appendBrowserUseAuditLine(
 
   const auditDirectory = dirname(auditPath)
   await mkdir(auditDirectory, { recursive: true, mode: 0o700 })
-  await chmod(auditDirectory, 0o700)
+  await applyPosixMode(auditDirectory, 0o700)
   const currentBytes = await fileSize(auditPath)
   if (currentBytes > maxFileBytes) {
     await unlinkIfPresent(auditPath)
@@ -46,7 +46,7 @@ export async function appendBrowserUseAuditLine(
     await rotateAuditFiles(auditPath, maxArchives)
   }
   await appendFile(auditPath, payload, { encoding: 'utf8', mode: 0o600 })
-  await chmod(auditPath, 0o600)
+  await applyPosixMode(auditPath, 0o600)
 }
 
 async function rotateAuditFiles(auditPath: string, maxArchives: number): Promise<void> {
@@ -92,7 +92,7 @@ async function unlinkIfPresent(path: string): Promise<void> {
 
 async function chmodIfPresent(path: string, mode: number): Promise<void> {
   try {
-    await chmod(path, mode)
+    await applyPosixMode(path, mode)
   } catch (error) {
     if (!isMissingFile(error)) throw error
   }

--- a/src/main/data-migration/kunpack-zip.ts
+++ b/src/main/data-migration/kunpack-zip.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { createReadStream, createWriteStream } from 'node:fs'
-import { chmod, lstat, mkdir, rm } from 'node:fs/promises'
+import { lstat, mkdir, rm } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { Transform } from 'node:stream'
@@ -13,6 +13,7 @@ import {
   type DataMigrationPackageEntryKind,
   type PackageRelativePath
 } from '../../shared/data-migration'
+import { applyPosixMode } from '../../../kun/src/security/posix-permissions.js'
 
 const FIXED_ZIP_TIME = new Date('1980-01-01T00:00:00.000Z')
 const DEFAULT_FILE_MODE = 0o100600
@@ -241,7 +242,7 @@ export async function extractZip64ArchiveEntries(input: {
 }): Promise<{ bytes: number; entries: number }> {
   const root = resolve(input.destinationRoot)
   await mkdir(root, { recursive: true, mode: 0o700 })
-  await chmod(root, 0o700)
+  await applyPosixMode(root, 0o700)
   const declarations = new Map(input.entries.map((entry) => [entry.path, entry]))
   const extracted = new Set<string>()
   let bytes = 0
@@ -295,7 +296,7 @@ export async function extractZip64ArchiveEntries(input: {
         await rm(outputPath, { force: true }).catch(() => undefined)
         throw new Error(`Kunpack extracted entry integrity mismatch: ${declaration.path}`)
       }
-      await chmod(outputPath, 0o600 | ((declaration.mode ?? 0) & 0o111))
+      await applyPosixMode(outputPath, 0o600 | ((declaration.mode ?? 0) & 0o111))
       extracted.add(declaration.path)
       bytes += entryBytes
       entries += 1

--- a/src/main/data-migration/workspace-staging.ts
+++ b/src/main/data-migration/workspace-staging.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { chmod, lstat, mkdir, readlink, rename, rm, symlink } from 'node:fs/promises'
+import { lstat, mkdir, readlink, rename, rm, symlink } from 'node:fs/promises'
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import {
   buildMigrationDestinationPath,
@@ -14,6 +14,7 @@ import {
 import { validateKunpackLinkMetadata } from './archive-security'
 import { stableImportedSiblingPath } from './import-planner'
 import { extractZip64ArchiveEntries } from './kunpack-zip'
+import { applyPosixMode } from '../../../kun/src/security/posix-permissions.js'
 
 export type StagedWorkspaceFile = {
   entry: DataMigrationPackageEntry
@@ -423,7 +424,7 @@ function assertBelow(root: string, path: string): void {
 async function hardenTreePermissions(root: string): Promise<void> {
   const details = await lstat(root)
   if (details.isSymbolicLink()) return
-  await chmod(root, details.isDirectory() ? 0o700 : 0o600 | (details.mode & 0o111))
+  await applyPosixMode(root, details.isDirectory() ? 0o700 : 0o600 | (details.mode & 0o111))
   if (!details.isDirectory()) return
   const { readdir } = await import('node:fs/promises')
   for (const name of await readdir(root)) await hardenTreePermissions(join(root, name))

--- a/src/main/runtime-data-dir-migration-copy.ts
+++ b/src/main/runtime-data-dir-migration-copy.ts
@@ -1,5 +1,4 @@
 import {
-  chmodSync,
   closeSync,
   constants,
   copyFileSync,
@@ -48,6 +47,7 @@ import {
   runtimeStoreInventory,
   uniqueSiblingBackup
 } from './runtime-data-dir-migration-inventory'
+import { applyPosixModeSync } from '../../kun/src/security/posix-permissions.js'
 
 
 
@@ -96,7 +96,7 @@ export function copyRegularFilePreservingMetadata(sourcePath: string, targetPath
   const targetState = pathState(targetPath)
   if (targetState !== 'missing') {
     if (targetState === 'other' && sameRegularFileContent(sourcePath, targetPath)) {
-      chmodSync(targetPath, sourceMetadata.mode & 0o7777)
+      applyPosixModeSync(targetPath, sourceMetadata.mode & 0o7777)
       utimesSync(targetPath, sourceMetadata.atime, sourceMetadata.mtime)
       return
     }
@@ -119,7 +119,7 @@ export function copyRegularFilePreservingMetadata(sourcePath: string, targetPath
       partialPath,
       constants.COPYFILE_EXCL | constants.COPYFILE_FICLONE
     )
-    chmodSync(partialPath, sourceMetadata.mode & 0o7777)
+    applyPosixModeSync(partialPath, sourceMetadata.mode & 0o7777)
     utimesSync(partialPath, sourceMetadata.atime, sourceMetadata.mtime)
     // Source files may intentionally be read-only. A read descriptor is
     // sufficient for fsync and avoids requiring write permission after the
@@ -155,7 +155,7 @@ export function copyRuntimeTreePreservingSource(sourcePath: string, targetPath: 
   } else if (targetState !== 'dir') {
     throw new Error(`Runtime copy target is not a directory: ${targetPath}`)
   } else {
-    chmodSync(targetPath, (sourceMetadata.mode & 0o7777) | 0o700)
+    applyPosixModeSync(targetPath, (sourceMetadata.mode & 0o7777) | 0o700)
   }
 
   for (const targetName of readdirSync(targetPath)) {
@@ -190,7 +190,7 @@ export function copyRuntimeTreePreservingSource(sourcePath: string, targetPath: 
     }
     throw new Error(`Runtime source contains an unsupported entry: ${sourceEntry}`)
   }
-  chmodSync(targetPath, sourceMetadata.mode & 0o7777)
+  applyPosixModeSync(targetPath, sourceMetadata.mode & 0o7777)
   utimesSync(targetPath, sourceMetadata.atime, sourceMetadata.mtime)
   fsyncDirectoryBestEffort(targetPath)
 }
@@ -348,11 +348,7 @@ export function backUpRegularFile(
   }
   const backupPath = uniqueSiblingBackup(path, label, now)
   copyFileSync(path, backupPath, constants.COPYFILE_EXCL)
-  try {
-    chmodSync(backupPath, 0o600)
-  } catch {
-    // Windows ACLs are not represented by POSIX mode bits.
-  }
+  applyPosixModeSync(backupPath, 0o600)
   const backupHandle = openSync(backupPath, 'r+')
   try {
     fsyncFileBestEffort(backupHandle)

--- a/src/main/runtime-data-dir-recovery-candidates.ts
+++ b/src/main/runtime-data-dir-recovery-candidates.ts
@@ -1,5 +1,4 @@
 import {
-  chmodSync,
   closeSync,
   constants,
   copyFileSync,
@@ -43,6 +42,7 @@ import {
   inspectMigrationJournalVerifiedCandidate,
   migrationJournalPhaseCanProveStaging
 } from './runtime-data-dir-recovery-discovery'
+import { applyPosixModeSync } from '../../kun/src/security/posix-permissions.js'
 import {
   stringArraysEqual
 } from './runtime-data-dir-recovery-evidence'
@@ -354,14 +354,14 @@ export function copyRuntimeTree(sourcePath: string, targetPath: string): void {
       symlinkSync(readlinkSync(sourceEntry), targetEntry)
     } else if (metadata.isFile()) {
       copyFileSync(sourceEntry, targetEntry, constants.COPYFILE_EXCL | constants.COPYFILE_FICLONE)
-      chmodSync(targetEntry, metadata.mode & 0o7777)
+      applyPosixModeSync(targetEntry, metadata.mode & 0o7777)
       utimesSync(targetEntry, metadata.atime, metadata.mtime)
       fsyncFileBestEffort(targetEntry)
     } else {
       throw new Error('copy source contains an unsupported entry')
     }
   }
-  chmodSync(targetPath, source.mode & 0o7777)
+  applyPosixModeSync(targetPath, source.mode & 0o7777)
   utimesSync(targetPath, source.atime, source.mtime)
   fsyncDirectoryBestEffort(targetPath)
 }


### PR DESCRIPTION
## Summary

Prevent Windows-only chmod failures from breaking runtime persistence and migration features.

## Changes

- centralize POSIX permission hardening behind a platform-aware helper
- skip unsupported chmod operations on Windows while preserving macOS/Linux errors
- cover attachments, memory, artifacts, delegation, background shell output, traces, audit logs, imports, and runtime data migration paths
- add regression coverage for platform behavior

## Tests

- targeted Kun tests: 57 passed
- targeted main-process tests: 53 passed
- npm run build:kun
- npm run typecheck
- npm run check:file-lines
- git diff --check

Fixes #1188