### PR TITLE
fix(runtime): restart for Computer Use bridge changes

### DIFF
--- a/src/main/runtime-settings-apply-mode.test.ts
+++ b/src/main/runtime-settings-apply-mode.test.ts
@@ -180,6 +180,21 @@ function updateProvider(
   }
 }
 
+function updateComputerUse(
+  value: AppSettingsV1,
+  patch: Partial<AppSettingsV1['agents']['kun']['computerUse']>
+): AppSettingsV1 {
+  return {
+    ...value,
+    agents: {
+      kun: {
+        ...value.agents.kun,
+        computerUse: { ...value.agents.kun.computerUse, ...patch }
+      }
+    }
+  }
+}
+
 describe('runtimeSettingsApplyMode', () => {
   it('ignores UI-only settings', () => {
     const prev = settings()
@@ -509,6 +524,37 @@ describe('runtimeSettingsApplyMode', () => {
         }
       }
     })).toBe('restart')
+  })
+
+  it('requires restart when Computer Use is enabled', () => {
+    const prev = settings()
+    const next = updateComputerUse(prev, { enabled: true })
+
+    expect(runtimeSettingsApplyMode(prev, next)).toBe('restart')
+  })
+
+  it('requires restart when the Computer Use bridge image limit changes', () => {
+    const prev = updateComputerUse(settings(), { enabled: true })
+    const next = updateComputerUse(prev, {
+      maxImageDimension: prev.agents.kun.computerUse.maxImageDimension + 1
+    })
+
+    expect(runtimeSettingsApplyMode(prev, next)).toBe('restart')
+  })
+
+  it('keeps Computer Use policy-only changes on the hot path', () => {
+    const defaults = settings()
+    const enabled = updateComputerUse(defaults, { enabled: true })
+    const withPolicyChanges = updateComputerUse(enabled, {
+      mode: 'always',
+      maxActionsPerTurn: enabled.agents.kun.computerUse.maxActionsPerTurn + 1
+    })
+    const withDisabledImageLimit = updateComputerUse(defaults, {
+      maxImageDimension: defaults.agents.kun.computerUse.maxImageDimension + 1
+    })
+
+    expect(runtimeSettingsApplyMode(enabled, withPolicyChanges)).toBe('hot')
+    expect(runtimeSettingsApplyMode(defaults, withDisabledImageLimit)).toBe('hot')
   })
 
   it('requires restart when the active default provider switches between http and agent-sdk', () => {

--- a/src/main/runtime-settings-apply-mode.ts
+++ b/src/main/runtime-settings-apply-mode.ts
@@ -169,9 +169,13 @@ function runtimeProcessConfigFingerprint(settings: AppSettingsV1): string {
     storage: runtime.storage,
     insecure: runtime.insecure,
     defaultProviderKind: activeProvider.kind ?? 'http',
-    ...(process.platform === 'darwin'
-      ? { computerUseEnabled: runtime.computerUse.enabled }
-      : {})
+    // The GUI bridge URL and token are injected when the Kun process starts.
+    // Restart whenever bridge availability or capture sizing changes so the
+    // child never keeps a missing or stale bridge binding.
+    computerUseEnabled: runtime.computerUse.enabled,
+    computerUseMaxImageDimension: runtime.computerUse.enabled
+      ? runtime.computerUse.maxImageDimension
+      : null
   })
 }
 


### PR DESCRIPTION
## Summary

Fix Computer Use remaining unavailable after it is enabled at runtime on Windows and other non-macOS hosts.

The GUI bridge URL and token are injected into the Kun child process only at launch. Previously, changing `computerUse.enabled` restarted Kun only on macOS, while changing the live bridge image limit did not restart it anywhere. A hot apply could therefore leave Kun without a bridge or with stale bridge credentials.

## Changes

- include Computer Use enablement in the process fingerprint on every platform
- include `maxImageDimension` while Computer Use is enabled so bridge recreation also restarts Kun
- keep policy-only settings (`mode`, `maxActionsPerTurn`) and disabled image-limit edits on the hot path
- add regression coverage for restart and hot-apply boundaries

## Tests

- regression proof before the fix: 2 failed / 14 passed in `runtime-settings-apply-mode.test.ts` (`hot` instead of `restart`)
- `npx vitest run src/main/runtime-settings-apply-mode.test.ts src/main/main-runtime-settings.generation.test.ts src/main/computer-use/computer-use-bridge-service.test.ts` (21 passed)
- `npx eslint src/main/runtime-settings-apply-mode.ts src/main/runtime-settings-apply-mode.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #1239
