### PR TITLE
revert(ci): undo direct master prerelease backport

### DIFF
--- a/.github/workflows/daily-dev-prerelease.yml
+++ b/.github/workflows/daily-dev-prerelease.yml
@@ -47,10 +47,11 @@ jobs:
           head_sha="$(git rev-parse HEAD)"
 
           node -e '
+            const semver = require("semver")
             const [appVersion, devVersion] = process.argv.slice(1)
             if (!/^\d{8}\.\d{4}$/.test(devVersion)) throw new Error(`invalid daily dev version: ${devVersion}`)
-            const expectedAppVersion = `0.0.0-dev-${devVersion.replace(".", "-")}`
-            if (appVersion !== expectedAppVersion) throw new Error(`invalid daily app version: ${appVersion}`)
+            if (!semver.valid(appVersion)) throw new Error(`invalid daily app SemVer: ${appVersion}`)
+            if (!semver.prerelease(appVersion)?.some((part) => String(part).startsWith("dev-"))) throw new Error(`daily app version is not a dev prerelease: ${appVersion}`)
           ' "${app_version}" "${dev_version}"
 
           {


### PR DESCRIPTION
## Summary

Undo the direct-to-master merge of #1246. Repository changes must land through `develop`; the intended dependency removal is already present there via #1242.

## Changes

- Restore `.github/workflows/daily-dev-prerelease.yml` on `master` to its exact pre-#1246 content.
- Leave the corrected dependency-free workflow on `develop` unchanged.

## Tests

- `git diff --check`
- Verified the workflow file matches master commit `2994a348d` (the parent of the accidental merge).

Corrective revert of #1246.