### PR TITLE
fix(installer): recreate desktop shortcut after updates

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -176,6 +176,12 @@ Var /GLOBAL KunInstallerStopDiagnosticPath
     Quit
   ${endif}
 
+  ${if} ${isUpdated}
+    # electron-builder keeps existing shortcuts during --updated installs, but
+    # a scope/directory migration may already have removed the old link.
+    !insertmacro addDesktopLink "false"
+  ${endif}
+
   ${if} $KunInstallerInPlaceUpdate == 1
     !insertmacro kunRunMigrationHelper CleanupInPlaceLeftovers
     ${if} $KunInstallerHelperExitCode != 0

--- a/src/main/packaging-config.hooks.test.ts
+++ b/src/main/packaging-config.hooks.test.ts
@@ -280,6 +280,7 @@ it('passes the nested OfficeCLI executable through the Windows signing manager',
     expect(builderConfig.nsis.include).toBe('build/installer.nsh')
     expect(builderConfig.nsis.allowToChangeInstallationDirectory).toBe(false)
     expect(builderConfig.nsis.deleteAppDataOnUninstall).toBe(false)
+    expect(builderConfig.nsis.createDesktopShortcut).toBe('always')
     expect(installerScript).toContain('!include "${PROJECT_DIR}\\build\\installer-process-check.nsh"')
     expect(installerScript).toContain('!macro customInit')
     expect(installerScript).toContain('${if} ${isUpdated}')
@@ -377,6 +378,10 @@ it('passes the nested OfficeCLI executable through the Windows signing manager',
       'suppressed the selected-scope uninstaller until the new payload is installed'
     )
     expect(installerScript).toContain('!insertmacro kunRunMigrationHelper CleanupInPlaceLeftovers')
+    expect(installerScript).toContain('!insertmacro addDesktopLink "false"')
+    expect(installerScript.indexOf('!insertmacro kunRunMigrationHelper ValidatePayload')).toBeLessThan(
+      installerScript.indexOf('!insertmacro addDesktopLink "false"')
+    )
     expect(installerScript).toContain('KUN_INSTALLER_IN_PLACE_UPDATE')
     expect(installerScript).toContain('Function KunSecureSelectedUninstallRegistration')
     expect(installerScript).toContain('Function KunSecureCurrentUserUninstallRegistration')


### PR DESCRIPTION
## Summary

Restore the configured desktop shortcut after an automatic Windows update removes the old installation shell state.

## Changes

- recreate the desktop shortcut after the updated payload is validated
- reuse electron-builder's shortcut macro so no-desktop flags and AUMID behavior remain intact
- add packaging regression assertions for update ordering and the always-create policy

## Tests

- npx vitest run src/main/packaging-config.hooks.test.ts (11 passed)
- npx eslint src/main/packaging-config.hooks.test.ts
- npm run check:file-lines
- npm run build
- electron-builder 26.8.1 Windows NSIS compilation on macOS with native rebuild disabled
- package-size inspection
- git diff --check