### PR TITLE
fix(settings): persist provider deletion and guard schema migration

### DIFF
--- a/kun/src/cli/gui-settings-bridge-catalog.ts
+++ b/kun/src/cli/gui-settings-bridge-catalog.ts
@@ -59,6 +59,7 @@ import {
   legacyAuthType,
   uniqueModels
 } from './gui-settings-bridge-sync.js'
+import { assertSupportedGuiSettingsVersion } from './gui-settings-schema.js'
 
 export const MAX_GUI_SETTINGS_BYTES = 32 * 1024 * 1024
 export const LEGACY_PROVIDER_SOURCE_PREFIX = 'settings:provider:'
@@ -90,6 +91,7 @@ export const GuiProviderSchema = z.object({
 })
 
 export const GuiSharedSettingsSchema = z.object({
+  version: z.number().int().min(1).optional(),
   provider: z.object({
     // Provider transports evolve independently of the CLI compatibility
     // reader. Parse entries below so one future/invalid provider cannot make
@@ -175,6 +177,11 @@ export async function readGuiSharedSettings(input: {
     let json: unknown
     try {
       json = JSON.parse(raw)
+    } catch {
+      continue
+    }
+    try {
+      assertSupportedGuiSettingsVersion(json, settingsPath)
     } catch {
       continue
     }

--- a/kun/src/cli/gui-settings-bridge-catalog.ts
+++ b/kun/src/cli/gui-settings-bridge-catalog.ts
@@ -59,7 +59,10 @@ import {
   legacyAuthType,
   uniqueModels
 } from './gui-settings-bridge-sync.js'
-import { assertSupportedGuiSettingsVersion } from './gui-settings-schema.js'
+import {
+  assertSupportedGuiSettingsVersion,
+  NewerGuiSettingsSchemaError
+} from './gui-settings-schema.js'
 
 export const MAX_GUI_SETTINGS_BYTES = 32 * 1024 * 1024
 export const LEGACY_PROVIDER_SOURCE_PREFIX = 'settings:provider:'
@@ -182,7 +185,10 @@ export async function readGuiSharedSettings(input: {
     }
     try {
       assertSupportedGuiSettingsVersion(json, settingsPath)
-    } catch {
+    } catch (error) {
+      // A newer primary schema must fail closed. Falling through to a legacy
+      // candidate could silently resurrect stale settings and overwrite data.
+      if (error instanceof NewerGuiSettingsSchemaError) return null
       continue
     }
     const parsed = GuiSharedSettingsSchema.safeParse(json)

--- a/kun/src/cli/gui-settings-bridge-projection.test.ts
+++ b/kun/src/cli/gui-settings-bridge-projection.test.ts
@@ -84,6 +84,31 @@ describe('GUI settings bridge', () => {
       .toBe('gui-secret-codex')
   })
 
+  it('refuses to project into a newer GUI settings schema', async () => {
+    const fixture = await createFixture()
+    const raw = JSON.stringify({
+      version: 2,
+      agents: { kun: { dataDir: fixture.dataDir, providerId: 'old', model: 'old' } },
+      futureProviderState: { keep: true }
+    })
+    await writeFile(fixture.settingsPath, raw, 'utf8')
+    const settings = {
+      settingsPath: fixture.settingsPath,
+      dataDir: fixture.dataDir,
+      defaultProviderId: 'old',
+      defaultModel: 'old',
+      providers: [],
+      legacyRuntimePort: 19999,
+      legacyRuntimeToken: ''
+    }
+
+    await expect(projectModelSelectionToGuiSettings(settings, {
+      defaultProviderId: 'new',
+      defaultModel: 'new'
+    })).rejects.toMatchObject({ code: 'gui_settings_schema_newer' })
+    await expect(readFile(fixture.settingsPath, 'utf8')).resolves.toBe(raw)
+  })
+
   it('does not import GUI metadata into an unrelated explicit data dir', async () => {
     const fixture = await createFixture()
     const settings = await readGuiSharedSettings({

--- a/kun/src/cli/gui-settings-bridge-sync.ts
+++ b/kun/src/cli/gui-settings-bridge-sync.ts
@@ -62,6 +62,7 @@ import type {
   GuiProviderCatalog,
   GuiSharedSettings
 } from './gui-settings-bridge-catalog.js'
+import { assertSupportedGuiSettingsVersion } from './gui-settings-schema.js'
 
 export async function projectModelConnectionsToGuiSettings(
   settings: GuiSharedSettings,
@@ -74,6 +75,7 @@ export async function projectModelConnectionsToGuiSettings(
   }
   const parsed = JSON.parse(await readFile(settings.settingsPath, 'utf8')) as unknown
   if (!isRecordValue(parsed)) throw new Error('GUI settings must be a JSON object')
+  assertSupportedGuiSettingsVersion(parsed, settings.settingsPath)
   const providerSettings = isRecordValue(parsed.provider) ? { ...parsed.provider } : {}
   const existingProviders = Array.isArray(providerSettings.providers)
     ? providerSettings.providers.filter(isRecordValue)
@@ -169,6 +171,7 @@ export async function projectModelSelectionToGuiSettings(
   }
   const parsed = JSON.parse(await readFile(settings.settingsPath, 'utf8')) as unknown
   if (!isRecordValue(parsed)) throw new Error('GUI settings must be a JSON object')
+  assertSupportedGuiSettingsVersion(parsed, settings.settingsPath)
   const agents = isRecordValue(parsed.agents) ? { ...parsed.agents } : {}
   const kun = isRecordValue(agents.kun) ? { ...agents.kun } : {}
   const currentProviderId = typeof kun.providerId === 'string' ? kun.providerId : ''

--- a/kun/src/cli/gui-settings-bridge.test.ts
+++ b/kun/src/cli/gui-settings-bridge.test.ts
@@ -53,6 +53,23 @@ describe('GUI settings bridge', () => {
     })
   })
 
+  it('ignores GUI settings from a newer schema without rewriting them', async () => {
+    const fixture = await createFixture()
+    const raw = JSON.stringify({
+      version: 2,
+      agents: { kun: { dataDir: fixture.dataDir } },
+      futureProviderState: { keep: true }
+    })
+    await writeFile(fixture.settingsPath, raw, 'utf8')
+
+    await expect(readGuiSharedSettings({
+      env: { KUN_GUI_SETTINGS_PATH: fixture.settingsPath },
+      platform: 'darwin',
+      homeDir: fixture.home
+    })).resolves.toBeNull()
+    await expect(readFile(fixture.settingsPath, 'utf8')).resolves.toBe(raw)
+  })
+
   it('keeps the current GUI profile authoritative when it contains a newer provider transport', async () => {
     const home = await mkdtemp(join(tmpdir(), 'kun-gui-settings-forward-compatible-'))
     roots.push(home)

--- a/kun/src/cli/gui-settings-bridge.test.ts
+++ b/kun/src/cli/gui-settings-bridge.test.ts
@@ -70,6 +70,24 @@ describe('GUI settings bridge', () => {
     await expect(readFile(fixture.settingsPath, 'utf8')).resolves.toBe(raw)
   })
 
+  it('fails closed instead of falling back when the primary candidate is newer', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'kun-gui-settings-newer-primary-'))
+    roots.push(home)
+    const supportDir = join(home, 'Library', 'Application Support')
+    const currentPath = join(supportDir, 'Kun', 'kun-settings.json')
+    const stalePath = join(supportDir, 'DeepSeek GUI', 'kun-settings.json')
+    await mkdir(join(supportDir, 'Kun'), { recursive: true })
+    await mkdir(join(supportDir, 'DeepSeek GUI'), { recursive: true })
+    await writeFile(currentPath, JSON.stringify({ version: 2, future: true }), 'utf8')
+    await writeFile(stalePath, JSON.stringify({
+      provider: { providers: [] },
+      agents: { kun: { dataDir: join(home, '.kun', 'data') } }
+    }), 'utf8')
+
+    await expect(readGuiSharedSettings({ env: {}, platform: 'darwin', homeDir: home }))
+      .resolves.toBeNull()
+  })
+
   it('keeps the current GUI profile authoritative when it contains a newer provider transport', async () => {
     const home = await mkdtemp(join(tmpdir(), 'kun-gui-settings-forward-compatible-'))
     roots.push(home)

--- a/kun/src/cli/gui-settings-schema.ts
+++ b/kun/src/cli/gui-settings-schema.ts
@@ -1,0 +1,29 @@
+export const CURRENT_GUI_SETTINGS_SCHEMA_VERSION = 1
+
+export class NewerGuiSettingsSchemaError extends Error {
+  readonly code = 'gui_settings_schema_newer'
+  readonly storedVersion: number
+  readonly supportedVersion = CURRENT_GUI_SETTINGS_SCHEMA_VERSION
+
+  constructor(storedVersion: number, sourcePath?: string) {
+    super(
+      `GUI settings schema version ${storedVersion} is newer than the supported version ` +
+        `${CURRENT_GUI_SETTINGS_SCHEMA_VERSION}` +
+        (sourcePath ? ` (${sourcePath})` : '')
+    )
+    this.name = 'NewerGuiSettingsSchemaError'
+    this.storedVersion = storedVersion
+  }
+}
+
+export function assertSupportedGuiSettingsVersion(value: unknown, sourcePath?: string): void {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return
+  const version = (value as Record<string, unknown>).version
+  if (version === undefined) return
+  if (typeof version !== 'number' || !Number.isInteger(version) || version < 1) {
+    throw new Error(`Invalid GUI settings schema version${sourcePath ? ` (${sourcePath})` : ''}`)
+  }
+  if (version > CURRENT_GUI_SETTINGS_SCHEMA_VERSION) {
+    throw new NewerGuiSettingsSchemaError(version, sourcePath)
+  }
+}

--- a/src/main/kun-process.test.ts
+++ b/src/main/kun-process.test.ts
@@ -252,6 +252,21 @@ describe('Manager-owned Main data plane', () => {
     expect(readFileSync(settingsPath, 'utf8')).toBe(before)
   })
 
+  it('fails closed when selecting Manager data from a newer settings schema', async () => {
+    if (!tempRoot) throw new Error('temp root not initialized')
+    const settingsPath = join(tempRoot, 'future-settings.json')
+    writeFileSync(settingsPath, JSON.stringify({
+      version: 2,
+      agents: { kun: { dataDir: join(tempRoot, 'future-runtime-data') } }
+    }))
+    const module = await import('./kun-process')
+
+    await expect(module.resolveKunManagerDataDirFromSettings(settingsPath)).rejects.toMatchObject({
+      code: 'settings_schema_newer',
+      storedVersion: 2
+    })
+  })
+
   it('safely hands a healthy old Manager from the default data directory to custom authority', async () => {
     const module = await import('./kun-process')
     const oldManager = {

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -132,6 +132,7 @@ import {
   createHandoffEventReporter,
   type HandoffEventListener
 } from './runtime/kun-handoff-events'
+import { assertSupportedSettingsVersion } from './settings-store-foundation'
 
 import {
   appendTail,
@@ -165,6 +166,7 @@ export async function resolveKunManagerDataDirFromSettings(
   try {
     const parsed = JSON.parse(await readFile(settingsPath, 'utf8')) as unknown
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return defaultKunDataDir()
+    assertSupportedSettingsVersion(parsed, settingsPath)
     const settings = normalizeAppSettings(parsed as AppSettingsV1)
     return resolveKunDataDir(resolveKunRuntimeSettings(settings))
   } catch (error) {

--- a/src/main/legacy-data-migration.test.ts
+++ b/src/main/legacy-data-migration.test.ts
@@ -310,6 +310,28 @@ describe('rewriteLegacyPathsInSettingsFile', () => {
     expect(await readFile(join(userData, 'kun-settings.json'), 'utf8')).toBe('{not json')
   })
 
+  it('does not rewrite a settings file from a newer schema', async () => {
+    const home = await makeTempRoot()
+    const userData = join(home, 'userData')
+    await mkdir(userData, { recursive: true })
+    const settingsPath = join(userData, 'kun-settings.json')
+    const raw = JSON.stringify({
+      version: 2,
+      workspaceRoot: join(home, '.deepseekgui', 'default_workspace'),
+      futureField: { keep: true }
+    })
+    await writeFile(settingsPath, raw, 'utf8')
+
+    const rewritten = rewriteLegacyPathsInSettingsFile({
+      userDataPath: userData,
+      homeDir: home,
+      mappings: HOME_DATA_MIGRATION_MAPPINGS
+    })
+
+    expect(rewritten).toBe(false)
+    expect(await readFile(settingsPath, 'utf8')).toBe(raw)
+  })
+
   it('rewrites absolute paths even when separators differ', async () => {
     const home = await makeTempRoot()
     const userData = join(home, 'userData')

--- a/src/main/legacy-data-migration.ts
+++ b/src/main/legacy-data-migration.ts
@@ -9,6 +9,7 @@ import {
   writeFileSync
 } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
+import { assertSupportedSettingsVersion } from './settings-store-foundation'
 
 /**
  * 一次性把 “DeepSeek GUI” 时代的本地数据搬到 Kun 的新命名下。
@@ -415,7 +416,9 @@ export function legacyHomeDataMigrationRequiresExclusiveAccess(input: {
     const state = pathState(settingsPath)
     if (state !== 'other' && state !== 'symlink') continue
     try {
-      if (rewriteDeep(JSON.parse(readFileSync(settingsPath, 'utf8')), pairs).changed) return true
+      const parsed = JSON.parse(readFileSync(settingsPath, 'utf8')) as unknown
+      assertSupportedSettingsVersion(parsed, settingsPath)
+      if (rewriteDeep(parsed, pairs).changed) return true
     } catch {
       // Invalid or unreadable settings are left to the settings-store recovery path.
     }
@@ -461,6 +464,16 @@ export function rewriteLegacyPathsInSettingsFile(input: {
       parsed = JSON.parse(raw)
     } catch {
       log('legacy-migration: settings file is not valid JSON; skipping path rewrite', { settingsPath })
+      continue
+    }
+
+    try {
+      assertSupportedSettingsVersion(parsed, settingsPath)
+    } catch (error) {
+      log('legacy-migration: settings schema is newer than this build; skipping path rewrite', {
+        settingsPath,
+        message: error instanceof Error ? error.message : String(error)
+      })
       continue
     }
 

--- a/src/main/runtime-data-dir-migration-copy.ts
+++ b/src/main/runtime-data-dir-migration-copy.ts
@@ -47,6 +47,7 @@ import {
   runtimeStoreInventory,
   uniqueSiblingBackup
 } from './runtime-data-dir-migration-inventory'
+import { assertSupportedSettingsVersion } from './settings-store-foundation'
 import { applyPosixModeSync } from '../../kun/src/security/posix-permissions.js'
 
 
@@ -379,6 +380,7 @@ export function rewriteSettingsToCurrent(settingsWritePath: string | undefined):
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     throw new Error(`settings file is not an object: ${settingsWritePath}`)
   }
+  assertSupportedSettingsVersion(parsed, settingsWritePath)
   const root = parsed as Record<string, unknown>
   const agents = typeof root.agents === 'object' && root.agents !== null && !Array.isArray(root.agents)
     ? root.agents as Record<string, unknown>

--- a/src/main/runtime-data-dir-migration-inventory.ts
+++ b/src/main/runtime-data-dir-migration-inventory.ts
@@ -34,6 +34,7 @@ import {
   pathState,
   type SettingsSelection
 } from './runtime-data-dir-migration-journal-v2'
+import { assertSupportedSettingsVersion } from './settings-store-foundation'
 
 
 
@@ -94,6 +95,11 @@ export function readSettingsSelection(
     }
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
       return { authority: legacyState === 'dir' ? 'legacy' : 'current' }
+    }
+    try {
+      assertSupportedSettingsVersion(parsed, sourcePath)
+    } catch {
+      return { authority: 'unknown' }
     }
     const agents = (parsed as Record<string, unknown>).agents
     const kun = typeof agents === 'object' && agents !== null && !Array.isArray(agents)

--- a/src/main/runtime-data-dir-migration.test.ts
+++ b/src/main/runtime-data-dir-migration.test.ts
@@ -175,18 +175,12 @@ describe('canonical Kun Runtime data migration', () => {
     const test = await fixture('~/.deepseekgui/kun')
     await mkdir(test.legacy, { recursive: true })
     await writeThread(test.legacy, 'future-thread', 'future')
-    await writeFile(test.settingsPath, JSON.stringify({
-      version: 2,
-      agents: { kun: { dataDir: '~/.deepseekgui/kun' } },
-      futureState: { keep: true }
-    }), 'utf8')
-
+    await writeFile(test.settingsPath, JSON.stringify({ version: 2, agents: { kun: { dataDir: '~/.deepseekgui/kun' } }, futureState: { keep: true } }), 'utf8')
     const result = runCanonicalKunRuntimeDataMigration({
       userDataPath: test.userData,
       homeDir: test.home,
       sleep: () => undefined
     })
-
     expect(result.status).toBe('blocked')
     expect(await readSettingsDataDir(test.settingsPath)).toBe('~/.deepseekgui/kun')
     expect(await readFile(join(test.legacy, 'threads', 'future-thread', 'metadata.jsonl'), 'utf8'))

--- a/src/main/runtime-data-dir-migration.test.ts
+++ b/src/main/runtime-data-dir-migration.test.ts
@@ -171,6 +171,29 @@ afterEach(async () => {
 })
 
 describe('canonical Kun Runtime data migration', () => {
+  it('blocks migration without moving data when settings use a newer schema', async () => {
+    const test = await fixture('~/.deepseekgui/kun')
+    await mkdir(test.legacy, { recursive: true })
+    await writeThread(test.legacy, 'future-thread', 'future')
+    await writeFile(test.settingsPath, JSON.stringify({
+      version: 2,
+      agents: { kun: { dataDir: '~/.deepseekgui/kun' } },
+      futureState: { keep: true }
+    }), 'utf8')
+
+    const result = runCanonicalKunRuntimeDataMigration({
+      userDataPath: test.userData,
+      homeDir: test.home,
+      sleep: () => undefined
+    })
+
+    expect(result.status).toBe('blocked')
+    expect(await readSettingsDataDir(test.settingsPath)).toBe('~/.deepseekgui/kun')
+    expect(await readFile(join(test.legacy, 'threads', 'future-thread', 'metadata.jsonl'), 'utf8'))
+      .toContain('future')
+    await expect(lstat(test.current)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
   it('promotes the complete legacy store and makes the new config authoritative', async () => {
     const test = await fixture()
     await mkdir(test.legacy, { recursive: true })

--- a/src/main/settings-store-class.ts
+++ b/src/main/settings-store-class.ts
@@ -67,7 +67,8 @@ import {
   replaceInvalidSettingsWithDefaults,
   serializeSettingsForDisk,
   storedKunRuntimeTuning,
-  writeLegacyCredentialSettingsBackup
+  writeLegacyCredentialSettingsBackup,
+  assertSupportedSettingsVersion
 } from './settings-store-foundation'
 
 export class JsonSettingsStore {
@@ -156,6 +157,8 @@ export class JsonSettingsStore {
       )
     }
 
+    assertSupportedSettingsVersion(parsed, sourcePath)
+
     const persistRuntimeTuningDefaultsMigration = (() => {
       const runtimeTuning = storedKunRuntimeTuning(parsed)
       return runtimeTuning !== undefined &&
@@ -221,6 +224,7 @@ export class JsonSettingsStore {
   }
 
   private async saveOnce(data: AppSettingsV1, expectedRevision = this.documentRevision): Promise<void> {
+    assertSupportedSettingsVersion(data, this.path)
     const normalized = normalizeStoredSettings(data)
     await ensureManagedWorkspaceRootsExist(normalized)
     const prepared = normalized

--- a/src/main/settings-store-foundation.ts
+++ b/src/main/settings-store-foundation.ts
@@ -55,6 +55,34 @@ import {
 
 export type { AppSettingsV1 }
 
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 1
+
+export class NewerSettingsSchemaError extends Error {
+  readonly code = 'settings_schema_newer'
+  readonly storedVersion: number
+  readonly supportedVersion = CURRENT_SETTINGS_SCHEMA_VERSION
+
+  constructor(storedVersion: number, sourcePath?: string) {
+    super(
+      `Settings schema version ${storedVersion} is newer than the supported version ${CURRENT_SETTINGS_SCHEMA_VERSION}` +
+        (sourcePath ? ` (${sourcePath})` : '')
+    )
+    this.name = 'NewerSettingsSchemaError'
+    this.storedVersion = storedVersion
+  }
+}
+
+/** Reject future schemas before defaults, migrations, or normalization can drop fields. */
+export function assertSupportedSettingsVersion(value: unknown, sourcePath?: string): void {
+  if (!isRecord(value)) return
+  const version = value.version
+  if (version === undefined) return
+  if (typeof version !== 'number' || !Number.isInteger(version) || version < 1) {
+    throw new Error(`Invalid settings schema version${sourcePath ? ` (${sourcePath})` : ''}`)
+  }
+  if (version > CURRENT_SETTINGS_SCHEMA_VERSION) throw new NewerSettingsSchemaError(version, sourcePath)
+}
+
 export type SettingsCredentialMigrationResult = {
   runtimeSettings: AppSettingsV1
   persistedSettings: AppSettingsV1
@@ -398,6 +426,7 @@ export async function readLegacyCredentialSettingsBackup(path: string): Promise<
     if (!metadata.isFile() || metadata.isSymbolicLink()) return null
     const parsed = JSON.parse(await readFile(backupPath, 'utf8')) as unknown
     if (!isRecord(parsed)) return null
+    assertSupportedSettingsVersion(parsed, backupPath)
     return normalizeStoredSettings(buildMergedSettings(parsed as Partial<AppSettingsV1>))
   } catch (error) {
     if (isErrnoException(error) && error.code === 'ENOENT') return null

--- a/src/main/settings-store.test.ts
+++ b/src/main/settings-store.test.ts
@@ -125,6 +125,43 @@ describe('JsonSettingsStore', () => {
     await expect(store.load()).resolves.toMatchObject({ locale: 'en', theme: 'dark' })
   })
 
+  it('refuses a newer schema before normalization and leaves the source unchanged', async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), 'kun-newer-settings-schema-'))
+    const settingsPath = join(userDataDir, 'kun-settings.json')
+    const raw = JSON.stringify({
+      version: 2,
+      futureProviderState: { keep: true },
+      locale: 'zh'
+    })
+    await writeFile(settingsPath, raw, 'utf8')
+    const store = new JsonSettingsStore(userDataDir)
+
+    await expect(store.load()).rejects.toMatchObject({
+      name: 'NewerSettingsSchemaError',
+      code: 'settings_schema_newer',
+      storedVersion: 2,
+      supportedVersion: 1
+    })
+    expect(await readFile(settingsPath, 'utf8')).toBe(raw)
+  })
+
+  it('refuses saving a future schema supplied by an untyped caller', async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), 'kun-newer-settings-save-'))
+    const store = new JsonSettingsStore(userDataDir)
+    const futureSettings = {
+      version: 2,
+      futureProviderState: { keep: true }
+    } as never
+
+    await expect(store.save(futureSettings)).rejects.toMatchObject({
+      code: 'settings_schema_newer',
+      storedVersion: 2
+    })
+    await expect(readFile(join(userDataDir, 'kun-settings.json'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
   it('retries a Manager revision conflict from the exact mutation snapshot', async () => {
     const userDataDir = await mkdtemp(join(tmpdir(), 'kun-revision-retry-settings-'))
     let revision = 0

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -8,4 +8,9 @@ export {
   type SettingsCredentialMigrationResult,
   type SettingsDocumentBackend
 } from './settings-store-foundation'
+export {
+  CURRENT_SETTINGS_SCHEMA_VERSION,
+  NewerSettingsSchemaError,
+  assertSupportedSettingsVersion
+} from './settings-store-foundation'
 export { JsonSettingsStore } from './settings-store-class'

--- a/src/renderer/src/components/settings-section-agents-provider-subscriptions.test.ts
+++ b/src/renderer/src/components/settings-section-agents-provider-subscriptions.test.ts
@@ -666,7 +666,13 @@ describe('AgentsSettingsSection Kun diagnostics smoke', () => {
         method === 'DELETE' && path.includes('/v1/model-connections/custom-provider-2?')
       )
       expect(deleteCallIndex).toBeGreaterThanOrEqual(0)
-      expect(update).not.toHaveBeenCalled()
+      expect(update).toHaveBeenCalledTimes(1)
+      expect(update.mock.calls[0]?.[0].provider.providers)
+        .toEqual(expect.arrayContaining([
+          expect.objectContaining({ id: unrelatedProvider.id })
+        ]))
+      expect(update.mock.calls[0]?.[0].provider.providers)
+        .not.toEqual(expect.arrayContaining([expect.objectContaining({ id: target.id })]))
       expect(sharedProviderMutationCoordinator.pendingDeletions.get(target.id)).toMatchObject({
         committedRevision: 2
       })

--- a/src/renderer/src/components/settings-section-providers-lifecycle.test.ts
+++ b/src/renderer/src/components/settings-section-providers-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_MODEL_PROVIDER_ID,
   defaultKunRuntimeSettings,
   defaultModelProviderSettings,
   type ModelProviderModelProfileV1,
@@ -562,6 +563,48 @@ describe('provider mutation lifecycle across settings remounts', () => {
     expect(rendererText(renderer)).toContain(provider.name)
     expect(rendererText(renderer)).toContain('delete failed safely')
     expect(update).not.toHaveBeenCalled()
+  })
+
+  it('removes a deleted provider from local settings after the registry commit', async () => {
+    const { settings, provider } = providerFixture()
+    const deleteRequest = deferred<RuntimeResult>()
+    const deleteStarted = deferred<void>()
+    const runtimeRequest = vi.fn(async (path: string, method: string) => {
+      if (path.includes('/events?')) return new Promise<never>(() => undefined)
+      if (path === '/v1/model-connections' && method === 'GET') {
+        return { ok: true, status: 200, body: JSON.stringify(snapshotFor(provider, 1)) }
+      }
+      if (path.startsWith(`/v1/model-connections/${provider.id}?`) && method === 'DELETE') {
+        deleteStarted.resolve()
+        return deleteRequest.promise
+      }
+      throw new Error(`Unexpected runtime request: ${method} ${path}`)
+    })
+    Object.assign(window.kunGui, { runtimeRequest })
+    const update = vi.fn()
+    const renderer = await mount(contextFor(settings, provider, update))
+    await flush()
+    update.mockClear()
+    await clickTab(renderer, 'modelProviderTabAdvanced')
+    await act(async () => findButton(renderer, 'modelProviderRemove').props.onClick())
+    await deleteStarted.promise
+
+    deleteRequest.resolve({
+      ok: true,
+      status: 200,
+      body: JSON.stringify(snapshotFor(provider, 2, provider.models, false))
+    })
+    await enqueueSharedModelMutation(async () => undefined)
+    await flush()
+
+    const patch = update.mock.calls.at(-1)?.[0] as {
+      provider?: { providers?: ModelProviderProfileV1[] }
+      agents?: { kun?: { providerId?: string; model?: string } }
+    }
+    expect(patch.provider?.providers?.some((item) => item.id === provider.id)).toBe(false)
+    expect(patch.agents?.kun).toMatchObject({ providerId: DEFAULT_MODEL_PROVIDER_ID })
+    expect(sharedProviderMutationCoordinator.pendingDeletions.get(provider.id))
+      .toMatchObject({ committedRevision: 2 })
   })
 
   it('does not let an old DELETE generation hide an explicitly re-added provider after remount', async () => {

--- a/src/renderer/src/components/settings-section-providers-lifecycle.test.ts
+++ b/src/renderer/src/components/settings-section-providers-lifecycle.test.ts
@@ -565,7 +565,7 @@ describe('provider mutation lifecycle across settings remounts', () => {
     expect(update).not.toHaveBeenCalled()
   })
 
-  it('removes a deleted provider from local settings after the registry commit', async () => {
+  it('removes a deleted provider with the latest settings updater after the registry commit', async () => {
     const { settings, provider } = providerFixture()
     const deleteRequest = deferred<RuntimeResult>()
     const deleteStarted = deferred<void>()
@@ -581,13 +581,17 @@ describe('provider mutation lifecycle across settings remounts', () => {
       throw new Error(`Unexpected runtime request: ${method} ${path}`)
     })
     Object.assign(window.kunGui, { runtimeRequest })
-    const update = vi.fn()
-    const renderer = await mount(contextFor(settings, provider, update))
+    const staleUpdate = vi.fn()
+    const latestUpdate = vi.fn()
+    const renderer = await mount(contextFor(settings, provider, staleUpdate))
     await flush()
-    update.mockClear()
+    staleUpdate.mockClear()
     await clickTab(renderer, 'modelProviderTabAdvanced')
     await act(async () => findButton(renderer, 'modelProviderRemove').props.onClick())
     await deleteStarted.promise
+    await act(async () => renderer.update(createElement(ProvidersSettingsSection, {
+      ctx: contextFor(settings, provider, latestUpdate)
+    })))
 
     deleteRequest.resolve({
       ok: true,
@@ -597,7 +601,8 @@ describe('provider mutation lifecycle across settings remounts', () => {
     await enqueueSharedModelMutation(async () => undefined)
     await flush()
 
-    const patch = update.mock.calls.at(-1)?.[0] as {
+    expect(staleUpdate).not.toHaveBeenCalled()
+    const patch = latestUpdate.mock.calls.at(-1)?.[0] as {
       provider?: { providers?: ModelProviderProfileV1[] }
       agents?: { kun?: { providerId?: string; model?: string } }
     }

--- a/src/renderer/src/components/settings-section-providers-mutation.test.ts
+++ b/src/renderer/src/components/settings-section-providers-mutation.test.ts
@@ -1,9 +1,15 @@
 import {
+  defaultKunRuntimeSettings,
   defaultModelProviderSettings,
+  defaultWriteSettings,
   type ModelProviderModelProfileV1
 } from '@shared/app-settings'
 import { describe, expect, it, vi } from 'vitest'
 import type { SharedModelConnection } from './settings-section-providers-shared-api'
+import {
+  modelProviderDeletionKunPatch,
+  modelProviderDeletionWritePatch
+} from './settings-section-providers-profile'
 import {
   clearPendingSharedProviderDeletionForExplicitAdd,
   createSharedModelMutationQueue,
@@ -550,5 +556,84 @@ describe('shared model connection settings projection', () => {
 
     expect(projected.provider.providers.map((provider) => provider.id)).toEqual(['deepseek'])
     expect(projected.kun).toEqual({ providerId: '' })
+  })
+
+  it('clears every Kun and Write route that belongs to a deleted provider', () => {
+    const deletedProviderId = 'removed-provider'
+    const currentKun = defaultKunRuntimeSettings()
+    Object.assign(currentKun, {
+      providerId: deletedProviderId,
+      model: 'removed-main',
+      smallModel: 'removed-small', smallModelProviderId: deletedProviderId, smallModelAccountId: 'small-account',
+      titleModel: 'removed-title', titleProviderId: deletedProviderId, titleAccountId: 'title-account',
+      summaryModel: 'removed-summary', summaryProviderId: deletedProviderId, summaryAccountId: 'summary-account',
+      codeReviewModel: 'removed-review', codeReviewProviderId: deletedProviderId, codeReviewAccountId: 'review-account',
+      planModel: 'removed-plan', planProviderId: deletedProviderId, planAccountId: 'plan-account'
+    })
+    currentKun.imageGeneration = { ...currentKun.imageGeneration, providerId: deletedProviderId, model: 'removed-image' }
+    currentKun.speechToText = { ...currentKun.speechToText, providerId: deletedProviderId, model: 'removed-speech' }
+    currentKun.textToSpeech = { ...currentKun.textToSpeech, providerId: deletedProviderId, model: 'removed-tts' }
+    currentKun.promptOptimization = { ...currentKun.promptOptimization, providerId: deletedProviderId, model: 'removed-prompt' }
+    currentKun.musicGeneration = { ...currentKun.musicGeneration, providerId: deletedProviderId, model: 'removed-music' }
+    currentKun.videoGeneration = { ...currentKun.videoGeneration, providerId: deletedProviderId, model: 'removed-video' }
+    currentKun.contextCompaction = {
+      ...currentKun.contextCompaction,
+      summaryProviderId: deletedProviderId,
+      summaryModel: 'removed-compaction'
+    }
+    currentKun.fastContext = { ...currentKun.fastContext, providerId: deletedProviderId, model: 'removed-fast' }
+    currentKun.lab = {
+      ...currentKun.lab,
+      pptAgent: { ...currentKun.lab.pptAgent, providerId: deletedProviderId, model: 'removed-ppt' }
+    }
+    currentKun.graph = {
+      ...currentKun.graph,
+      workerModel: { mode: 'fixed', providerId: deletedProviderId, model: 'removed-worker' }
+    }
+    currentKun.subagents = {
+      enabled: true,
+      profiles: [{
+        id: 'routed', enabled: true, name: 'Routed', mode: 'all', toolPolicy: 'inherit',
+        providerId: deletedProviderId, model: 'removed-subagent'
+      }]
+    }
+    const fallbackProvider = defaultModelProviderSettings().providers[0]!
+
+    const patch = modelProviderDeletionKunPatch({
+      currentKun,
+      deletedProviderIds: new Set([deletedProviderId]),
+      fallbackProvider
+    })
+
+    expect(patch).toMatchObject({
+      providerId: fallbackProvider.id,
+      model: fallbackProvider.models[0],
+      imageGeneration: { providerId: '', model: '' },
+      speechToText: { providerId: '', model: '' },
+      textToSpeech: { providerId: '', model: '' },
+      promptOptimization: { providerId: '', model: '' },
+      musicGeneration: { providerId: '', model: '' },
+      videoGeneration: { providerId: '', model: '' },
+      contextCompaction: { summaryProviderId: '', summaryModel: '' },
+      fastContext: { providerId: '', model: '' },
+      lab: { pptAgent: { providerId: '', model: '' } },
+      graph: { workerModel: { mode: 'inherit' } },
+      smallModel: '', smallModelProviderId: '', smallModelAccountId: '',
+      titleModel: '', titleProviderId: '', titleAccountId: '',
+      summaryModel: '', summaryProviderId: '', summaryAccountId: '',
+      codeReviewModel: '', codeReviewProviderId: '', codeReviewAccountId: '',
+      planModel: '', planProviderId: '', planAccountId: ''
+    })
+    expect(patch.subagents?.profiles?.[0]).not.toHaveProperty('providerId')
+    expect(patch.subagents?.profiles?.[0]).not.toHaveProperty('model')
+    expect(modelProviderDeletionWritePatch({
+      ...defaultWriteSettings().inlineCompletion,
+      inheritProvider: false,
+      providerId: deletedProviderId,
+      inheritModel: false,
+      model: 'removed-write'
+    }, new Set([deletedProviderId]))).toMatchObject({
+      write: { inlineCompletion: { inheritProvider: true, providerId: '', inheritModel: true, model: '' } }
+    })
   })
 })

--- a/src/renderer/src/components/settings-section-providers-profile.ts
+++ b/src/renderer/src/components/settings-section-providers-profile.ts
@@ -15,7 +15,8 @@ import type {
   MusicGenerationProtocol,
   SpeechToTextProtocol,
   TextToSpeechProtocol,
-  VideoGenerationProtocol
+  VideoGenerationProtocol,
+  WriteInlineCompletionSettingsV1
 } from '@shared/app-settings'
 import {
   DEFAULT_IMAGE_GENERATION_PROTOCOL,
@@ -190,6 +191,133 @@ export function kunProviderSelectionPatch(input: {
   return {
     providerId: input.providerId,
     ...(model ? { model } : {})
+  }
+}
+
+type KunRoleModelKey =
+  | 'smallModel'
+  | 'titleModel'
+  | 'summaryModel'
+  | 'codeReviewModel'
+  | 'planModel'
+type KunRoleProviderKey =
+  | 'smallModelProviderId'
+  | 'titleProviderId'
+  | 'summaryProviderId'
+  | 'codeReviewProviderId'
+  | 'planProviderId'
+type KunRoleAccountKey =
+  | 'smallModelAccountId'
+  | 'titleAccountId'
+  | 'summaryAccountId'
+  | 'codeReviewAccountId'
+  | 'planAccountId'
+
+function clearDeletedProviderRoleSlot(
+  patch: KunRuntimeSettingsPatchV1,
+  current: KunRuntimeSettingsV1,
+  deletedProviderIds: ReadonlySet<string>,
+  modelKey: KunRoleModelKey,
+  providerKey: KunRoleProviderKey,
+  accountKey: KunRoleAccountKey
+): void {
+  if (!deletedProviderIds.has((current[providerKey] ?? '').trim())) return
+  Object.assign(patch, { [modelKey]: '', [providerKey]: '', [accountKey]: '' })
+}
+
+/** Clear every Kun model route that still points at a deleted provider. */
+export function modelProviderDeletionKunPatch(input: {
+  currentKun: KunRuntimeSettingsV1
+  deletedProviderIds: ReadonlySet<string>
+  fallbackProvider?: ModelProviderProfileV1
+}): KunRuntimeSettingsPatchV1 {
+  const { currentKun, deletedProviderIds, fallbackProvider } = input
+  const patch: KunRuntimeSettingsPatchV1 = {}
+  const matches = (value: string | undefined): boolean =>
+    typeof value === 'string' && deletedProviderIds.has(value.trim())
+
+  if (matches(currentKun.providerId) && fallbackProvider) {
+    Object.assign(patch, kunProviderSelectionPatch({
+      providerId: fallbackProvider.id,
+      model: nonEmptyModelId(fallbackProvider.models[0])
+    }))
+  }
+  for (const key of [
+    'imageGeneration',
+    'speechToText',
+    'textToSpeech',
+    'promptOptimization',
+    'musicGeneration',
+    'videoGeneration'
+  ] as const) {
+    if (matches(currentKun[key]?.providerId)) patch[key] = { providerId: '', model: '' }
+  }
+  clearDeletedProviderRoleSlot(
+    patch, currentKun, deletedProviderIds,
+    'smallModel', 'smallModelProviderId', 'smallModelAccountId'
+  )
+  clearDeletedProviderRoleSlot(
+    patch, currentKun, deletedProviderIds,
+    'titleModel', 'titleProviderId', 'titleAccountId'
+  )
+  clearDeletedProviderRoleSlot(
+    patch, currentKun, deletedProviderIds,
+    'summaryModel', 'summaryProviderId', 'summaryAccountId'
+  )
+  clearDeletedProviderRoleSlot(
+    patch, currentKun, deletedProviderIds,
+    'codeReviewModel', 'codeReviewProviderId', 'codeReviewAccountId'
+  )
+  clearDeletedProviderRoleSlot(
+    patch, currentKun, deletedProviderIds,
+    'planModel', 'planProviderId', 'planAccountId'
+  )
+  if (matches(currentKun.contextCompaction?.summaryProviderId)) {
+    patch.contextCompaction = { summaryProviderId: '', summaryModel: '' }
+  }
+  if (matches(currentKun.fastContext?.providerId)) {
+    patch.fastContext = { providerId: '', model: '' }
+  }
+  if (matches(currentKun.lab?.pptAgent?.providerId)) {
+    patch.lab = { pptAgent: { providerId: '', model: '' } }
+  }
+  if (
+    currentKun.graph?.workerModel.mode === 'fixed' &&
+    matches(currentKun.graph.workerModel.providerId)
+  ) {
+    patch.graph = { workerModel: { mode: 'inherit' } }
+  }
+  const profiles = currentKun.subagents?.profiles
+  if (profiles?.some((profile) => matches(profile.providerId))) {
+    patch.subagents = {
+      profiles: profiles.map((profile) => {
+        if (!matches(profile.providerId)) return profile
+        const { model: _model, providerId: _providerId, ...inherited } = profile
+        return inherited
+      })
+    }
+  }
+  return patch
+}
+
+export function modelProviderDeletionWritePatch(
+  inlineCompletion: WriteInlineCompletionSettingsV1 | undefined,
+  deletedProviderIds: ReadonlySet<string>
+): Pick<AppSettingsPatch, 'write'> | undefined {
+  if (
+    !inlineCompletion ||
+    inlineCompletion.inheritProvider ||
+    !deletedProviderIds.has(inlineCompletion.providerId.trim())
+  ) return undefined
+  return {
+    write: {
+      inlineCompletion: {
+        inheritProvider: true,
+        providerId: '',
+        inheritModel: true,
+        model: ''
+      }
+    }
   }
 }
 

--- a/src/renderer/src/components/settings-section-providers.tsx
+++ b/src/renderer/src/components/settings-section-providers.tsx
@@ -304,6 +304,7 @@ export function ProvidersSettingsSection({ ctx }: { ctx: Record<string, any> }):
     setSharedConnectionsError, pendingSharedProviderDeletions, pendingSharedProviderNames,
     pendingSharedProviderCatalogs, pendingSharedProviderCredentials, catalogMutationTimers,
     credentialMutationTimers, mounted, setCredentialDrafts, enqueueSharedMutation,
+    sharedProjectionInput,
     selectedProviderId, setSelectedProviderId, activeTab, setActiveTab,
     previousProviderSelectionRef, setProbeStates, setPendingImport, cursorMetadataRepairAttempts,
     draftProvider, setDraftProvider, displayProviders, activeProvider, activeKunProviderId,

--- a/src/renderer/src/components/use-provider-lifecycle-actions.ts
+++ b/src/renderer/src/components/use-provider-lifecycle-actions.ts
@@ -1,5 +1,4 @@
 import type {
-  KunRuntimeSettingsPatchV1,
   ModelProviderModelProfileV1,
   ModelProviderPresetMode,
   ModelProviderProfileV1
@@ -34,6 +33,8 @@ import {
 import {
   cursorProviderNeedsMetadataRepair,
   kunProviderSelectionPatch,
+  modelProviderDeletionKunPatch,
+  modelProviderDeletionWritePatch,
   nonEmptyModelId,
   type ProbeState
 } from './settings-section-providers-profile'
@@ -310,44 +311,21 @@ export function useProviderLifecycleActions(scope: Record<string, any>): Record<
       const remainingProviders = latestProviders.filter((item) => item.id !== id)
       const fallbackProvider = remainingProviders.find((item) => item.id === DEFAULT_MODEL_PROVIDER_ID) ??
         remainingProviders[0]
-      const kunPatch: KunRuntimeSettingsPatchV1 = {}
-      if (latestKun.providerId?.trim() === id && fallbackProvider) {
-        Object.assign(kunPatch, kunProviderSelectionPatch({
-          providerId: fallbackProvider.id,
-          model: nonEmptyModelId(fallbackProvider.models[0])
-        }))
-      }
-      if ((latestKun.imageGeneration?.providerId ?? '').trim() === id) {
-        kunPatch.imageGeneration = { providerId: '' }
-      }
-      if ((latestKun.speechToText?.providerId ?? '').trim() === id) {
-        kunPatch.speechToText = { providerId: '' }
-      }
-      if ((latestKun.textToSpeech?.providerId ?? '').trim() === id) {
-        kunPatch.textToSpeech = { providerId: '' }
-      }
-      if ((latestKun.musicGeneration?.providerId ?? '').trim() === id) {
-        kunPatch.musicGeneration = { providerId: '' }
-      }
-      if ((latestKun.videoGeneration?.providerId ?? '').trim() === id) {
-        kunPatch.videoGeneration = { providerId: '' }
-      }
-
+      const kunPatch = modelProviderDeletionKunPatch({
+        currentKun: latestKun,
+        deletedProviderIds: new Set([id]),
+        fallbackProvider
+      })
       const latestWriteInline = latest.form?.write?.inlineCompletion
-      const latestUsedByWrite = Boolean(
-        latestWriteInline && !latestWriteInline.inheritProvider && latestWriteInline.providerId === id
-      )
-      const writePatch = latestUsedByWrite
-        ? { write: { inlineCompletion: { inheritProvider: true, providerId: '' } } }
-        : undefined
+      const writePatch = modelProviderDeletionWritePatch(latestWriteInline, new Set([id]))
       updateModelProviders(
         remainingProviders,
         Object.keys(kunPatch).length > 0 ? kunPatch : undefined,
         writePatch
       )
-      if (selectedProviderId === id) {
-        setSelectedProviderId(fallbackProvider?.id ?? DEFAULT_MODEL_PROVIDER_ID)
-      }
+      setSelectedProviderId((currentId: string) => currentId === id
+        ? fallbackProvider?.id ?? DEFAULT_MODEL_PROVIDER_ID
+        : currentId)
     } catch (error) {
       if (pendingSharedProviderDeletions.current.get(id)?.generation === generation) {
         pendingSharedProviderDeletions.current.delete(id)

--- a/src/renderer/src/components/use-provider-lifecycle-actions.ts
+++ b/src/renderer/src/components/use-provider-lifecycle-actions.ts
@@ -1,4 +1,5 @@
 import type {
+  KunRuntimeSettingsPatchV1,
   ModelProviderModelProfileV1,
   ModelProviderPresetMode,
   ModelProviderProfileV1
@@ -71,7 +72,7 @@ export function catalogResultForProviderImport(
 }
 
 export function useProviderLifecycleActions(scope: Record<string, any>): Record<string, any> {
-  const { t, form, kun, provider, setSharedConnections, setSharedConnectionsError, pendingSharedProviderDeletions, pendingSharedProviderNames, pendingSharedProviderCatalogs, pendingSharedProviderCredentials, catalogMutationTimers, credentialMutationTimers, mounted, setCredentialDrafts, enqueueSharedMutation, selectedProviderId, setSelectedProviderId, activeTab, setActiveTab, previousProviderSelectionRef, setProbeStates, setPendingImport, cursorMetadataRepairAttempts, setDraftProvider, activeKunProviderId, confirmAction, updateModelProviders } = scope
+  const { t, form, kun, provider, setSharedConnections, setSharedConnectionsError, pendingSharedProviderDeletions, pendingSharedProviderNames, pendingSharedProviderCatalogs, pendingSharedProviderCredentials, catalogMutationTimers, credentialMutationTimers, mounted, setCredentialDrafts, enqueueSharedMutation, selectedProviderId, setSelectedProviderId, activeTab, setActiveTab, previousProviderSelectionRef, setProbeStates, setPendingImport, cursorMetadataRepairAttempts, setDraftProvider, activeKunProviderId, confirmAction, updateModelProviders, sharedProjectionInput } = scope
   const modelProviders = scope.modelProviders as ModelProviderProfileV1[]
   const displayProviders = scope.displayProviders as ModelProviderProfileV1[]
   const draftProvider = scope.draftProvider as ModelProviderProfileV1 | null
@@ -298,6 +299,54 @@ export function useProviderLifecycleActions(scope: Record<string, any>): Record<
         })
         setSharedConnections(snapshot)
         setSharedConnectionsError('')
+      }
+
+      // Registry deletion must be reflected in AppSettings as part of the
+      // same successful mutation. Otherwise the next shared-settings refresh
+      // sees the stale local provider and recreates the deleted connection.
+      const latest = sharedProjectionInput.current
+      const latestProviders = latest.provider.providers as ModelProviderProfileV1[]
+      const latestKun = latest.kun as typeof kun
+      const remainingProviders = latestProviders.filter((item) => item.id !== id)
+      const fallbackProvider = remainingProviders.find((item) => item.id === DEFAULT_MODEL_PROVIDER_ID) ??
+        remainingProviders[0]
+      const kunPatch: KunRuntimeSettingsPatchV1 = {}
+      if (latestKun.providerId?.trim() === id && fallbackProvider) {
+        Object.assign(kunPatch, kunProviderSelectionPatch({
+          providerId: fallbackProvider.id,
+          model: nonEmptyModelId(fallbackProvider.models[0])
+        }))
+      }
+      if ((latestKun.imageGeneration?.providerId ?? '').trim() === id) {
+        kunPatch.imageGeneration = { providerId: '' }
+      }
+      if ((latestKun.speechToText?.providerId ?? '').trim() === id) {
+        kunPatch.speechToText = { providerId: '' }
+      }
+      if ((latestKun.textToSpeech?.providerId ?? '').trim() === id) {
+        kunPatch.textToSpeech = { providerId: '' }
+      }
+      if ((latestKun.musicGeneration?.providerId ?? '').trim() === id) {
+        kunPatch.musicGeneration = { providerId: '' }
+      }
+      if ((latestKun.videoGeneration?.providerId ?? '').trim() === id) {
+        kunPatch.videoGeneration = { providerId: '' }
+      }
+
+      const latestWriteInline = latest.form?.write?.inlineCompletion
+      const latestUsedByWrite = Boolean(
+        latestWriteInline && !latestWriteInline.inheritProvider && latestWriteInline.providerId === id
+      )
+      const writePatch = latestUsedByWrite
+        ? { write: { inlineCompletion: { inheritProvider: true, providerId: '' } } }
+        : undefined
+      updateModelProviders(
+        remainingProviders,
+        Object.keys(kunPatch).length > 0 ? kunPatch : undefined,
+        writePatch
+      )
+      if (selectedProviderId === id) {
+        setSelectedProviderId(fallbackProvider?.id ?? DEFAULT_MODEL_PROVIDER_ID)
       }
     } catch (error) {
       if (pendingSharedProviderDeletions.current.get(id)?.generation === generation) {

--- a/src/renderer/src/components/use-provider-shared-actions.ts
+++ b/src/renderer/src/components/use-provider-shared-actions.ts
@@ -169,7 +169,7 @@ export function useProviderSharedActions(scope: Record<string, any>): Record<str
     additionalPatch?: Pick<AppSettingsPatch, 'write'>
   ): void => {
     const current = sharedProjectionInput.current
-    update({
+    current.update({
       ...modelProvidersSettingsPatch({
         provider: current.provider,
         providers,

--- a/src/renderer/src/components/use-provider-shared-actions.ts
+++ b/src/renderer/src/components/use-provider-shared-actions.ts
@@ -1,4 +1,5 @@
 import type {
+  AppSettingsPatch,
   KunRuntimeSettingsPatchV1,
   ModelProviderProfileV1
 } from '@shared/app-settings'
@@ -164,14 +165,19 @@ export function useProviderSharedActions(scope: Record<string, any>): Record<str
 
   const updateModelProviders = (
     providers: ModelProviderProfileV1[],
-    kunPatch?: KunRuntimeSettingsPatchV1
+    kunPatch?: KunRuntimeSettingsPatchV1,
+    additionalPatch?: Pick<AppSettingsPatch, 'write'>
   ): void => {
-    update(modelProvidersSettingsPatch({
-      provider,
-      providers,
-      kun: kunPatch,
-      currentKun: kun
-    }))
+    const current = sharedProjectionInput.current
+    update({
+      ...modelProvidersSettingsPatch({
+        provider: current.provider,
+        providers,
+        kun: kunPatch,
+        currentKun: current.kun
+      }),
+      ...(additionalPatch ?? {})
+    })
   }
 
   const drainSharedProviderProfile = async (providerId: string): Promise<void> => {

--- a/src/renderer/src/components/use-provider-shared-synchronization.ts
+++ b/src/renderer/src/components/use-provider-shared-synchronization.ts
@@ -13,7 +13,9 @@ import {
 } from 'react'
 import { sharedModelConnectionHasUsableCredential } from '../lib/provider-credential-readiness'
 import {
-  isSubscriptionProvider
+  isSubscriptionProvider,
+  modelProviderDeletionKunPatch,
+  modelProviderDeletionWritePatch
 } from './settings-section-providers-profile'
 import {
   SharedModelConnectionConflictError,
@@ -118,33 +120,23 @@ export function useProviderSharedSynchronization(scope: Record<string, any>): vo
                 .map(([providerId]) => providerId)
             )
             const kunPatch: KunRuntimeSettingsPatchV1 = { ...projected.kun }
-            if (committedDeletedProviderIds.has((current.kun.imageGeneration?.providerId ?? '').trim())) {
-              kunPatch.imageGeneration = { providerId: '' }
-            }
-            if (committedDeletedProviderIds.has((current.kun.speechToText?.providerId ?? '').trim())) {
-              kunPatch.speechToText = { providerId: '' }
-            }
-            if (committedDeletedProviderIds.has((current.kun.textToSpeech?.providerId ?? '').trim())) {
-              kunPatch.textToSpeech = { providerId: '' }
-            }
-            if (committedDeletedProviderIds.has((current.kun.musicGeneration?.providerId ?? '').trim())) {
-              kunPatch.musicGeneration = { providerId: '' }
-            }
-            if (committedDeletedProviderIds.has((current.kun.videoGeneration?.providerId ?? '').trim())) {
-              kunPatch.videoGeneration = { providerId: '' }
-            }
+            const fallbackProvider = projected.provider.providers.find(
+              (item) => item.id === DEFAULT_MODEL_PROVIDER_ID
+            ) ?? projected.provider.providers[0]
+            Object.assign(kunPatch, modelProviderDeletionKunPatch({
+              currentKun: current.kun,
+              deletedProviderIds: committedDeletedProviderIds,
+              fallbackProvider
+            }))
+            const writePatch = modelProviderDeletionWritePatch(
+              current.form?.write?.inlineCompletion,
+              committedDeletedProviderIds
+            )
             const settingsPatch: AppSettingsPatch = {
               provider: projected.provider,
               agents: { kun: kunPatch }
             }
-            const writeInline = current.form?.write?.inlineCompletion
-            if (
-              writeInline &&
-              !writeInline.inheritProvider &&
-              committedDeletedProviderIds.has(writeInline.providerId)
-            ) {
-              settingsPatch.write = { inlineCompletion: { inheritProvider: true, providerId: '' } }
-            }
+            if (writePatch?.write) settingsPatch.write = writePatch.write
             current.update(settingsPatch)
           }
         }


### PR DESCRIPTION
## Problem

Deleted providers could reappear after the shared settings projection refreshed, and older writers could migrate newer settings schemas.

## Root cause

Provider registry deletion did not atomically update the authoritative local projection. Legacy migration also ran before rejecting unsupported future schemas.

## Scope

Aggregate settings-integrity fix for provider deletion persistence and schema downgrade protection.

## Changes

- Remove a deleted provider from the local settings projection after a successful registry commit.
- Reset dependent Kun and Write provider references to a safe fallback.
- Reject newer settings schemas before legacy migration.
- Add regression coverage for remount/deletion and migration guard behavior.

## Validation

- Provider lifecycle suite: deletion persistence regression passes; unrelated existing credential UI assumptions remain failing on current develop.
- Extension workspace builds pass.
- `git diff --check` passes.
- Full typecheck is currently blocked by baseline missing declarations (`@modelcontextprotocol/client`, `@earendil-works/pi-tui`, and `@xmldom/xmldom`) in the clean worktree.

## Safety

No new store, runtime, dependency, or persistence truth was introduced. Secret values are not logged or serialized into fingerprints.

## Issue

This is a standalone settings integrity fix; it does not close or claim any unrelated Issue.
