### PR TITLE
fix(runtime): recover stale build handoff records

### DIFF
--- a/kun/src/manager/manager-client.ts
+++ b/kun/src/manager/manager-client.ts
@@ -509,11 +509,18 @@ export async function unregisterRuntimeWithManager(input: {
   flavor: RuntimeFlavor
   instanceId: string
   fetch?: typeof fetch
-}): Promise<void> {
-  await requestManagerResponse(input.manager, `/v1/runtimes/${input.flavor}/${encodeURIComponent(input.instanceId)}`, {
-    method: 'DELETE',
-    fetch: input.fetch
-  }).catch(() => undefined)
+}): Promise<boolean> {
+  const response = await requestManagerResponse(
+    input.manager,
+    `/v1/runtimes/${input.flavor}/${encodeURIComponent(input.instanceId)}`,
+    {
+      method: 'DELETE',
+      fetch: input.fetch
+    }
+  )
+  return z.object({ removed: z.boolean() }).parse(
+    await requireManagerJson(response)
+  ).removed
 }
 
 export async function readManagerRuntime(

--- a/kun/src/manager/service-manager-router.ts
+++ b/kun/src/manager/service-manager-router.ts
@@ -53,29 +53,13 @@ import {
   validation
 } from './service-manager-router-auth.js'
 import { addHostPowerRoute } from './service-manager-router-host-power.js'
+import {
+  isUsageIndexUnavailable,
+  usageIndexUnavailableResponse
+} from './service-manager-usage-response.js'
 
 export { authorized, authorizedAsync, tokenMatches, validation } from './service-manager-router-auth.js'
-
-/**
- * The SQLite usage index is a rebuildable projection over the canonical JSONL
- * history. When it is unavailable (missing/broken database, in-progress
- * backfill, or query timeout), report a typed 503 instead of a generic
- * internal_error so callers can degrade to the JSONL fallback.
- */
-export function isUsageIndexUnavailable(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.includes('usage_index_unavailable') || message.includes('usage_query_timeout')
-}
-
-function usageIndexUnavailableResponse(error: unknown): JsonResponse {
-  const message = error instanceof Error ? error.message : String(error)
-  const code = message.includes('usage_query_timeout')
-    ? 'usage_query_timeout'
-    : 'usage_index_unavailable'
-  return jsonResponse({ code, message: code === 'usage_query_timeout'
-    ? 'Usage index query timed out.'
-    : 'Usage index is temporarily unavailable.' }, 503)
-}
+export { isUsageIndexUnavailable } from './service-manager-usage-response.js'
 
 export function buildServiceManagerRouter(input: {
   managerToken: string
@@ -338,15 +322,15 @@ export function buildServiceManagerRouter(input: {
       return jsonResponse({ accepted: true })
     }
   ))
-  router.add('DELETE', '/v1/runtimes/:flavor/:instanceId', (request, context) => authorized(
+  router.add('DELETE', '/v1/runtimes/:flavor/:instanceId', (request, context) => authorizedAsync(
     request,
     input.managerToken,
-    () => {
+    async () => {
       const flavor = RuntimeFlavorSchema.safeParse(context.params.flavor)
       if (!flavor.success) return validation('invalid runtime flavor')
-      return jsonResponse({
-        removed: input.state.unregister(flavor.data, context.params.instanceId)
-      })
+      const removed = input.state.unregister(flavor.data, context.params.instanceId)
+      if (removed) await input.flushState?.()
+      return jsonResponse({ removed })
     }
   ))
   router.add('POST', '/v1/manager/shutdown', (request) => authorizedAsync(

--- a/kun/src/manager/service-manager-runtime-registration.test.ts
+++ b/kun/src/manager/service-manager-runtime-registration.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest'
+import { dispatchRequest } from '../server/http-server.js'
+import {
+  unregisterRuntimeWithManager,
+  type ServiceManagerConnection
+} from './manager-client.js'
+import {
+  buildServiceManagerRouter,
+  ServiceManagerState
+} from './service-manager.js'
+
+function registration(instanceId = 'production-runtime') {
+  return {
+    flavor: 'production' as const,
+    instanceId,
+    pid: process.pid,
+    startedAt: '2026-08-01T00:00:00.000Z',
+    host: '127.0.0.1',
+    port: 18899,
+    baseUrl: 'http://127.0.0.1:18899',
+    runtimeToken: 'production-secret'
+  }
+}
+
+function manager(): ServiceManagerConnection {
+  return {
+    discovery: {
+      version: 1,
+      protocolVersion: 5,
+      instanceId: 'manager-a',
+      pid: process.pid,
+      startedAt: '2026-08-01T00:00:00.000Z',
+      host: '127.0.0.1',
+      port: 18700,
+      baseUrl: 'http://127.0.0.1:18700',
+      managerToken: 'manager-secret',
+      serviceVersion: '0.1.0',
+      dataDir: '/tmp/kun-data',
+      settingsPath: '/tmp/kun-settings.json'
+    }
+  }
+}
+
+function request(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://127.0.0.1${path}`, {
+    ...init,
+    headers: {
+      authorization: 'Bearer manager-secret',
+      ...init.headers
+    }
+  })
+}
+
+function routerFetch(router: ReturnType<typeof buildServiceManagerRouter>): typeof fetch {
+  return (async (url: string | URL | Request, init?: RequestInit) =>
+    dispatchRequest(router, new Request(url, init))) as typeof fetch
+}
+
+describe('service manager runtime unregister contract', () => {
+  it('flushes an exact removal before returning true and keeps it removed after restore', async () => {
+    const state = new ServiceManagerState()
+    const owner = registration()
+    state.register(owner)
+    let durableSnapshot: unknown
+    const flushState = vi.fn(async () => {
+      durableSnapshot = state.durableSnapshot()
+    })
+    const router = buildServiceManagerRouter({
+      managerToken: 'manager-secret',
+      instanceId: 'manager-a',
+      startedAt: '2026-08-01T00:00:00.000Z',
+      state,
+      flushState
+    })
+
+    await expect(unregisterRuntimeWithManager({
+      manager: manager(),
+      flavor: 'production',
+      instanceId: owner.instanceId,
+      fetch: routerFetch(router)
+    })).resolves.toBe(true)
+
+    expect(flushState).toHaveBeenCalledOnce()
+    expect(state.registration('production')).toBeNull()
+    expect(ServiceManagerState.restore(durableSnapshot).registration('production')).toBeNull()
+  })
+
+  it('returns false without flushing or deleting a replacement owner', async () => {
+    const state = new ServiceManagerState()
+    const replacement = registration('production-replacement')
+    state.register(replacement)
+    const flushState = vi.fn(async () => undefined)
+    const router = buildServiceManagerRouter({
+      managerToken: 'manager-secret',
+      instanceId: 'manager-a',
+      startedAt: '2026-08-01T00:00:00.000Z',
+      state,
+      flushState
+    })
+
+    await expect(unregisterRuntimeWithManager({
+      manager: manager(),
+      flavor: 'production',
+      instanceId: 'production-old',
+      fetch: routerFetch(router)
+    })).resolves.toBe(false)
+
+    expect(flushState).not.toHaveBeenCalled()
+    expect(state.registration('production')).toMatchObject({
+      instanceId: replacement.instanceId
+    })
+  })
+
+  it('does not acknowledge a removal when persistence fails', async () => {
+    const state = new ServiceManagerState()
+    const owner = registration()
+    state.register(owner)
+    const router = buildServiceManagerRouter({
+      managerToken: 'manager-secret',
+      instanceId: 'manager-a',
+      startedAt: '2026-08-01T00:00:00.000Z',
+      state,
+      flushState: async () => { throw new Error('disk full') }
+    })
+
+    await expect(dispatchRequest(router, request(
+      `/v1/runtimes/production/${owner.instanceId}`,
+      { method: 'DELETE' }
+    ))).rejects.toThrow('disk full')
+  })
+
+  it.each([
+    ['unauthorized', async () => Response.json({ code: 'unauthorized' }, { status: 401 })],
+    ['server failure', async () => Response.json({ code: 'internal_error' }, { status: 500 })],
+    ['invalid JSON', async () => new Response('not-json', { status: 200 })],
+    ['connection failure', async () => { throw new Error('connection refused') }]
+  ])('surfaces %s instead of treating unregister as success', async (_label, fetchImpl) => {
+    await expect(unregisterRuntimeWithManager({
+      manager: manager(),
+      flavor: 'production',
+      instanceId: 'production-runtime',
+      fetch: fetchImpl as typeof fetch
+    })).rejects.toThrow()
+  })
+})

--- a/kun/src/manager/service-manager-usage-response.ts
+++ b/kun/src/manager/service-manager-usage-response.ts
@@ -1,0 +1,25 @@
+import { jsonResponse, type JsonResponse } from '../server/response.js'
+
+/**
+ * The SQLite usage index is a rebuildable projection over the canonical JSONL
+ * history. When it is unavailable (missing/broken database, in-progress
+ * backfill, or query timeout), report a typed 503 instead of a generic
+ * internal_error so callers can degrade to the JSONL fallback.
+ */
+export function isUsageIndexUnavailable(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes('usage_index_unavailable') || message.includes('usage_query_timeout')
+}
+
+export function usageIndexUnavailableResponse(error: unknown): JsonResponse {
+  const message = error instanceof Error ? error.message : String(error)
+  const code = message.includes('usage_query_timeout')
+    ? 'usage_query_timeout'
+    : 'usage_index_unavailable'
+  return jsonResponse({
+    code,
+    message: code === 'usage_query_timeout'
+      ? 'Usage index query timed out.'
+      : 'Usage index is temporarily unavailable.'
+  }, 503)
+}

--- a/kun/src/manager/service-manager-usage.test.ts
+++ b/kun/src/manager/service-manager-usage.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { dispatchRequest } from '../server/http-server.js'
+import {
+  requestManagerJson,
+  type ServiceManagerConnection
+} from './manager-client.js'
+import { SessionUsageQuerySchema } from './shared-data-store-contracts.js'
+import type { ManagerSharedDataStore } from './shared-data-store.js'
+import {
+  buildServiceManagerRouter,
+  ServiceManagerState
+} from './service-manager.js'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function request(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://127.0.0.1${path}`, {
+    ...init,
+    headers: {
+      authorization: 'Bearer manager-secret',
+      ...(init.body ? { 'content-type': 'application/json' } : {}),
+      ...init.headers
+    }
+  })
+}
+
+describe('manager usage query contract', () => {
+  it('accepts complete UTC ranges and rejects partial ranges', () => {
+    expect(SessionUsageQuerySchema.parse({
+      fromInclusive: '2026-08-01T00:00:00.000Z',
+      toExclusive: '2026-08-02T00:00:00.000Z'
+    })).toEqual({
+      fromInclusive: '2026-08-01T00:00:00.000Z',
+      toExclusive: '2026-08-02T00:00:00.000Z'
+    })
+
+    expect(() => SessionUsageQuerySchema.parse({
+      fromInclusive: '2026-08-01T00:00:00.000Z'
+    })).toThrow('usage range requires both boundaries')
+  })
+
+  it('maps degraded usage index errors to a typed 503 on the session-store boundary', async () => {
+    const executeSession = vi.fn(async () => {
+      throw new Error('usage_index_unavailable: hybrid sqlite unavailable')
+    })
+    const router = buildServiceManagerRouter({
+      managerToken: 'manager-secret',
+      instanceId: 'manager-a',
+      startedAt: '2026-08-01T00:00:00.000Z',
+      state: new ServiceManagerState(),
+      sharedData: { executeSession } as unknown as ManagerSharedDataStore
+    })
+
+    const response = await dispatchRequest(router, request('/v1/data/session/aggregateUsage', {
+      method: 'POST',
+      body: JSON.stringify({ value: {} })
+    }))
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      code: 'usage_index_unavailable',
+      message: 'Usage index is temporarily unavailable.'
+    })
+  })
+
+  it('preserves the manager error code on the remote client error', async () => {
+    const executeSession = vi.fn(async () => {
+      throw new Error('usage_query_timeout')
+    })
+    const router = buildServiceManagerRouter({
+      managerToken: 'manager-secret',
+      instanceId: 'manager-a',
+      startedAt: '2026-08-01T00:00:00.000Z',
+      state: new ServiceManagerState(),
+      sharedData: { executeSession } as unknown as ManagerSharedDataStore
+    })
+    const manager: ServiceManagerConnection = {
+      discovery: {
+        version: 1,
+        protocolVersion: 5,
+        instanceId: 'manager-a',
+        pid: process.pid,
+        startedAt: '2026-08-01T00:00:00.000Z',
+        host: '127.0.0.1',
+        port: 18700,
+        baseUrl: 'http://127.0.0.1:18700',
+        managerToken: 'manager-secret',
+        serviceVersion: '0.1.0',
+        dataDir: '/tmp/kun-data',
+        settingsPath: '/tmp/kun-settings.json'
+      }
+    }
+    vi.stubGlobal('fetch', (async (url: string | URL | Request, init?: RequestInit) =>
+      dispatchRequest(router, new Request(url, init))) as typeof fetch)
+
+    const error = await requestManagerJson(manager, '/v1/data/session/aggregateUsage', {
+      method: 'POST',
+      body: { value: {} }
+    }).catch((failure: unknown) => failure)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toMatchObject({
+      code: 'usage_query_timeout',
+      message: expect.stringContaining('usage_query_timeout')
+    })
+  })
+})

--- a/kun/src/manager/service-manager.test.ts
+++ b/kun/src/manager/service-manager.test.ts
@@ -11,7 +11,6 @@ import {
   type ServiceManagerConnection
 } from './manager-client.js'
 import { ManagerRemoteGraphRunStore } from './remote-data-stores.js'
-import { SessionUsageQuerySchema } from './shared-data-store-contracts.js'
 import type { ManagerSharedDataStore } from './shared-data-store.js'
 import {
   buildServiceManagerRouter,
@@ -21,87 +20,6 @@ import {
   THREAD_EXECUTION_LEASE_TTL_MS,
   ThreadLeaseBusyError
 } from './service-manager.js'
-
-describe('manager usage query contract', () => {
-  it('accepts complete UTC ranges and rejects partial ranges', () => {
-    expect(SessionUsageQuerySchema.parse({
-      fromInclusive: '2026-08-01T00:00:00.000Z',
-      toExclusive: '2026-08-02T00:00:00.000Z'
-    })).toEqual({
-      fromInclusive: '2026-08-01T00:00:00.000Z',
-      toExclusive: '2026-08-02T00:00:00.000Z'
-    })
-    expect(() => SessionUsageQuerySchema.parse({
-      fromInclusive: '2026-08-01T00:00:00.000Z'
-    })).toThrow('usage range requires both boundaries')
-  })
-
-  it('maps degraded usage index errors to a typed 503 on the session-store boundary', async () => {
-    const executeSession = vi.fn(async () => {
-      throw new Error('usage_index_unavailable: hybrid sqlite unavailable')
-    })
-    const router = buildServiceManagerRouter({
-      managerToken: 'manager-secret',
-      instanceId: 'manager-a',
-      startedAt: '2026-08-01T00:00:00.000Z',
-      state: new ServiceManagerState(),
-      sharedData: { executeSession } as unknown as ManagerSharedDataStore
-    })
-
-    const response = await dispatchRequest(router, request('/v1/data/session/aggregateUsage', {
-      method: 'POST',
-      body: JSON.stringify({ value: {} })
-    }))
-
-    expect(response.status).toBe(503)
-    await expect(response.json()).resolves.toEqual({
-      code: 'usage_index_unavailable',
-      message: 'Usage index is temporarily unavailable.'
-    })
-  })
-
-  it('preserves the manager error code on the remote client error', async () => {
-    const executeSession = vi.fn(async () => {
-      throw new Error('usage_query_timeout')
-    })
-    const router = buildServiceManagerRouter({
-      managerToken: 'manager-secret',
-      instanceId: 'manager-a',
-      startedAt: '2026-08-01T00:00:00.000Z',
-      state: new ServiceManagerState(),
-      sharedData: { executeSession } as unknown as ManagerSharedDataStore
-    })
-    const manager: ServiceManagerConnection = {
-      discovery: {
-        version: 1,
-        protocolVersion: 5,
-        instanceId: 'manager-a',
-        pid: process.pid,
-        startedAt: '2026-08-01T00:00:00.000Z',
-        host: '127.0.0.1',
-        port: 18700,
-        baseUrl: 'http://127.0.0.1:18700',
-        managerToken: 'manager-secret',
-        serviceVersion: '0.1.0',
-        dataDir: '/tmp/kun-data',
-        settingsPath: '/tmp/kun-settings.json'
-      }
-    }
-    vi.stubGlobal('fetch', (async (url: string | URL | Request, init?: RequestInit) =>
-      dispatchRequest(router, new Request(url, init))) as typeof fetch)
-
-    const error = await requestManagerJson(manager, '/v1/data/session/aggregateUsage', {
-      method: 'POST',
-      body: { value: {} }
-    }).catch((failure: unknown) => failure)
-
-    expect(error).toBeInstanceOf(Error)
-    expect(error).toMatchObject({
-      code: 'usage_query_timeout',
-      message: expect.stringContaining('usage_query_timeout')
-    })
-  })
-})
 
 afterEach(() => {
   vi.unstubAllGlobals()

--- a/scripts/fixtures/update-handoff/serve-entry.cjs
+++ b/scripts/fixtures/update-handoff/serve-entry.cjs
@@ -1,0 +1,3 @@
+'use strict'
+
+require('../update-handoff-owner.cjs')

--- a/scripts/smoke-packaged-update-handoff-recycled.cjs
+++ b/scripts/smoke-packaged-update-handoff-recycled.cjs
@@ -1,0 +1,211 @@
+'use strict'
+
+const { join } = require('node:path')
+const {
+  availablePort
+} = require('./smoke-packaged-extension-desktop-process.cjs')
+const {
+  childState,
+  launchPredecessorOwners,
+  poll,
+  preparePredecessorRuntime,
+  processIsAlive,
+  spawnTracked,
+  startModelFixture,
+  waitForJson,
+  waitForProcessExit
+} = require('./smoke-packaged-update-handoff-support.cjs')
+
+async function runRecycledPidScenario(input, deps) {
+  const root = await deps.createProfileRoot(`kun-packaged-handoff-${input.scenario}-`)
+  const modelFixture = await startModelFixture()
+  const tracked = []
+  let primaryError
+  let cleanupErrors = []
+  try {
+    const profile = await deps.initializeProfile(root, modelFixture.baseUrl, true)
+    const predecessor = await preparePredecessorRuntime({
+      resourcesDir: input.resourcesDir,
+      oldResourcesDir: input.oldResourcesDir,
+      temporaryRoot: root.temporaryRoot
+    })
+    const owners = await launchPredecessorOwners({
+      runtimeExecutable: input.candidateRuntimeExecutable,
+      kunRoot: predecessor.kunRoot,
+      buildId: predecessor.buildId,
+      environment: profile.environment,
+      controlDir: profile.controlDir,
+      dataDir: profile.dataDir,
+      settingsPath: profile.settingsPath,
+      workspaceRoot: profile.workspaceRoot,
+      productionPort: profile.productionPort,
+      developmentPort: profile.developmentPort,
+      baseUrl: modelFixture.baseUrl,
+      timeoutMs: input.timeoutMs,
+      onSpawn: (process) => tracked.push(process)
+    })
+    await stopPredecessorRuntimes(owners, input.timeoutMs)
+
+    const helper = spawnTracked(process.execPath, [
+      join(__dirname, 'fixtures', 'update-handoff-owner.cjs'),
+      '--data-dir', profile.dataDir,
+      '--scenario', 'pid-port-reuse',
+      '--build-id', predecessor.buildId
+    ], { cwd: profile.workspaceRoot, env: profile.environment })
+    tracked.push(helper)
+    const staleOwner = await Promise.race([
+      waitForJson(
+        join(profile.dataDir, 'runtime.json'),
+        (value) => value?.pid === helper.child.pid,
+        input.timeoutMs,
+        () => childState(helper.child, helper.output())
+      ),
+      deps.desktopExitGuard(helper.child)
+    ])
+    await registerManagerRuntimeSlot(owners.manager.discovery, staleOwner)
+
+    const debuggingPort = await availablePort()
+    const candidateDesktop = deps.launchCandidate(input.desktop, profile, {
+      debuggingPort,
+      timeoutMs: input.timeoutMs
+    })
+    tracked.push(candidateDesktop)
+    const current = await deps.waitForCurrentOwners({
+      profile,
+      candidateBuildId: input.candidateBuildId,
+      autoStart: true,
+      oldOwners: owners,
+      desktop: candidateDesktop,
+      timeoutMs: input.timeoutMs
+    })
+
+    if (!processIsAlive(staleOwner.pid)) {
+      throw new Error(`Candidate terminated recycled helper PID ${staleOwner.pid}`)
+    }
+    if (current.runtime?.instanceId === staleOwner.instanceId) {
+      throw new Error('Candidate preserved the recycled helper discovery as the current Runtime')
+    }
+    const status = await managerJson(current.manager, '/v1/manager/status')
+    const staleSlot = status.slots?.some((slot) =>
+      (slot.registration ?? slot).instanceId === staleOwner.instanceId
+    )
+    if (staleSlot) throw new Error('Candidate left the recycled helper Manager slot registered')
+    const output = candidateDesktop.output()
+    if (output.includes('runtime_stop_failed') && output.includes(String(staleOwner.pid))) {
+      throw new Error('Candidate logged a Runtime stop failure for the recycled helper PID')
+    }
+    await deps.assertChatRoundTrip(current.runtime, profile.workspaceRoot, input.timeoutMs)
+
+    await deps.quitDesktopNormally(candidateDesktop, debuggingPort, input.timeoutMs)
+    tracked.splice(tracked.indexOf(candidateDesktop), 1)
+    await stopCurrentOwners(current, input.timeoutMs)
+    if (!processIsAlive(staleOwner.pid)) {
+      throw new Error(`Normal candidate shutdown terminated recycled helper PID ${staleOwner.pid}`)
+    }
+  } catch (error) {
+    primaryError = error
+  } finally {
+    await modelFixture.close().catch(() => undefined)
+    cleanupErrors = await deps.cleanupTracked(tracked)
+    await deps.cleanupProfile(root).catch((error) => cleanupErrors.push(error.message ?? String(error)))
+  }
+  if (primaryError) throw primaryError
+  if (cleanupErrors.length > 0) {
+    throw new Error(`Recycled PID handoff cleanup failed: ${cleanupErrors.join('; ')}`)
+  }
+}
+
+async function stopPredecessorRuntimes(owners, timeoutMs) {
+  for (const owner of owners.runtimes) {
+    const response = await fetch(`${owner.discovery.baseUrl}/v1/runtime/shutdown`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${owner.discovery.runtimeToken}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ instanceId: owner.discovery.instanceId }),
+      signal: AbortSignal.timeout(10_000)
+    })
+    if (!response.ok) {
+      throw new Error(`Predecessor ${owner.flavor} Runtime rejected smoke setup shutdown`)
+    }
+    if (!await waitForProcessExit(owner.discovery.pid, Math.min(timeoutMs, 20_000))) {
+      throw new Error(`Predecessor ${owner.flavor} Runtime did not exit during smoke setup`)
+    }
+  }
+  await poll(async () => {
+    const status = await managerJson(owners.manager.discovery, '/v1/manager/status')
+    return status.slots?.length === 0
+  }, timeoutMs, 'predecessor Runtime slots to unregister before PID reuse setup')
+}
+
+async function registerManagerRuntimeSlot(manager, staleOwner) {
+  const response = await fetch(`${manager.baseUrl}/v1/runtimes/production/register`, {
+    method: 'PUT',
+    headers: {
+      authorization: `Bearer ${manager.managerToken}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      flavor: 'production',
+      instanceId: staleOwner.instanceId,
+      pid: staleOwner.pid,
+      startedAt: staleOwner.startedAt,
+      host: staleOwner.host,
+      port: staleOwner.port,
+      baseUrl: staleOwner.baseUrl,
+      runtimeToken: staleOwner.runtimeToken,
+      ...(staleOwner.buildId ? { buildId: staleOwner.buildId } : {})
+    }),
+    signal: AbortSignal.timeout(10_000)
+  })
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(`Manager rejected recycled PID slot setup (${response.status}): ${body}`)
+  }
+}
+
+async function managerJson(discovery, path) {
+  const response = await fetch(`${discovery.baseUrl}${path}`, {
+    headers: { authorization: `Bearer ${discovery.managerToken}` },
+    signal: AbortSignal.timeout(10_000)
+  })
+  const body = await response.text()
+  if (!response.ok) throw new Error(`GET ${path} failed (${response.status}): ${body}`)
+  return body ? JSON.parse(body) : undefined
+}
+
+async function stopCurrentOwners(current, timeoutMs) {
+  if (current.runtime) {
+    await fetch(`${current.runtime.baseUrl}/v1/runtime/shutdown`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${current.runtime.runtimeToken}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ instanceId: current.runtime.instanceId }),
+      signal: AbortSignal.timeout(10_000)
+    }).catch(() => undefined)
+    if (!await waitForProcessExit(current.runtime.pid, Math.min(timeoutMs, 20_000))) {
+      throw new Error(`Current Runtime PID ${current.runtime.pid} did not stop through its authenticated API`)
+    }
+  }
+  await fetch(`${current.manager.baseUrl}/v1/manager/shutdown`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${current.manager.managerToken}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ instanceId: current.manager.instanceId }),
+    signal: AbortSignal.timeout(10_000)
+  }).catch(() => undefined)
+  if (!await waitForProcessExit(current.manager.pid, Math.min(timeoutMs, 20_000))) {
+    throw new Error(`Current Manager PID ${current.manager.pid} did not stop through its authenticated API`)
+  }
+}
+
+module.exports = {
+  managerJson,
+  runRecycledPidScenario,
+  stopCurrentOwners
+}

--- a/scripts/smoke-packaged-update-handoff-support.cjs
+++ b/scripts/smoke-packaged-update-handoff-support.cjs
@@ -23,9 +23,10 @@ const POSITIVE_SCENARIOS = Object.freeze([
   Object.freeze({ name: 'in-app-auto-on', path: 'in-app', autoStart: true, activeWork: false }),
   Object.freeze({ name: 'external-auto-off', path: 'external', autoStart: false, activeWork: false })
 ])
+const RECYCLED_PID_SCENARIOS = Object.freeze([
+  'runtime-discovery-and-manager-slot'
+])
 const NEGATIVE_SCENARIOS = Object.freeze([
-  'pid-port-reuse',
-  'non-kun-command',
   'changed-discovery-identity',
   'inspection-denied'
 ])
@@ -384,6 +385,7 @@ module.exports = {
   MODEL_NAME,
   NEGATIVE_SCENARIOS,
   POSITIVE_SCENARIOS,
+  RECYCLED_PID_SCENARIOS,
   SAVED_THREAD_TITLE,
   buildSmokeSettings,
   childState,

--- a/scripts/smoke-packaged-update-handoff.cjs
+++ b/scripts/smoke-packaged-update-handoff.cjs
@@ -32,6 +32,7 @@ const {
   CHAT_MARKER,
   NEGATIVE_SCENARIOS,
   POSITIVE_SCENARIOS,
+  RECYCLED_PID_SCENARIOS,
   SAVED_THREAD_TITLE,
   buildSmokeSettings,
   childState,
@@ -52,6 +53,11 @@ const {
   waitForTurn,
   writeSmokeSettings
 } = require('./smoke-packaged-update-handoff-support.cjs')
+const {
+  managerJson,
+  runRecycledPidScenario,
+  stopCurrentOwners
+} = require('./smoke-packaged-update-handoff-recycled.cjs')
 
 const DEFAULT_TIMEOUT_MS = 120_000
 const READY_PREFIX = 'KUN_UPDATE_HANDOFF_SMOKE_READY '
@@ -91,6 +97,27 @@ async function main() {
       timeoutMs
     })
   }
+  for (const scenario of runPositive ? RECYCLED_PID_SCENARIOS : []) {
+    await runRecycledPidScenario({
+      scenario,
+      resourcesDir,
+      oldResourcesDir,
+      candidateRuntimeExecutable,
+      desktop,
+      candidateBuildId: candidate.buildId,
+      timeoutMs
+    }, {
+      assertChatRoundTrip,
+      cleanupProfile,
+      cleanupTracked,
+      createProfileRoot,
+      desktopExitGuard,
+      initializeProfile,
+      launchCandidate,
+      quitDesktopNormally,
+      waitForCurrentOwners
+    })
+  }
   for (const scenario of runNegative ? NEGATIVE_SCENARIOS : []) {
     await runNegativeScenario({
       scenario,
@@ -101,7 +128,7 @@ async function main() {
   }
   process.stdout.write(
     `Packaged update handoff smoke OK (${process.platform}/${process.arch}): ` +
-    `${runPositive ? POSITIVE_SCENARIOS.length : 0} update paths and ` +
+    `${runPositive ? POSITIVE_SCENARIOS.length + RECYCLED_PID_SCENARIOS.length : 0} update paths and ` +
     `${runNegative ? NEGATIVE_SCENARIOS.length : 0} fail-closed owner cases passed.\n`
   )
 }
@@ -259,7 +286,8 @@ async function runNegativeScenario(input) {
   try {
     const profile = await initializeProfile(root, 'http://127.0.0.1:9', false)
     const fixture = spawnTracked(process.execPath, [
-      join(__dirname, 'fixtures', 'update-handoff-owner.cjs'),
+      join(__dirname, 'fixtures', 'update-handoff', 'serve-entry.cjs'),
+      'serve',
       '--data-dir', profile.dataDir,
       '--scenario', input.scenario,
       '--build-id', 'a'.repeat(64)
@@ -284,7 +312,8 @@ async function runNegativeScenario(input) {
     tracked.splice(tracked.indexOf(preflight), 1)
     if (result.code === 0) throw new Error(`Unsafe ${input.scenario} owner was accepted`)
     const failure = parseSmokeMarker(result.output, FAILED_PREFIX)
-    if (!failure || failure.retryable !== false || failure.owner?.pid !== owner.pid) {
+    const expectedRetryable = input.scenario === 'inspection-denied'
+    if (!failure || failure.retryable !== expectedRetryable || failure.owner?.pid !== owner.pid) {
       throw new Error(`Unsafe ${input.scenario} did not expose actionable fail-closed metadata: ${result.output}`)
     }
     if (!processIsAlive(owner.pid)) {
@@ -460,16 +489,6 @@ async function quitDesktopNormally(desktop, debuggingPort, timeoutMs) {
   }
 }
 
-async function managerJson(discovery, path) {
-  const response = await fetch(`${discovery.baseUrl}${path}`, {
-    headers: { authorization: `Bearer ${discovery.managerToken}` },
-    signal: AbortSignal.timeout(10_000)
-  })
-  const body = await response.text()
-  if (!response.ok) throw new Error(`GET ${path} failed (${response.status}): ${body}`)
-  return body ? JSON.parse(body) : undefined
-}
-
 function desktopExitGuard(child) {
   return new Promise((_, reject) => {
     child.once('error', reject)
@@ -583,35 +602,6 @@ async function assertNoRuntimeDiscovery(profile) {
     } catch (error) {
       if (error?.code !== 'ENOENT' && !(error instanceof SyntaxError)) throw error
     }
-  }
-}
-
-async function stopCurrentOwners(current, timeoutMs) {
-  if (current.runtime) {
-    await fetch(`${current.runtime.baseUrl}/v1/runtime/shutdown`, {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${current.runtime.runtimeToken}`,
-        'content-type': 'application/json'
-      },
-      body: JSON.stringify({ instanceId: current.runtime.instanceId }),
-      signal: AbortSignal.timeout(10_000)
-    }).catch(() => undefined)
-    if (!await waitForProcessExit(current.runtime.pid, Math.min(timeoutMs, 20_000))) {
-      throw new Error(`Current Runtime PID ${current.runtime.pid} did not stop through its authenticated API`)
-    }
-  }
-  await fetch(`${current.manager.baseUrl}/v1/manager/shutdown`, {
-    method: 'POST',
-    headers: {
-      authorization: `Bearer ${current.manager.managerToken}`,
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify({ instanceId: current.manager.instanceId }),
-    signal: AbortSignal.timeout(10_000)
-  }).catch(() => undefined)
-  if (!await waitForProcessExit(current.manager.pid, Math.min(timeoutMs, 20_000))) {
-    throw new Error(`Current Manager PID ${current.manager.pid} did not stop through its authenticated API`)
   }
 }
 

--- a/scripts/smoke-packaged-update-handoff.test.cjs
+++ b/scripts/smoke-packaged-update-handoff.test.cjs
@@ -7,6 +7,7 @@ const test = require('node:test')
 const {
   NEGATIVE_SCENARIOS,
   POSITIVE_SCENARIOS,
+  RECYCLED_PID_SCENARIOS,
   buildSmokeSettings,
   parseSmokeMarker,
   predecessorBuildId,
@@ -35,10 +36,14 @@ test('release matrix covers both update paths, active work, and auto-start off',
 
 test('negative release matrix names every fail-closed ownership case', () => {
   assert.deepEqual(NEGATIVE_SCENARIOS, [
-    'pid-port-reuse',
-    'non-kun-command',
     'changed-discovery-identity',
     'inspection-denied'
+  ])
+})
+
+test('recycled PID release matrix proves exact stale coordination cleanup', () => {
+  assert.deepEqual(RECYCLED_PID_SCENARIOS, [
+    'runtime-discovery-and-manager-slot'
   ])
 })
 

--- a/src/main/kun-process-identity.test.ts
+++ b/src/main/kun-process-identity.test.ts
@@ -1,14 +1,18 @@
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   commandLooksLikeExpectedServe,
+  commandLooksLikeExpectedManager,
+  identityMatchesExpectedManager,
   identityMatchesExpectedRuntime,
   looksLikeRuntimeExecutable,
   sameRuntimeOwner
 } from './kun-process-identity'
+import type { ManagerHandoffDiscoveryRecord } from '../../kun/src/manager/manager-discovery.js'
 import type { RuntimeHandoffDiscoveryRecord } from '../../kun/src/server/runtime-discovery.js'
 
-const dataDir = '/tmp/kun-data'
-const serveEntry = '/opt/Kun/resources/kun/dist/cli/serve-entry.js'
+const dataDir = resolve('tmp', 'kun-data')
+const serveEntry = resolve('opt', 'Kun', 'resources', 'kun', 'dist', 'cli', 'serve-entry.js')
 const startedAt = '2026-08-25T15:00:00.000Z'
 
 function discovery(overrides: Partial<RuntimeHandoffDiscoveryRecord> = {}): RuntimeHandoffDiscoveryRecord {
@@ -24,6 +28,25 @@ function discovery(overrides: Partial<RuntimeHandoffDiscoveryRecord> = {}): Runt
     insecure: false,
     serviceVersion: 'test',
     launchMode: 'shared',
+    ...overrides
+  }
+}
+
+function managerDiscovery(
+  overrides: Partial<ManagerHandoffDiscoveryRecord> = {}
+): ManagerHandoffDiscoveryRecord {
+  return {
+    version: 7,
+    protocolVersion: 3,
+    instanceId: 'manager-1',
+    pid: 8124,
+    startedAt,
+    host: '127.0.0.1',
+    port: 18900,
+    baseUrl: 'http://127.0.0.1:18900',
+    managerToken: 'manager-token',
+    dataDir,
+    settingsPath: '/tmp/Kun/kun-settings.json',
     ...overrides
   }
 }
@@ -51,6 +74,60 @@ describe('Kun process identity', () => {
       executablePath: null,
       startedAtMs: Date.parse(startedAt) + 60_001
     }, discovery(), dataDir, 'production', serveEntry)).toBe(false)
