### PR TITLE
fix(chat): keep branch picker above scroll containers

### DIFF
--- a/src/renderer/src/components/chat/GitBranchPicker.tsx
+++ b/src/renderer/src/components/chat/GitBranchPicker.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../lib/thread-worktree-registry'
 import { useChatStore } from '../../store/chat-store'
 import { rememberCodeWorkspaceRoots } from '../../store/chat-store-helpers'
+import { useGitBranchPickerPopover } from './use-git-branch-picker-popover'
 
 const BRANCH_ROW_LABEL_MAX_LENGTH = 42
 const BRANCH_TRIGGER_LABEL_MAX_LENGTH = 32
@@ -79,6 +80,12 @@ export function GitBranchPicker({
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_GIT_BRANCH_PREFIX)
   const wrapRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const closePanel = useCallback((): void => setOpen(false), [])
+  const { panelRef, panelStyle, updatePanelPosition } = useGitBranchPickerPopover({
+    open,
+    anchorRef: wrapRef,
+    onClose: closePanel
+  })
 
   const load = useCallback(async (): Promise<void> => {
     if (!root || typeof window.kunGui?.getGitBranches !== 'function') return
@@ -129,17 +136,6 @@ export function GitBranchPicker({
     void load()
     window.setTimeout(() => inputRef.current?.focus(), 0)
   }, [load, open])
-
-  useEffect(() => {
-    if (!open) return
-    const onPointerDown = (event: PointerEvent): void => {
-      const target = event.target
-      if (target instanceof Node && wrapRef.current?.contains(target)) return
-      setOpen(false)
-    }
-    window.addEventListener('pointerdown', onPointerDown)
-    return () => window.removeEventListener('pointerdown', onPointerDown)
-  }, [open])
 
   useEffect(() => {
     if (!open) setTooltip(null)
@@ -395,7 +391,12 @@ export function GitBranchPicker({
         data-composer-launch-settings-trigger
         data-composer-launch-mode={useWorktreePool ? 'worktree' : 'current-directory'}
         className="flex h-8 max-w-[360px] min-w-0 items-center gap-2 rounded-lg px-2 text-[14px] font-medium text-ds-muted transition hover:bg-ds-hover hover:text-ds-ink"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          updatePanelPosition()
+          setOpen((v) => !v)
+        }}
+        aria-expanded={open}
+        aria-haspopup="dialog"
         aria-label={t('composerLaunchTriggerLabel', { branch: label, mode: launchModeLabel })}
       >
         <GitBranch className="h-4 w-4 shrink-0" strokeWidth={1.8} />
@@ -407,10 +408,14 @@ export function GitBranchPicker({
         )}
       </button>
 
-      {open ? (
+      {open && typeof document !== 'undefined' ? createPortal(
         <div
+          ref={panelRef}
           data-composer-launch-settings-panel
-          className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[min(560px,calc(100vw-48px))] overflow-hidden rounded-2xl border border-ds-border bg-ds-elevated shadow-[0_24px_70px_rgba(44,55,78,0.18)] backdrop-blur-xl dark:shadow-[0_30px_80px_rgba(0,0,0,0.42)]"
+          role="dialog"
+          aria-label={t('composerLaunchSettingsTitle')}
+          style={panelStyle}
+          className="fixed z-[1000] overflow-y-auto overscroll-contain rounded-2xl border border-ds-border bg-ds-elevated shadow-[0_24px_70px_rgba(44,55,78,0.18)] backdrop-blur-xl dark:shadow-[0_30px_80px_rgba(0,0,0,0.42)]"
         >
           <div className="flex items-center justify-between gap-4 border-b border-ds-border-muted px-4 py-3.5">
             <div className="min-w-0">
@@ -671,7 +676,8 @@ export function GitBranchPicker({
               {t('composerLaunchDone')}
             </button>
           </div>
-        </div>
+        </div>,
+        document.body
       ) : null}
       {tooltip ? createPortal(
         <div

--- a/src/renderer/src/components/chat/composer-worktree-launch-settings.test.ts
+++ b/src/renderer/src/components/chat/composer-worktree-launch-settings.test.ts
@@ -7,6 +7,13 @@ import { useChatStore } from '../../store/chat-store'
 import i18n from '../../i18n'
 import { FloatingComposer } from './FloatingComposer'
 import { GitBranchPicker } from './GitBranchPicker'
+import { calculateComposerPopoverPlacement } from './floating-composer-popover-placement'
+
+const { createPortalMock } = vi.hoisted(() => ({
+  createPortalMock: vi.fn((children: unknown) => children)
+}))
+
+vi.mock('react-dom', () => ({ createPortal: createPortalMock }))
 
 const BRANCH_RESULT: GitBranchesResult = {
   ok: true,
@@ -67,6 +74,7 @@ describe('composer worktree launch settings', () => {
   let previousLanguage: string
 
   beforeEach(async () => {
+    createPortalMock.mockClear()
     previousLanguage = i18n.language
     await i18n.changeLanguage('en')
     rendererRuntimeClient.invalidateSettings()
@@ -87,6 +95,19 @@ describe('composer worktree launch settings', () => {
     vi.unstubAllGlobals()
     Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
     await i18n.changeLanguage(previousLanguage)
+  })
+
+  it('bounds a tall branch panel inside a short viewport', () => {
+    const placement = calculateComposerPopoverPlacement({
+      anchorRect: { left: 240, right: 434, top: 440, bottom: 472 },
+      popoverHeight: 580,
+      viewportHeight: 562,
+      viewportWidth: 675,
+      preferredWidth: 560,
+      maximumHeight: 640
+    })
+
+    expect(placement).toEqual({ left: 57, top: 12, width: 560, maxHeight: 420 })
   })
 
   it('summarizes the selected branch and toggles isolated-worktree mode', async () => {
@@ -122,6 +143,13 @@ describe('composer worktree launch settings', () => {
       const toggle = renderer!.root.findByProps({
         'data-composer-worktree-mode-toggle': true
       })
+      const panel = renderer!.root.findByProps({
+        'data-composer-launch-settings-panel': true
+      })
+      expect(createPortalMock).toHaveBeenCalledWith(expect.anything(), document.body)
+      expect(panel.props.className).toContain('fixed')
+      expect(panel.props.className).toContain('z-[1000]')
+      expect(panel.props.role).toBe('dialog')
       expect(toggle.findByProps({ role: 'switch' }).props['aria-checked']).toBe(true)
 
       await act(async () => {

--- a/src/renderer/src/components/chat/use-git-branch-picker-popover.ts
+++ b/src/renderer/src/components/chat/use-git-branch-picker-popover.ts
@@ -1,0 +1,94 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type RefObject
+} from 'react'
+import {
+  calculateComposerPopoverPlacement,
+  currentComposerBodyZoom,
+  type ComposerPopoverPlacement
+} from './floating-composer-popover-placement'
+
+const POPOVER_WIDTH = 560
+const POPOVER_MAX_HEIGHT = 640
+const POPOVER_ESTIMATED_HEIGHT = 580
+
+export function useGitBranchPickerPopover({
+  open,
+  anchorRef,
+  onClose
+}: {
+  open: boolean
+  anchorRef: RefObject<HTMLDivElement | null>
+  onClose: () => void
+}): {
+  panelRef: RefObject<HTMLDivElement | null>
+  panelStyle: CSSProperties
+  updatePanelPosition: () => void
+} {
+  const panelRef = useRef<HTMLDivElement | null>(null)
+  const [placement, setPlacement] = useState<ComposerPopoverPlacement | null>(null)
+
+  const updatePanelPosition = useCallback((): void => {
+    const anchor = anchorRef.current
+    if (!anchor) return
+    setPlacement(calculateComposerPopoverPlacement({
+      anchorRect: anchor.getBoundingClientRect(),
+      popoverHeight: Math.max(
+        panelRef.current?.scrollHeight ?? 0,
+        POPOVER_ESTIMATED_HEIGHT
+      ),
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+      preferredWidth: POPOVER_WIDTH,
+      maximumHeight: POPOVER_MAX_HEIGHT,
+      coordinateScale: currentComposerBodyZoom()
+    }))
+  }, [anchorRef])
+
+  useEffect(() => {
+    if (!open) return
+    updatePanelPosition()
+    const frame = window.requestAnimationFrame(updatePanelPosition)
+    const onPointerDown = (event: PointerEvent): void => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (anchorRef.current?.contains(target) || panelRef.current?.contains(target)) return
+      onClose()
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('pointerdown', onPointerDown)
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('resize', updatePanelPosition)
+    window.addEventListener('scroll', updatePanelPosition, true)
+    return () => {
+      window.cancelAnimationFrame(frame)
+      window.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('resize', updatePanelPosition)
+      window.removeEventListener('scroll', updatePanelPosition, true)
+    }
+  }, [anchorRef, onClose, open, updatePanelPosition])
+
+  const panelStyle: CSSProperties = placement
+    ? {
+        left: `${placement.left}px`,
+        top: `${placement.top}px`,
+        width: `${placement.width}px`,
+        maxHeight: `${placement.maxHeight}px`
+      }
+    : {
+        left: 0,
+        top: 0,
+        width: `${POPOVER_WIDTH}px`,
+        maxHeight: `${POPOVER_MAX_HEIGHT}px`,
+        visibility: 'hidden'
+      }
+
+  return { panelRef, panelStyle, updatePanelPosition }
+}


### PR DESCRIPTION
## Summary

Keep the Git branch/worktree picker visible in the initial chat layout instead of clipping it inside the scroll container.

## Changes

- render the picker through a document-body portal with fixed positioning
- choose the available side of the trigger and constrain tall panels to the viewport
- recalculate on resize and nested scrolling
- preserve outside-click and Escape dismissal
- add portal and short-viewport regression coverage

## Tests

- npx vitest run src/renderer/src/components/chat/composer-worktree-launch-settings.test.ts src/renderer/src/components/chat/FloatingComposerGraphProgress.test.ts (21 passed)
- npm run typecheck
- targeted eslint
- npm run check:file-lines
- git diff --check

Fixes #1189