### PR TITLE
feat(sse): detect runtime event sequence conflicts and resync authoritatively

### DIFF
--- a/src/main/runtime-sse-ipc.test.ts
+++ b/src/main/runtime-sse-ipc.test.ts
@@ -353,4 +353,93 @@ describe('runtime-sse-ipc', () => {
       expect.objectContaining({ streamId: started.streamId, message: 'oversized replay record' })
     )
   })
+
+  it('emits a structured seq_conflict error when the wire regresses within one connection', async () => {
+    registerRuntimeSseIpc({
+      ipcMain: mockIpcMain,
+      store: mockStore,
+      ensureRuntime: mockEnsureRuntime,
+      logError: mockLogError
+    })
+    const startHandler = handlers.get('runtime:sse:start')
+    expect(startHandler).toBeDefined()
+
+    // Same connection: a data event with seq 1 after a delivered seq 2 can
+    // never be legal replay — replay is strictly ascending.
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: mockReadableStream([
+        'id: 1\ndata: {"text": "a"}\n\n',
+        'id: 2\ndata: {"text": "b"}\n\n',
+        'id: 1\ndata: {"text": "regressed"}\n\n'
+      ])
+    })
+
+    const started = await startHandler!(mockEvent, { threadId: 'thr_conflict', sinceSeq: 0 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The transport stops immediately — no blind reconnect from the dead cursor.
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockEvent.sender.send).toHaveBeenCalledWith(
+      'runtime:sse-error',
+      expect.objectContaining({ streamId: started.streamId, code: 'seq_conflict' })
+    )
+    expect(mockLogError).toHaveBeenCalledWith(
+      'sse',
+      expect.stringContaining('sequence conflict'),
+      expect.objectContaining({ regressedFrom: 2, observed: 1, streamId: started.streamId })
+    )
+    // The legal prefix was delivered exactly once; the regressed frame never is.
+    const deliveredSeqs = mockEvent.sender.send.mock.calls
+      .filter((call: any) => call[0] === 'runtime:sse-event')
+      .flatMap((call: any) => call[1].events)
+      .map((event: any) => event.seq)
+    expect(deliveredSeqs).toEqual([1, 2])
+  })
+
+  it('catches cross-connection seq reuse on the first frame of a reconnected stream', async () => {
+    registerRuntimeSseIpc({
+      ipcMain: mockIpcMain,
+      store: mockStore,
+      ensureRuntime: mockEnsureRuntime,
+      logError: mockLogError
+    })
+    const startHandler = handlers.get('runtime:sse:start')
+    expect(startHandler).toBeDefined()
+
+    const first = mockReadableStream([
+      'id: 5\ndata: {"text": "durable"}\n\n',
+      '__TERMINATED__'
+    ])
+    // A truncated persisted tail makes the runtime reissue an already
+    // consumed seq below the cursor the reconnect requested.
+    const second = mockReadableStream([
+      'id: 3\ndata: {"text": "reused"}\n\n'
+    ])
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200, body: first })
+      .mockResolvedValueOnce({ ok: true, status: 200, body: second })
+      .mockResolvedValue({ ok: false, status: 400 })
+
+    const started = await startHandler!(mockEvent, { threadId: 'thr_reuse', sinceSeq: 0 })
+    await vi.advanceTimersByTimeAsync(0)
+    // 'terminated' is transient: reconnect after the initial 750ms backoff.
+    await vi.advanceTimersByTimeAsync(750)
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch.mock.calls[1][0].toString()).toContain('since_seq=5')
+    expect(mockEvent.sender.send).toHaveBeenCalledWith(
+      'runtime:sse-error',
+      expect.objectContaining({ streamId: started.streamId, code: 'seq_conflict' })
+    )
+    expect(mockLogError).toHaveBeenCalledWith(
+      'sse',
+      expect.stringContaining('sequence conflict'),
+      expect.objectContaining({ regressedFrom: 5, observed: 3 })
+    )
+    // No further reconnect: replaying from the same cursor would freeze the projection.
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/main/runtime-sse-ipc.ts
+++ b/src/main/runtime-sse-ipc.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { URL } from 'node:url'
 import type { AppSettingsV1 } from '../shared/app-settings'
 import { kunThreadEventsPath } from '../shared/kun-endpoints'
+import { checkSseConnectionMonotonicity, SSE_SEQ_CONFLICT_CODE } from '../shared/sse-sequence'
 import { sseAckPayloadSchema, sseStartPayloadSchema, streamIdSchema } from './ipc/app-ipc-schemas'
 import type { JsonSettingsStore } from './settings-store'
 import { getRuntimeBaseUrlForSettings, runtimeAuthHeaders } from './runtime/kun-adapter'
@@ -142,6 +143,26 @@ function isFatalSseStatus(status: number | undefined): boolean {
   return typeof status === 'number' && status >= 400 && status < 500 && status !== 408 && status !== 429
 }
 
+/**
+ * Transport-boundary violation (WP-03): within one HTTP connection the wire
+ * delivered a data event whose seq regressed below the connection watermark.
+ * The watermark is seeded with the requested cursor, so this also catches
+ * cross-connection seq reuse (a truncated persisted tail makes the runtime
+ * re-issue already consumed seqs), not just intra-connection reordering.
+ * Replay from the same cursor can never heal this; the renderer must take
+ * the authoritative snapshot resync path.
+ */
+class SseSequenceConflictError extends Error {
+  readonly code = SSE_SEQ_CONFLICT_CODE
+  constructor(
+    readonly regressedFrom: number,
+    readonly observed: number
+  ) {
+    super(`SSE sequence conflict: event seq ${observed} regressed below connection watermark ${regressedFrom}`)
+    this.name = 'SseSequenceConflictError'
+  }
+}
+
 function isTransientSseErrorMessage(message: string): boolean {
   return /sse start timeout|sse renderer acknowledgement timeout|fetch failed|network|terminated|aborted|socket|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR/i.test(message)
 }
