### PR TITLE
fix(ipc): allow thread utility runtime endpoints

### DIFF
--- a/src/main/ipc/app-ipc-schemas.test.ts
+++ b/src/main/ipc/app-ipc-schemas.test.ts
@@ -17,6 +17,17 @@ import {
   skillListPayloadSchema
 } from './app-ipc-schemas'
 
+describe('runtime endpoint allow-list', () => {
+  it('allows specific utility routes and generalized placeholders', () => {
+    expect(runtimeRequestPayloadSchema.parse({ path: '/v1/threads/bulk-delete', method: 'POST', body: '{}' }).path).toBe('/v1/threads/bulk-delete')
+    expect(runtimeRequestPayloadSchema.parse({ path: '/v1/threads/content-search', method: 'GET' }).path).toBe('/v1/threads/content-search')
+    expect(() => runtimeRequestPayloadSchema.parse({ path: '/v1/threads/bulk-delete', method: 'GET' })).toThrow()
+    expect(runtimeRequestPayloadSchema.parse({ path: '/v1/background-shells/session-1', method: 'GET' }).path).toBe('/v1/background-shells/session-1')
+    expect(runtimeRequestPayloadSchema.parse({ path: '/v1/background-shells/session-1/stop', method: 'POST' }).path).toBe('/v1/background-shells/session-1/stop')
+    expect(runtimeRequestPayloadSchema.parse({ path: '/v1/sessions/session-1/resume-metadata', method: 'GET' }).path).toBe('/v1/sessions/session-1/resume-metadata')
+  })
+})
+
 describe('schedule task IPC schemas', () => {
   const future = '2099-01-01T10:00:00.000Z'
 

--- a/src/main/ipc/app-ipc-schemas/runtime.ts
+++ b/src/main/ipc/app-ipc-schemas/runtime.ts
@@ -36,8 +36,11 @@ import {
   KUN_SUPPLY_CHAIN_AUDIT_TEMPLATE,
   KUN_SUPPLY_CHAIN_UPDATE_CHECK_TEMPLATE,
   KUN_SESSION_RESUME_TEMPLATE,
+  KUN_SESSION_RESUME_METADATA_TEMPLATE,
   KUN_SKILLS_TEMPLATE,
   KUN_THREADS_TEMPLATE,
+  KUN_THREADS_BULK_DELETE_TEMPLATE,
+  KUN_THREADS_CONTENT_SEARCH_TEMPLATE,
   KUN_THREAD_COMPACT_TEMPLATE,
   KUN_THREAD_PRUNE_TEMPLATE,
   KUN_THREAD_FORK_TEMPLATE,
@@ -150,7 +153,7 @@ function compileEndpoint(
   // substituting the `{id}` / `{turn}` placeholders with `[^/]+`. The
   // template fragments are URL-encoded by the path helpers, so they
   // contain only characters that are safe to escape directly.
-  const pattern = template.replace(/[.+*?^$()|[\]\\]/g, '\\$&').replace(/\{(?:id|turn)\}/g, '[^/]+')
+  const pattern = template.replace(/[.+*?^$()|[\]\\]/g, '\\$&').replace(/\{[^/{}]+\}/g, '[^/]+')
   const regex = new RegExp(`^${pattern}$`)
   return {
     match: (path: string) => regex.test(path),
@@ -195,6 +198,8 @@ const ENDPOINTS: readonly EndpointTemplate[] = [
   compileEndpoint(KUN_MEMORY_RECORD_TEMPLATE, ['PATCH', 'DELETE']),
   compileEndpoint(KUN_MCP_OAUTH_TEMPLATE, ['GET', 'DELETE']),
   compileEndpoint(KUN_MCP_OAUTH_SERVER_TEMPLATE, ['DELETE']),
+  compileEndpoint(KUN_THREADS_BULK_DELETE_TEMPLATE, ['POST']),
+  compileEndpoint(KUN_THREADS_CONTENT_SEARCH_TEMPLATE, ['GET']),
   compileEndpoint(KUN_THREADS_TEMPLATE, ['GET', 'POST']),
   compileEndpoint(KUN_THREAD_STATES_TEMPLATE, ['POST']),
   compileEndpoint(KUN_THREAD_STATE_TEMPLATE, ['GET']),
@@ -218,6 +223,7 @@ const ENDPOINTS: readonly EndpointTemplate[] = [
   compileEndpoint(KUN_THREAD_MODEL_REQUESTS_TEMPLATE, ['GET']),
   compileEndpoint(KUN_USER_INPUT_TEMPLATE, ['POST']),
   compileEndpoint(KUN_SESSION_RESUME_TEMPLATE, ['POST']),
+  compileEndpoint(KUN_SESSION_RESUME_METADATA_TEMPLATE, ['GET']),
   compileEndpoint(KUN_USAGE_TEMPLATE, ['GET']),
   compileEndpoint(KUN_DEBUG_LLM_ROUNDS_TEMPLATE, ['GET']),
   compileEndpoint(KUN_BACKGROUND_SHELLS_TEMPLATE, ['GET']),

--- a/src/shared/kun-endpoints.ts
+++ b/src/shared/kun-endpoints.ts
@@ -216,6 +216,8 @@ export function kunGraphProjectConsolidatePath(projectId: string): string {
 
 export const KUN_THREADS_PATH = '/v1/threads'
 export const KUN_THREADS_TEMPLATE = '/v1/threads'
+export const KUN_THREADS_BULK_DELETE_TEMPLATE = '/v1/threads/bulk-delete'
+export const KUN_THREADS_CONTENT_SEARCH_TEMPLATE = '/v1/threads/content-search'
 
 export const KUN_THREAD_STATES_PATH = '/v1/threads/states'
 export const KUN_THREAD_STATES_TEMPLATE = '/v1/threads/states'
@@ -346,7 +348,6 @@ export const KUN_SESSION_RESUME_TEMPLATE = '/v1/sessions/{id}/resume-thread'
 export function kunSessionResumePath(sessionId: string): string {
   return `/v1/sessions/${encodeURIComponent(sessionId)}/resume-thread`
 }
-
 export const KUN_SESSION_RESUME_METADATA_TEMPLATE = '/v1/sessions/{id}/resume-metadata'
 export function kunSessionResumeMetadataPath(sessionId: string): string {
   return `/v1/sessions/${encodeURIComponent(sessionId)}/resume-metadata`


### PR DESCRIPTION
## Summary\nFixes the runtime IPC allowlist so workspace bulk deletion and thread content search are not shadowed by the generic thread route. Generalizes endpoint placeholder compilation and registers background-shell and resume-metadata routes.\n\n## Tests\n- npm.cmd exec vitest run src/main/ipc/app-ipc-schemas.test.ts (46 passed)\n- targeted eslint passed\n- git diff --check passed\n- Full typecheck is blocked by baseline missing module: kun/src/adapters/tool/edit-diff.ts imports 'diff'.\n\nFixes #1252