### PR TITLE
feat(provider): support provider-scoped proxy settings

### DIFF
--- a/src/main/runtime/kun-runtime-model-config.ts
+++ b/src/main/runtime/kun-runtime-model-config.ts
@@ -4,7 +4,7 @@ import {
   projectExecutableModelRoutePools,
   resolveKunRuntimeSettings,
   resolveModelProviderPresetSource,
-  resolveModelProviderProxyUrl,
+  resolveModelProviderProxyUrlForProvider,
   type AppSettingsV1,
   type KunRuntimeSettingsV1,
   type ModelProviderModelProfileV1,
@@ -59,7 +59,6 @@ export function providersConfigForRuntime(
   settings: AppSettingsV1
 ): Record<string, Record<string, unknown>> {
   const out: Record<string, Record<string, unknown>> = {}
-  const proxyUrl = resolveModelProviderProxyUrl(settings)
   const runtime = resolveKunRuntimeSettings(settings)
   for (const provider of getModelProviderSettings(settings).providers as ModelProviderProfileV1[]) {
     const id = provider.id?.trim()
@@ -94,7 +93,7 @@ export function providersConfigForRuntime(
       ...(selectedModel ? { selectedModel } : {}),
       retry: provider.retry,
       modelProfiles: modelConfigProfilesFromProviderProfiles(provider.modelProfiles),
-      ...(proxyUrl ? { modelProxyUrl: proxyUrl } : {}),
+      ...((resolveModelProviderProxyUrlForProvider(settings, id)) ? { modelProxyUrl: resolveModelProviderProxyUrlForProvider(settings, id) } : {}),
       // Credential-derived transport headers are reconstructed in Kun from
       // the protected binding and are never persisted in config.json.
     }

--- a/src/renderer/src/components/settings-section-providers-connection-panels.tsx
+++ b/src/renderer/src/components/settings-section-providers-connection-panels.tsx
@@ -322,6 +322,33 @@ export function ProviderConnectionAdvancedPanels({ view }: { view: Record<string
                       ))}
                     </select>
                   </label>
+                  <div className="grid gap-3 rounded-xl border border-ds-border-muted bg-ds-main/20 p-3">
+                    <label className="flex items-center justify-between gap-3 text-[13px] text-ds-muted">
+                      <span>{t('proxyEnabled')}</span>
+                      <Toggle
+                        ariaLabel={t('proxyEnabled')}
+                        checked={activeProvider.proxy?.enabled === true}
+                        onChange={(enabled) => updateModelProvider(activeProvider.id, {
+                          proxy: { enabled, url: activeProvider.proxy?.url ?? '' }
+                        })}
+                      />
+                    </label>
+                    <input
+                      className={textInputClass}
+                      placeholder={t('proxyUrlPlaceholder')}
+                      value={activeProvider.proxy?.url ?? ''}
+                      spellCheck={false}
+                      aria-label={t('proxyUrl')}
+                      onChange={(e) => updateModelProvider(activeProvider.id, {
+                        proxy: { enabled: activeProvider.proxy?.enabled === true, url: e.target.value }
+                      })}
+                    />
+                    <p className="text-[12px] leading-5 text-ds-muted">
+                      {zh
+                        ? '仅此 Provider 的模型请求使用该代理；留空则回退到全局代理设置。'
+                        : 'Only this provider uses this proxy for model requests; leave it unset to use the legacy global proxy.'}
+                    </p>
+                  </div>
                   {isCodexProvider(activeProvider) ? (
                     <p className="text-[12px] leading-5 text-ds-muted">
                       {t('codexEndpointLocked')}

--- a/src/shared/app-settings-provider-core.ts
+++ b/src/shared/app-settings-provider-core.ts
@@ -354,6 +354,12 @@ export function resolveModelProviderProxyUrl(settings: AppSettingsV1): string {
   // means "no proxy" for outbound requests instead of wiping the saved value.
   return normalizeProxyUrl(proxy.url)
 }
+export function resolveModelProviderProxyUrlForProvider(settings: AppSettingsV1, providerId?: string): string {
+  const provider = providerId ? getModelProviderProfile(settings, providerId) : undefined
+  return provider?.proxy !== undefined
+    ? (provider.proxy.enabled ? normalizeProxyUrl(provider.proxy.url) : '')
+    : resolveModelProviderProxyUrl(settings)
+}
 
 export function getDefaultModelProviderProfile(settings: AppSettingsV1): ModelProviderProfileV1 {
   return getModelProviderProfile(settings, DEFAULT_MODEL_PROVIDER_ID)

--- a/src/shared/app-settings-provider-profiles.ts
+++ b/src/shared/app-settings-provider-profiles.ts
@@ -93,6 +93,7 @@ import {
   normalizeModelProviderSpeechCapability,
   normalizeModelProviderTextToSpeechCapability,
   normalizeModelProviderVideoCapability,
+  normalizeNetworkProxySettings,
   normalizeProviderModels,
   presetModelProfilesForProvider
 } from './app-settings-provider-capabilities'
@@ -189,6 +190,7 @@ export function normalizeModelProviderProfile(
           : '',
     baseUrl,
     endpointFormat,
+    proxy: input?.proxy ? normalizeNetworkProxySettings(input.proxy) : undefined,
     retry: normalizeModelRequestRetrySettings(
       input?.retry,
       resolvedPresetSource?.mode === 'api'

--- a/src/shared/app-settings-provider.test.ts
+++ b/src/shared/app-settings-provider.test.ts
@@ -44,6 +44,7 @@ import {
   resolveKunMusicGenerationSettings,
   resolveModelProviderBaseUrl,
   resolveModelProviderProxyUrl,
+  resolveModelProviderProxyUrlForProvider,
   resolveKunRuntimeSettings,
   resolveKunSpeechToTextSettings,
   resolveKunTextToSpeechSettings,
@@ -51,6 +52,22 @@ import {
   type AppSettingsV1,
   type ModelProviderModelProfileV1
 } from './app-settings'
+
+describe('provider-scoped proxy', () => {
+  it('uses each provider proxy and lets explicit disable override global', () => {
+    const settings = normalizeModelProviderSettings({
+      proxy: { enabled: true, url: 'http://global.proxy:8080' },
+      providers: [
+        { id: 'alpha', name: 'Alpha', baseUrl: 'https://alpha.test', proxy: { enabled: true, url: 'socks5://alpha.proxy:1080' } },
+        { id: 'beta', name: 'Beta', baseUrl: 'https://beta.test', proxy: { enabled: false, url: 'http://unused.proxy:1' } }
+      ]
+    })
+    const appSettings = { provider: settings } as AppSettingsV1
+    expect(resolveModelProviderProxyUrlForProvider(appSettings, 'alpha')).toBe('socks5://alpha.proxy:1080')
+    expect(resolveModelProviderProxyUrlForProvider(appSettings, 'beta')).toBe('')
+    expect(resolveModelProviderProxyUrlForProvider(appSettings, 'missing')).toBe('http://global.proxy:8080/')
+  })
+})
 
 describe('model provider retry settings', () => {
   it('adds default retry settings to default providers', () => {

--- a/src/shared/app-settings-provider.ts
+++ b/src/shared/app-settings-provider.ts
@@ -40,6 +40,7 @@ export {
   resolveModelProviderApiKey,
   resolveModelProviderBaseUrl,
   resolveModelProviderProxyUrl,
+  resolveModelProviderProxyUrlForProvider,
   resolveModelRouteTargetReference
 } from './app-settings-provider-core'
 export {

--- a/src/shared/app-settings-types-provider.ts
+++ b/src/shared/app-settings-types-provider.ts
@@ -437,6 +437,7 @@ export type ModelProviderProfileV1 = {
   apiKey: string
   baseUrl: string
   endpointFormat: ModelEndpointFormat
+  proxy?: NetworkProxySettingsV1
   /** 模型请求遇到临时失败或限流响应时使用的 HTTP 重试策略。 */
   retry?: ModelRequestRetrySettingsV1
   /**


### PR DESCRIPTION
## Summary
Adds provider-scoped proxy settings in the Provider Connection tab while preserving the legacy global proxy as a fallback. Explicitly disabled provider proxies override the global setting, preventing proxy leakage between providers.

## Changes
- Add optional normalized proxy settings to each provider profile.
- Resolve proxy per provider with explicit disable precedence and global compatibility fallback.
- Pass the scoped proxy into Kun runtime provider configs.
- Add Connection-tab toggle and URL input using existing provider mutation flow.

## Tests
- 
pm.cmd exec vitest run src/shared/app-settings-provider.test.ts src/main/legacy-provider-settings-migration.test.ts -> 37 passed.
- 
pm.cmd exec eslint src/main/runtime/kun-runtime-model-config.ts src/renderer/src/components/settings-section-providers-connection-panels.tsx src/shared/app-settings-provider-core.ts src/shared/app-settings-provider-profiles.ts src/shared/app-settings-provider.test.ts src/shared/app-settings-provider.ts src/shared/app-settings-types-provider.ts -> passed.
- git diff --check -> passed.
- Full typecheck/build are blocked by baseline dependency issues and disk space; see follow-up comment.

## Issue
Fixes #1248