@@ -253,6 +274,12 @@ export function registerRuntimeSseIpc(options: {
 
             let pendingEvents: Record<string, unknown>[] = []
             let pendingBytes = 0
+            // Per-connection sequence invariant (WP-03), seeded with the
+            // cursor this connection requested: replay delivers strictly
+            // ascending seqs, and the first live frame below the requested
+            // cursor proves the runtime reissued already consumed seqs.
+            // Heartbeats are exempt (they reuse the connection cursor).
+            let connectionWatermark: number | null = nextSinceSeq
 
             const flushEvents = async (): Promise<boolean> => {
               if (state.stoppedByClient || ac.signal.aborted) {
@@ -307,13 +334,22 @@ export function registerRuntimeSseIpc(options: {
                 throw new Error(typeof message === 'string' ? message : 'SSE server replay error')
               }
               const bytes = Buffer.byteLength(block, 'utf8')
+              const coerced = coerceSsePayload(parsed)
+              const monotonicity = checkSseConnectionMonotonicity(connectionWatermark, coerced)
+              if (!monotonicity.ok) {
+                // Do not flush the pending prefix here: an authoritative
+                // resync re-reads the whole snapshot, so the prefix is
+                // redundant — and ack-ing it would advance the doomed cursor.
+                throw new SseSequenceConflictError(monotonicity.regressedFrom, monotonicity.observed)
+              }
+              connectionWatermark = monotonicity.watermark
               if (
                 pendingEvents.length > 0 &&
                 (pendingEvents.length >= MAX_SSE_BATCH_EVENTS || pendingBytes + bytes > MAX_SSE_BATCH_BYTES)
               ) {
                 if (!await flushEvents()) return false
               }
-              pendingEvents.push(coerceSsePayload(parsed))
+              pendingEvents.push(coerced)
               pendingBytes += bytes
               if (pendingEvents.length >= MAX_SSE_BATCH_EVENTS || pendingBytes >= MAX_SSE_BATCH_BYTES) {
                 return flushEvents()
@@ -354,6 +390,23 @@ export function registerRuntimeSseIpc(options: {
             }
           } catch (e) {
             if (state.stoppedByClient || ac.signal.aborted) return
+            if (e instanceof SseSequenceConflictError) {
+              if (!sendSseMessage(wc, 'runtime:sse-error', {
+                streamId: id,
+                message: e.message,
+                code: SSE_SEQ_CONFLICT_CODE
+              })) {
+                state.stoppedByClient = true
+                ac.abort()
+                return
+              }
+              logError('sse', `SSE sequence conflict for thread ${request.threadId}`, {
+                streamId: id,
+                regressedFrom: e.regressedFrom,
+                observed: e.observed
+              })
+              return
+            }
             const msg = e instanceof Error ? e.message : String(e)
             if (isTransientSseErrorMessage(msg)) {
               await sleepWithAbort(reconnectDelayMs, ac.signal)

--- a/src/renderer/src/agent/kun-runtime-services.ts
+++ b/src/renderer/src/agent/kun-runtime-services.ts
@@ -8,6 +8,7 @@ import type {
   UserInputAnswer
 } from './types'
 import { getKunRuntimeSettings } from '@shared/app-settings-kun-defaults'
+import { createSseSeqGate, observeSseSeq } from '@shared/sse-sequence'
 import {
   KUN_ATTACHMENT_DIAGNOSTICS_PATH,
   KUN_ATTACHMENTS_PATH,
@@ -93,9 +94,13 @@ import type { DesignDocumentTarget } from './design-task-profile'
 
 const MAX_PENDING_SSE_DISPATCH_BATCHES = 32
 
-/** Preserves the native SSE failure status for the store's recovery policy. */
+/** Preserves the native SSE failure status (and structured code, WP-03) for the store's recovery policy. */
 export class KunSseSubscriptionError extends Error {
-  constructor(message: string, readonly status?: number) {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly code?: string
+  ) {
     super(message)
     this.name = 'KunSseSubscriptionError'
   }
@@ -440,12 +445,12 @@ export class KunRuntimeProviderServices {
       let settled = false
       let dispatchTail: Promise<void> = Promise.resolve()
       let queuedDispatchBatches = 0
-      // The subscription cursor is also the projection high-water mark.  A
-      // reconnect may replay already persisted non-delta events (tool running,
-      // completion, approval, Graph activity, ...), so filter the whole wire
-      // event before normalization.  This keeps reducer work and side effects
-      // behind the same monotonic gate instead of deduplicating text only.
-      let projectionSeqHighWater = sinceSeq
+      // The gate owns all dedupe/advance math (WP-03). Reconnects may replay
+      // already persisted non-delta events (tool running, completion,
+      // approval, Graph activity, ...), hidden model-only records make raw
+      // forward jumps legal, and heartbeats may reuse the cursor — the shared
+      // gate is the single place where those wire rules live.
+      let projectionSeqGate = createSseSeqGate(sinceSeq)
       const finish = (): void => {
         if (settled) return
         settled = true
@@ -484,25 +489,28 @@ export class KunRuntimeProviderServices {
         const task = dispatchTail.then(async () => {
           if (signal.aborted || settled) return
           const acceptedBatch: CoreRuntimeEventJson[] = []
-          let acceptedMaxSeq: number | null = null
           let heartbeatSeq: number | null = null
-          let candidateSeqHighWater = projectionSeqHighWater
+          let candidateGate = projectionSeqGate
           for (const event of batch) {
-            if (typeof event.seq === 'number') {
-              if (event.seq <= candidateSeqHighWater) {
-                // Heartbeats deliberately reuse the current event cursor. They
-                // are stale for projection purposes, but still prove that the
-                // live stream is healthy and must keep the busy watchdog from
-                // aborting a quiet, long-running tool call.
-                if (event.kind === 'heartbeat') {
-                  heartbeatSeq = Math.max(heartbeatSeq ?? event.seq, event.seq)
-                }
-                continue
-              }
-              candidateSeqHighWater = event.seq
-              acceptedMaxSeq = event.seq
+            const observation = observeSseSeq(candidateGate, event)
+            candidateGate = observation.state
+            switch (observation.kind) {
+              case 'accept':
+              case 'accept-unsequenced':
+                acceptedBatch.push(event)
+                break
+              case 'accept-heartbeat':
+              case 'stale-heartbeat':
+                // Fresh heartbeats advance the committed cursor (the server
+                // advertised delivery through this seq); stale ones only
+                // prove liveness. Neither is dispatched — they carry no
+                // projection payload — but both must keep the busy watchdog
+                // from aborting a quiet, long-running tool call.
+                heartbeatSeq = Math.max(heartbeatSeq ?? observation.seq, observation.seq)
+                break
+              case 'stale':
+                break
             }
-            acceptedBatch.push(event)
           }
           if (acceptedBatch.length > 0) {
             await dispatchKunRuntimeEvents(acceptedBatch, sink, (runtimeEvent, eventSink) =>
@@ -513,11 +521,13 @@ export class KunRuntimeProviderServices {
           // Commit the local replay gate only after every accepted event was
           // projected. If a reducer/effect throws, the unadvanced cursor lets
           // recovery replay the whole unacknowledged batch.
-          projectionSeqHighWater = candidateSeqHighWater
+          const uncommittedHighWater = projectionSeqGate.highWater
+          projectionSeqGate = candidateGate
           // Commit the renderer cursor only after the whole ordered batch has
           // been projected. ACK is flow control for the main process and must
           // never precede the renderer's durable in-memory projection.
-          const observedSeq = acceptedMaxSeq ?? heartbeatSeq
+          const observedSeq =
+            candidateGate.highWater !== uncommittedHighWater ? candidateGate.highWater : heartbeatSeq
           if (observedSeq !== null) sink.onSeq(observedSeq)
           if (signal.aborted || settled) return
           if (payload.batchId) {
@@ -535,9 +545,9 @@ export class KunRuntimeProviderServices {
           queuedDispatchBatches = Math.max(0, queuedDispatchBatches - 1)
         })
       })
-      const offErr = rendererRuntimeClient.onSseError(({ streamId: sid, message, status }) => {
+      const offErr = rendererRuntimeClient.onSseError(({ streamId: sid, message, status, code }) => {
         if (sid !== streamId) return
-        sink.onError(new KunSseSubscriptionError(message ?? `sse error ${status ?? ''}`, status))
+        sink.onError(new KunSseSubscriptionError(message ?? `sse error ${status ?? ''}`, status, code))
         finish()
       })
       const offEnd = rendererRuntimeClient.onSseEnd(({ streamId: sid }) => {

--- a/src/renderer/src/agent/kun-runtime-stream-recovery.test.ts
+++ b/src/renderer/src/agent/kun-runtime-stream-recovery.test.ts
@@ -125,6 +125,50 @@ describe('KunRuntimeProvider', () => {
     })
   })
 
+  it('preserves a structured seq_conflict code for the store recovery policy', async () => {
+    let onSseError:
+      | ((payload: { streamId: string; message?: string; status?: number; code?: string }) => void)
+      | null = null
+    const onError = vi.fn()
+    const sink: ThreadEventSink = {
+      onSeq: vi.fn(),
+      onDeltas: vi.fn(),
+      onUserMessage: vi.fn(),
+      onTool: vi.fn(),
+      onCompaction: vi.fn(),
+      onApproval: vi.fn(),
+      onUserInput: vi.fn(),
+      onUserInputStatus: vi.fn(),
+      onGoal: vi.fn(),
+      onTodos: vi.fn(),
+      onTurnComplete: vi.fn(),
+      onError
+    }
+    installDsGui({
+      onSseError: vi.fn((handler) => {
+        onSseError = handler
+        return () => undefined
+      }),
+      startSse: vi.fn(async (_threadId, _sinceSeq, streamId) => {
+        queueMicrotask(() => onSseError?.({
+          streamId: streamId ?? 'stream-1',
+          message: 'SSE sequence conflict: event seq 3 regressed below connection watermark 5',
+          code: 'seq_conflict'
+        }))
+        return { streamId: streamId ?? 'stream-1' }
+      })
+    })
+
+    await new KunRuntimeProvider().subscribeThreadEvents('thr_1', 0, sink, new AbortController().signal)
+
+    const [error] = onError.mock.calls[0] ?? []
+    expect(error).toMatchObject({
+      name: 'KunSseSubscriptionError',
+      code: 'seq_conflict'
+    })
+    expect(String(error?.message ?? '')).toContain('sequence conflict')
+  })
+
   it('advances the renderer cursor after dispatch and only then acknowledges the SSE batch', async () => {
     let onData: ((payload: { streamId: string; events: unknown[]; batchId?: string }) => void) | null = null
     let releaseAck: (() => void) | undefined

--- a/src/renderer/src/agent/kun-runtime-stream.test.ts
+++ b/src/renderer/src/agent/kun-runtime-stream.test.ts
@@ -367,6 +367,62 @@ describe('KunRuntimeProvider', () => {
     expect(ackSse).toHaveBeenCalledWith(expect.any(String), 'heartbeat-batch')
   })
 
+  it('advances the renderer cursor on a fresh heartbeat without dispatching a payload', async () => {
+    let onData: ((payload: { streamId: string; events: unknown[]; batchId?: string }) => void) | null = null
+    const ac = new AbortController()
+    const ackSse = vi.fn(async () => {
+      ac.abort()
+      return true
+    })
+    const sink: ThreadEventSink = {
+      onSeq: vi.fn(),
+      onDeltas: vi.fn(),
+      onUserMessage: vi.fn(),
+      onTool: vi.fn(),
+      onCompaction: vi.fn(),
+      onApproval: vi.fn(),
+      onUserInput: vi.fn(),
+      onUserInputStatus: vi.fn(),
+      onGoal: vi.fn(),
+      onTodos: vi.fn(),
+      onThreadUpdated: vi.fn(),
+      onTurnComplete: vi.fn(),
+      onError: vi.fn()
+    }
+    installDsGui({
+      ackSse,
+      onSseEvent: vi.fn((handler) => {
+        onData = handler
+        return () => undefined
+      }),
+      startSse: vi.fn(async (_threadId, _sinceSeq, streamId) => {
+        queueMicrotask(() => onData?.({
+          streamId: streamId ?? 'stream-1',
+          batchId: 'fresh-heartbeat-batch',
+          events: [
+            { kind: 'assistant_text_delta', seq: 201, item: {
+              id: 'item_text', turnId: 'turn_1', threadId: 'thr_1', role: 'assistant',
+              status: 'running', createdAt: 't1', kind: 'assistant_text', text: 'kept'
+            } },
+            // Heartbeat advertises hidden model-only seqs past the last public event.
+            { kind: 'heartbeat', seq: 205, threadId: 'thr_1' }
+          ]
+        }))
+        return { streamId: streamId ?? 'stream-1' }
+      })
+    })
+
+    await new KunRuntimeProvider().subscribeThreadEvents('thr_1', 200, sink, ac.signal)
+
+    // The data event dispatches normally; the heartbeat carries no payload.
+    expect(sink.onDeltas).toHaveBeenCalledTimes(1)
+    expect(sink.onTurnComplete).not.toHaveBeenCalled()
+    // ...but the renderer cursor still advances past the hidden 202–204 hole.
+    expect(sink.onSeq).toHaveBeenCalledOnce()
+    expect(sink.onSeq).toHaveBeenCalledWith(205)
+    expect(ackSse).toHaveBeenCalledWith(expect.any(String), 'fresh-heartbeat-batch')
+  })
+
   it('replays an unacknowledged batch after projection fails without losing its event', async () => {
     const replayedEvent = {
       kind: 'item_completed',

--- a/src/renderer/src/store/chat-store-thread-action-helpers.test.ts
+++ b/src/renderer/src/store/chat-store-thread-action-helpers.test.ts
@@ -42,4 +42,59 @@ describe('subscribeThreadEventsWithRecovery', () => {
     expect(recoverActiveTurn).toHaveBeenCalledOnce()
     controller.abort()
   })
+
+  it('compounds backoff for ordinary errors but treats a seq_conflict as a fresh incident', async () => {
+    vi.useFakeTimers()
+    const recoverActiveTurn = vi.fn(async () => false)
+    const state = {
+      activeThreadId: 'thread_seq_conflict',
+      busy: true,
+      recoverActiveTurn
+    } as unknown as ChatState
+    const sink = { onError: vi.fn() } as unknown as ThreadEventSink
+    const subscribeWith = (makeError: () => Error) => {
+      const controller = new AbortController()
+      const provider = {
+        subscribeThreadEvents: vi.fn(async (
+          _threadId: string,
+          _sinceSeq: number,
+          eventSink: ThreadEventSink
+        ) => {
+          eventSink.onError(makeError())
+        })
+      } as unknown as AgentProvider
+      subscribeThreadEventsWithRecovery(
+        provider,
+        'thread_seq_conflict',
+        42,
+        sink,
+        controller.signal,
+        () => state
+      )
+      return controller
+    }
+
+    // First ordinary failure recovers after the initial 250ms delay.
+    subscribeWith(() => new Error('boom-1'))
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(250)
+    expect(recoverActiveTurn).toHaveBeenCalledTimes(1)
+
+    // Second ordinary failure compounds: it needs the full 500ms, not 250ms.
+    subscribeWith(() => new Error('boom-2'))
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(250)
+    expect(recoverActiveTurn).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(250)
+    expect(recoverActiveTurn).toHaveBeenCalledTimes(2)
+
+    // A wire seq conflict means the cursor is provably dead: idempotent
+    // backoff must not stall a frozen thread, so this fires after 250ms
+    // (fresh-incident) instead of the compounded 1000ms.
+    const conflict = Object.assign(new Error('wire regression'), { code: 'seq_conflict' })
+    subscribeWith(() => conflict)
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(250)
+    expect(recoverActiveTurn).toHaveBeenCalledTimes(3)
+  })
 })

--- a/src/renderer/src/store/chat-store-thread-action-helpers.ts
+++ b/src/renderer/src/store/chat-store-thread-action-helpers.ts
@@ -1,4 +1,5 @@
 import type { AgentProvider, NormalizedThread, ThreadEventSink } from '../agent/types'
+import { decideSseRecovery, type SseStreamCloseSignal } from '@shared/sse-sequence'
 import type { ChatState, ChatStoreGet } from './chat-store-types'
 import {
   composerModelSelectable,
@@ -124,7 +125,21 @@ function scheduleSseRecovery(
 ): void {
   const state = sseRecoveries.get(threadId) ?? { attempts: 0 }
   if (state.timer) return
-  state.attempts = Math.min(state.attempts + 1, 8)
+  const decision = decideSseRecovery(sseCloseSignal(error), 0)
+  if (decision.strategy === 'none') {
+    sseRecoveries.delete(threadId)
+    return
+  }
+  if (decision.strategy === 'authoritative-resync') {
+    // seq_conflict (WP-03): the projection cursor is provably dead — the wire
+    // regressed below what was already delivered. Compounding idempotent
+    // backoff only stalls a thread that cannot advance anyway; reset the
+    // attempt accounting and let recoverActiveTurn re-read the authoritative
+    // snapshot and re-baseline the cursor right away.
+    state.attempts = 1
+  } else {
+    state.attempts = Math.min(state.attempts + 1, 8)
+  }
   const status = sseStatus(error)
   const baseDelay = status === 401 || status === 403
     ? SSE_RECOVERY_AUTH_DELAY_MS
@@ -145,4 +160,15 @@ function scheduleSseRecovery(
 function sseStatus(error: Error | undefined): number | undefined {
   const value = error as (Error & { status?: unknown }) | undefined
   return typeof value?.status === 'number' ? value.status : undefined
+}
+
+/** Maps a settled subscription outcome onto the shared close-signal shape (WP-03). */
+function sseCloseSignal(error: Error | undefined): SseStreamCloseSignal {
+  if (!error) return { kind: 'stream-ended' }
+  const tagged = error as Error & { status?: unknown; code?: unknown }
+  return {
+    kind: 'stream-error',
+    ...(typeof tagged.status === 'number' ? { status: tagged.status } : {}),
+    ...(typeof tagged.code === 'string' ? { code: tagged.code } : {})
+  } as SseStreamCloseSignal
 }

--- a/src/shared/kun-gui-api-contracts.ts
+++ b/src/shared/kun-gui-api-contracts.ts
@@ -620,7 +620,18 @@ export type SseEventPayload = { streamId: string; events: unknown[]; batchId?: s
 
 export type SseEndPayload = { streamId: string }
 
-export type SseErrorPayload = { streamId: string; status?: number; message?: string }
+export type SseErrorPayload = {
+  streamId: string
+  status?: number
+  message?: string
+  /**
+   * Structured failure classification (WP-03). Currently defined value:
+   * `seq_conflict` — the wire stream violated per-connection sequence
+   * monotonicity, so the projection cursor can no longer be trusted and
+   * replay-from-cursor must be replaced by an authoritative snapshot resync.
+   */
+  code?: string
+}
 
 export type TrayActionPayload =
   | { type: 'new-chat' }

--- a/src/shared/sse-sequence.fuzz.test.ts
+++ b/src/shared/sse-sequence.fuzz.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type SseSeqGateState,
+  type SseSeqObservation,
+  type SseStreamCloseSignal,
+  SSE_SEQ_CONFLICT_CODE,
+  checkSseConnectionMonotonicity,
+  createSseSeqGate,
+  decideSseRecovery,
+  observeSseSeq
+} from './sse-sequence'
+
+/** Deterministic PRNG (mulberry32) so failures reproduce from the logged seed. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+type FuzzEvent = { seq?: number; kind: string }
+
+function randomInt(rand: () => number, min: number, max: number): number {
+  return min + Math.floor(rand() * (max - min + 1))
+}
+
+/**
+ * Generate one legal server stream: persisted public seqs ascending with
+ * hidden-event holes, optional duplicate replay overlap injected around
+ * reconnects, heartbeat frames reusing the current cursor, and an optional
+ * regression burst (corrupt wire) at a random index.
+ */
+function generateStream(rand: () => number, withRegression: boolean): {
+  delivered: FuzzEvent[]
+  expectedAcceptedPublic: number[]
+  regressionAt: number | null
+  watermarkBeforeRegression: number
+} {
+  const delivered: FuzzEvent[] = []
+  const expectedAcceptedPublic: number[] = []
+  let serverSeq = randomInt(rand, 0, 5)
+  const publicCount = randomInt(rand, 20, 200)
+  let regressionAt: number | null = null
+  let watermarkBeforeRegression = 0
+
+  for (let i = 0; i < publicCount; i += 1) {
+    // Hidden model-only records consume some seqs without delivery.
+    serverSeq += 1 + (rand() < 0.35 ? randomInt(rand, 0, 3) : 0)
+    const publicSeq = serverSeq
+    delivered.push({ seq: publicSeq, kind: 'item_updated' })
+    // Reconnect replay overlap: emit a few already delivered seqs again.
+    if (rand() < 0.15 && expectedAcceptedPublic.length > 0) {
+      const dupFrom = expectedAcceptedPublic[randomInt(rand, 0, expectedAcceptedPublic.length - 1)]
+      delivered.push({ seq: dupFrom, kind: 'item_updated' })
+    }
+    if (rand() < 0.2) {
+      delivered.push({ seq: publicSeq, kind: 'heartbeat' })
+    }
+    expectedAcceptedPublic.push(publicSeq)
+    if (withRegression && regressionAt === null && expectedAcceptedPublic.length > 5 && rand() < 0.05) {
+      regressionAt = delivered.length
+      watermarkBeforeRegression = publicSeq
+      // Wire seqs are always non-negative; clamp so the injected frame stays
+      // inside the contract the guard validates (negative seqs are invalid
+      // input and legitimately exempt).
+      delivered.push({ seq: Math.max(0, publicSeq - randomInt(rand, 5, 10)), kind: 'assistant_text_delta' })
+    }
+  }
+  return { delivered, expectedAcceptedPublic, regressionAt, watermarkBeforeRegression }
+}
+
+/** Replay of the renderer batch loop: gate now owns the dedupe/advance math. */
+function project(gate: SseSeqGateState, events: FuzzEvent[]): {
+  gate: SseSeqGateState
+  projected: FuzzEvent[]
+  observations: SseSeqObservation[]
+} {
+  const projected: FuzzEvent[] = []
+  const observations: SseSeqObservation[] = []
+  for (const event of events) {
+    const obs = observeSseSeq(gate, event)
+    observations.push(obs)
+    gate = obs.state
+    if (obs.kind === 'accept' || obs.kind === 'accept-unsequenced') projected.push(event)
+  }
+  return { gate, projected, observations }
+}
+
+describe('sse-sequence fuzz (seeded)', () => {
+  const SEEDS = [0xC0FFEE, 0x1CEB00DA, 0x600DF00D, 0xDEC0DE, 0xABCDEF]
+
+  it('projects every legal stream exactly once, in ascending order, with monotone cursors', () => {
+    for (const seed of SEEDS) {
+      const rand = mulberry32(seed)
+      for (let run = 0; run < 40; run += 1) {
+        const { delivered, expectedAcceptedPublic } = generateStream(rand, false)
+        const { gate, projected } = project(createSseSeqGate(0), delivered)
+        const projectedSeqs = projected.map((event) => event.seq)
+        // Exactly-once, no loss, ascending (the contract the chat reducer relies on).
+        expect(projectedSeqs, `seed=${seed} run=${run}`).toEqual(expectedAcceptedPublic)
+        expect(gate.highWater).toBe(expectedAcceptedPublic[expectedAcceptedPublic.length - 1] ?? 0)
+        // The monotonicity guard never trips on a legal stream.
+        let watermark: number | null = null
+        for (const event of delivered) {
+          const check = checkSseConnectionMonotonicity(watermark, event)
+          // Duplicate replay injections above regress vs the *connection*
+          // watermark by construction; those arrive on separate connections
+          // in production, so the guard only runs on non-duplicates here.
+          if (check.ok) watermark = check.watermark
+          else {
+            expect(expectedAcceptedPublic).toContain(event.seq)
+          }
+        }
+        // Stale observations never move the committed cursor backwards.
+        expect(gate.highWater).toBeGreaterThanOrEqual(0)
+        expect(gate.advertisedHighWater).toBeGreaterThanOrEqual(gate.highWater)
+      }
+    }
+  })
+
+  it('gate stays total and side-effect free under arbitrary seq noise', () => {
+    const rand = mulberry32(0xFEEDFACE)
+    for (let run = 0; run < 2000; run += 1) {
+      let gate = createSseSeqGate(randomInt(rand, 0, 50))
+      const before = gate.highWater
+      const events: FuzzEvent[] = Array.from({ length: randomInt(rand, 1, 64) }, () => {
+        const roll = rand()
+        if (roll < 0.2) return { kind: 'item_updated' } // unsequenced
+        if (roll < 0.35) return { seq: randomInt(rand, -5, 3), kind: 'item_updated' } // stale/invalid
+        if (roll < 0.5) return { seq: randomInt(rand, 0, 400), kind: 'heartbeat' }
+        return { seq: randomInt(rand, 0, 400), kind: 'usage' }
+      })
+      const result = project(gate, events)
+      gate = result.gate
+      for (const obs of result.observations) {
+        // Exhaustive discriminator: every observation has a defined next state,
+        // and the server-advertised watermark never trails the committed cursor.
+        expect(obs.state.highWater).toBeGreaterThanOrEqual(0)
+        expect(obs.state.advertisedHighWater).toBeGreaterThanOrEqual(obs.state.highWater)
+      }
+      // The committed cursor never regresses, no matter the wire noise.
+      expect(gate.highWater).toBeGreaterThanOrEqual(before)
+    }
+  })
+
+  it('flags every injected regression exactly once with correct seq values', () => {
+    for (const seed of SEEDS) {
+      const rand = mulberry32(seed ^ 0x9E3779B9)
+      for (let run = 0; run < 40; run += 1) {
+        const { delivered, expectedAcceptedPublic, regressionAt, watermarkBeforeRegression } =
+          generateStream(rand, true)
+        let watermark: number | null = null
+        let conflicts = 0
+        delivered.forEach((event, index) => {
+          const check = checkSseConnectionMonotonicity(watermark, event)
+          if (!check.ok) {
+            if (index === regressionAt) {
+              // The injected corruption must trip the guard here, exactly once.
+              conflicts += 1
+              expect(check.regressedFrom).toBe(watermarkBeforeRegression)
+            } else {
+              // Replay-overlap duplicates regress against this merged tape by
+              // construction; in production they arrive on separate
+              // connections, so the guard never sees them. They are only legal
+              // when they re-deliver an already accepted public seq.
+              expect(expectedAcceptedPublic, `seed=${seed} run=${run} idx=${index}`).toContain(
+                event.seq
+              )
+            }
+          } else {
+            watermark = check.watermark
+          }
+        })
+        if (regressionAt !== null) {
+          expect(conflicts, `seed=${seed} run=${run}`).toBe(1)
+        }
+      }
+    }
+  })
+
+  it('decideSseRecovery is total over the close-signal space', () => {
+    const rand = mulberry32(0xB16B00B5)
+    const signals: SseStreamCloseSignal[] = [
+      { kind: 'client-abort' },
+      { kind: 'stream-ended' },
+      { kind: 'stream-error' },
+      { kind: 'stream-error', status: 408 },
+      { kind: 'stream-error', status: 429 },
+      { kind: 'stream-error', status: 401 },
+      { kind: 'stream-error', status: 404 },
+      { kind: 'stream-error', code: 'seq_conflict' },
+      { kind: 'stream-error', status: 500 },
+      { kind: 'stream-error', code: 'seq_conflict', status: 409 }
+    ]
+    for (let run = 0; run < 500; run += 1) {
+      const signal = signals[randomInt(rand, 0, signals.length - 1)]
+      const decision = decideSseRecovery(signal, randomInt(rand, 0, 10_000))
+      switch (signal.kind) {
+        case 'client-abort':
+          expect(decision.strategy).toBe('none')
+          break
+        case 'stream-error':
+          // Only an explicit wire-regression code disqualifies the cursor;
+          // bare HTTP statuses (even fatal-looking 4xx) still replay from it.
+          expect(decision.strategy).toBe(
+            signal.code === SSE_SEQ_CONFLICT_CODE ? 'authoritative-resync' : 'replay-from-cursor'
+          )
+          break
+        default:
+          expect(decision.strategy).toBe('replay-from-cursor')
+      }
+    }
+  })
+})

--- a/src/shared/sse-sequence.test.ts
+++ b/src/shared/sse-sequence.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SSE_SEQ_CONFLICT_CODE,
+  checkSseConnectionMonotonicity,
+  createSseSeqGate,
+  decideSseRecovery,
+  observeSseSeq
+} from './sse-sequence'
+
+describe('observeSseSeq', () => {
+  it('accepts ascending events and advances the high-water with hidden-seq holes tolerated', () => {
+    let state = createSseSeqGate(5)
+    // Public jump 5 -> 8: seqs 6/7 belonged to hidden model-only records.
+    const a = observeSseSeq(state, { seq: 8, kind: 'item_updated' })
+    expect(a.kind).toBe('accept')
+    state = a.state
+    expect(state.highWater).toBe(8)
+    const b = observeSseSeq(state, { seq: 9, kind: 'assistant_text_delta' })
+    expect(b.kind).toBe('accept')
+    expect(b.state.highWater).toBe(9)
+  })
+
+  it('drops duplicates and replay overlap without advancing', () => {
+    let state = createSseSeqGate(10)
+    const dup = observeSseSeq(state, { seq: 10, kind: 'item_updated' })
+    expect(dup.kind).toBe('stale')
+    expect(dup.state.highWater).toBe(10)
+    expect(dup.state.staleCount).toBe(1)
+    const older = observeSseSeq(dup.state, { seq: 3, kind: 'turn_completed' })
+    expect(older.kind).toBe('stale')
+    state = older.state
+    expect(state.highWater).toBe(10)
+    expect(state.staleCount).toBe(2)
+  })
+
+  it('accepts events without a numeric seq without moving the cursor', () => {
+    const state = createSseSeqGate(4)
+    for (const seq of [undefined, 'nope', -1, 1.5, Number.NaN]) {
+      const obs = observeSseSeq(state, { seq, kind: 'item_created' })
+      expect(obs.kind).toBe('accept-unsequenced')
+      expect(obs.state.highWater).toBe(4)
+    }
+  })
+
+  it('implements heartbeat semantics: stale heartbeats never rewind, fresh ones advance', () => {
+    let state = createSseSeqGate(20)
+    // Heartbeat reusing the already delivered cursor: liveness only.
+    const staleHb = observeSseSeq(state, { seq: 20, kind: 'heartbeat' })
+    expect(staleHb.kind).toBe('stale-heartbeat')
+    expect(staleHb.state.highWater).toBe(20)
+    // Heartbeat may advertise hidden seqs beyond the last public event.
+    const freshHb = observeSseSeq(staleHb.state, { seq: 25, kind: 'heartbeat' })
+    expect(freshHb.kind).toBe('accept-heartbeat')
+    state = freshHb.state
+    expect(state.highWater).toBe(25)
+    expect(state.advertisedHighWater).toBe(25)
+    // An older heartbeat afterwards is stale, not a regression.
+    const rewind = observeSseSeq(state, { seq: 22, kind: 'heartbeat' })
+    expect(rewind.kind).toBe('stale-heartbeat')
+    expect(rewind.state.highWater).toBe(25)
+  })
+
+  it('keeps advertisedHighWater monotone across accepted and stale heartbeats', () => {
+    let state = createSseSeqGate(0)
+    state = observeSseSeq(state, { seq: 30, kind: 'heartbeat' }).state
+    state = observeSseSeq(state, { seq: 12, kind: 'heartbeat' }).state
+    state = observeSseSeq(state, { seq: 31, kind: 'item_updated' }).state
+    expect(state.advertisedHighWater).toBe(31)
+    expect(state.highWater).toBe(31)
+  })
+})
+
+describe('checkSseConnectionMonotonicity', () => {
+  it('accepts ascending streams and resets per connection', () => {
+    let watermark: number | null = null
+    for (const seq of [1, 2, 3, 40]) {
+      const check = checkSseConnectionMonotonicity(watermark, { seq, kind: 'item_updated' })
+      expect(check.ok).toBe(true)
+      if (check.ok) watermark = check.watermark
+    }
+    expect(watermark).toBe(40)
+  })
+
+  it('flags a regression with the offending seq values', () => {
+    const check = checkSseConnectionMonotonicity(25, { seq: 7, kind: 'assistant_text_delta' })
+    expect(check).toEqual({ ok: false, regressedFrom: 25, observed: 7 })
+  })
+
+  it('exempts heartbeats and unsequenced frames from the invariant', () => {
+    const hb = checkSseConnectionMonotonicity(25, { seq: 25, kind: 'heartbeat' })
+    expect(hb.ok).toBe(true)
+    if (hb.ok) expect(hb.watermark).toBe(25)
+    const bare = checkSseConnectionMonotonicity(25, { kind: 'usage' })
+    expect(bare).toEqual({ ok: true, watermark: 25 })
+  })
+})
+
+describe('decideSseRecovery', () => {
+  it('never recovers from a client abort', () => {
+    expect(decideSseRecovery({ kind: 'client-abort' }, 42)).toEqual({ strategy: 'none' })
+  })
+
+  it('demands an authoritative resync for a wire seq conflict', () => {
+    expect(decideSseRecovery({ kind: 'stream-error', code: SSE_SEQ_CONFLICT_CODE }, 42)).toEqual({
+      strategy: 'authoritative-resync'
+    })
+    // The conflict code wins over every status heuristic: the cursor is dead.
+    expect(
+      decideSseRecovery({ kind: 'stream-error', code: SSE_SEQ_CONFLICT_CODE, status: 409 }, 7)
+    ).toEqual({ strategy: 'authoritative-resync' })
+  })
+
+  it('replays from the cursor for clean ends and transient or fatal-status errors', () => {
+    expect(decideSseRecovery({ kind: 'stream-ended' }, 42)).toEqual({
+      strategy: 'replay-from-cursor',
+      sinceSeq: 42
+    })
+    expect(decideSseRecovery({ kind: 'stream-error' }, 7)).toEqual({
+      strategy: 'replay-from-cursor',
+      sinceSeq: 7
+    })
+    // HTTP statuses never disqualify the cursor: only a wire regression does.
+    for (const status of [429, 408, 401, 403, 404, 500]) {
+      expect(decideSseRecovery({ kind: 'stream-error', status }, 3)).toEqual({
+        strategy: 'replay-from-cursor',
+        sinceSeq: 3
+      })
+    }
+  })
+
+  it('normalizes a bogus cursor to zero instead of propagating it', () => {
+    expect(decideSseRecovery({ kind: 'stream-ended' }, -3.7)).toEqual({
+      strategy: 'replay-from-cursor',
+      sinceSeq: 0
+    })
+  })
+})

--- a/src/shared/sse-sequence.ts
+++ b/src/shared/sse-sequence.ts
@@ -1,0 +1,195 @@
+/**
+ * Per-thread SSE sequence contract: gate + recovery policy (WP-03).
+ *
+ * Wire invariants (kun server `src/server/routes/events.ts`):
+ * - `seq` is a per-thread, persisted, non-decreasing integer; an SSE
+ *   connection replays events with `seq > since_seq` exactly once each and
+ *   then delivers live events, so within one connection public events may
+ *   only regress if the persisted log or the live bus is corrupt.
+ * - Non-public (model-only) events consume seqs without being delivered, so
+ *   a forward *jump* on the public stream (e.g. 5 -> 8) is normal and is
+ *   NOT evidence of loss. Client-side "raw jump" gap detection is therefore
+ *   impossible by design; the honest detection points are (a) transport
+ *   boundary monotonicity and (b) structured server error frames.
+ * - Heartbeats advertise the connection high-water mark. They may reuse an
+ *   already delivered seq and must never rewind a client cursor; a client
+ *   MAY advance its cursor to a heartbeat seq because the server guarantees
+ *   every public event at or below that point has been delivered (any seqs
+ *   in between belonged to hidden model-only records).
+ *
+ * This module is deliberately dependency-free so the renderer projection, the
+ * main-process SSE bridge, and tests all share one implementation.
+ */
+
+/** Structured error code sent from the main-process SSE bridge when the wire violates monotonicity. */
+export const SSE_SEQ_CONFLICT_CODE = 'seq_conflict'
+
+export type SseSeqGateState = {
+  /**
+   * Committed projection high-water mark. Events at or below this seq were
+   * already projected (or proven delivered) and must never be replayed into
+   * the projection again.
+   */
+  readonly highWater: number
+  /**
+   * Highest seq the server advertised via heartbeats, including hidden
+   * model-only seqs. Diagnostic only; never used to drop public events.
+   */
+  readonly advertisedHighWater: number
+  /** Count of already-seen events observed and dropped (replay overlap). */
+  readonly staleCount: number
+  /** Count of accepted events that carried no numeric seq (legacy/tolerant path). */
+  readonly unsequencedCount: number
+}
+
+export function createSseSeqGate(initialHighWater: number): SseSeqGateState {
+  const base = Number.isSafeInteger(initialHighWater) && initialHighWater >= 0 ? initialHighWater : 0
+  return {
+    highWater: base,
+    advertisedHighWater: base,
+    staleCount: 0,
+    unsequencedCount: 0
+  }
+}
+
+export type SseSeqObservation =
+  | { readonly kind: 'accept'; readonly seq: number; readonly state: SseSeqGateState }
+  | { readonly kind: 'accept-heartbeat'; readonly seq: number; readonly state: SseSeqGateState }
+  | { readonly kind: 'stale-heartbeat'; readonly seq: number; readonly state: SseSeqGateState }
+  | { readonly kind: 'accept-unsequenced'; readonly state: SseSeqGateState }
+  | { readonly kind: 'stale'; readonly seq: number; readonly state: SseSeqGateState }
+
+/**
+ * Observe one wire event against the gate. Pure: returns the next state plus
+ * how the caller must treat the event.
+ *
+ * - `accept`: project the event and advance the cursor to `seq`.
+ * - `accept-heartbeat`: cursor advances (server advertised delivery through
+ *   `seq`), but the heartbeat itself carries no projection payload.
+ * - `stale-heartbeat`: do not project and do not rewind; still proves the
+ *   live stream is healthy (keep watchdogs fed) and may raise
+ *   `advertisedHighWater` when it exceeds the current high-water.
+ * - `accept-unsequenced`: project, cursor unchanged (events without a
+ *   numeric seq cannot participate in the replay contract).
+ * - `stale`: drop; the event was already projected (duplicate replay,
+ *   reconnect overlap, or intra-batch duplicate).
+ *
+ * A heartbeat seq below the committed high-water is legal (heartbeats reuse
+ * the server connection cursor after reconnect replay overlap) and is NOT a
+ * regression signal on its own.
+ */
+export function observeSseSeq(
+  state: SseSeqGateState,
+  event: { seq?: unknown; kind?: unknown }
+): SseSeqObservation {
+  const seq = typeof event.seq === 'number' && Number.isSafeInteger(event.seq) && event.seq >= 0
+    ? event.seq
+    : null
+  if (seq === null) {
+    return {
+      kind: 'accept-unsequenced',
+      state: { ...state, unsequencedCount: state.unsequencedCount + 1 }
+    }
+  }
+  const advertisedHighWater = Math.max(state.advertisedHighWater, seq)
+  if (seq <= state.highWater) {
+    if (event.kind === 'heartbeat') {
+      return {
+        kind: 'stale-heartbeat',
+        seq,
+        state: { ...state, advertisedHighWater, staleCount: state.staleCount + 1 }
+      }
+    }
+    return {
+      kind: 'stale',
+      seq,
+      state: { ...state, advertisedHighWater, staleCount: state.staleCount + 1 }
+    }
+  }
+  const next: SseSeqGateState = { ...state, highWater: seq, advertisedHighWater }
+  return event.kind === 'heartbeat'
+    ? { kind: 'accept-heartbeat', seq, state: next }
+    : { kind: 'accept', seq, state: next }
+}
+
+/**
+ * Per-connection transport invariant check, used by the main-process SSE
+ * bridge. Within one HTTP connection the server must deliver non-decreasing
+ * seqs (replay ascending, then buffered live drained in seq order, then
+ * live). Heartbeats are exempt: they reuse the connection cursor.
+ *
+ * Returns the next connection watermark, or a conflict descriptor when
+ * `seq` regressed below the watermark — proof the wire stream is corrupt
+ * and replay from the same cursor cannot heal the projection.
+ */
+export function checkSseConnectionMonotonicity(
+  connectionWatermark: number | null,
+  event: { seq?: unknown; kind?: unknown }
+):
+  | { readonly ok: true; readonly watermark: number | null }
+  | { readonly ok: false; readonly regressedFrom: number; readonly observed: number } {
+  const seq = typeof event.seq === 'number' && Number.isSafeInteger(event.seq) && event.seq >= 0
+    ? event.seq
+    : null
+  if (seq === null || event.kind === 'heartbeat') {
+    return { ok: true, watermark: connectionWatermark }
+  }
+  if (connectionWatermark !== null && seq < connectionWatermark) {
+    return { ok: false, regressedFrom: connectionWatermark, observed: seq }
+  }
+  return { ok: true, watermark: connectionWatermark === null ? seq : Math.max(connectionWatermark, seq) }
+}
+
+export type SseStreamCloseSignal =
+  | { readonly kind: 'client-abort' }
+  | { readonly kind: 'stream-ended' }
+  | {
+      readonly kind: 'stream-error'
+      readonly status?: number
+      readonly code?: string
+    }
+
+export type SseRecoveryDecision =
+  /** No recovery; the client deliberately stopped listening. */
+  | { readonly strategy: 'none' }
+  /**
+   * Reconnect with `since_seq = sinceSeq`; the cursor is still
+   * authoritative and replay heals the interruption.
+   */
+  | { readonly strategy: 'replay-from-cursor'; readonly sinceSeq: number }
+  /**
+   * The cursor can no longer be trusted (wire regression, corrupt persisted
+   * tail). Refetch the authoritative thread snapshot, re-baseline the
+   * cursor to the snapshot's `latestSeq`, then resubscribe from there.
+   */
+  | { readonly strategy: 'authoritative-resync' }
+
+/**
+ * Recovery policy for a terminated subscription. Total function: every close
+ * signal maps to exactly one decision.
+ *
+ * - `client-abort` never recovers (user navigating away / stream replaced).
+ * - `seq_conflict` demands an authoritative resync: the projection cursor
+ *   can no longer be trusted (a truncated `events.jsonl` tail that lets the
+ *   persisted stream regress is the canonical case). The caller must refetch
+ *   the thread snapshot, re-baseline the cursor to the snapshot's
+ *   `latestSeq`, then resubscribe from there — replaying from the old cursor
+ *   would silently freeze the projection at a watermark the runtime can no
+ *   longer reproduce. Anything else (clean end, transient transport
+ *   failure, fatal or throttled HTTP status) still trusts the cursor and
+ *   replays from it, since every resubscribe in this codebase rehydrates
+ *   from the authoritative snapshot before listening.
+ *
+ * The main process keeps a deliberately separate connect-time policy
+ * (`isFatalSseStatus` in `runtime-sse-ipc.ts`): it decides whether to OPEN
+ * a connection at all (fatal 4xx short-circuits the retry loop). That is a
+ * different decision from this post-close recovery policy; do not unify
+ * them by importing one into the other's domain.
+ */
+export function decideSseRecovery(signal: SseStreamCloseSignal, cursor: number): SseRecoveryDecision {
+  if (signal.kind === 'client-abort') return { strategy: 'none' }
+  if (signal.kind === 'stream-error' && signal.code === SSE_SEQ_CONFLICT_CODE) {
+    return { strategy: 'authoritative-resync' }
+  }
+  return { strategy: 'replay-from-cursor', sinceSeq: Math.max(0, cursor | 0) }
+}


### PR DESCRIPTION
## 概述

按交接文档 WP-03 实施「SSE sequence gap 检测与恢复契约」：main 进程用单调性检测（种子=请求 nextSinceSeq）发现 seq_conflict，经 runtime:sse-error 上抛；renderer 订阅层映射为 KunSseSubscriptionError.code；chat-store 的 decideSseRecovery 将其路由到 authoritative-resync（fresh incident attempts=1）。

## 改动（11 文件，8 改 3 增，+925/-31）

- shared：新增 sse-sequence.ts（checkSseConnectionMonotonicity）+ 单测 + fuzz 测试；kun-gui-api-contracts.ts 的 SseErrorPayload 新增可选 code 字段
- main：runtime-sse-ipc.ts 检测 seq 冲突并发 SseSequenceConflictError（code=seq_conflict）
- renderer：kun-runtime-stream/services 透传 error code；chat-store-thread-action-helpers 按 seq_conflict 决策 authoritative resync

## 兼容性

- SSE payload 仅新增可选字段，旧端忽略；touch 面不含 .github/workflows
- 不复兴任何 legacy runtime/provider 路径

## 验证（基线 kunagent/develop ecdf4685 全量复跑）

- 定向 vitest 6 文件 39/39 通过（node node_modules/vitest/vitest.mjs run --no-file-parallelism）
- npm run typecheck：0 错误
- eslint 11 文件：0 警告
- npm run build 全量：通过
- git diff --check：clean

执行留档与五轮 Review（自审/契约/并发/兼容/安全）PASS 记录：KIMI_K3_KUN_FULL_IMPLEMENTATION_HANDOFF ledger。