### PR TITLE
fix(release): remove hoisted Kun binary shims

### DIFF
--- a/scripts/after-pack-hoisted-dependencies.cjs
+++ b/scripts/after-pack-hoisted-dependencies.cjs
@@ -1,7 +1,7 @@
 'use strict'
 
-const { existsSync, readFileSync } = require('node:fs')
-const { dirname, join } = require('node:path')
+const { existsSync, lstatSync, readFileSync, readdirSync, rmSync } = require('node:fs')
+const { dirname, join, relative } = require('node:path')
 
 // Shared pure-JS runtimes that the root app and Kun resolve identically.
 // after-pack removes the Kun copy from app.asar.unpacked/kun/node_modules; the
@@ -117,9 +117,112 @@ function validateRootHoistedDependencyClosure(root) {
   }
 }
 
+function pathEntryExists(path) {
+  try {
+    lstatSync(path)
+    return true
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false
+    throw error
+  }
+}
+
+function packedDependencyPackageRoots(dependencyRoot) {
+  if (existsSync(join(dependencyRoot, 'package.json'))) return [dependencyRoot]
+  if (!existsSync(dependencyRoot)) return []
+  return readdirSync(dependencyRoot, { withFileTypes: true })
+    .filter((entry) =>
+      (entry.isDirectory() || entry.isSymbolicLink()) &&
+      existsSync(join(dependencyRoot, entry.name, 'package.json'))
+    )
+    .map((entry) => join(dependencyRoot, entry.name))
+}
+
+function packageBinNames(packageRoot) {
+  const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))
+  let names = []
+  if (typeof packageJson.bin === 'string') {
+    const packageName = packageJson.name?.split('/').pop()
+    if (packageName) names = [packageName]
+  } else if (packageJson.bin && typeof packageJson.bin === 'object') {
+    names = Object.keys(packageJson.bin)
+  }
+  for (const name of names) {
+    if (!name || name === '.' || name === '..' || name.includes('/') || name.includes('\\')) {
+      throw new Error(`[after-pack] Unsafe packaged Kun binary name: ${String(name)}`)
+    }
+  }
+  return names
+}
+
+function packedKunPackageRoots(kunModules) {
+  return readdirSync(kunModules, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) return []
+    const packageRoot = join(kunModules, entry.name)
+    return entry.name.startsWith('@')
+      ? packedDependencyPackageRoots(packageRoot)
+      : packedDependencyPackageRoots(packageRoot).slice(0, 1)
+  })
+}
+
+function assertNoPackedKunBinOwnerCollisions(kunModules, dependencyRoots) {
+  const prunedPackageRoots = new Set(dependencyRoots.flatMap(packedDependencyPackageRoots))
+  const owners = new Map()
+  for (const packageRoot of packedKunPackageRoots(kunModules)) {
+    for (const binName of packageBinNames(packageRoot)) {
+      const binOwners = owners.get(binName) || []
+      binOwners.push(packageRoot)
+      owners.set(binName, binOwners)
+    }
+  }
+  for (const packageRoot of prunedPackageRoots) {
+    for (const binName of packageBinNames(packageRoot)) {
+      const retainedOwners = (owners.get(binName) || [])
+        .filter((owner) => !prunedPackageRoots.has(owner))
+      if (retainedOwners.length > 0) {
+        const ownerNames = retainedOwners
+          .map((owner) => relative(kunModules, owner))
+          .join(', ')
+        throw new Error(
+          `[after-pack] Kun binary launcher collision for ${binName}: retained by ${ownerNames}`
+        )
+      }
+    }
+  }
+}
+
+function prunePackedKunBinLaunchers(kunModules, dependencyRoot) {
+  const binRoot = join(kunModules, '.bin')
+  if (!existsSync(binRoot)) return
+  const binNames = new Set(packedDependencyPackageRoots(dependencyRoot).flatMap(packageBinNames))
+  for (const binName of binNames) {
+    for (const suffix of ['', '.cmd', '.ps1']) {
+      const launcher = join(binRoot, `${binName}${suffix}`)
+      if (!pathEntryExists(launcher)) continue
+      rmSync(launcher, { force: true })
+      console.log(`[after-pack] Removed hoisted Kun binary launcher: ${binName}${suffix}`)
+    }
+  }
+}
+
+function validatePackedKunBinLinks(kunModules) {
+  const binRoot = join(kunModules, '.bin')
+  if (!existsSync(binRoot)) return
+  for (const entry of readdirSync(binRoot)) {
+    const launcher = join(binRoot, entry)
+    if (lstatSync(launcher).isSymbolicLink() && !existsSync(launcher)) {
+      throw new Error(`[after-pack] Dangling packaged Kun binary launcher: ${entry}`)
+    }
+  }
+}
+
 module.exports = {
   KUN_ROOT_HOISTED_SHARED_JS_PACKAGES,
   KUN_ROOT_HOISTED_SUPPORTING_JS_PACKAGES,
   KUN_ROOT_UNPACKED_SHARED_JS_PACKAGES,
+  assertNoPackedKunBinOwnerCollisions,
+  pathEntryExists,
+  prunePackedKunBinLaunchers,
+  validatePackedKunBinLinks,
   validateRootHoistedDependencyClosure
 }

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -121,6 +121,10 @@ const KUN_ROOT_HOISTED_DEPENDENCY_PATHS = [
   ...require('./after-pack-hoisted-dependencies.cjs').KUN_ROOT_HOISTED_SHARED_JS_PACKAGES
 ]
 const {
+  assertNoPackedKunBinOwnerCollisions,
+  pathEntryExists,
+  prunePackedKunBinLaunchers,
+  validatePackedKunBinLinks,
   validateRootHoistedDependencyClosure
 } = require('./after-pack-hoisted-dependencies.cjs')
 const KUN_ROOT_HOISTED_VERSION_ANCHORS = [
@@ -284,6 +288,10 @@ function prunePackedHoistedKunDependencies(context) {
   const root = unpackedAppRoot(context)
   const modules = join(root, 'node_modules')
   const kunModules = join(root, 'kun', 'node_modules')
+  assertNoPackedKunBinOwnerCollisions(
+    kunModules,
+    KUN_ROOT_HOISTED_DEPENDENCY_PATHS.map((relativePath) => join(kunModules, relativePath))
+  )
   for (const packageName of KUN_ROOT_HOISTED_VERSION_ANCHORS) {
     const relativeManifest = join(...packageName.split('/'), 'package.json')
     const rootManifest = join(modules, relativeManifest)
@@ -303,6 +311,7 @@ function prunePackedHoistedKunDependencies(context) {
     const duplicate = join(kunModules, relativePath)
     assertExists(rootDependency, `root-hoisted runtime dependency ${relativePath}`)
     if (!existsSync(duplicate)) continue
+    prunePackedKunBinLaunchers(kunModules, duplicate)
     rmSync(duplicate, { recursive: true, force: true })
     console.log(`[after-pack] Removed root-hoisted Kun dependency duplicate: ${relativePath}`)
   }
@@ -316,7 +325,7 @@ function prunePackedApplicationPayload(context) {
 }
 
 function assertMissing(path, label) {
-  if (existsSync(path)) {
+  if (pathEntryExists(path)) {
     throw new Error(`[after-pack] Unexpected packaged ${label}: ${path}`)
   }
 }
@@ -377,6 +386,7 @@ function validatePackedApplicationPayload(context) {
     assertExists(join(modules, relativePath), `root-hoisted runtime dependency ${relativePath}`)
     assertMissing(join(kunModules, relativePath), `duplicate Kun dependency ${relativePath}`)
   }
+  validatePackedKunBinLinks(kunModules)
   validateRootHoistedDependencyClosure(root)
 }
 
@@ -655,6 +665,7 @@ exports._internals = {
   prunePackedClaudeCodeBinary,
   prunePackedBetterSqliteBuildFiles,
   prunePackedTesseractResources,
+  prunePackedKunBinLaunchers,
   prunePackedHoistedKunDependencies,
   prunePackedApplicationPayload,
   validatePackedApplicationPayload,
@@ -676,6 +687,7 @@ exports._internals = {
   BETTER_SQLITE_BUILD_PATHS,
   KUN_ROOT_HOISTED_DEPENDENCY_PATHS,
   KUN_ROOT_HOISTED_VERSION_ANCHORS,
+  validatePackedKunBinLinks,
   validateRootHoistedDependencyClosure
 }
 exports.default = afterPack

--- a/scripts/after-pack.test.cjs
+++ b/scripts/after-pack.test.cjs
@@ -5,6 +5,7 @@ const { execFileSync } = require('node:child_process')
 const {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -36,10 +37,12 @@ const {
     BETTER_SQLITE_BUILD_PATHS,
     KUN_ROOT_HOISTED_DEPENDENCY_PATHS,
     KUN_ROOT_HOISTED_VERSION_ANCHORS,
+    validatePackedKunBinLinks,
     validateRootHoistedDependencyClosure
   }
 } = require('./after-pack.cjs')
 const {
+  assertNoPackedKunBinOwnerCollisions,
   KUN_ROOT_HOISTED_SHARED_JS_PACKAGES
 } = require('./after-pack-hoisted-dependencies.cjs')
 
@@ -187,6 +190,42 @@ test('removes only regenerable or on-demand payload from packaged applications',
     writeFixture(join(modules, relativeManifest), JSON.stringify({ version: '1.0.0' }))
     writeFixture(join(kunModules, relativeManifest), JSON.stringify({ version: '1.0.0' }))
   }
+  const binPackageFixtures = [
+    {
+      name: 'escodegen',
+      bin: { escodegen: 'bin/escodegen.js', esgenerate: 'bin/esgenerate.js' }
+    },
+    { name: 'yaml', bin: 'bin.mjs' }
+  ]
+  const binRoot = join(kunModules, '.bin')
+  for (const packageFixture of binPackageFixtures) {
+    const packageRoot = join(kunModules, packageFixture.name)
+    const manifest = JSON.stringify({ ...packageFixture, version: '1.0.0' })
+    writeFixture(join(modules, packageFixture.name, 'package.json'), manifest)
+    writeFixture(join(packageRoot, 'package.json'), manifest)
+    const bins = typeof packageFixture.bin === 'string'
+      ? { [packageFixture.name]: packageFixture.bin }
+      : packageFixture.bin
+    for (const [binName, target] of Object.entries(bins)) {
+      writeFixture(join(packageRoot, target))
+      mkdirSync(binRoot, { recursive: true })
+      if (process.platform === 'win32') {
+        writeFixture(join(binRoot, binName), 'launcher')
+      } else {
+        symlinkSync(join('..', packageFixture.name, target), join(binRoot, binName))
+      }
+      writeFixture(join(binRoot, `${binName}.cmd`), 'launcher')
+      writeFixture(join(binRoot, `${binName}.ps1`), 'launcher')
+    }
+  }
+  writeFixture(join(kunModules, 'typescript', 'bin', 'tsc'))
+  if (process.platform === 'win32') {
+    writeFixture(join(binRoot, 'tsc'), 'launcher')
+  } else {
+    symlinkSync(join('..', 'typescript', 'bin', 'tsc'), join(binRoot, 'tsc'))
+  }
+  writeFixture(join(binRoot, 'tsc.cmd'), 'launcher')
+  writeFixture(join(binRoot, 'tsc.ps1'), 'launcher')
 
   prunePackedApplicationPayload(context)
   assert.doesNotThrow(() => validatePackedApplicationPayload(context))
@@ -204,11 +243,56 @@ test('removes only regenerable or on-demand payload from packaged applications',
     assert.equal(existsSync(join(modules, relativePath)), true)
     assert.equal(existsSync(join(kunModules, relativePath)), false)
   }
+  for (const binName of ['escodegen', 'esgenerate', 'yaml']) {
+    for (const suffix of ['', '.cmd', '.ps1']) {
+      assert.throws(
+        () => lstatSync(join(binRoot, `${binName}${suffix}`)),
+        { code: 'ENOENT' }
+      )
+    }
+  }
+  for (const suffix of ['', '.cmd', '.ps1']) {
+    assert.doesNotThrow(() => lstatSync(join(binRoot, `tsc${suffix}`)))
+  }
 
   writeFixture(join(claudePlatformRoot, 'claude'))
   assert.throws(
     () => validatePackedApplicationPayload(context),
     /on-demand Claude Code binary package/
+  )
+})
+
+test('rejects dangling packaged Kun binary launchers before signing', {
+  skip: process.platform === 'win32' && 'requires POSIX symbolic links'
+}, (t) => {
+  const { root } = payloadFixture(t)
+  const kunModules = join(root, 'kun', 'node_modules')
+  const binRoot = join(kunModules, '.bin')
+  mkdirSync(binRoot, { recursive: true })
+  symlinkSync(join('..', 'missing-package', 'bin', 'missing'), join(binRoot, 'missing'))
+
+  assert.throws(
+    () => validatePackedKunBinLinks(kunModules),
+    /Dangling packaged Kun binary launcher: missing/
+  )
+})
+
+test('rejects a hoisted binary name owned by a retained Kun package', (t) => {
+  const { root } = payloadFixture(t)
+  const kunModules = join(root, 'kun', 'node_modules')
+  const escodegenRoot = join(kunModules, 'escodegen')
+  writeFixture(
+    join(escodegenRoot, 'package.json'),
+    JSON.stringify({ name: 'escodegen', bin: { escodegen: 'bin/escodegen.js' } })
+  )
+  writeFixture(
+    join(kunModules, 'retained-cli', 'package.json'),
+    JSON.stringify({ name: 'retained-cli', bin: { escodegen: 'cli.js' } })
+  )
+
+  assert.throws(
+    () => assertNoPackedKunBinOwnerCollisions(kunModules, [escodegenRoot]),
+    /Kun binary launcher collision for escodegen: retained by retained-cli/
   )
 })
 


### PR DESCRIPTION
## Summary

Fix the deterministic macOS 0.3.7 signing failure caused by dangling Kun `node_modules/.bin` links after hoisted duplicate pruning.

## Changes

- remove POSIX and Windows binary launchers declared by each pruned hoisted package
- retain unrelated Kun launchers such as `tsc`
- fail before signing when a dangling packaged Kun binary symlink remains
- cover object/string `package.json#bin` declarations and platform shims

## Tests

- `node --test ./scripts/after-pack.test.cjs ./scripts/check-packaged-runtime-dependencies.test.cjs` (23 passed)
- targeted ESLint for the three changed files
- `npm run check:file-lines`
- `git diff --check`