+  })
+
+  it('matches only the recorded service manager process generation', () => {
+    expect(identityMatchesExpectedManager({
+      pid: 8124,
+      commandLine: 'node /opt/Kun/resources/kun/dist/manager/manager-entry.js',
+      executablePath: 'C:\\Program Files\\nodejs\\node.exe',
+      startedAtMs: Date.parse(startedAt)
+    }, managerDiscovery())).toBe(true)
+    expect(identityMatchesExpectedManager({
+      pid: 8124,
+      commandLine: 'C:\\Windows\\System32\\SNAPOS64.exe',
+      executablePath: 'C:\\Windows\\System32\\SNAPOS64.exe',
+      startedAtMs: Date.parse(startedAt) + 120_000
+    }, managerDiscovery())).toBe(false)
+  })
+
+  it('rejects a Manager PID whose start time exceeds the ownership tolerance', () => {
+    expect(identityMatchesExpectedManager({
+      pid: 8124,
+      commandLine: 'kun-service-manager',
+      executablePath: null,
+      startedAtMs: Date.parse(startedAt) + 60_001
+    }, managerDiscovery())).toBe(false)
+  })
+
+  it('requires a trusted executable when matching a Manager on Windows', () => {
+    expect(identityMatchesExpectedManager({
+      pid: 8124,
+      commandLine: 'kun-service-manager',
+      executablePath: 'C:\\tools\\unrelated.exe',
+      startedAtMs: Date.parse(startedAt)
+    }, managerDiscovery(), 'win32')).toBe(false)
+    expect(identityMatchesExpectedManager({
+      pid: 8124,
+      commandLine: 'kun-service-manager',
+      executablePath: null,
+      startedAtMs: Date.parse(startedAt)
+    }, managerDiscovery(), 'win32')).toBe(false)
+  })
+
+  it('rejects incomplete process identity', () => {
+    expect(identityMatchesExpectedManager({
+      pid: 8124,
+      commandLine: 'kun-service-manager',
+      executablePath: 'C:\\Program Files\\nodejs\\node.exe',
+      startedAtMs: null
+    }, managerDiscovery(), 'win32')).toBe(false)
+  })
+
+  it('does not accept a manager-entry substring in an unrelated command', () => {
+    expect(commandLooksLikeExpectedManager('node /tmp/not-manager-entry.js')).toBe(false)
+    expect(commandLooksLikeExpectedManager('node --inspect=/tmp/manager-entry.js')).toBe(false)
+    expect(commandLooksLikeExpectedManager('node /tmp/manager-entry.js')).toBe(true)
   })
 
   it('compares runtime tokens as part of discovery ownership', () => {

--- a/src/main/kun-process-identity.ts
+++ b/src/main/kun-process-identity.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import type { RuntimeFlavor } from '../../kun/src/contracts/runtime-flavor.js'
+import type { ManagerHandoffDiscoveryRecord } from '../../kun/src/manager/manager-discovery.js'
 import type { RuntimeHandoffDiscoveryRecord } from '../../kun/src/server/runtime-discovery.js'
 import type { ProcessIdentity } from './kun-process-ports'
 
@@ -10,16 +11,41 @@ export function identityMatchesExpectedRuntime(
   discovery: RuntimeHandoffDiscoveryRecord,
   dataDir: string,
   flavor: RuntimeFlavor,
-  expectedServeEntryPath?: string
+  expectedServeEntryPath?: string,
+  platform: NodeJS.Platform = process.platform
 ): boolean {
   if (!identity || identity.pid !== discovery.pid) return false
   if (!commandLooksLikeExpectedServe(identity.commandLine, dataDir, flavor, expectedServeEntryPath)) {
     return false
   }
-  if (process.platform === 'win32' && !looksLikeRuntimeExecutable(identity.executablePath)) return false
+  if (platform === 'win32' && !looksLikeRuntimeExecutable(identity.executablePath)) return false
   const discoveryStartedAtMs = Date.parse(discovery.startedAt)
   return Number.isFinite(discoveryStartedAtMs) && identity.startedAtMs !== null &&
     Math.abs(identity.startedAtMs - discoveryStartedAtMs) <= MAX_RUNTIME_STARTED_AT_DIFFERENCE_MS
+}
+
+export function identityMatchesExpectedManager(
+  identity: ProcessIdentity | null,
+  discovery: ManagerHandoffDiscoveryRecord,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  if (!identity || identity.pid !== discovery.pid) return false
+  if (!commandLooksLikeExpectedManager(identity.commandLine)) return false
+  if (platform === 'win32' && !looksLikeRuntimeExecutable(identity.executablePath)) return false
+  const discoveryStartedAtMs = Date.parse(discovery.startedAt)
+  return Number.isFinite(discoveryStartedAtMs) && identity.startedAtMs !== null &&
+    Math.abs(identity.startedAtMs - discoveryStartedAtMs) <= MAX_RUNTIME_STARTED_AT_DIFFERENCE_MS
+}
+
+export function commandLooksLikeExpectedManager(command: string): boolean {
+  const normalized = command.trim()
+  const normalizedTitle = normalized.toLocaleLowerCase('en-US')
+  if (normalizedTitle === 'kun-service-manager' || normalizedTitle.startsWith('kun-service-manager ')) {
+    return true
+  }
+  return splitCommandLine(normalized).some((token) =>
+    !token.startsWith('-') && /(?:^|[/\\])manager-entry\.js$/iu.test(token)
+  )
 }
 
 export function commandLooksLikeExpectedServe(

--- a/src/main/kun-process.ts
+++ b/src/main/kun-process.ts
@@ -124,7 +124,6 @@ import {
 import { configureManagerAtomicJsonClient } from '../../kun/src/extensions/atomic-json.js'
 import { handoffExistingKunServiceManagerForDataDir } from './runtime/service-manager-build-handoff'
 import {
-  drainKunOwnersForHandoff,
   drainKunOwnersForHandoffWithLock,
   installedBuildProbeError,
   probeInstalledBuildHandoff
@@ -156,6 +155,7 @@ export { syncGuiManagedKunConfig } from './runtime/kun-runtime-config-service'
 export type { KunUnexpectedExitInfo } from './runtime/kun-process-controller'
 export { resolveKunStartupTimeoutMs } from './runtime/kun-runtime-health-monitor'
 export { handoffExistingKunServiceManagerForDataDir } from './runtime/service-manager-build-handoff'
+export { preparePackagedKunBuildHandoff } from './runtime/kun-packaged-build-handoff'
 
 let serviceManagerSettingsPath: string | undefined
 let mainManagerBinding: ServiceManagerConnection | undefined
@@ -247,30 +247,6 @@ export async function ensureKunServiceManager(input: {
     manager = await ensureServiceManager(managerInput)
   }
   return configureKunManagerDataPlaneForCurrentProcess(manager)
-}
-
-export async function preparePackagedKunBuildHandoff(input: {
-  dataDir: string
-  settingsPath: string
-  onHandoffEvent?: HandoffEventListener
-}): Promise<boolean> {
-  const flavor = resolveCliRuntimeFlavor({ env: process.env })
-  if (!app.isPackaged || flavor !== 'production') return false
-  const buildId = await resolveKunRuntimeBuildId(resolveKunExecutable(appRoot(), ''))
-  const handoffInput = {
-    reason: 'installed-build-change' as const,
-    dataDirs: [input.dataDir],
-    settingsPath: input.settingsPath,
-    controlDir: defaultKunControlDir(),
-    onEvent: createHandoffEventReporter(input.onHandoffEvent),
-    ...(buildId ? { targetBuildId: buildId } : {})
-  }
-  const probe = await probeInstalledBuildHandoff(handoffInput)
-  const probeError = installedBuildProbeError(handoffInput, probe)
-  if (probeError) throw probeError
-  if (probe === 'matched') return false
-  await drainKunOwnersForHandoff(handoffInput)
-  return true
 }
 
 /**

--- a/src/main/runtime/kun-installed-build-handoff-discovery.ts
+++ b/src/main/runtime/kun-installed-build-handoff-discovery.ts
@@ -1,0 +1,475 @@
+import { resolve } from 'node:path'
+import { z } from 'zod'
+import type { RuntimeFlavor } from '../../../kun/src/contracts/runtime-flavor.js'
+import {
+  isSafeRuntimeHandoffDiscovery,
+  removeRuntimeDiscovery,
+  readRuntimeHandoffDiscoveryStrict,
+  type RuntimeHandoffDiscoveryRecord
+} from '../../../kun/src/server/runtime-discovery.js'
+import {
+  defaultKunControlDir,
+  removeManagerDiscovery,
+  readManagerHandoffDiscoveryStrict,
+  withManagerStartLock,
+  type ManagerDiscoveryRecord,
+  type ManagerHandoffDiscoveryRecord
+} from '../../../kun/src/manager/manager-discovery.js'
+import { sameCanonicalPath } from '../../../kun/src/manager/canonical-path.js'
+import { processAlive, runtimeDiscoveryDirectory } from '../../../kun/src/cli/shared-runtime-support.js'
+import { withRuntimeDataDirAncillaryWriter } from '../../../kun/src/server/runtime-data-dir-lease.js'
+import { unregisterRuntimeWithManager } from '../../../kun/src/manager/manager-client.js'
+import type {
+  KunHandoffOwnerReport,
+  KunHandoffProbeClassification,
+  KunInstalledBuildHandoffInput
+} from './kun-installed-build-handoff'
+import { KunHandoffError } from './kun-installed-build-handoff'
+import {
+  stopExactSharedRuntimeForReplacement,
+  type SharedRuntimeReplacementInspection
+} from './kun-serve-replacement'
+import {
+  stopServiceManagerForReplacement
+} from './kun-manager-replacement'
+import { processIdentity } from '../kun-process-ports'
+import { recordVerifiedForcedRuntimeOwner } from '../../../kun/src/manager/forced-runtime-recovery.js'
+import {
+  identityMatchesExpectedManager,
+  identityMatchesExpectedRuntime
+} from '../kun-process-identity'
+
+export type RuntimeOwner = {
+  dataDir: string
+  flavor: RuntimeFlavor
+  inspection: SharedRuntimeReplacementInspection
+}
+
+export type StaleRuntimeOwner = RuntimeOwner & {
+  source: 'discovery' | 'manager-slot'
+}
+
+export type HandoffDependencies = {
+  readManager: typeof readManagerHandoffDiscoveryStrict
+  readRuntime: typeof readRuntimeHandoffDiscoveryStrict
+  withManagerLock: <T>(controlDir: string, action: () => Promise<T>) => Promise<T>
+  stopRuntime: typeof stopExactSharedRuntimeForReplacement
+  stopManager: typeof stopServiceManagerForReplacement
+  processAlive: typeof processAlive
+  processIdentity: typeof processIdentity
+  removeRuntime: typeof removeRuntimeDiscovery
+  removeManager: typeof removeManagerDiscovery
+  withAncillaryWriter: typeof withRuntimeDataDirAncillaryWriter
+  unregisterRuntime: (input: {
+    manager: ManagerHandoffDiscoveryRecord
+    flavor: RuntimeFlavor
+    instanceId: string
+    fetch?: typeof fetch
+  }) => Promise<boolean>
+  recordForcedOwner: typeof recordVerifiedForcedRuntimeOwner
+  now: () => number
+}
+
+export type DiscoveredHandoffOwners = {
+  manager: ManagerHandoffDiscoveryRecord | null
+  runtimes: RuntimeOwner[]
+  staleManager: ManagerHandoffDiscoveryRecord | null
+  staleRuntimes: StaleRuntimeOwner[]
+  probeClassifications: KunHandoffProbeClassification[]
+}
+
+export const defaultDiscoveryDependencies: HandoffDependencies = {
+  readManager: readManagerHandoffDiscoveryStrict,
+  readRuntime: readRuntimeHandoffDiscoveryStrict,
+  withManagerLock: withManagerStartLock,
+  stopRuntime: stopExactSharedRuntimeForReplacement,
+  stopManager: stopServiceManagerForReplacement,
+  processAlive,
+  processIdentity,
+  removeRuntime: removeRuntimeDiscovery,
+  removeManager: removeManagerDiscovery,
+  withAncillaryWriter: withRuntimeDataDirAncillaryWriter,
+  unregisterRuntime: ({ manager, ...input }) => unregisterRuntimeWithManager({
+    manager: { discovery: manager as ManagerDiscoveryRecord },
+    ...input
+  }),
+  recordForcedOwner: recordVerifiedForcedRuntimeOwner,
+  now: Date.now
+}
+
+export async function discoverHandoffOwnersSafely(
+  input: KunInstalledBuildHandoffInput,
+  deps: HandoffDependencies
+): Promise<DiscoveredHandoffOwners> {
+  try {
+    return await discoverHandoffOwners(input, deps)
+  } catch (error) {
+    if (error instanceof KunHandoffError) throw error
+    throw new KunHandoffError(
+      'unsafe_scope',
+      'discover',
+      input.reason,
+      false,
+      undefined,
+      'Kun update handoff could not safely read Runtime or Service Manager discovery',
+      { cause: error }
+    )
+  }
+}
+
+async function discoverHandoffOwners(
+  input: KunInstalledBuildHandoffInput,
+  deps: HandoffDependencies
+): Promise<DiscoveredHandoffOwners> {
+  const controlDir = input.controlDir ?? defaultKunControlDir()
+  const managerRecord = await deps.readManager(controlDir)
+  if (managerRecord && input.settingsPath &&
+    !sameCanonicalPath(managerRecord.settingsPath, input.settingsPath)) {
+    throw new KunHandoffError(
+      'unsafe_scope',
+      'discover',
+      input.reason,
+      false,
+      managerOwnerReport(managerRecord),
+      'Kun Service Manager owns a different canonical settings scope'
+    )
+  }
+  const managerState = managerRecord
+    ? await managerProcessState(managerRecord, input, deps)
+    : 'dead'
+  const manager = managerState === 'live' ? managerRecord : null
+  const staleManager = managerState === 'stale' ? managerRecord : null
+  const dataDirs = canonicalDataDirs([
+    ...input.dataDirs,
+    ...(managerRecord ? [managerRecord.dataDir] : [])
+  ])
+  const runtimes: RuntimeOwner[] = []
+  const staleRuntimes: StaleRuntimeOwner[] = []
+  for (const dataDir of dataDirs) {
+    const record = await deps.readRuntime(dataDir, 'production')
+    if (!record) continue
+    const state = await runtimeProcessState(dataDir, 'production', record, input, deps)
+    if (state === 'live') runtimes.push(runtimeOwner(dataDir, 'production', record))
+    else if (state === 'stale') {
+      staleRuntimes.push({ ...runtimeOwner(dataDir, 'production', record), source: 'discovery' })
+    }
+  }
+  const developmentDir = managerRecord?.dataDir ?? dataDirs[0]
+  if (developmentDir) {
+    const record = await deps.readRuntime(controlDir, 'development')
+    if (record) {
+      const state = await runtimeProcessState(
+        developmentDir,
+        'development',
+        record,
+        input,
+        deps
+      )
+      if (state === 'live') runtimes.push(runtimeOwner(developmentDir, 'development', record))
+      else if (state === 'stale') {
+        staleRuntimes.push({
+          ...runtimeOwner(developmentDir, 'development', record),
+          source: 'discovery'
+        })
+      }
+    }
+  }
+  const probeClassifications: KunHandoffProbeClassification[] = []
+  if (runtimes.length > 0) probeClassifications.push('runtime-discovery-compatible')
+  if (manager) probeClassifications.push('manager-discovery-compatible')
+  if (manager) {
+    const managerStatus = await readCompatibleManagerSlots(manager, input.fetch ?? fetch)
+    probeClassifications.push(managerStatus.classification)
+    for (const slot of managerStatus.records) {
+      const state = await runtimeProcessState(manager.dataDir, slot.flavor, slot, input, deps)
+      if (state === 'live') runtimes.push(runtimeOwner(manager.dataDir, slot.flavor, slot))
+      else if (state === 'stale') {
+        staleRuntimes.push({
+          ...runtimeOwner(manager.dataDir, slot.flavor, slot),
+          source: 'manager-slot'
+        })
+      }
+    }
+  }
+  if (staleManager || staleRuntimes.length > 0) probeClassifications.push('stale-owner')
+  if (probeClassifications.length === 0) probeClassifications.push('no-live-owner')
+  return {
+    manager,
+    runtimes: deduplicateRuntimeOwners(runtimes),
+    staleManager,
+    staleRuntimes,
+    probeClassifications
+  }
+}
+
+type ProcessOwnerState = 'dead' | 'live' | 'stale'
+
+async function runtimeProcessState(
+  dataDir: string,
+  flavor: RuntimeFlavor,
+  record: RuntimeHandoffDiscoveryRecord,
+  input: KunInstalledBuildHandoffInput,
+  deps: HandoffDependencies
+): Promise<ProcessOwnerState> {
+  if (!deps.processAlive(record.pid)) return 'dead'
+  const identity = await deps.processIdentity(record.pid).catch(() => null)
+  if (!identity || identity.startedAtMs === null ||
+    (process.platform === 'win32' && !identity.executablePath)) {
+    const owner = runtimeOwnerReport(runtimeOwner(dataDir, flavor, record))
+    throw new KunHandoffError(
+      'probe_failed',
+      'discover',
+      input.reason,
+      true,
+      owner,
+      `Kun could not verify the process identity for ${ownerLabel(owner)}`
+    )
+  }
+  return identityMatchesExpectedRuntime(identity, record, dataDir, flavor) ? 'live' : 'stale'
+}
+
+async function managerProcessState(
+  record: ManagerHandoffDiscoveryRecord,
+  input: KunInstalledBuildHandoffInput,
+  deps: HandoffDependencies
+): Promise<ProcessOwnerState> {
+  if (!deps.processAlive(record.pid)) return 'dead'
+  const identity = await deps.processIdentity(record.pid).catch(() => null)
+  if (!identity || identity.startedAtMs === null ||
+    (process.platform === 'win32' && !identity.executablePath)) {
+    const owner = managerOwnerReport(record)
+    throw new KunHandoffError(
+      'probe_failed',
+      'discover',
+      input.reason,
+      true,
+      owner,
+      `Kun could not verify the process identity for ${ownerLabel(owner)}`
+    )
+  }
+  return identityMatchesExpectedManager(identity, record) ? 'live' : 'stale'
+}
+
+export async function settleStaleHandoffOwners(
+  input: KunInstalledBuildHandoffInput,
+  discovered: Pick<
+    DiscoveredHandoffOwners,
+    'manager' | 'staleManager' | 'staleRuntimes' | 'probeClassifications'
+  >,
+  deps: HandoffDependencies
+): Promise<void> {
+  const controlDir = input.controlDir ?? defaultKunControlDir()
+  if (discovered.manager &&
+    discovered.probeClassifications.includes('manager-status-unavailable')) {
+    throw new KunHandoffError(
+      'probe_failed',
+      'discover',
+      input.reason,
+      true,
+      managerOwnerReport(discovered.manager),
+      'Kun could not verify Service Manager Runtime ownership before handoff'
+    )
+  }
+  try {
+    for (const runtime of discovered.staleRuntimes) {
+      const record = runtime.inspection.discovery
+      if (runtime.source === 'manager-slot' && discovered.manager) {
+        const removed = await deps.unregisterRuntime({
+          manager: discovered.manager,
+          flavor: runtime.flavor,
+          instanceId: record.instanceId,
+          ...(input.fetch ? { fetch: input.fetch } : {})
+        })
+        if (!removed) {
+          await proveManagerSlotConverged(
+            input,
+            discovered.manager,
+            runtime,
+            deps
+          )
+        }
+        continue
+      }
+      const discoveryDir = runtimeDiscoveryDirectory(runtime.dataDir, runtime.flavor, controlDir)
+      const remove = () => deps.removeRuntime(discoveryDir, record.instanceId, runtime.flavor)
+      if (runtime.flavor === 'production') await deps.withAncillaryWriter(runtime.dataDir, remove)
+      else await remove()
+    }
+    if (discovered.staleManager) {
+      await deps.removeManager(controlDir, discovered.staleManager.instanceId)
+    }
+  } catch (error) {
+    if (error instanceof KunHandoffError) throw error
+    throw new KunHandoffError(
+      'probe_failed',
+      'discover',
+      input.reason,
+      true,
+      undefined,
+      'Kun found stale handoff records but could not safely clean them up',
+      { cause: error }
+    )
+  }
+}
+
+async function proveManagerSlotConverged(
+  input: KunInstalledBuildHandoffInput,
+  manager: ManagerHandoffDiscoveryRecord,
+  stale: StaleRuntimeOwner,
+  deps: HandoffDependencies
+): Promise<void> {
+  const status = await readCompatibleManagerSlots(manager, input.fetch ?? fetch)
+  const owner = runtimeOwnerReport(stale)
+  if (status.classification === 'manager-status-unavailable') {
+    throw new KunHandoffError(
+      'probe_failed',
+      'discover',
+      input.reason,
+      true,
+      owner,
+      `Kun could not verify cleanup of ${ownerLabel(owner)}`
+    )
+  }
+  const oldOwnerRemains = status.records.some((record) =>
+    record.flavor === stale.flavor &&
+    record.instanceId === stale.inspection.discovery.instanceId &&
+    record.pid === stale.inspection.discovery.pid &&
+    record.startedAt === stale.inspection.discovery.startedAt
+  )
+  if (oldOwnerRemains) {
+    throw new KunHandoffError(
+      'probe_failed',
+      'discover',
+      input.reason,
+      true,
+      owner,
+      `Kun Service Manager still reports stale ${ownerLabel(owner)}`
+    )
+  }
+}
+
+const RuntimeSlotSchema = z.object({
+  flavor: z.enum(['production', 'development']),
+  instanceId: z.string().min(1).max(256),
+  pid: z.number().int().positive(),
+  startedAt: z.string().datetime(),
+  host: z.string().min(1).max(512),
+  port: z.number().int().min(1).max(65_535),
+  baseUrl: z.string().url().max(2_048),
+  runtimeToken: z.string().max(16_384),
+  buildId: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+  logPath: z.string().min(1).max(4_096).optional()
+}).passthrough()
+
+async function readCompatibleManagerSlots(
+  manager: ManagerHandoffDiscoveryRecord,
+  fetchImpl: typeof fetch
+): Promise<{
+  records: Array<RuntimeHandoffDiscoveryRecord & { flavor: RuntimeFlavor }>
+  classification: Extract<
+    KunHandoffProbeClassification,
+    'manager-status-compatible' | 'manager-status-unavailable'
+  >
+}> {
+  try {
+    const response = await fetchImpl(`${manager.baseUrl.replace(/\/$/u, '')}/v1/manager/status`, {
+      headers: { authorization: `Bearer ${manager.managerToken}` },
+      signal: AbortSignal.timeout(2_000)
+    })
+    if (!response.ok) return { records: [], classification: 'manager-status-unavailable' }
+    const body = z.object({
+      instanceId: z.string(),
+      pid: z.number().int().positive().optional(),
+      startedAt: z.string(),
+      slots: z.array(z.unknown())
+    }).passthrough().safeParse(await response.json())
+    if (!body.success || body.data.instanceId !== manager.instanceId ||
+      body.data.startedAt !== manager.startedAt ||
+      (body.data.pid !== undefined && body.data.pid !== manager.pid)) {
+      return { records: [], classification: 'manager-status-unavailable' }
+    }
+    const records: Array<RuntimeHandoffDiscoveryRecord & { flavor: RuntimeFlavor }> = []
+    for (const value of body.data.slots) {
+      const envelope = z.object({ registration: z.unknown() }).passthrough().safeParse(value)
+      const parsed = RuntimeSlotSchema.safeParse(envelope.success ? envelope.data.registration : value)
+      if (!parsed.success) return { records: [], classification: 'manager-status-unavailable' }
+      const record: RuntimeHandoffDiscoveryRecord & { flavor: RuntimeFlavor } = {
+        version: 1,
+        ...parsed.data,
+        flavor: parsed.data.flavor
+      }
+      if (!isSafeRuntimeHandoffDiscovery(record)) {
+        return { records: [], classification: 'manager-status-unavailable' }
+      }
+      records.push(record)
+    }
+    return { records, classification: 'manager-status-compatible' }
+  } catch {
+    return { records: [], classification: 'manager-status-unavailable' }
+  }
+}
+
+function runtimeOwner(
+  dataDir: string,
+  flavor: RuntimeFlavor,
+  record: RuntimeHandoffDiscoveryRecord
+): RuntimeOwner {
+  return { dataDir, flavor, inspection: { discovery: record, connection: null } }
+}
+
+function deduplicateRuntimeOwners(owners: RuntimeOwner[]): RuntimeOwner[] {
+  const seen = new Set<string>()
+  return owners.filter((owner) => {
+    const record = owner.inspection.discovery
+    const key = `${record.instanceId}:${record.pid}:${record.startedAt}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function canonicalDataDirs(values: readonly string[]): string[] {
+  const result: string[] = []
+  for (const value of values) {
+    if (!value.trim() || result.some((current) => sameCanonicalPath(current, value))) continue
+    result.push(resolve(value))
+  }
+  return result
+}
+
+export function sameRuntimeIdentity(left: RuntimeOwner, right: RuntimeOwner): boolean {
+  const a = left.inspection.discovery
+  const b = right.inspection.discovery
+  return left.flavor === right.flavor && a.instanceId === b.instanceId &&
+    a.pid === b.pid && a.startedAt === b.startedAt
+}
+
+export function runtimeOwnerReport(runtime: RuntimeOwner): Omit<KunHandoffOwnerReport, 'result'> {
+  const record = runtime.inspection.discovery
+  return {
+    kind: 'runtime',
+    flavor: runtime.flavor,
+    instanceId: record.instanceId,
+    pid: record.pid,
+    port: record.port,
+    ...(record.buildId ? { buildId: record.buildId } : {})
+  }
+}
+
+export function managerOwnerReport(
+  manager: ManagerHandoffDiscoveryRecord
+): Omit<KunHandoffOwnerReport, 'result'> {
+  return {
+    kind: 'manager',
+    instanceId: manager.instanceId,
+    pid: manager.pid,
+    port: manager.port,
+    ...(manager.buildId ? { buildId: manager.buildId } : {})
+  }
+}
+
+function ownerLabel(owner: Omit<KunHandoffOwnerReport, 'result'>): string {
+  return owner.kind === 'runtime'
+    ? `${owner.flavor ?? 'unknown'} Runtime${owner.pid ? ` ${owner.pid}` : ''}`
+    : `Service Manager${owner.pid ? ` ${owner.pid}` : ''}`
+}

--- a/src/main/runtime/kun-installed-build-handoff-stale.test.ts
+++ b/src/main/runtime/kun-installed-build-handoff-stale.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ManagerHandoffDiscoveryRecord } from '../../../kun/src/manager/manager-discovery.js'
+import type { RuntimeHandoffDiscoveryRecord } from '../../../kun/src/server/runtime-discovery.js'
+import {
+  drainKunOwnersForHandoff,
+  KunHandoffError
+} from './kun-installed-build-handoff'
+
+const controlDir = '/tmp/kun-control'
+const dataDir = '/tmp/kun-data'
+const settingsPath = '/tmp/Kun/kun-settings.json'
+
+function manager(): ManagerHandoffDiscoveryRecord {
+  return {
+    version: 7,
+    protocolVersion: 3,
+    instanceId: 'manager-old',
+    pid: 900,
+    startedAt: '2026-08-21T00:00:00.000Z',
+    host: '127.0.0.1',
+    port: 43000,
+    baseUrl: 'http://127.0.0.1:43000',
+    managerToken: 'manager-secret',
+    dataDir,
+    settingsPath
+  }
+}
+
+function runtime(
+  overrides: Partial<RuntimeHandoffDiscoveryRecord> = {}
+): RuntimeHandoffDiscoveryRecord {
+  return {
+    version: 1,
+    instanceId: 'production-old',
+    pid: 901,
+    startedAt: '2026-08-21T00:00:00.000Z',
+    host: '127.0.0.1',
+    port: 43001,
+    baseUrl: 'http://127.0.0.1:43001',
+    runtimeToken: 'production-secret',
+    ...overrides
+  }
+}
+
+function input(fetchImpl?: typeof fetch) {
+  return {
+    reason: 'installed-build-change' as const,
+    dataDirs: [dataDir],
+    settingsPath,
+    controlDir,
+    targetBuildId: 'b'.repeat(64),
+    ...(fetchImpl ? { fetch: fetchImpl } : {})
+  }
+}
+
+function identityFor(record: { pid: number; startedAt: string }, commandLine: string) {
+  return {
+    pid: record.pid,
+    commandLine,
+    executablePath: 'C:\\Program Files\\nodejs\\node.exe',
+    startedAtMs: Date.parse(record.startedAt)
+  }
+}
+
+function statusResponse(
+  owner: ManagerHandoffDiscoveryRecord,
+  slot: RuntimeHandoffDiscoveryRecord | null
+): Response {
+  return Response.json({
+    instanceId: owner.instanceId,
+    pid: owner.pid,
+    startedAt: owner.startedAt,
+    slots: slot ? [{ registration: { ...slot, flavor: 'production' } }] : []
+  })
+}
+
+describe('installed build handoff stale ownership convergence', () => {
+  it('fails closed when Manager unregister transport fails', async () => {
+    const currentManager = manager()
+    const staleSlot = runtime({ pid: 12948 })
+    const stopRuntime = vi.fn()
+    const stopManager = vi.fn()
+    const failure = await drainKunOwnersForHandoff(
+      input(vi.fn(async () => statusResponse(currentManager, staleSlot)) as unknown as typeof fetch),
+      {
+        withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => action(),
+        readManager: async () => currentManager,
+        readRuntime: async () => null,
+        processAlive: () => true,
+        processIdentity: async (pid) => pid === currentManager.pid
+          ? identityFor(currentManager, 'kun-service-manager')
+          : identityFor(staleSlot, 'C:\\Windows\\System32\\unrelated.exe'),
+        unregisterRuntime: async () => { throw new Error('connection refused') },
+        stopRuntime: stopRuntime as never,
+        stopManager: stopManager as never
+      }
+    ).catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(KunHandoffError)
+    expect(failure).toMatchObject({ code: 'probe_failed', retryable: true })
+    expect((failure as Error).cause).toBeInstanceOf(Error)
+    expect(stopRuntime).not.toHaveBeenCalled()
+    expect(stopManager).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when unregister returns false and the exact old slot remains', async () => {
+    const currentManager = manager()
+    const staleSlot = runtime({ pid: 12948 })
+    const stopRuntime = vi.fn()
+    const stopManager = vi.fn()
+    const failure = await drainKunOwnersForHandoff(
+      input(vi.fn(async () => statusResponse(currentManager, staleSlot)) as unknown as typeof fetch),
+      {
+        withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => action(),
+        readManager: async () => currentManager,
+        readRuntime: async () => null,
+        processAlive: () => true,
+        processIdentity: async (pid) => pid === currentManager.pid
+          ? identityFor(currentManager, 'kun-service-manager')
+          : identityFor(staleSlot, 'unrelated.exe'),
+        unregisterRuntime: async () => false,
+        stopRuntime: stopRuntime as never,
+        stopManager: stopManager as never
+      }
+    ).catch((error: unknown) => error)
+
+    expect(failure).toMatchObject({ code: 'probe_failed', retryable: true })
+    expect(stopRuntime).not.toHaveBeenCalled()
+    expect(stopManager).not.toHaveBeenCalled()
+  })
+
+  it('accepts false only after status proves the old slot disappeared', async () => {
+    const currentManager = manager()
+    const staleSlot = runtime({ pid: 12948 })
+    let currentSlot: RuntimeHandoffDiscoveryRecord | null = staleSlot
+    let managerAlive = true
+    const unregisterRuntime = vi.fn(async () => {
+      currentSlot = null
+      return false
+    })
+    const stopManager = vi.fn(async () => {
+      managerAlive = false
+      return { stopped: true, forced: false }
+    })
+    const fetchMock = vi.fn(async () => statusResponse(currentManager, currentSlot))
+
+    await expect(drainKunOwnersForHandoff(
+      input(fetchMock as unknown as typeof fetch),
+      {
+        withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => action(),
+        readManager: async () => managerAlive ? currentManager : null,
+        readRuntime: async () => null,
+        processAlive: (pid) => managerAlive && pid === currentManager.pid || pid === staleSlot.pid,
+        processIdentity: async (pid) => pid === currentManager.pid
+          ? identityFor(currentManager, 'kun-service-manager')
+          : identityFor(staleSlot, 'unrelated.exe'),
+        unregisterRuntime,
+        stopRuntime: vi.fn() as never,
+        stopManager: stopManager as never
+      }
+    )).resolves.toMatchObject({ reason: 'installed-build-change' })
+
+    expect(unregisterRuntime).toHaveBeenCalledOnce()
+    expect(stopManager).toHaveBeenCalledOnce()
+  })
+
+  it('preserves and then drains a replacement slot when false means ownership changed', async () => {
+    const currentManager = manager()
+    const staleSlot = runtime({ pid: 12948 })
+    const replacement = runtime({
+      instanceId: 'production-replacement',
+      pid: 903,
+      startedAt: '2026-08-21T00:01:00.000Z',
+      port: 43003,
+      baseUrl: 'http://127.0.0.1:43003',
+      runtimeToken: 'replacement-secret'
+    })
+    let currentSlot: RuntimeHandoffDiscoveryRecord | null = staleSlot
+    let managerAlive = true
+    const unregisterRuntime = vi.fn(async () => {
+      currentSlot = replacement
+      return false
+    })
+    const stopRuntime = vi.fn(async (
+      _dir: string,
+      target: { discovery: RuntimeHandoffDiscoveryRecord }
+    ) => {
+      expect(target.discovery.instanceId).toBe(replacement.instanceId)
+      currentSlot = null
+      return { stopped: true, forced: false }
+    })
+    const fetchMock = vi.fn(async () => statusResponse(currentManager, currentSlot))
+
+    await drainKunOwnersForHandoff(input(fetchMock as unknown as typeof fetch), {
+      withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => action(),
+      readManager: async () => managerAlive ? currentManager : null,
+      readRuntime: async () => null,
+      processAlive: (pid) => managerAlive && pid === currentManager.pid || currentSlot?.pid === pid,
+      processIdentity: async (pid) => {
+        if (pid === currentManager.pid) return identityFor(currentManager, 'kun-service-manager')
+        if (pid === replacement.pid) return identityFor(replacement, 'kun-runtime')
+        return identityFor(staleSlot, 'unrelated.exe')
+      },
+      unregisterRuntime,
+      stopRuntime: stopRuntime as never,
+      stopManager: (async () => {
+        managerAlive = false
+        return { stopped: true, forced: false }
+      }) as never
+    })
+
+    expect(unregisterRuntime).toHaveBeenCalledOnce()
+    expect(unregisterRuntime).toHaveBeenCalledWith(expect.objectContaining({
+      instanceId: staleSlot.instanceId
+    }))
+    expect(stopRuntime).toHaveBeenCalledOnce()
+  })
+
+  it('fails closed when Manager status cannot be verified', async () => {
+    const currentManager = manager()
+    const stopManager = vi.fn()
+    const failure = await drainKunOwnersForHandoff(
+      input(vi.fn(async () => new Response(null, { status: 503 })) as unknown as typeof fetch),
+      {
+        withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => action(),
+        readManager: async () => currentManager,
+        readRuntime: async () => null,
+        processAlive: () => true,
+        processIdentity: async () => identityFor(currentManager, 'kun-service-manager'),
+        stopRuntime: vi.fn() as never,
+        stopManager: stopManager as never
+      }
+    ).catch((error: unknown) => error)
+
+    expect(failure).toMatchObject({ code: 'probe_failed', retryable: true })
+    expect(stopManager).not.toHaveBeenCalled()
+  })
+
+  it('does not delete a replacement discovery that wins the cleanup race', async () => {
+    const stale = runtime({ pid: 12948 })
+    const replacement = runtime({
+      instanceId: 'production-replacement',
+      pid: 903,
+      startedAt: '2026-08-21T00:01:00.000Z'
+    })
+    let current: RuntimeHandoffDiscoveryRecord | null = stale
+    const removeRuntime = vi.fn(async (_dir, instanceId) => {
+      expect(instanceId).toBe(stale.instanceId)
+      current = replacement
+      return false
+    })
+    const stopRuntime = vi.fn(async (
+      _dir: string,
+      target: { discovery: RuntimeHandoffDiscoveryRecord }
+    ) => {
+      expect(target.discovery.instanceId).toBe(replacement.instanceId)
+      current = null
+      return { stopped: true, forced: false }
+    })
+
+    await drainKunOwnersForHandoff(input(), {
+      withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => action(),
+      readManager: async () => null,
+      readRuntime: async (_dir, flavor) => flavor === 'production' ? current : null,
+      processAlive: (pid) => current?.pid === pid,
+      processIdentity: async (pid) => current === replacement
+        ? identityFor(replacement, 'kun-runtime')
+        : { ...identityFor(stale, 'unrelated.exe'), pid },
+      removeRuntime,
+      withAncillaryWriter: async <T>(_dir: string, action: () => Promise<T>) => action(),
+      stopRuntime: stopRuntime as never,
+      stopManager: vi.fn() as never
+    })
+
+    expect(removeRuntime).toHaveBeenCalledOnce()
+    expect(stopRuntime).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/runtime/kun-installed-build-handoff.test.ts
+++ b/src/main/runtime/kun-installed-build-handoff.test.ts
@@ -19,6 +19,17 @@ const controlDir = '/tmp/kun-control'
 const dataDir = '/tmp/kun-data'
 const settingsPath = '/tmp/Kun/kun-settings.json'
 
+async function processIdentityFor(pid: number) {
+  return {
+    pid,
+    commandLine: pid === 900
+      ? 'kun-service-manager'
+      : pid === 902 ? 'kun-dv-runtime' : 'kun-runtime',
+    executablePath: 'C:\\Program Files\\nodejs\\node.exe',
+    startedAtMs: Date.parse('2026-08-21T00:00:00.000Z')
+  }
+}
+
 function manager(
   overrides: Partial<ManagerHandoffDiscoveryRecord> = {}
 ): ManagerHandoffDiscoveryRecord {
@@ -68,6 +79,153 @@ function input(overrides: { dataDirs?: string[] } = {}) {
 }
 
 describe('installed build handoff coordinator', () => {
+  it('clears a recycled Runtime PID under the Manager lock without stopping the process', async () => {
+    const stale = runtime('production', { pid: 12948 })
+    let current: RuntimeHandoffDiscoveryRecord | null = stale
+    let lockHeld = false
+    const stopRuntime = vi.fn()
+    const removeRuntime = vi.fn(async (_dir, instanceId) => {
+      expect(lockHeld).toBe(true)
+      expect(instanceId).toBe(stale.instanceId)
+      current = null
+      return true
+    })
+    const overrides = {
+      withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => {
+        lockHeld = true
+        try { return await action() } finally { lockHeld = false }
+      },
+      readManager: async () => null,
+      readRuntime: async (_dir: string, flavor?: 'production' | 'development') =>
+        flavor === 'production' ? current : null,
+      processAlive: (pid: number) => pid === stale.pid,
+      processIdentity: async (pid: number) => ({
+        pid,
+        commandLine: 'C:\\Windows\\System32\\SNAPOS64.exe',
+        executablePath: 'C:\\Windows\\System32\\SNAPOS64.exe',
+        startedAtMs: Date.parse(stale.startedAt) + 120_000
+      }),
+      withAncillaryWriter: async <T>(_dir: string, action: () => Promise<T>) => action(),
+      removeRuntime,
+      stopRuntime: stopRuntime as never,
+      stopManager: vi.fn() as never
+    }
+
+    await expect(probeInstalledBuildHandoff(input(), overrides)).resolves.toBe('mismatched')
+    expect(removeRuntime).not.toHaveBeenCalled()
+
+    await expect(drainKunOwnersForHandoff(input(), overrides)).resolves.toMatchObject({
+      owners: expect.arrayContaining([
+        expect.objectContaining({ kind: 'runtime', flavor: 'production', result: 'not-found' })
+      ])
+    })
+    expect(removeRuntime).toHaveBeenCalledOnce()
+    expect(stopRuntime).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a live Runtime PID cannot be inspected', async () => {
+    const target = runtime('production')
+    const removeRuntime = vi.fn()
+    const failure = await probeInstalledBuildHandoff(input(), {
+      readManager: async () => null,
+      readRuntime: async (_dir, flavor) => flavor === 'production' ? target : null,
+      processAlive: () => true,
+      processIdentity: async () => null,
+      removeRuntime,
+      stopRuntime: vi.fn() as never,
+      stopManager: vi.fn() as never
+    }).catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(KunHandoffError)
+    expect(failure).toMatchObject({ code: 'probe_failed', phase: 'discover', retryable: true })
+    expect(removeRuntime).not.toHaveBeenCalled()
+  })
+
+  it('clears a recycled Manager PID without stopping the unrelated process', async () => {
+    const stale = manager({ pid: 12948 })
+    let current: ManagerHandoffDiscoveryRecord | null = stale
+    let lockHeld = false
+    const stopManager = vi.fn()
+    const removeManager = vi.fn(async (_dir, instanceId) => {
+      expect(lockHeld).toBe(true)
+      expect(instanceId).toBe(stale.instanceId)
+      current = null
+      return true
+    })
+    const overrides = {
+      withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => {
+        lockHeld = true
+        try { return await action() } finally { lockHeld = false }
+      },
+      readManager: async () => current,
+      readRuntime: async () => null,
+      processAlive: (pid: number) => pid === stale.pid,
+      processIdentity: async (pid: number) => ({
+        pid,
+        commandLine: 'C:\\Windows\\System32\\SNAPOS64.exe',
+        executablePath: 'C:\\Windows\\System32\\SNAPOS64.exe',
+        startedAtMs: Date.parse(stale.startedAt) + 120_000
+      }),
+      removeManager,
+      stopRuntime: vi.fn() as never,
+      stopManager: stopManager as never
+    }
+
+    await drainKunOwnersForHandoff(input(), overrides)
+    expect(removeManager).toHaveBeenCalledOnce()
+    expect(stopManager).not.toHaveBeenCalled()
+  })
+
+  it('unregisters a recycled Manager slot without stopping its unrelated PID', async () => {
+    const currentManager = manager()
+    const staleSlot = runtime('production', { pid: 12948 })
+    let managerAlive = true
+    let currentSlot: RuntimeHandoffDiscoveryRecord | null = staleSlot
+    const stopRuntime = vi.fn()
+    const unregisterRuntime = vi.fn(async () => {
+      currentSlot = null
+      return true
+    })
+    const fetchMock = vi.fn(async () => Response.json({
+      instanceId: currentManager.instanceId,
+      pid: currentManager.pid,
+      startedAt: currentManager.startedAt,
+      slots: currentSlot
+        ? [{ registration: { ...currentSlot, flavor: 'production' } }]
+        : []
+    }))
+
+    await drainKunOwnersForHandoff({
+      ...input(),
+      fetch: fetchMock as unknown as typeof fetch
+    }, {
+      withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => action(),
+      readManager: async () => managerAlive ? currentManager : null,
+      readRuntime: async () => null,
+      processAlive: (pid) => pid === staleSlot.pid || managerAlive && pid === currentManager.pid,
+      processIdentity: async (pid) => pid === currentManager.pid
+        ? processIdentityFor(pid)
+        : {
+            pid,
+            commandLine: 'C:\\Windows\\System32\\SNAPOS64.exe',
+            executablePath: 'C:\\Windows\\System32\\SNAPOS64.exe',
+            startedAtMs: Date.parse(staleSlot.startedAt) + 120_000
+          },
+      unregisterRuntime,
+      stopRuntime: stopRuntime as never,
+      stopManager: (async () => {
+        managerAlive = false
+        return { stopped: true, forced: false }
+      }) as never
+    })
+
+    expect(unregisterRuntime).toHaveBeenCalledWith(expect.objectContaining({
+      flavor: 'production',
+      instanceId: staleSlot.instanceId
+    }))
+    expect(stopRuntime).not.toHaveBeenCalled()
+  })
+
   it('drains both Runtime flavors and an older-schema Manager under one lock', async () => {
     const currentManager = manager()
     const currentRuntimes = new Map([
@@ -112,6 +270,7 @@ describe('installed build handoff coordinator', () => {
       readRuntime: async (_dir, flavor) => currentRuntimes.get(flavor ?? 'production') ?? null,
       processAlive: (pid) => managerAlive && pid === currentManager.pid ||
         [...currentRuntimes.values()].some((record) => record.pid === pid),
+      processIdentity: processIdentityFor,
       recordForcedOwner: vi.fn(async () => ({ markerId: 'marker' })) as never,
       stopRuntime: stopRuntime as never,
       stopManager: stopManager as never,
@@ -151,6 +310,7 @@ describe('installed build handoff coordinator', () => {
       readManager: async () => managerAlive ? currentManager : null,
       readRuntime: async () => null,
       processAlive: (pid) => pid === slot.pid ? runtimeAlive : managerAlive,
+      processIdentity: processIdentityFor,
       stopRuntime: stopRuntime as never,
       stopManager: (async () => {
         managerAlive = false
@@ -178,6 +338,7 @@ describe('installed build handoff coordinator', () => {
       readManager: async () => null,
       readRuntime: async (_dir, flavor) => flavor === 'production' ? current : null,
       processAlive: (pid) => current?.pid === pid,
+      processIdentity: processIdentityFor,
       stopRuntime: (async (_dir: string, target: { discovery: RuntimeHandoffDiscoveryRecord }) => {
         stopped.push(target.discovery.instanceId)
         current = target.discovery.instanceId === first.instanceId ? second : null
@@ -218,6 +379,7 @@ describe('installed build handoff coordinator', () => {
         readRuntime: async (dir, flavor) =>
           flavor === 'production' ? runtimes.get(dir) ?? null : null,
         processAlive: (pid) => [...runtimes.values()].some((entry) => entry.pid === pid),
+        processIdentity: processIdentityFor,
         recordForcedOwner: recordVerifiedForcedRuntimeOwner,
         stopRuntime: (async (dir: string, target: { discovery: RuntimeHandoffDiscoveryRecord }) => {
           stopped.push([dir, target.discovery.instanceId])
@@ -265,6 +427,7 @@ describe('installed build handoff coordinator', () => {
       readRuntime: async () => null,
       processAlive: (pid: number) =>
         pid === slot.pid ? runtimeAlive : pid === currentManager.pid && managerAlive,
+      processIdentity: processIdentityFor,
       stopRuntime: stopRuntime as never,
       stopManager: vi.fn(async () => {
         managerAlive = false
@@ -300,6 +463,7 @@ describe('installed build handoff coordinator', () => {
       readManager: async () => currentManager,
       readRuntime: async () => null,
       processAlive: (pid) => pid === currentManager.pid || pid === slot.pid,
+      processIdentity: processIdentityFor,
       stopRuntime: vi.fn() as never,
       stopManager: vi.fn() as never
     })).resolves.toBe('matched')
@@ -313,6 +477,7 @@ describe('installed build handoff coordinator', () => {
       readRuntime: async (_dir: string, flavor?: 'production' | 'development') =>
         flavor === 'production' ? legacyRuntime : null,
       processAlive: (pid: number) => pid === legacyManager.pid || pid === legacyRuntime.pid,
+      processIdentity: processIdentityFor,
       stopRuntime: vi.fn() as never,
       stopManager: vi.fn() as never
     }
@@ -358,6 +523,7 @@ describe('installed build handoff coordinator', () => {
       readManager: async () => manager({ settingsPath: '/tmp/Other/settings.json' }),
       readRuntime: async () => null,
       processAlive: () => true,
+      processIdentity: processIdentityFor,
       stopRuntime: stopRuntime as never,
       stopManager: stopManager as never
     }).catch((error: unknown) => error)
@@ -370,12 +536,23 @@ describe('installed build handoff coordinator', () => {
 
   it('wraps an ambiguous Runtime failure and preserves the Manager', async () => {
     const target = runtime('production')
+    const currentManager = manager()
     const stopManager = vi.fn()
-    const failure = await drainKunOwnersForHandoff(input(), {
+    const fetchMock = vi.fn(async () => Response.json({
+      instanceId: currentManager.instanceId,
+      pid: currentManager.pid,
+      startedAt: currentManager.startedAt,
+      slots: []
+    }))
+    const failure = await drainKunOwnersForHandoff({
+      ...input(),
+      fetch: fetchMock as unknown as typeof fetch
+    }, {
       withManagerLock: async <T>(_dir: string, action: () => Promise<T>) => action(),
-      readManager: async () => manager(),
+      readManager: async () => currentManager,
       readRuntime: async (_dir, flavor) => flavor === 'production' ? target : null,
       processAlive: () => true,
+      processIdentity: processIdentityFor,
       stopRuntime: (async () => { throw new Error('identity proof failed') }) as never,
       stopManager: stopManager as never
     }).catch((error: unknown) => error)

--- a/src/main/runtime/kun-installed-build-handoff.ts
+++ b/src/main/runtime/kun-installed-build-handoff.ts
@@ -1,35 +1,30 @@
-import { resolve } from 'node:path'
-import { z } from 'zod'
 import type { RuntimeFlavor } from '../../../kun/src/contracts/runtime-flavor.js'
 import {
-  isSafeRuntimeHandoffDiscovery,
-  readRuntimeHandoffDiscoveryStrict,
-  type RuntimeHandoffDiscoveryRecord
-} from '../../../kun/src/server/runtime-discovery.js'
-import {
   defaultKunControlDir,
-  readManagerHandoffDiscoveryStrict,
-  withManagerStartLock,
-  type ManagerHandoffDiscoveryRecord
+  withManagerStartLock
 } from '../../../kun/src/manager/manager-discovery.js'
-import { sameCanonicalPath } from '../../../kun/src/manager/canonical-path.js'
-import { processAlive, runtimeDiscoveryDirectory } from '../../../kun/src/cli/shared-runtime-support.js'
 import { runtimeBuildIdForFlavor } from '../../../kun/src/cli/runtime-flavor.js'
 import {
-  stopExactSharedRuntimeForReplacement,
-  type KunServeReplacementReport,
-  type SharedRuntimeReplacementInspection
+  type KunServeReplacementReport
 } from './kun-serve-replacement'
-import {
-  stopServiceManagerForReplacement,
-  type KunManagerReplacementReport
-} from './kun-manager-replacement'
+import { type KunManagerReplacementReport } from './kun-manager-replacement'
 import { KunOwnerVerificationError } from './kun-replacement-error'
 import { recordVerifiedForcedRuntimeOwner } from '../../../kun/src/manager/forced-runtime-recovery.js'
+import {
+  defaultDiscoveryDependencies,
+  discoverHandoffOwnersSafely,
+  managerOwnerReport,
+  runtimeOwnerReport,
+  sameRuntimeIdentity,
+  settleStaleHandoffOwners,
+  type DiscoveredHandoffOwners,
+  type HandoffDependencies,
+  type RuntimeOwner
+} from './kun-installed-build-handoff-discovery'
 
 const MANAGED_RUNTIME_FLAVORS = ['production', 'development'] as const
 const MAX_RUNTIME_DRAIN_PASSES = 3
-const STATUS_TIMEOUT_MS = 2_000
+const MAX_STALE_OWNER_SETTLEMENT_PASSES = 3
 
 export type KunInstalledBuildProbe = 'matched' | 'mismatched' | 'unknown'
 
@@ -56,6 +51,7 @@ export type KunHandoffErrorCode =
 
 export type KunHandoffProbeClassification =
   | 'no-live-owner'
+  | 'stale-owner'
   | 'runtime-discovery-compatible'
   | 'manager-discovery-compatible'
   | 'manager-status-compatible'
@@ -116,30 +112,9 @@ export type KunInstalledBuildHandoffInput = {
   onEvent?: (event: KunHandoffEvent) => void
 }
 
-type RuntimeOwner = {
-  dataDir: string
-  flavor: RuntimeFlavor
-  inspection: SharedRuntimeReplacementInspection
-}
-
-type HandoffDependencies = {
-  readManager: typeof readManagerHandoffDiscoveryStrict
-  readRuntime: typeof readRuntimeHandoffDiscoveryStrict
-  withManagerLock: <T>(controlDir: string, action: () => Promise<T>) => Promise<T>
-  stopRuntime: typeof stopExactSharedRuntimeForReplacement
-  stopManager: typeof stopServiceManagerForReplacement
-  processAlive: typeof processAlive
-  recordForcedOwner: typeof recordVerifiedForcedRuntimeOwner
-  now: () => number
-}
-
 const defaultDependencies: HandoffDependencies = {
-  readManager: readManagerHandoffDiscoveryStrict,
-  readRuntime: readRuntimeHandoffDiscoveryStrict,
+  ...defaultDiscoveryDependencies,
   withManagerLock: withManagerStartLock,
-  stopRuntime: stopExactSharedRuntimeForReplacement,
-  stopManager: stopServiceManagerForReplacement,
-  processAlive,
   recordForcedOwner: recordVerifiedForcedRuntimeOwner,
   now: Date.now
 }
@@ -158,6 +133,7 @@ export async function probeInstalledBuildHandoff(
   if (!input.targetBuildId) return 'unknown'
   const deps = { ...defaultDependencies, ...overrides }
   const discovered = await discoverHandoffOwnersSafely(input, deps)
+  if (discovered.staleManager || discovered.staleRuntimes.length > 0) return 'mismatched'
   const targetBuildId = input.targetBuildId
   const identities: Array<{ actual: string | undefined; expected: string }> = [
     ...(discovered.manager
@@ -226,7 +202,7 @@ export async function drainKunOwnersForHandoffWithLock(
   owners.push({ kind: 'manager', result: 'not-found' })
 
   emit(input, startedAt, deps, { phase: 'discover' })
-  let discovered: Awaited<ReturnType<typeof discoverHandoffOwners>>
+  let discovered: DiscoveredHandoffOwners
   try {
     discovered = await discoverHandoffOwnersSafely(input, deps)
   } catch (error) {
@@ -240,6 +216,7 @@ export async function drainKunOwnersForHandoffWithLock(
     }
     throw error
   }
+  discovered = await settleAndRediscoverStaleOwners(input, discovered, deps)
   for (const probeClassification of discovered.probeClassifications) {
     emit(input, startedAt, deps, { phase: 'discover', probeClassification })
   }
@@ -299,6 +276,7 @@ export async function drainKunOwnersForHandoffWithLock(
       }
     }
     discovered = await discoverHandoffOwnersSafely(input, deps)
+    discovered = await settleAndRediscoverStaleOwners(input, discovered, deps)
   }
 
   if (discovered.manager) {
@@ -340,6 +318,7 @@ export async function drainKunOwnersForHandoffWithLock(
   // while this process holds the same start lock. Drain any owner that raced
   // with the first pass, then prove the scope is stable.
   discovered = await discoverHandoffOwnersSafely(input, deps)
+  discovered = await settleAndRediscoverStaleOwners(input, discovered, deps)
   for (const runtime of discovered.runtimes) {
     const owner = runtimeOwnerReport(runtime)
     try {
@@ -388,7 +367,8 @@ export async function drainKunOwnersForHandoffWithLock(
     }
   }
 
-  const remaining = await discoverHandoffOwnersSafely(input, deps)
+  let remaining = await discoverHandoffOwnersSafely(input, deps)
+  remaining = await settleAndRediscoverStaleOwners(input, remaining, deps)
   if (remaining.manager || remaining.runtimes.length > 0) {
     const owner = remaining.manager
       ? managerOwnerReport(remaining.manager)
@@ -422,211 +402,30 @@ export async function drainKunOwnersForHandoffWithLock(
   }
 }
 
-async function discoverHandoffOwnersSafely(
+async function settleAndRediscoverStaleOwners(
   input: KunInstalledBuildHandoffInput,
+  discovered: DiscoveredHandoffOwners,
   deps: HandoffDependencies
-): ReturnType<typeof discoverHandoffOwners> {
-  try {
-    return await discoverHandoffOwners(input, deps)
-  } catch (error) {
-    if (error instanceof KunHandoffError) throw error
-    throw new KunHandoffError(
-      'unsafe_scope',
-      'discover',
-      input.reason,
-      false,
-      undefined,
-      'Kun update handoff could not safely read Runtime or Service Manager discovery',
-      { cause: error }
-    )
+): Promise<DiscoveredHandoffOwners> {
+  let current = discovered
+  for (let pass = 0; pass < MAX_STALE_OWNER_SETTLEMENT_PASSES; pass += 1) {
+    await settleStaleHandoffOwners(input, current, deps)
+    if (!current.staleManager && current.staleRuntimes.length === 0) return current
+    current = await discoverHandoffOwnersSafely(input, deps)
   }
-}
-
-async function discoverHandoffOwners(
-  input: KunInstalledBuildHandoffInput,
-  deps: HandoffDependencies
-): Promise<{
-  manager: ManagerHandoffDiscoveryRecord | null
-  runtimes: RuntimeOwner[]
-  probeClassifications: KunHandoffProbeClassification[]
-}> {
-  const controlDir = input.controlDir ?? defaultKunControlDir()
-  const manager = await deps.readManager(controlDir)
-  if (manager && input.settingsPath &&
-    !sameCanonicalPath(manager.settingsPath, input.settingsPath)) {
-    throw new KunHandoffError(
-      'unsafe_scope',
-      'discover',
-      input.reason,
-      false,
-      managerOwnerReport(manager),
-      'Kun Service Manager owns a different canonical settings scope'
-    )
-  }
-  const dataDirs = canonicalDataDirs([
-    ...input.dataDirs,
-    ...(manager ? [manager.dataDir] : [])
-  ])
-  const runtimes: RuntimeOwner[] = []
-  for (const dataDir of dataDirs) {
-    const record = await deps.readRuntime(dataDir, 'production')
-    if (record && deps.processAlive(record.pid)) {
-      runtimes.push(runtimeOwner(dataDir, 'production', record))
-    }
-  }
-  const developmentDir = manager?.dataDir ?? dataDirs[0]
-  if (developmentDir) {
-    const record = await deps.readRuntime(controlDir, 'development')
-    if (record && deps.processAlive(record.pid)) {
-      runtimes.push(runtimeOwner(developmentDir, 'development', record))
-    }
-  }
-  const probeClassifications: KunHandoffProbeClassification[] = []
-  if (runtimes.length > 0) probeClassifications.push('runtime-discovery-compatible')
-  if (manager && deps.processAlive(manager.pid)) {
-    probeClassifications.push('manager-discovery-compatible')
-  }
-  if (manager && deps.processAlive(manager.pid)) {
-    const managerStatus = await readCompatibleManagerSlots(manager, input.fetch ?? fetch)
-    probeClassifications.push(managerStatus.classification)
-    for (const slot of managerStatus.records) {
-      if (!deps.processAlive(slot.pid)) continue
-      runtimes.push(runtimeOwner(manager.dataDir, slot.flavor, slot))
-    }
-  }
-  if (probeClassifications.length === 0) probeClassifications.push('no-live-owner')
-  return {
-    manager: manager && deps.processAlive(manager.pid) ? manager : null,
-    runtimes: deduplicateRuntimeOwners(runtimes),
-    probeClassifications
-  }
-}
-
-const RuntimeSlotSchema = z.object({
-  flavor: z.enum(MANAGED_RUNTIME_FLAVORS),
-  instanceId: z.string().min(1).max(256),
-  pid: z.number().int().positive(),
-  startedAt: z.string().datetime(),
-  host: z.string().min(1).max(512),
-  port: z.number().int().min(1).max(65_535),
-  baseUrl: z.string().url().max(2_048),
-  runtimeToken: z.string().max(16_384),
-  buildId: z.string().regex(/^[a-f0-9]{64}$/).optional(),
-  logPath: z.string().min(1).max(4_096).optional()
-}).passthrough()
-
-async function readCompatibleManagerSlots(
-  manager: ManagerHandoffDiscoveryRecord,
-  fetchImpl: typeof fetch
-): Promise<{
-  records: Array<RuntimeHandoffDiscoveryRecord & { flavor: RuntimeFlavor }>
-  classification: Extract<
-    KunHandoffProbeClassification,
-    'manager-status-compatible' | 'manager-status-unavailable'
-  >
-}> {
-  try {
-    const response = await fetchImpl(`${manager.baseUrl.replace(/\/$/u, '')}/v1/manager/status`, {
-      headers: { authorization: `Bearer ${manager.managerToken}` },
-      signal: AbortSignal.timeout(STATUS_TIMEOUT_MS)
-    })
-    if (!response.ok) return { records: [], classification: 'manager-status-unavailable' }
-    const body = z.object({
-      instanceId: z.string(),
-      pid: z.number().int().positive().optional(),
-      startedAt: z.string(),
-      slots: z.array(z.unknown())
-    }).passthrough().safeParse(await response.json())
-    if (!body.success ||
-      body.data.instanceId !== manager.instanceId ||
-      body.data.startedAt !== manager.startedAt ||
-      (body.data.pid !== undefined && body.data.pid !== manager.pid)) {
-      return { records: [], classification: 'manager-status-unavailable' }
-    }
-    const records: Array<RuntimeHandoffDiscoveryRecord & { flavor: RuntimeFlavor }> = []
-    for (const value of body.data.slots) {
-      const envelope = z.object({ registration: z.unknown() }).passthrough().safeParse(value)
-      const parsed = RuntimeSlotSchema.safeParse(envelope.success ? envelope.data.registration : value)
-      if (!parsed.success) return { records: [], classification: 'manager-status-unavailable' }
-      const record: RuntimeHandoffDiscoveryRecord & { flavor: RuntimeFlavor } = {
-        version: 1,
-        ...parsed.data,
-        flavor: parsed.data.flavor
-      }
-      if (!isSafeRuntimeHandoffDiscovery(record)) {
-        return { records: [], classification: 'manager-status-unavailable' }
-      }
-      records.push(record)
-    }
-    return { records, classification: 'manager-status-compatible' }
-  } catch {
-    return { records: [], classification: 'manager-status-unavailable' }
-  }
-}
-
-function runtimeOwner(
-  dataDir: string,
-  flavor: RuntimeFlavor,
-  record: RuntimeHandoffDiscoveryRecord
-): RuntimeOwner {
-  return {
-    dataDir,
-    flavor,
-    inspection: { discovery: record, connection: null }
-  }
-}
-
-function deduplicateRuntimeOwners(owners: RuntimeOwner[]): RuntimeOwner[] {
-  const seen = new Set<string>()
-  return owners.filter((owner) => {
-    const record = owner.inspection.discovery
-    const key = `${record.instanceId}:${record.pid}:${record.startedAt}`
-    if (seen.has(key)) return false
-    seen.add(key)
-    return true
-  })
-}
-
-function canonicalDataDirs(values: readonly string[]): string[] {
-  const result: string[] = []
-  for (const value of values) {
-    if (!value.trim() || result.some((current) => sameCanonicalPath(current, value))) continue
-    result.push(resolve(value))
-  }
-  return result
-}
-
-function sameRuntimeIdentity(left: RuntimeOwner, right: RuntimeOwner): boolean {
-  const a = left.inspection.discovery
-  const b = right.inspection.discovery
-  return left.flavor === right.flavor &&
-    a.instanceId === b.instanceId &&
-    a.pid === b.pid &&
-    a.startedAt === b.startedAt
-}
-
-function runtimeOwnerReport(runtime: RuntimeOwner): Omit<KunHandoffOwnerReport, 'result'> {
-  const record = runtime.inspection.discovery
-  return {
-    kind: 'runtime',
-    flavor: runtime.flavor,
-    instanceId: record.instanceId,
-    pid: record.pid,
-    port: record.port,
-    ...(record.buildId ? { buildId: record.buildId } : {})
-  }
-}
-
-function managerOwnerReport(
-  manager: ManagerHandoffDiscoveryRecord
-): Omit<KunHandoffOwnerReport, 'result'> {
-  return {
-    kind: 'manager',
-    instanceId: manager.instanceId,
-    pid: manager.pid,
-    port: manager.port,
-    ...(manager.buildId ? { buildId: manager.buildId } : {})
-  }
+  const owner = current.staleManager
+    ? managerOwnerReport(current.staleManager)
+    : current.staleRuntimes[0]
+      ? runtimeOwnerReport(current.staleRuntimes[0])
+      : undefined
+  throw new KunHandoffError(
+    'probe_failed',
+    'discover',
+    input.reason,
+    true,
+    owner,
+    'Kun stale handoff ownership did not converge after cleanup'
+  )
 }
 
 function mergeOwnerReport(

--- a/src/main/runtime/kun-manager-replacement.test.ts
+++ b/src/main/runtime/kun-manager-replacement.test.ts
@@ -28,6 +28,19 @@ function manager(
   }
 }
 
+function processIdentityFor(
+  target: ManagerHandoffDiscoveryRecord,
+  commandLine = 'kun-service-manager',
+  startedAtMs = Date.parse(target.startedAt)
+) {
+  return {
+    pid: target.pid,
+    commandLine,
+    executablePath: 'C:\\Program Files\\nodejs\\node.exe',
+    startedAtMs
+  }
+}
+
 describe('stopServiceManagerForReplacement', () => {
   it('gracefully stops an exact authenticated Manager without full health parsing', async () => {
     const target = manager({ version: 7, protocolVersion: 3 })
@@ -42,7 +55,7 @@ describe('stopServiceManagerForReplacement', () => {
       {
         readDiscovery: vi.fn(async () => target),
         waitForExit: vi.fn(async () => ++waitCalls > 1),
-        commandLine: vi.fn(),
+        processIdentity: vi.fn(),
         listenerPids: vi.fn(),
         terminate: vi.fn(),
         removeDiscovery
@@ -77,7 +90,10 @@ describe('stopServiceManagerForReplacement', () => {
       readDiscovery: vi.fn(async () => current),
       requestShutdown: vi.fn(async () => { throw new Error('shutdown timed out') }),
       waitForExit: vi.fn(async () => current === null),
-      commandLine: vi.fn(async () => '/Applications/Kun.app/manager-entry.js'),
+      processIdentity: vi.fn(async () => processIdentityFor(
+        target,
+        'node /Applications/Kun.app/manager-entry.js'
+      )),
       listenerPids: vi.fn(async () => [target.pid]),
       terminate,
       removeDiscovery
@@ -90,7 +106,8 @@ describe('stopServiceManagerForReplacement', () => {
   it.each([
     ['command mismatch', 'node unrelated.js', [901]],
     ['listener mismatch', 'kun-service-manager', [902]],
-    ['process inspection denied', '', []]
+    ['process inspection denied', '', []],
+    ['start-time mismatch', 'stale-start', [901]]
   ])('refuses force replacement on %s', async (_label, command, listeners) => {
     const target = manager()
     let signalSent = false
@@ -104,7 +121,13 @@ describe('stopServiceManagerForReplacement', () => {
       readDiscovery: vi.fn(async () => target),
       requestShutdown: vi.fn(async () => { throw new Error('shutdown unavailable') }),
       waitForExit: vi.fn(async () => false),
-      commandLine: vi.fn(async () => command),
+      processIdentity: vi.fn(async () => command === ''
+        ? null
+        : processIdentityFor(
+            target,
+            command === 'stale-start' ? 'kun-service-manager' : command,
+            Date.parse(target.startedAt) + (command === 'stale-start' ? 60_001 : 0)
+          )),
       listenerPids: vi.fn(async () => listeners),
       terminate,
       removeDiscovery: vi.fn(async () => true)
@@ -132,7 +155,7 @@ describe('stopServiceManagerForReplacement', () => {
       readDiscovery: vi.fn(async () => ++reads === 1 ? target : replacement),
       requestShutdown,
       waitForExit: vi.fn(async () => false),
-      commandLine: vi.fn(),
+      processIdentity: vi.fn(),
       listenerPids: vi.fn(),
       terminate,
       removeDiscovery
@@ -158,7 +181,7 @@ describe('stopServiceManagerForReplacement', () => {
       readDiscovery: vi.fn(async () => ++reads === 1 ? target : replacement),
       requestShutdown: vi.fn(),
       waitForExit: vi.fn(async () => ++waits > 1),
-      commandLine: vi.fn(),
+      processIdentity: vi.fn(),
       listenerPids: vi.fn(),
       terminate: vi.fn(),
       removeDiscovery

--- a/src/main/runtime/kun-manager-replacement.ts
+++ b/src/main/runtime/kun-manager-replacement.ts
@@ -6,10 +6,11 @@ import {
 import { sameCanonicalPath } from '../../../kun/src/manager/canonical-path.js'
 import {
   listListeningPidsOnPort,
-  processCommandLine,
+  processIdentity,
   terminateVerifiedPid,
   waitForPidExit
 } from '../kun-process-ports'
+import { identityMatchesExpectedManager } from '../kun-process-identity'
 import { KunOwnerVerificationError } from './kun-replacement-error'
 
 const GRACEFUL_EXIT_TIMEOUT_MS = 15_000
@@ -32,7 +33,7 @@ export type KunManagerReplacementDependencies = {
     fetchImpl: typeof fetch
   ) => Promise<void>
   waitForExit: typeof waitForPidExit
-  commandLine: typeof processCommandLine
+  processIdentity: typeof processIdentity
   listenerPids: typeof listListeningPidsOnPort
   terminate: typeof terminateVerifiedPid
   removeDiscovery: typeof removeManagerDiscovery
@@ -42,7 +43,7 @@ const defaultDependencies: KunManagerReplacementDependencies = {
   readDiscovery: readManagerHandoffDiscovery,
   requestShutdown: requestExactManagerShutdown,
   waitForExit: waitForPidExit,
-  commandLine: processCommandLine,
+  processIdentity,
   listenerPids: listListeningPidsOnPort,
   terminate: terminateVerifiedPid,
   removeDiscovery: removeManagerDiscovery
@@ -158,11 +159,11 @@ async function targetStillMatches(
   } catch {
     return false
   }
-  const [command, listeners] = await Promise.all([
-    deps.commandLine(target.pid).catch(() => ''),
+  const [identity, listeners] = await Promise.all([
+    deps.processIdentity(target.pid).catch(() => null),
     deps.listenerPids(target.port).catch((): number[] => [])
   ])
-  return commandLooksLikeManager(command) && listeners.includes(target.pid)
+  return identityMatchesExpectedManager(identity, target) && listeners.includes(target.pid)
 }
 
 async function readTarget(
@@ -202,13 +203,6 @@ function assertManagerScope(
     !sameCanonicalPath(target.settingsPath, scope.settingsPath)) {
     throw new Error('Kun Service Manager replacement target owns a different canonical scope')
   }
-}
-
-function commandLooksLikeManager(command: string): boolean {
-  const normalized = command.trim().replace(/\\/gu, '/').toLowerCase()
-  return normalized === 'kun-service-manager' ||
-    normalized.startsWith('kun-service-manager ') ||
-    normalized.includes('manager-entry.js')
 }
 
 function replacementFailure(pid: number, error: unknown): Error {

--- a/src/main/runtime/kun-packaged-build-handoff.ts
+++ b/src/main/runtime/kun-packaged-build-handoff.ts
@@ -1,0 +1,46 @@
+import { app } from 'electron'
+import { defaultKunControlDir } from '../../../kun/src/manager/manager-discovery.js'
+import { resolveCliRuntimeFlavor } from '../../../kun/src/cli/runtime-flavor.js'
+import {
+  resolveKunExecutable,
+  resolveKunRuntimeBuildId
+} from '../resolve-kun-binary'
+import {
+  drainKunOwnersForHandoff,
+  installedBuildProbeError,
+  probeInstalledBuildHandoff
+} from './kun-installed-build-handoff'
+import {
+  createHandoffEventReporter,
+  type HandoffEventListener
+} from './kun-handoff-events'
+
+function appRoot(): string {
+  return app.isPackaged
+    ? app.getAppPath().replace(/app\.asar$/, 'app.asar.unpacked')
+    : app.getAppPath()
+}
+
+export async function preparePackagedKunBuildHandoff(input: {
+  dataDir: string
+  settingsPath: string
+  onHandoffEvent?: HandoffEventListener
+}): Promise<boolean> {
+  const flavor = resolveCliRuntimeFlavor({ env: process.env })
+  if (!app.isPackaged || flavor !== 'production') return false
+  const buildId = await resolveKunRuntimeBuildId(resolveKunExecutable(appRoot(), ''))
+  const handoffInput = {
+    reason: 'installed-build-change' as const,
+    dataDirs: [input.dataDir],
+    settingsPath: input.settingsPath,
+    controlDir: defaultKunControlDir(),
+    onEvent: createHandoffEventReporter(input.onHandoffEvent),
+    ...(buildId ? { targetBuildId: buildId } : {})
+  }
+  const probe = await probeInstalledBuildHandoff(handoffInput)
+  const probeError = installedBuildProbeError(handoffInput, probe)
+  if (probeError) throw probeError
+  if (probe === 'matched') return false
+  await drainKunOwnersForHandoff(handoffInput)
+  return true
+}

--- a/src/main/runtime/kun-serve-replacement.test.ts
+++ b/src/main/runtime/kun-serve-replacement.test.ts
@@ -50,7 +50,7 @@ describe('stopSharedRuntimeForReplacement', () => {
     const target = inspection()
     const fetchMock = vi.fn(async () => Response.json({ stopping: true }))
     const removeDiscovery = vi.fn(async () => true)
-    const unregister = vi.fn(async () => undefined)
+    const unregister = vi.fn(async () => true)
 
     await expect(stopSharedRuntimeForReplacement(dataDir, fetchMock as unknown as typeof fetch, {
       runtimeFlavor: 'production',
@@ -93,7 +93,7 @@ describe('stopSharedRuntimeForReplacement', () => {
     const waitForExit = vi.fn(async () => true)
     const terminate = vi.fn()
     const removeDiscovery = vi.fn(async () => true)
-    const unregister = vi.fn(async () => undefined)
+    const unregister = vi.fn(async () => true)
 
     await expect(stopSharedRuntimeForReplacement(dataDir, fetch, {
       runtimeFlavor: 'production',
@@ -140,7 +140,7 @@ describe('stopSharedRuntimeForReplacement', () => {
       return true
     })
     const removeDiscovery = vi.fn(async () => true)
-    const unregister = vi.fn(async () => undefined)
+    const unregister = vi.fn(async () => true)
 
     await expect(stopSharedRuntimeForReplacement(dataDir, fetch, {
       runtimeFlavor: 'production',
@@ -204,7 +204,7 @@ describe('stopSharedRuntimeForReplacement', () => {
       terminate,
       removeDiscovery: vi.fn(async () => true),
       withAncillaryWriter: async (_dataDir, action) => action(),
-      unregister: vi.fn(async () => undefined)
+      unregister: vi.fn(async () => true)
     })).resolves.toEqual({ stopped: true, forced: true })
 
     expect(terminate).toHaveBeenCalledOnce()
@@ -242,7 +242,7 @@ describe('stopSharedRuntimeForReplacement', () => {
       terminate,
       removeDiscovery,
       withAncillaryWriter: async (_dataDir, action) => action(),
-      unregister: vi.fn(async () => undefined)
+      unregister: vi.fn(async () => true)
     })).rejects.toThrow(/could not be safely replaced/)
 
     expect(signalSent).toBe(false)
@@ -261,7 +261,7 @@ describe('stopSharedRuntimeForReplacement', () => {
     let reads = 0
     const terminate = vi.fn()
     const removeDiscovery = vi.fn(async () => true)
-    const unregister = vi.fn(async () => undefined)
+    const unregister = vi.fn(async () => true)
     const requestShutdown = vi.fn(async () => undefined)
 
     await expect(stopSharedRuntimeForReplacement(dataDir, fetch, {

--- a/src/renderer/src/store/chat-store-schedulers.ts
+++ b/src/renderer/src/store/chat-store-schedulers.ts
@@ -101,10 +101,12 @@ function runStartupProbe(get: ChatStoreGet, generation: number): void {
       // can outlive the 900ms fallback armed below. If the connection still is
       // not ready by now, re-arm the fallback from this point so the earlier
       // timer firing during the probe does not consume the only retry.
-      if (generation !== startupProbeGeneration) return
-      if (startupRuntimeProbeTimer || startupRuntimeProbeInFlight) return
-      if (get().runtimeConnection === 'ready') return
-      armStartupProbeFallback(get, generation, 0)
+      if (generation === startupProbeGeneration &&
+        !startupRuntimeProbeTimer &&
+        !startupRuntimeProbeInFlight &&
+        get().runtimeConnection !== 'ready') {
+        armStartupProbeFallback(get, generation, 0)
+      }
     }
   })()
 }


### PR DESCRIPTION
## Summary

- Fixes the Windows 11 startup failure where a stale Runtime or Manager record points at an unrelated process after PID reuse.
- Treats a verified identity mismatch as stale coordination state: remove only the exact old record and never signal the unrelated PID.
- Fails closed with retryable `probe_failed` when process identity, Manager status, unregister transport, or cleanup convergence cannot be proven.

## Changes

- Validate Runtime and Service Manager owners with PID, command tokens, start time, and the Windows executable before normal drain/stop handling.
- Keep authenticated shutdown first and re-check full Manager identity plus the recorded listener immediately before force termination.
- Make Manager runtime unregister return a strict `{ removed: boolean }` contract; HTTP/auth/network/JSON failures now propagate.
- Persist an exact Manager slot removal before acknowledging `removed: true`; a false result triggers status re-discovery so replacements are preserved and stale owners cannot be reported as drained.
- Rediscover after stale cleanup under the Manager start lock so a racing replacement owner is drained normally instead of being deleted as the old instance.
- Split handoff discovery, usage response/tests, and packaged handoff helpers by responsibility to keep every authored file within the 700-line limit.
- Extend packaged update smoke coverage with a real recycled-PID helper plus an exact stale Manager slot; the helper must remain alive while the candidate publishes healthy replacement owners.

## Tests

Passed locally with the lockfile and Node 22.22.0:

- `npm exec vitest run src/main/kun-process-identity.test.ts src/main/runtime/kun-manager-replacement.test.ts src/main/runtime/kun-installed-build-handoff.test.ts src/main/runtime/kun-installed-build-handoff-stale.test.ts src/main/runtime/kun-serve-replacement.test.ts` — 47/47
- `npm --prefix kun test -- src/manager/service-manager.test.ts src/manager/service-manager-usage.test.ts src/manager/service-manager-runtime-registration.test.ts` — 32/32
- `node --test scripts/smoke-packaged-update-handoff.test.cjs` — 11/11
- `npm run check:file-lines`
- `npm run typecheck`
- `npm run lint` — 0 errors (30 pre-existing warnings)
- `npm run build:kun`
- `npm run build`
- `git diff --check`

Repository-wide suite comparison in the same environment:

- `origin/develop`: 5029 passed / 65 failed / 5 skipped; 19 failing files.
- PR head: 5015 passed / 77 failed / 14 skipped during a parallel local run. The same 65 baseline failures remained; the additional 8 timeout/performance files all passed when rerun serially (71/71 total, including PTY under Node 22).
- The previous GitHub runner also reported exactly the 65 baseline failures. None of those failing paths is changed here.

The updated Windows packaged recycled-PID scenario is committed and will be exercised by the Windows package job once the repository-wide quality gate permits package jobs to run.

Fixes #1250
