### PR TITLE
fix(ci): backport daily prerelease bootstrap to default branch

### DIFF
--- a/.github/workflows/daily-dev-prerelease.yml
+++ b/.github/workflows/daily-dev-prerelease.yml
@@ -47,11 +47,10 @@ jobs:
           head_sha="$(git rev-parse HEAD)"
 
           node -e '
-            const semver = require("semver")
             const [appVersion, devVersion] = process.argv.slice(1)
             if (!/^\d{8}\.\d{4}$/.test(devVersion)) throw new Error(`invalid daily dev version: ${devVersion}`)
-            if (!semver.valid(appVersion)) throw new Error(`invalid daily app SemVer: ${appVersion}`)
-            if (!semver.prerelease(appVersion)?.some((part) => String(part).startsWith("dev-"))) throw new Error(`daily app version is not a dev prerelease: ${appVersion}`)
+            const expectedAppVersion = `0.0.0-dev-${devVersion.replace(".", "-")}`
+            if (appVersion !== expectedAppVersion) throw new Error(`invalid daily app version: ${appVersion}`)
           ' "${app_version}" "${dev_version}"
 
           {


### PR DESCRIPTION
## Summary

Backports the Daily Dev prerelease bootstrap fix to the repository default branch, where scheduled workflows are loaded.

Companion to #1242, which keeps `develop` consistent. This PR targets `master` because GitHub schedule events use the workflow definition from the default branch before the job checks out `develop`.

## Changes

- remove the pre-install `require("semver")` dependency from the version step
- validate the exact generated `0.0.0-dev-YYYYMMDD-HHMM` value with built-in JavaScript

## Tests

- `npm ci` (exit 0)
- `node scripts/check-extension-release-gate-workflows.mjs` (exit 0)
- PyYAML parse of `.github/workflows/daily-dev-prerelease.yml` (exit 0)
- valid/mismatched/malformed version matrix (exit 0)
- `git diff --check origin/master..HEAD` (exit 0)

## Review

Sol Medium independent review: Blocker 0, High 0, Medium 0; Ready.

## Actual validation

After merge, the next scheduled run must be observed to confirm that the default-branch workflow reaches the platform build jobs. This cannot be exercised from a fork PR because schedule events load from the upstream default branch.
