### PR TITLE
fix(ci): raise macOS renderer build heap

### DIFF
--- a/.github/workflows/daily-dev-prerelease.yml
+++ b/.github/workflows/daily-dev-prerelease.yml
@@ -72,6 +72,10 @@ jobs:
       DEEPSEEK_GUI_ARTIFACT_VERSION: ${{ needs.prepare.outputs.dev_version }}
       DEEPSEEK_GUI_UPDATE_CHANNEL: frontier
       RELEASE_CHANNEL: frontier
+      # The renderer bundle can exceed Node's default ~2 GiB heap on the
+      # macOS ARM runner. Keep prerelease packaging consistent with PR and
+      # stable release builds.
+      NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - name: Check out develop commit
         uses: actions/checkout@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -133,6 +133,9 @@ jobs:
       # PR validation intentionally uses the afterPack ad-hoc signature only.
       # It never consumes Developer ID or notarization secrets.
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+      # The renderer bundle can exceed Node's default ~2 GiB heap on the
+      # macOS ARM runner. Keep the PR build aligned with release packaging.
+      NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,10 @@ jobs:
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
       CSC_FOR_PULL_REQUEST: 'true'
+      # The renderer bundle can exceed Node's default ~2 GiB heap on the
+      # macOS ARM runner; signed release packaging needs the same allowance
+      # that PR packaging uses.
+      NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - name: Check out merge commit
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Raise the Node heap cap to 4 GiB for every macOS packaging workflow.

## Root cause

The v0.3.6 release PR native macOS package check failed while `electron-vite build` exhausted Node’s default ~2 GiB heap (exit 134). The failure occurred after the current renderer bundle grew past that limit, before macOS packaging began.

## Changes

- PR macOS ad-hoc package job
- Stable release signed macOS package job
- Daily prerelease macOS package job

All use `NODE_OPTIONS=--max-old-space-size=4096`.

## Validation

- Parsed all changed workflow YAML and asserted the job environment values
- `git diff --check`
- `npm run check:file-lines`
- Native macOS packaging matrix pending on this PR