### PR TITLE
fix(ci): remove prerelease semver bootstrap dependency

### DIFF
--- a/.github/workflows/daily-dev-prerelease.yml
+++ b/.github/workflows/daily-dev-prerelease.yml
@@ -47,11 +47,10 @@ jobs:
           head_sha="$(git rev-parse HEAD)"
 
           node -e '
-            const semver = require("semver")
             const [appVersion, devVersion] = process.argv.slice(1)
             if (!/^\d{8}\.\d{4}$/.test(devVersion)) throw new Error(`invalid daily dev version: ${devVersion}`)
-            if (!semver.valid(appVersion)) throw new Error(`invalid daily app SemVer: ${appVersion}`)
-            if (!semver.prerelease(appVersion)?.some((part) => String(part).startsWith("dev-"))) throw new Error(`daily app version is not a dev prerelease: ${appVersion}`)
+            const expectedAppVersion = `0.0.0-dev-${devVersion.replace(".", "-")}`
+            if (appVersion !== expectedAppVersion) throw new Error(`invalid daily app version: ${appVersion}`)
           ' "${app_version}" "${dev_version}"
 
           {


### PR DESCRIPTION
## Summary

Restore the Daily Dev Prerelease prepare job, which currently fails before any platform build starts because it requires `semver` before dependencies are installed.

Recent runs `33187362921`, `33223408802`, and `33248594729` all stop in `Compute dev version` with `MODULE_NOT_FOUND: semver`.

## Changes

- remove the prepare job's undeclared runtime dependency on `semver`
- validate the generated version against the exact canonical `0.0.0-dev-YYYYMMDD-HHMM` value derived from `dev_version`
- preserve the existing date-format validation and all output values

## Tests

- dependency-free reproduction before the fix: `node -e 'require("semver")'` exits 1 with `MODULE_NOT_FOUND`
- canonical valid pair accepted with exit 0
- mismatched app version rejected with exit 1
- malformed dev version rejected with exit 1
- workflow YAML parse passed
- `node scripts/check-extension-release-gate-workflows.mjs` passed
- `git diff --check` passed

