### PR TITLE
fix(chat): stop the plan checklist from faking Graph progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "smoke:extension-native-media": "node ./scripts/run-extension-native-media-smoke.cjs",
     "smoke:development-video-editor-layout": "node ./scripts/smoke-development-video-editor-layout.cjs",
     "smoke:development-ui-plugin-layout": "node ./scripts/smoke-development-ui-plugin-layout.cjs",
+    "smoke:development-graph-plan-progress": "node ./scripts/smoke-development-graph-plan-progress.cjs",
     "smoke:development-graph-workbench": "node ./scripts/smoke-development-graph-workbench.cjs",
     "evidence:extension-native": "node ./scripts/write-extension-native-evidence.mjs",
     "verify:extension-native-evidence": "node ./scripts/verify-extension-native-evidence.mjs",

--- a/scripts/smoke-development-graph-plan-progress.cjs
+++ b/scripts/smoke-development-graph-plan-progress.cjs
@@ -1,0 +1,699 @@
+#!/usr/bin/env node
+
+'use strict'
+
+/**
+ * Desktop end-to-end evidence for issue #1202: the GUI plan checklist must stop
+ * reporting itself as live execution progress while a Graph run owns the thread.
+ *
+ * Boots the development renderer against the built Main process, seeds a real
+ * thread carrying a 19-item plan checklist through the Kun runtime, then:
+ *   1. captures the stale reading the reporter saw ("Step 1 / 19");
+ *   2. puts a Graph run (11 nodes, 7 accepted, 1 running) on the thread;
+ *   3. asserts the checklist demotes to "Plan outline · 19 steps" while the
+ *      Graph card reports the authoritative "7/11 accepted · 1 running".
+ *
+ * The Graph projection is seeded straight into the renderer Graph store through
+ * the Vite dev module graph. Driving 11 real subagent nodes would need a live
+ * model and hours of wall clock; every component, selector, translation, and
+ * style under test here is the production one.
+ */
+
+const { spawn } = require('node:child_process')
+const { existsSync } = require('node:fs')
+const { copyFile, mkdir, mkdtemp, rm, writeFile } = require('node:fs/promises')
+const { createConnection, createServer } = require('node:net')
+const { tmpdir } = require('node:os')
+const { join, resolve } = require('node:path')
+const { _electron } = require('playwright-core')
+const { makeTreeWritable } = require('./smoke-packaged-extensions.cjs')
+const {
+  createIsolatedEnvironment,
+  desktopSmokeSettings,
+  desktopSmokeWorkspaceParent,
+  desktopUserDataCandidates,
+  platformDesktopArguments,
+  stopIsolatedServiceManager,
+  stopIsolatedSharedRuntime,
+  terminateProcessTree
+} = require('./smoke-packaged-extension-desktop.cjs')
+const { developmentRendererEnvironment } = require('./development-renderer-environment.cjs')
+const { findWorkbenchWindow } = require('./smoke-packaged-video-editor-desktop.cjs')
+
+const DEFAULT_TIMEOUT_MS = 180_000
+const MAX_OPERATION_TIMEOUT_MS = 60_000
+const MAX_CLEANUP_TIMEOUT_MS = 15_000
+const GRACEFUL_CLOSE_TIMEOUT_MS = 5_000
+const MODEL_NAME = 'deepseek-chat'
+const THREAD_TITLE = 'Graph plan progress E2E'
+const PLAN_RELATIVE_PATH = '.kunsdd/plan/graph-plan-progress.md'
+const PLAN_ID = 'plan_graph_progress'
+const CHECKLIST_ITEMS = 19
+const GRAPH_NODES = 11
+const GRAPH_ACCEPTED = 7
+const WINDOW_WIDTH = 1360
+const WINDOW_HEIGHT = 900
+const STALE_LABEL = `Step 1 / ${CHECKLIST_ITEMS}`
+const OUTLINE_LABEL = `Plan outline · ${CHECKLIST_ITEMS} steps`
+const GRAPH_LABEL = `${GRAPH_ACCEPTED}/${GRAPH_NODES} accepted`
+
+async function main() {
+  const repositoryRoot = resolve(join(__dirname, '..'))
+  const timeoutMs = positiveIntegerArgument('--timeout-ms', DEFAULT_TIMEOUT_MS)
+  const evidenceRoot = resolve(
+    argumentValue('--evidence') ?? join(repositoryRoot, 'dist', 'graph-plan-progress-smoke')
+  )
+  const electronExecutable = require('electron')
+  const viteCli = join(repositoryRoot, 'node_modules', 'vite', 'bin', 'vite.js')
+  const rendererConfig = join(repositoryRoot, 'scripts', 'vite-development-renderer.config.mjs')
+  const mainEntry = join(repositoryRoot, 'out', 'main', 'index.js')
+  const runtimeEntry = join(repositoryRoot, 'kun', 'dist', 'cli', 'serve-entry.js')
+  const prerequisites = [
+    ['Electron executable', electronExecutable], ['Vite CLI', viteCli],
+    ['renderer config', rendererConfig], ['built Main entry', mainEntry],
+    ['built Kun runtime entry', runtimeEntry]
+  ]
+  for (const [label, path] of prerequisites) {
+    if (!existsSync(path)) throw new Error(`${label} is missing: ${path}. Run npm run build first.`)
+  }
+
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'kun-graph-plan-progress-smoke-'))
+  const home = join(temporaryRoot, 'home')
+  const profile = join(home, '.kun', 'data')
+  const userData = join(temporaryRoot, 'electron-user-data')
+  const appData = join(temporaryRoot, 'app-data')
+  const localAppData = join(temporaryRoot, 'local-app-data')
+  const temporaryDirectory = join(temporaryRoot, 'tmp')
+  const videoDirectory = join(temporaryRoot, 'video')
+  const workspaceParent = desktopSmokeWorkspaceParent(repositoryRoot)
+  await mkdir(workspaceParent, { recursive: true })
+  const workspaceRoot = await mkdtemp(join(workspaceParent, 'graph-plan-progress-'))
+  // The runtime resolves plan-sourced todos against a real GUI plan file.
+  await mkdir(join(workspaceRoot, '.kunsdd', 'plan'), { recursive: true })
+  await writeFile(join(workspaceRoot, PLAN_RELATIVE_PATH), planMarkdown())
+  const runtimePort = await availablePort()
+  let rendererPort = await availablePort()
+  while (rendererPort === runtimePort) rendererPort = await availablePort()
+
+  let rendererProcess
+  let electronApplication
+  let electronProcess
+  let recordedVideo
+  let result
+  let primaryError
+  let rendererOutput = ''
+  let electronOutput = ''
+  try {
+    await Promise.all([
+      home, profile, userData, appData, localAppData,
+      temporaryDirectory, videoDirectory, evidenceRoot
+    ].map((directory) => mkdir(directory, { recursive: true })))
+
+    const settings = {
+      ...desktopSmokeSettings(runtimePort, workspaceRoot, profile),
+      locale: 'en',
+      theme: 'light'
+    }
+    // Graph Mode is experimental and off by default; the composer only offers a
+    // Graph progress surface when it is enabled.
+    settings.agents.kun.graph = { enabled: true }
+    const serializedSettings = `${JSON.stringify(settings, null, 2)}\n`
+    await Promise.all(desktopUserDataCandidates({
+      platform: process.platform,
+      home,
+      appData,
+      explicitUserData: userData
+    }).map(async (directory) => {
+      await mkdir(directory, { recursive: true })
+      await writeFile(join(directory, 'kun-settings.json'), serializedSettings)
+    }))
+
+    const isolatedEnvironment = developmentRendererEnvironment(
+      createIsolatedEnvironment(process.env, {
+        home,
+        appData,
+        localAppData,
+        temporaryDirectory
+      }),
+      { rendererPort, temporaryRoot }
+    )
+    isolatedEnvironment.NODE_ENV = 'development'
+    rendererProcess = spawn(
+      process.execPath,
+      [viteCli, '--config', rendererConfig, '--logLevel', 'warn'],
+      {
+        cwd: repositoryRoot,
+        env: isolatedEnvironment,
+        detached: process.platform !== 'win32',
+        windowsHide: true,
+        stdio: ['ignore', 'pipe', 'pipe']
+      }
+    )
+    rendererProcess.stdout?.on('data', (chunk) => {
+      rendererOutput = `${rendererOutput}${String(chunk)}`.slice(-64 * 1024)
+    })
+    rendererProcess.stderr?.on('data', (chunk) => {
+      rendererOutput = `${rendererOutput}${String(chunk)}`.slice(-64 * 1024)
+    })
+    await waitForPortOpen(rendererPort, timeoutMs, rendererProcess)
+
+    electronApplication = await _electron.launch({
+      executablePath: electronExecutable,
+      args: [
+        `--user-data-dir=${userData}`,
+        '--no-first-run',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-default-apps',
+        ...platformDesktopArguments(process.platform),
+        repositoryRoot
+      ],
+      cwd: repositoryRoot,
+      env: isolatedEnvironment,
+      chromiumSandbox: true,
+      recordVideo: {
+        dir: videoDirectory,
+        size: { width: WINDOW_WIDTH, height: WINDOW_HEIGHT }
+      },
+      timeout: timeoutMs
+    })
+    electronProcess = electronApplication.process()
+    electronProcess.stdout?.on('data', (chunk) => {
+      electronOutput = `${electronOutput}${String(chunk)}`.slice(-64 * 1024)
+    })
+    electronProcess.stderr?.on('data', (chunk) => {
+      electronOutput = `${electronOutput}${String(chunk)}`.slice(-64 * 1024)
+    })
+    const operationTimeoutMs = Math.min(timeoutMs, MAX_OPERATION_TIMEOUT_MS)
+    await withTimeout(
+      electronApplication.evaluate(({ BrowserWindow }, bounds) => {
+        const window = BrowserWindow.getAllWindows().find((candidate) => !candidate.isDestroyed())
+        window?.setBounds(bounds)
+      }, { x: 20, y: 20, width: WINDOW_WIDTH, height: WINDOW_HEIGHT }),
+      operationTimeoutMs,
+      'resizing the graph plan progress window'
+    )
+    const page = await findWorkbenchWindow(electronApplication, timeoutMs)
+    recordedVideo = page.video()
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(1_500)
+
+    const threadId = await withTimeout(
+      seedPlanChecklistThread(page, workspaceRoot),
+      operationTimeoutMs,
+      'seeding the plan checklist thread'
+    )
+
+    // The sidebar hydrates its thread list on load; reload so the seeded thread
+    // (and its persisted checklist) is a real row the user could open.
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(2_500)
+    const row = page.locator('.ds-sidebar-tree-row', { hasText: THREAD_TITLE }).first()
+    await row.waitFor({ state: 'visible', timeout: operationTimeoutMs })
+    await row.click()
+
+    // Stage 1 — exactly what the reporter saw: an untouched plan checklist
+    // presenting itself as live step progress.
+    const todoChip = page.locator('[data-composer-stack-item="todo"] button')
+    await todoChip.waitFor({ state: 'visible', timeout: operationTimeoutMs })
+    const staleLabel = normalize(await todoChip.innerText())
+    if (!staleLabel.includes(STALE_LABEL)) {
+      throw new Error(`Plan checklist chip did not start at "${STALE_LABEL}": ${staleLabel}`)
+    }
+    if (await todoChip.getAttribute('data-todo-plan-outline') !== null) {
+      throw new Error('Plan checklist chip was demoted before any Graph run existed')
+    }
+    await page.waitForTimeout(1_500)
+    await page.screenshot({ path: join(evidenceRoot, '1-plan-checklist-before-graph.png') })
+
+    // Stage 2 — a Graph run takes over execution for this thread.
+    const seededGraph = await withTimeout(
+      seedGraphRun(page, threadId),
+      operationTimeoutMs,
+      'seeding the Graph run projection'
+    )
+    if (seededGraph.accepted !== GRAPH_ACCEPTED || seededGraph.total !== GRAPH_NODES) {
+      throw new Error(`Graph fixture is wrong: ${JSON.stringify(seededGraph)}`)
+    }
+
+    await page.locator('[data-todo-plan-outline="true"]').waitFor({
+      state: 'visible',
+      timeout: operationTimeoutMs
+    })
+    const outlineLabel = normalize(await todoChip.innerText())
+    if (!outlineLabel.includes(OUTLINE_LABEL)) {
+      throw new Error(`Plan checklist chip did not demote to an outline: ${outlineLabel}`)
+    }
+    if (outlineLabel.includes(STALE_LABEL)) {
+      throw new Error(`Plan checklist chip still claims step progress: ${outlineLabel}`)
+    }
+    const graphChip = page.locator('[data-composer-stack-item="graph"] button')
+    await graphChip.waitFor({ state: 'visible', timeout: operationTimeoutMs })
+    const graphLabel = normalize(await graphChip.innerText())
+    if (!graphLabel.includes(GRAPH_LABEL)) {
+      throw new Error(`Graph chip did not report ${GRAPH_LABEL}: ${graphLabel}`)
+    }
+    await page.waitForTimeout(1_500)
+    await page.screenshot({ path: join(evidenceRoot, '2-plan-outline-and-graph-progress.png') })
+
+    // Stage 3 — the detail popover has to say why the checklist stopped moving.
+    await todoChip.hover()
+    const hint = page.locator('[data-todo-plan-outline-hint]')
+    await hint.waitFor({ state: 'visible', timeout: operationTimeoutMs })
+    const hintText = normalize(await hint.innerText())
+    for (const fragment of ['Graph orchestration is running', 'not live execution progress']) {
+      if (!hintText.includes(fragment)) {
+        throw new Error(`Plan outline hint omits "${fragment}": ${hintText}`)
+      }
+    }
+    await page.waitForTimeout(2_000)
+    await page.screenshot({ path: join(evidenceRoot, '3-plan-outline-popover-hint.png') })
+    await page.mouse.move(WINDOW_WIDTH / 2, 120)
+    await page.waitForTimeout(1_000)
+
+    // Stage 4 — once every Graph run is terminal the checklist owns its own
+    // reading again, so the demotion is scoped to live orchestration.
+    await withTimeout(
+      completeGraphRun(page),
+      operationTimeoutMs,
+      'completing the seeded Graph run'
+    )
+    await page.locator('[data-todo-plan-outline="true"]').waitFor({
+      state: 'detached',
+      timeout: operationTimeoutMs
+    })
+    const restoredLabel = normalize(await todoChip.innerText())
+    if (!restoredLabel.includes(STALE_LABEL)) {
+      throw new Error(`Plan checklist chip did not return to step progress: ${restoredLabel}`)
+    }
+    await page.waitForTimeout(1_500)
+    await page.screenshot({ path: join(evidenceRoot, '4-checklist-restored-after-run.png') })
+
+    result = {
+      ok: true,
+      issue: 1202,
+      platform: process.platform,
+      threadId,
+      evidenceRoot,
+      graphStateSource:
+        'seeded into the renderer Graph store via the Vite dev module graph (no live model run)',
+      checklistItems: CHECKLIST_ITEMS,
+      graph: seededGraph,
+      labels: {
+        beforeGraph: staleLabel,
+        duringGraph: outlineLabel,
+        graphChip: graphLabel,
+        popoverHint: hintText,
+        afterGraph: restoredLabel
+      },
+      screenshots: [
+        join(evidenceRoot, '1-plan-checklist-before-graph.png'),
+        join(evidenceRoot, '2-plan-outline-and-graph-progress.png'),
+        join(evidenceRoot, '3-plan-outline-popover-hint.png'),
+        join(evidenceRoot, '4-checklist-restored-after-run.png')
+      ]
+    }
+  } catch (error) {
+    const diagnostics = [
+      rendererOutput.trim() ? `Renderer output:\n${rendererOutput.trim()}` : '',
+      electronOutput.trim() ? `Electron output:\n${electronOutput.trim()}` : ''
+    ].filter(Boolean).join('\n\n')
+    primaryError = new Error(`${error instanceof Error ? error.stack ?? error.message : String(error)}${
+      diagnostics ? `\n\n${diagnostics}` : ''
+    }`)
+  } finally {
+    const cleanupErrors = []
+    let electronClosePromise
+    if (electronApplication) {
+      electronClosePromise = electronApplication.close()
+      await withTimeout(
+        electronClosePromise,
+        GRACEFUL_CLOSE_TIMEOUT_MS,
+        'closing the graph plan progress Electron application'
+      ).catch(() => undefined)
+    }
+    // The video is only flushed once the recording context is gone.
+    if (recordedVideo) {
+      const videoTarget = join(evidenceRoot, 'graph-plan-progress.webm')
+      await withTimeout(
+        recordedVideo.saveAs(videoTarget),
+        MAX_CLEANUP_TIMEOUT_MS,
+        'saving the graph plan progress recording'
+      ).catch(async (error) => {
+        const fallback = await recordedVideo.path().catch(() => undefined)
+        if (!fallback || !existsSync(fallback)) throw error
+        await copyFile(fallback, videoTarget)
+      }).then(async () => {
+        if (result) result.video = videoTarget
+        const mp4 = await transcodeToMp4(videoTarget).catch(() => undefined)
+        if (result && mp4) result.videoMp4 = mp4
+      }).catch((error) => cleanupErrors.push(error))
+    }
+    if (electronProcess) {
+      await terminateProcessTree(electronProcess, process.platform, {
+        timeoutMs: MAX_CLEANUP_TIMEOUT_MS,
+        detached: process.platform !== 'win32'
+      }).catch((error) => cleanupErrors.push(error))
+    }
+    await withTimeout(
+      stopIsolatedSharedRuntime(repositoryRoot, profile),
+      MAX_CLEANUP_TIMEOUT_MS + 5_000,
+      'stopping the isolated graph plan progress Kun runtime'
+    ).catch((error) => cleanupErrors.push(error))
+    await withTimeout(
+      stopIsolatedServiceManager(home, profile),
+      MAX_CLEANUP_TIMEOUT_MS + 5_000,
+      'stopping the isolated graph plan progress Kun Service Manager'
+    ).catch((error) => cleanupErrors.push(error))
+    if (electronClosePromise) {
+      await withTimeout(electronClosePromise, 1_000, 'settling the Electron connection')
+        .catch(() => undefined)
+    }
+    releaseChildProcessHandles(electronProcess)
+    if (rendererProcess) {
+      await terminateProcessTree(rendererProcess, process.platform, {
+        timeoutMs: MAX_CLEANUP_TIMEOUT_MS,
+        detached: process.platform !== 'win32'
+      }).catch((error) => cleanupErrors.push(error))
+    }
+    releaseChildProcessHandles(rendererProcess)
+    if (result) {
+      await writeFile(join(evidenceRoot, 'report.json'), `${JSON.stringify(result, null, 2)}\n`)
+        .catch((error) => cleanupErrors.push(error))
+    }
+    await withTimeout(
+      Promise.all([makeTreeWritable(temporaryRoot), makeTreeWritable(workspaceRoot)]),
+      MAX_CLEANUP_TIMEOUT_MS,
+      'making graph plan progress smoke directories writable'
+    ).catch((error) => cleanupErrors.push(error))
+    await withTimeout(
+      Promise.all([
+        rm(temporaryRoot, { recursive: true, force: true, maxRetries: 8, retryDelay: 250 }),
+        rm(workspaceRoot, { recursive: true, force: true, maxRetries: 8, retryDelay: 250 })
+      ]),
+      MAX_CLEANUP_TIMEOUT_MS,
+      'removing graph plan progress smoke directories'
+    ).catch((error) => cleanupErrors.push(error))
+    if (cleanupErrors.length > 0) {
+      const cleanupDiagnostics = cleanupErrors
+        .map((error) => `- ${error instanceof Error ? error.message : String(error)}`)
+        .join('\n')
+      primaryError = primaryError
+        ? new Error(`${primaryError.stack ?? primaryError.message}\n\nCleanup failures:\n${cleanupDiagnostics}`)
+        : new Error(`Graph plan progress smoke cleanup failed:\n${cleanupDiagnostics}`)
+    }
+  }
+  if (primaryError) throw primaryError
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+}
+
+function normalize(value) {
+  return String(value).replace(/\s+/gu, ' ').trim()
+}
+
+/**
+ * Playwright only records WebM. Most issue trackers and reviewers want H.264,
+ * so hand the run an MP4 too whenever ffmpeg is on PATH.
+ */
+async function transcodeToMp4(webmPath) {
+  const mp4Path = webmPath.replace(/\.webm$/u, '.mp4')
+  const code = await new Promise((resolvePromise) => {
+    const child = spawn('ffmpeg', [
+      '-y', '-i', webmPath, '-c:v', 'libx264', '-preset', 'slow', '-crf', '20',
+      '-pix_fmt', 'yuv420p', '-vf', 'scale=trunc(iw/2)*2:trunc(ih/2)*2',
+      '-movflags', '+faststart', mp4Path
+    ], { stdio: 'ignore', windowsHide: true })
+    child.once('error', () => resolvePromise(null))
+    child.once('exit', resolvePromise)
+  })
+  if (code !== 0 || !existsSync(mp4Path)) throw new Error('ffmpeg could not transcode the recording')
+  return mp4Path
+}
+
+function checklistContent(index) {
+  return `Plan step ${index + 1}: ship the compiled implementation task`
+}
+
+function checklistContents() {
+  return Array.from({ length: CHECKLIST_ITEMS }, (_unused, index) => checklistContent(index))
+}
+
+/** The 19-item GUI implementation plan, every box still unchecked. */
+function planMarkdown() {
+  const tasks = checklistContents().map((content) => `- [ ] ${content}`).join('\n')
+  return `# Compiled implementation plan\n\n## Tasks\n\n${tasks}\n`
+}
+
+/**
+ * Creates a real thread and writes the plan checklist the GUI plan flow would
+ * persist: every item plan-sourced, every item still pending.
+ */
+async function seedPlanChecklistThread(page, workspaceRoot) {
+  return page.evaluate(async (input) => {
+    const request = async (path, method, body) => {
+      const response = await globalThis.kunGui.runtimeRequest(
+        path,
+        method,
+        body === undefined ? undefined : JSON.stringify(body)
+      )
+      if (!response.ok) throw new Error(`${method} ${path} failed (${response.status}): ${response.body}`)
+      return response.body ? JSON.parse(response.body) : undefined
+    }
+    const thread = await request('/v1/threads', 'POST', {
+      title: input.title,
+      workspace: input.workspace,
+      model: input.model,
+      mode: 'agent',
+      approvalPolicy: 'auto',
+      sandboxMode: 'danger-full-access'
+    })
+    const todos = input.contents.map((content, index) => ({
+      content,
+      status: 'pending',
+      source: {
+        kind: 'plan',
+        planId: input.planId,
+        relativePath: input.relativePath,
+        ordinal: index,
+        contentHash: `hash_${index}`
+      }
+    }))
+    await request(`/v1/threads/${encodeURIComponent(thread.id)}/todos`, 'POST', { todos })
+    return thread.id
+  }, {
+    workspace: workspaceRoot,
+    model: MODEL_NAME,
+    title: THREAD_TITLE,
+    contents: checklistContents(),
+    planId: PLAN_ID,
+    relativePath: PLAN_RELATIVE_PATH
+  })
+}
+
+/**
+ * Publishes a Graph run projection for the thread: 11 compiled nodes, 7 already
+ * accepted by the Lead, 1 executing, 1 ready, 2 blocked on dependencies — the
+ * exact distribution in the report.
+ */
+async function seedGraphRun(page, threadId) {
+  return page.evaluate(async (input) => {
+    const graphStore = await import('/src/graph/graph-store.ts')
+    const statuses = [
+      ...Array.from({ length: input.accepted }, () => 'accepted'),
+      'running', 'ready', 'blocked', 'blocked'
+    ].slice(0, input.total)
+    const now = new Date().toISOString()
+    const planNodes = statuses.map((_status, index) => ({
+      id: `node_${index + 1}`,
+      phaseId: `phase_${Math.min(3, Math.floor(index / 4) + 1)}`,
+      kind: 'work',
+      title: `Compiled node ${index + 1}`,
+      objective: `Deliver compiled execution node ${index + 1}.`,
+      priority: 1,
+      required: true,
+      riskClass: 'low',
+      assignment: { kind: 'ephemeral', name: `Executor ${index + 1}`, systemPrompt: 'Execute.' },
+      readScopes: [],
+      writeScopes: []
+    }))
+    const nodes = {}
+    statuses.forEach((status, index) => {
+      const planNode = planNodes[index]
+      nodes[planNode.id] = {
+        node: planNode,
+        status,
+        attempts: status === 'blocked' ? [] : [{
+          id: `attempt_${index + 1}`,
+          attemptNumber: 1,
+          status: status === 'accepted' ? 'accepted' : status,
+          assignment: {
+            profileId: `executor-${index + 1}`, profileVersion: 1, profileOrigin: 'ephemeral',
+            name: `Executor ${index + 1}`, model: 'k3', providerId: 'provider',
+            allowedModelProviderIds: ['provider'], allowedModels: ['k3'],
+            allowedProviderIds: ['builtin'], reasoningEffort: 'medium',
+            systemPrompt: 'Execute.', toolPolicy: 'readOnly',
+            allowedTools: [], blockedTools: [], allowedSkills: [], blockedSkills: [],
+            allowedMcpServers: [], blockedMcpServers: [],
+            approvalPolicy: 'never', sandboxMode: 'read-only', workspaceRoot: '/repo',
+            readScopes: [], writeScopes: [], networkAllowed: false,
+            maxWallTimeMs: 86_400_000, capturedAt: now
+          },
+          queuedAt: now, startedAt: now, tokenUsage: 0, elapsedMs: 0
+        }],
+        loopIteration: 0
+      }
+    })
+    const run = {
+      version: 1,
+      id: 'run_plan_progress',
+      projectId: 'project_plan_progress',
+      threadId: input.threadId,
+      sourceTurnId: 'turn_plan_progress',
+      status: 'running',
+      currentRevision: 1,
+      plans: [{
+        version: 1,
+        revision: 1,
+        title: 'Compiled implementation plan',
+        goal: 'Execute the compiled plan.',
+        workspaceRoot: '/repo',
+        phases: [
+          { id: 'phase_1', title: 'Backend', order: 1 },
+          { id: 'phase_2', title: 'CLI', order: 2 },
+          { id: 'phase_3', title: 'UI', order: 3 }
+        ],
+        nodes: planNodes,
+        edges: [],
+        completionNodeIds: planNodes.map((planNode) => planNode.id),
+        createdAt: now
+      }],
+      nodes,
+      reviews: [], messages: [], artifacts: [], cleanup: [], steering: [],
+      budget: {
+        limits: { maxWallTimeMs: 86_400_000, maxAttemptsPerNode: 3 },
+        attempts: input.total,
+        revisions: 0,
+        loopIterations: 0,
+        elapsedMs: 0,
+        totalTokens: 0,
+        messages: 0,
+        artifactBytes: 0,
+        warningKinds: [],
+        closed: false
+      },
+      lastEventSeq: 42,
+      createdAt: now,
+      updatedAt: now
+    }
+    graphStore.useGraphStore.setState({
+      threadId: input.threadId,
+      runs: [run],
+      selectedRunId: run.id,
+      childRuns: {},
+      // Holds the seeded projection still: a live refresh would replace it with
+      // the empty runtime state, since no real Graph run exists on disk.
+      refreshThread: async () => undefined
+    })
+    return {
+      runId: run.id,
+      total: planNodes.length,
+      accepted: statuses.filter((status) => status === 'accepted').length,
+      running: statuses.filter((status) => status === 'running').length
+    }
+  }, { threadId, total: GRAPH_NODES, accepted: GRAPH_ACCEPTED })
+}
+
+async function completeGraphRun(page) {
+  await page.evaluate(async () => {
+    const graphStore = await import('/src/graph/graph-store.ts')
+    const state = graphStore.useGraphStore.getState()
+    graphStore.useGraphStore.setState({
+      runs: state.runs.map((run) => ({ ...run, status: 'completed' }))
+    })
+  })
+}
+
+function releaseChildProcessHandles(child) {
+  child?.stdout?.destroy()
+  child?.stderr?.destroy()
+  child?.unref?.()
+}
+
+async function withTimeout(operation, timeoutMs, description) {
+  let timeout
+  try {
+    return await Promise.race([
+      operation,
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Timed out while ${description}`)), timeoutMs)
+      })
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+async function availablePort() {
+  const server = createServer()
+  await new Promise((resolvePromise, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolvePromise)
+  })
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : 0
+  await new Promise((resolvePromise, reject) => {
+    server.close((error) => error ? reject(error) : resolvePromise())
+  })
+  if (!port) throw new Error('Could not allocate a graph plan progress smoke port')
+  return port
+}
+
+async function waitForPortOpen(port, timeoutMs, child) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`Renderer exited before port ${port} opened`)
+    }
+    if (await isPortOpen(port)) return
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100))
+  }
+  throw new Error(`Timed out waiting for renderer port ${port}`)
+}
+
+function isPortOpen(port) {
+  return new Promise((resolvePromise) => {
+    const socket = createConnection({ host: '127.0.0.1', port })
+    let settled = false
+    const finish = (open) => {
+      if (settled) return
+      settled = true
+      socket.destroy()
+      resolvePromise(open)
+    }
+    socket.setTimeout(250, () => finish(false))
+    socket.once('connect', () => finish(true))
+    socket.once('error', () => finish(false))
+    socket.unref()
+  })
+}
+
+function argumentValue(name) {
+  const index = process.argv.indexOf(name)
+  if (index < 0) return undefined
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`)
+  return value
+}
+
+function positiveIntegerArgument(name, fallback) {
+  const value = argumentValue(name)
+  if (value === undefined) return fallback
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`)
+  return parsed
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/src/renderer/src/components/chat/FloatingComposerStackView.tsx
+++ b/src/renderer/src/components/chat/FloatingComposerStackView.tsx
@@ -31,7 +31,7 @@ export function FloatingComposerStackView({
     <>
         <FloatingComposerAboveInputStack
           todo={showTodoProgress && activeThreadTodos ? (
-            <FloatingComposerTodoProgress todos={activeThreadTodos} />
+            <FloatingComposerTodoProgress todos={activeThreadTodos} enabled={showGraphProgress} />
           ) : null}
           graph={(
             <FloatingComposerGraphProgress

--- a/src/renderer/src/components/chat/FloatingComposerTodoProgress.test.ts
+++ b/src/renderer/src/components/chat/FloatingComposerTodoProgress.test.ts
@@ -95,11 +95,12 @@ describe('plan checklist against live Graph execution (#1202)', () => {
     })
   })
 
-  async function renderChecklist(): Promise<ReactTestRenderer> {
+  async function renderChecklist(enabled?: boolean): Promise<ReactTestRenderer> {
     let renderer: ReactTestRenderer
     await act(async () => {
       renderer = create(createElement(FloatingComposerTodoProgress, {
-        todos: planChecklist('thread-1', 19)
+        todos: planChecklist('thread-1', 19),
+        ...(enabled === undefined ? {} : { enabled })
       }))
     })
     return renderer!
@@ -134,6 +135,22 @@ describe('plan checklist against live Graph execution (#1202)', () => {
       })
     })
     const renderer = await renderChecklist()
+    const trigger = renderer.root.findByType('button')
+
+    expect(trigger.props['data-todo-plan-outline']).toBeUndefined()
+    expect(JSON.stringify(renderer.toJSON())).toContain('Step 1 / 19')
+    expect(trigger.props['aria-label']).toContain('step 1 of 19')
+    renderer.unmount()
+  })
+
+  it('keeps step progress while the Graph progress surface is disabled', async () => {
+    act(() => {
+      useGraphStore.setState({
+        runs: [graphRunFor('thread-1', 'running')],
+        selectedRunId: 'run_1'
+      })
+    })
+    const renderer = await renderChecklist(false)
     const trigger = renderer.root.findByType('button')
 
     expect(trigger.props['data-todo-plan-outline']).toBeUndefined()

--- a/src/renderer/src/components/chat/FloatingComposerTodoProgress.test.ts
+++ b/src/renderer/src/components/chat/FloatingComposerTodoProgress.test.ts
@@ -1,13 +1,15 @@
 import { createElement } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 import type { ThreadTodoItem, ThreadTodoList } from '../../agent/types'
+import { useGraphStore } from '../../graph/graph-store'
+import type { GraphRun, GraphRunStatus } from '../../graph/graph-types'
 import {
   FloatingComposerTodoProgress,
   calculateTodoProgressPopoverPlacement,
   getTodoProgress
 } from './FloatingComposerTodoProgress'
-import '../../i18n'
+import i18n from '../../i18n'
 
 function item(id: string, status: ThreadTodoItem['status']): ThreadTodoItem {
   return {
@@ -23,6 +25,19 @@ const todos: ThreadTodoList = {
   threadId: 'thread-1',
   items: [item('one', 'completed'), item('two', 'in_progress'), item('three', 'pending')],
   updatedAt: '2026-07-16T00:00:00.000Z'
+}
+
+/** Only the fields `graphRunOwnsThreadProgress` reads. */
+function graphRunFor(threadId: string, status: GraphRunStatus): GraphRun {
+  return { id: 'run_1', threadId, status } as unknown as GraphRun
+}
+
+function planChecklist(threadId: string, total: number): ThreadTodoList {
+  return {
+    threadId,
+    items: Array.from({ length: total }, (_unused, index) => item(`plan-${index}`, 'pending')),
+    updatedAt: '2026-08-16T13:49:46.127Z'
+  }
 }
 
 describe('FloatingComposerTodoProgress', () => {
@@ -65,5 +80,65 @@ describe('FloatingComposerTodoProgress', () => {
 
     expect(renderer!.root.findByType('button').props['aria-expanded']).toBe(true)
     renderer!.unmount()
+  })
+})
+
+describe('plan checklist against live Graph execution (#1202)', () => {
+  beforeAll(async () => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    await i18n.changeLanguage('en')
+  })
+
+  afterEach(() => {
+    act(() => {
+      useGraphStore.setState({ runs: [], selectedRunId: null })
+    })
+  })
+
+  async function renderChecklist(): Promise<ReactTestRenderer> {
+    let renderer: ReactTestRenderer
+    await act(async () => {
+      renderer = create(createElement(FloatingComposerTodoProgress, {
+        todos: planChecklist('thread-1', 19)
+      }))
+    })
+    return renderer!
+  }
+
+  it('stops reporting the untouched checklist count as execution progress', async () => {
+    act(() => {
+      useGraphStore.setState({
+        runs: [graphRunFor('thread-1', 'running')],
+        selectedRunId: 'run_1'
+      })
+    })
+    const renderer = await renderChecklist()
+    const trigger = renderer.root.findByType('button')
+
+    const tree = JSON.stringify(renderer.toJSON())
+    expect(trigger.props['data-todo-plan-outline']).toBe('true')
+    expect(tree).toContain('Plan outline · 19 steps')
+    expect(tree).not.toContain('Step 1 / 19')
+    expect(trigger.props['aria-label']).toContain('Original plan outline')
+    renderer.unmount()
+  })
+
+  it('keeps step progress when no Graph run owns the thread', async () => {
+    act(() => {
+      useGraphStore.setState({
+        runs: [
+          graphRunFor('thread-1', 'completed'),
+          graphRunFor('other-thread', 'running')
+        ],
+        selectedRunId: 'run_1'
+      })
+    })
+    const renderer = await renderChecklist()
+    const trigger = renderer.root.findByType('button')
+
+    expect(trigger.props['data-todo-plan-outline']).toBeUndefined()
+    expect(JSON.stringify(renderer.toJSON())).toContain('Step 1 / 19')
+    expect(trigger.props['aria-label']).toContain('step 1 of 19')
+    renderer.unmount()
   })
 })

--- a/src/renderer/src/components/chat/FloatingComposerTodoProgress.tsx
+++ b/src/renderer/src/components/chat/FloatingComposerTodoProgress.tsx
@@ -82,9 +82,12 @@ export function calculateTodoProgressPopoverPlacement({
 }
 
 export function FloatingComposerTodoProgress({
-  todos
+  todos,
+  enabled = true
 }: {
   todos: ThreadTodoList
+  /** Mirrors FloatingComposerGraphProgress: only demote while the Graph card reports progress. */
+  enabled?: boolean
 }): ReactElement | null {
   const { t } = useTranslation('common')
   const [open, setOpen] = useState(false)
@@ -96,8 +99,11 @@ export function FloatingComposerTodoProgress({
   // A Graph run compiles the plan into its own node set, and no reliable
   // checklist-to-node mapping exists. While Graph executes, this list is a
   // static plan outline, so it must stop claiming to be live step progress.
+  // Gated on the same `enabled` flag as the Graph card so the demotion (and
+  // its popover hint pointing at the Graph card) only applies while that
+  // card can actually report execution progress.
   const graphOwnsProgress = useGraphStore((state) => (
-    graphRunOwnsThreadProgress(state.runs, todos.threadId, state.selectedRunId)
+    enabled && graphRunOwnsThreadProgress(state.runs, todos.threadId, state.selectedRunId)
   ))
   const progress = getTodoProgress(todos.items)
   const estimatedPopoverHeight = Math.min(

--- a/src/renderer/src/components/chat/FloatingComposerTodoProgress.tsx
+++ b/src/renderer/src/components/chat/FloatingComposerTodoProgress.tsx
@@ -5,10 +5,12 @@ import {
   type CSSProperties,
   type ReactElement
 } from 'react'
-import { CheckCircle2, Circle } from 'lucide-react'
+import { CheckCircle2, Circle, ListTodo } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import type { ThreadTodoItem, ThreadTodoList } from '../../agent/types'
+import { useGraphStore } from '../../graph/graph-store'
+import { graphRunOwnsThreadProgress } from './composer-graph-preview'
 import {
   calculateComposerPopoverPlacement,
   currentComposerBodyZoom,
@@ -91,6 +93,12 @@ export function FloatingComposerTodoProgress({
   const buttonRef = useRef<HTMLButtonElement | null>(null)
   const popoverRef = useRef<HTMLDivElement | null>(null)
   const hoverCloseTimerRef = useRef<number | null>(null)
+  // A Graph run compiles the plan into its own node set, and no reliable
+  // checklist-to-node mapping exists. While Graph executes, this list is a
+  // static plan outline, so it must stop claiming to be live step progress.
+  const graphOwnsProgress = useGraphStore((state) => (
+    graphRunOwnsThreadProgress(state.runs, todos.threadId, state.selectedRunId)
+  ))
   const progress = getTodoProgress(todos.items)
   const estimatedPopoverHeight = Math.min(
     TODO_POPOVER_MAX_HEIGHT,
@@ -185,10 +193,18 @@ export function FloatingComposerTodoProgress({
         maxHeight: `${TODO_POPOVER_MAX_HEIGHT}px`,
         visibility: 'hidden'
       }
-  const progressLabel = t('todoProgressStep', {
-    current: progress.current,
-    total: progress.total
-  })
+  const progressLabel = graphOwnsProgress
+    ? t('todoPlanOutline', { total: progress.total })
+    : t('todoProgressStep', {
+        current: progress.current,
+        total: progress.total
+      })
+  const triggerAriaLabel = graphOwnsProgress
+    ? t('todoPlanOutlineAria', { total: progress.total })
+    : t('todoProgressAria', {
+        current: progress.current,
+        total: progress.total
+      })
 
   return (
     <>
@@ -204,6 +220,14 @@ export function FloatingComposerTodoProgress({
               onMouseEnter={cancelClose}
               onMouseLeave={closeDetailsSoon}
             >
+              {graphOwnsProgress ? (
+                <p
+                  data-todo-plan-outline-hint
+                  className="mb-1.5 rounded-xl bg-ds-hover px-2.5 py-2 text-[12px] leading-[1.125rem] text-ds-muted"
+                >
+                  {t('todoPlanOutlineHint')}
+                </p>
+              ) : null}
               <ol className="space-y-0.5">
                 {todos.items.map((item) => (
                   <TodoDetailRow key={item.id} item={item} />
@@ -227,14 +251,14 @@ export function FloatingComposerTodoProgress({
           onMouseEnter={openDetails}
           onMouseLeave={closeDetailsSoon}
           className="ds-no-drag inline-flex h-11 items-center gap-2.5 rounded-full border border-ds-border bg-white/96 px-4 text-[14px] font-medium text-ds-muted shadow-[0_10px_30px_rgba(20,47,95,0.10)] backdrop-blur-xl transition hover:border-ds-border-strong hover:text-ds-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 dark:bg-ds-card/96"
-          aria-label={t('todoProgressAria', {
-            current: progress.current,
-            total: progress.total
-          })}
+          aria-label={triggerAriaLabel}
           aria-expanded={open}
           aria-haspopup="dialog"
+          data-todo-plan-outline={graphOwnsProgress ? 'true' : undefined}
         >
-          {progress.allComplete ? (
+          {graphOwnsProgress ? (
+            <ListTodo className="h-5 w-5 shrink-0 text-ds-faint" strokeWidth={1.9} />
+          ) : progress.allComplete ? (
             <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-600" strokeWidth={1.9} />
           ) : (
             <span

--- a/src/renderer/src/components/chat/composer-graph-preview.test.ts
+++ b/src/renderer/src/components/chat/composer-graph-preview.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   fitComposerGraphLabel,
   getComposerGraphProgress,
+  graphRunOwnsThreadProgress,
   layoutComposerGraph
 } from './composer-graph-preview'
 
@@ -205,6 +206,25 @@ describe('composer Graph progress', () => {
     waitingRun.status = 'completed'
     expect(layoutComposerGraph(waitingRun, { child_1: child('running') }).edges[0]?.flowing)
       .toBe(false)
+  })
+})
+
+describe('graphRunOwnsThreadProgress (#1202)', () => {
+  it('hands progress authority to a live Graph run on the same thread', () => {
+    expect(graphRunOwnsThreadProgress([graphRun(readyNode())], 'thread_1')).toBe(true)
+  })
+
+  it('leaves authority with the plan checklist once every run is terminal', () => {
+    const run = graphRun(readyNode())
+    run.status = 'completed'
+
+    expect(graphRunOwnsThreadProgress([run], 'thread_1')).toBe(false)
+  })
+
+  it('ignores live runs that belong to another thread', () => {
+    expect(graphRunOwnsThreadProgress([graphRun(readyNode())], 'thread_2')).toBe(false)
+    expect(graphRunOwnsThreadProgress([graphRun(readyNode())], null)).toBe(false)
+    expect(graphRunOwnsThreadProgress([], 'thread_1')).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/chat/composer-graph-preview.ts
+++ b/src/renderer/src/components/chat/composer-graph-preview.ts
@@ -200,6 +200,25 @@ export function selectComposerGraphRun(
   return runs.find((run) => !terminalRunStatuses.has(run.status)) ?? null
 }
 
+/**
+ * True when a Graph run owns execution for this thread, so Graph node state —
+ * not the originating plan checklist — is the authoritative progress metric.
+ *
+ * Deliberately shares `selectComposerGraphRun` with the Graph chip: the two
+ * surfaces can never disagree about which one is reporting live progress.
+ */
+export function graphRunOwnsThreadProgress(
+  runs: readonly GraphRun[],
+  threadId: string | null,
+  selectedRunId: string | null = null
+): boolean {
+  if (!threadId) return false
+  return selectComposerGraphRun(
+    runs.filter((run) => run.threadId === threadId),
+    selectedRunId
+  ) != null
+}
+
 export function getComposerGraphProgress(
   run: GraphRun,
   childRuns: Readonly<Record<string, GraphChildRuntime>> = {}

--- a/src/renderer/src/locales/en/common/commands-sdd.json
+++ b/src/renderer/src/locales/en/common/commands-sdd.json
@@ -388,6 +388,9 @@
   "todoProgressStep": "Step {{current}} / {{total}}",
   "todoProgressAria": "Todo progress: step {{current}} of {{total}}",
   "todoProgressDetails": "Todo details",
+  "todoPlanOutline": "Plan outline · {{total}} steps",
+  "todoPlanOutlineAria": "Original plan outline: {{total}} steps. Graph reports live execution progress separately.",
+  "todoPlanOutlineHint": "Graph orchestration is running. This checklist is the original plan outline, not live execution progress — see the Graph card for accepted nodes.",
   "todoStatus": {
     "pending": "Pending",
     "in_progress": "Active",

--- a/src/renderer/src/locales/hi/common/commands-sdd.json
+++ b/src/renderer/src/locales/hi/common/commands-sdd.json
@@ -382,6 +382,9 @@
   "todoProgressStep": "Step {{current}} / {{total}}",
   "todoProgressAria": "Todo progress: step {{current}} of {{total}}",
   "todoProgressDetails": "कार्य विवरण",
+  "todoPlanOutline": "योजना रूपरेखा · {{total}} चरण",
+  "todoPlanOutlineAria": "मूल योजना रूपरेखा: {{total}} चरण। लाइव निष्पादन प्रगति Graph अलग से दिखाता है।",
+  "todoPlanOutlineHint": "Graph ऑर्केस्ट्रेशन चल रहा है। यह चेकलिस्ट मूल योजना रूपरेखा है, लाइव निष्पादन प्रगति नहीं — स्वीकृत नोड्स के लिए Graph कार्ड देखें।",
   "todoStatus": {
     "pending": "लंबित",
     "in_progress": "सक्रिय",

--- a/src/renderer/src/locales/ja/common/commands-sdd.json
+++ b/src/renderer/src/locales/ja/common/commands-sdd.json
@@ -382,6 +382,9 @@
   "todoProgressStep": "ステップ {{current}} / {{total}}",
   "todoProgressAria": "Todo の進行状況: ステップ {{current}} / {{total}}",
   "todoProgressDetails": "Todoの詳細",
+  "todoPlanOutline": "プラン概要 · {{total}} ステップ",
+  "todoPlanOutlineAria": "元のプラン概要: 全 {{total}} ステップ。実行の進捗は Graph が個別に表示します。",
+  "todoPlanOutlineHint": "Graph オーケストレーションが実行中です。このチェックリストは元のプラン概要であり、実行の進捗ではありません。受理済みノードは Graph カードを参照してください。",
   "todoStatus": {
     "pending": "保留中",
     "in_progress": "アクティブ",

--- a/src/renderer/src/locales/ko/common/commands-sdd.json
+++ b/src/renderer/src/locales/ko/common/commands-sdd.json
@@ -382,6 +382,9 @@
   "todoProgressStep": "Step {{current}} / {{total}}",
   "todoProgressAria": "Todo progress: step {{current}} of {{total}}",
   "todoProgressDetails": "할일 세부정보",
+  "todoPlanOutline": "계획 개요 · {{total}}단계",
+  "todoPlanOutlineAria": "원본 계획 개요: 총 {{total}}단계. 실행 진행률은 Graph에서 따로 표시합니다.",
+  "todoPlanOutlineHint": "Graph 오케스트레이션이 실행 중입니다. 이 체크리스트는 원본 계획 개요이며 실시간 실행 진행률이 아닙니다. 수락된 노드는 Graph 카드를 확인하세요.",
   "todoStatus": {
     "pending": "보류 중",
     "in_progress": "활성",

--- a/src/renderer/src/locales/ru/common/commands-sdd.json
+++ b/src/renderer/src/locales/ru/common/commands-sdd.json
@@ -382,6 +382,9 @@
   "todoProgressStep": "Step {{current}} / {{total}}",
   "todoProgressAria": "Прогресс в задаче: шаг {{current}} из {{total}}",
   "todoProgressDetails": "Подробности задачи",
+  "todoPlanOutline": "План · {{total}} шагов",
+  "todoPlanOutlineAria": "Исходный план: {{total}} шагов. Реальный прогресс выполнения показывает Graph отдельно.",
+  "todoPlanOutlineHint": "Выполняется оркестрация Graph. Этот список — исходный план, а не текущий прогресс выполнения: принятые узлы смотрите в карточке Graph.",
   "todoStatus": {
     "pending": "В ожидании",
     "in_progress": "Активный",

--- a/src/renderer/src/locales/th/common/commands-sdd.json
+++ b/src/renderer/src/locales/th/common/commands-sdd.json
@@ -382,6 +382,9 @@
   "todoProgressStep": "ขั้นตอนที่ {{current}} / {{total}}",
   "todoProgressAria": "ความคืบหน้าของสิ่งที่ต้องทำ: ขั้นตอนที่ {{current}} จาก {{total}}",
   "todoProgressDetails": "รายละเอียดสิ่งที่ต้องทำ",
+  "todoPlanOutline": "โครงร่างแผน · {{total}} ขั้นตอน",
+  "todoPlanOutlineAria": "โครงร่างแผนต้นฉบับ: {{total}} ขั้นตอน Graph จะแสดงความคืบหน้าการทำงานจริงแยกต่างหาก",
+  "todoPlanOutlineHint": "การจัดการแบบ Graph กำลังทำงาน รายการนี้คือโครงร่างแผนต้นฉบับ ไม่ใช่ความคืบหน้าการทำงานจริง — ดูโหนดที่ยอมรับแล้วได้ที่การ์ด Graph",
   "todoStatus": {
     "pending": "รอดำเนินการ",
     "in_progress": "ใช้งานอยู่",

--- a/src/renderer/src/locales/zh/common/commands-sdd.json
+++ b/src/renderer/src/locales/zh/common/commands-sdd.json
@@ -388,6 +388,9 @@
   "todoProgressStep": "第 {{current}} / {{total}} 步",
   "todoProgressAria": "Todo 进度：第 {{current}} 步，共 {{total}} 步",
   "todoProgressDetails": "Todo 详情",
+  "todoPlanOutline": "计划大纲 · {{total}} 步",
+  "todoPlanOutlineAria": "原始计划大纲：共 {{total}} 步。Graph 会单独显示实时执行进度。",
+  "todoPlanOutlineHint": "Graph 编排正在运行。此清单是原始计划大纲，不是实时执行进度——已接受的节点请查看 Graph 卡片。",
   "todoStatus": {
     "pending": "待处理",
     "in_progress": "进行中",


### PR DESCRIPTION
## Summary

Fixes #1202.

https://github.com/user-attachments/assets/d65a1864-fe21-478e-bd4e-891823575aeb


While Graph orchestration executed a compiled plan, the composer kept showing the originating plan checklist as live step progress — `Step 1 / 19` — while the Graph card one row below it already reported `7/11 accepted · 1 running`. A healthy run read as almost completely stalled, and the two surfaces contradicted each other.

**Root cause.** `FloatingComposerTodoProgress` renders `todoProgressStep` (`"Step {{current}} / {{total}}"`) from the thread todo list. That list is seeded exactly once — by `syncPlanTodosFromMarkdown`, from the `- [ ]` lines of the plan markdown, and only when the user saves a plan in `PlanPanel`. Nothing in a Graph run writes back to it.

**Option (a) from the issue is not implementable.** Graph nodes carry no reference to thread todos in either direction (`kun/src/graph/*.ts` contains no `todo` reference at all), so the 19 → 11 mapping the reporter suspected does not exist to be synchronised.

**The authoritative number was already on screen.** `FloatingComposerGraphProgress` renders `graphCompletedAndRunning`, and `completedNodeStatuses` is strictly `['accepted']`. So the defect is the contradiction, not a missing metric — this PR takes acceptable behaviours (b) and (c) from the issue.

## Changes

- `composer-graph-preview.ts` — new `graphRunOwnsThreadProgress()`. It shares `selectComposerGraphRun` with the Graph card, so the two surfaces can never disagree about which one is reporting live progress.
- `FloatingComposerTodoProgress.tsx` — while a live Graph run owns the thread the chip switches to a `ListTodo` icon and `Plan outline · 19 steps`, its accessible name states that Graph reports execution progress separately, and the detail popover gains a hint pointing at the Graph card. Marked with `data-todo-plan-outline` for tests.
- 7 locales — `todoPlanOutline`, `todoPlanOutlineAria`, `todoPlanOutlineHint`.
- `scripts/smoke-development-graph-plan-progress.cjs` + `npm run smoke:development-graph-plan-progress` — desktop end-to-end evidence.

**Scoped deliberately.** The demotion applies only while a run is non-terminal. Widening it to any past run would permanently mislabel a thread that later runs ordinary `todo_write` turns, so the rule matches what the issue describes: *while Graph orchestration is active*.

## Tests

- `composer-graph-preview.test.ts` — 3 selector cases: live run on the thread, all runs terminal, runs belonging to another thread.
- `FloatingComposerTodoProgress.test.ts` — the regression test the reporter asked for: 19 untouched checklist items plus a live 11-node Graph run must not report the unchanged checklist count; and the inverse, that step progress survives when no Graph run owns the thread.
- End-to-end (`npm run smoke:development-graph-plan-progress`), isolated HOME/userData, Vite dev renderer against the built Main and a real Kun runtime. It writes a real 19-item GUI plan at `.kunsdd/plan/…` and persists all 19 plan-sourced todos over `POST /v1/threads/{id}/todos`, then asserts four states and records screenshots plus a WebM/MP4 walkthrough:

  | # | state | asserted |
  | - | - | - |
  | 1 | before any Graph run | `Step 1 / 19` |
  | 2 | live Graph run | `Plan outline · 19 steps` + `7/11 accepted · 1 running` |
  | 3 | popover | *"…the original plan outline, not live execution progress…"* |
  | 4 | run terminal | `Step 1 / 19` again — the demotion is not a one-way latch |

  The Graph projection (11 nodes / 7 accepted / 1 running / 1 ready / 2 blocked) is seeded into the renderer Graph store rather than produced by a live orchestration run; driving 11 real subagent nodes needs a live model and is nondeterministic. This is recorded as `graphStateSource` in the run's `report.json`. Every component, selector, translation and style downstream of that state is the production one.

- `npm run typecheck` (web/node/kun) clean · `npm run lint` 0 errors · `npm run check:file-lines` passes · `npm run build` exit 0 · 692 chat-component tests and 29 locale-parity tests pass.