### PR TITLE
docs: fix merged checklist items in kun-contributing.en.md

### DIFF
--- a/docs/kun-contributing.en.md
+++ b/docs/kun-contributing.en.md
@@ -584,7 +584,8 @@ Before submitting a PR, confirm each item:
       Write it in the PR description
 - [ ] When the public contract is changed, update the `kun/README.md` endpoint table
 - [ ] When references/acknowledgments change, update root directories `README.md` and `README.en.md`
-- [ ] When adding a new SSE event, add a line to `docs/kun-architecture.md`- [ ] in the borrow map of `docs/kun-architecture.md` (as in the future
+- [ ] When adding a new SSE event, add a line to `docs/kun-architecture.md`
+- [ ] in the borrow map of `docs/kun-architecture.md` (as in the future
       Add OpenAI-style reference) to explain the design source
 
 ### 6.3 Don’t do it


### PR DESCRIPTION
## Summary

Fixes a markdown formatting regression in `docs/kun-contributing.en.md` where two checklist items under section 6.2 "Recommended" were concatenated onto a single line, so the second item did not render as a separate checkbox.

## Why

In the English contribution guide (`docs/kun-contributing.en.md`), the following two checklist items were merged onto one line:

```text
- [ ] When adding a new SSE event, add a line to `docs/kun-architecture.md`- [ ] in the borrow map of `docs/kun-architecture.md` (as in the future
      Add OpenAI-style reference) to explain the design source
```

Because the second `- [ ]` directly follows the first item's text on the same line, it is not parsed as a new list item, so it does not render as an independent checkbox. The Chinese counterpart (`docs/kun-contributing.md`) correctly splits these into two separate list items:

```text
- [ ] 新增 SSE 事件时,给 `docs/kun-architecture.md` 加一行
- [ ] 在 `docs/kun-architecture.md` 的 borrow map 中(如未来
      添加 OpenAI-style 借鉴)说明设计来源
```

This PR restores the missing line break so the English version matches the Chinese version and both checklist items render correctly.

## Validation

- `git diff` confirms a single-file change (`docs/kun-contributing.en.md`, 2 insertions / 1 deletion).
- Verified the surrounding section still renders as a valid markdown checklist with two independent items.
- No code, dependencies, or build behavior affected — documentation-only change.
