### PR TITLE
fix(windows): stabilize installer and update handoff smoke

### DIFF
--- a/.github/workflows/daily-dev-prerelease.yml
+++ b/.github/workflows/daily-dev-prerelease.yml
@@ -122,7 +122,8 @@ jobs:
   build-windows:
     name: Build Windows
     runs-on: windows-latest
-    timeout-minutes: 90
+    # Keep the same Windows validation budget as PR and release packaging.
+    timeout-minutes: 180
     needs:
       - prepare
     env:
@@ -173,7 +174,7 @@ jobs:
         run: npm run dist:win
 
       - name: Smoke Windows installer migration
-        timeout-minutes: 60
+        timeout-minutes: 120
         env:
           KUN_INSTALLER_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}\artifacts\windows-installer-smoke
         run: npm run smoke:windows-installer-migration -- -InstallerPath (Get-ChildItem dist/Kun-*-win-x64.exe | Select-Object -First 1 -ExpandProperty FullName)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -234,7 +234,9 @@ jobs:
     name: Build Windows NSIS installer (PR)
     runs-on: windows-latest
     needs: quality
-    timeout-minutes: 90
+    # The packaged migration matrix alone takes more than 60 minutes on hosted
+    # runners. Leave room for dependency install, packaging, and handoff smoke.
+    timeout-minutes: 180
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
     steps:
@@ -293,7 +295,7 @@ jobs:
         run: npm run dist:win
 
       - name: Smoke Windows installer migration
-        timeout-minutes: 60
+        timeout-minutes: 120
         env:
           KUN_INSTALLER_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}\artifacts\windows-installer-smoke
         run: npm run smoke:windows-installer-migration -- -InstallerPath (Get-ChildItem dist/Kun-*-win-x64.exe | Select-Object -First 1 -ExpandProperty FullName)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,8 @@ jobs:
   build-windows:
     name: Build Windows
     runs-on: windows-latest
-    timeout-minutes: 90
+    # Keep the same Windows validation budget as PR and daily packaging.
+    timeout-minutes: 180
     needs:
       - prepare
     env:
@@ -208,7 +209,7 @@ jobs:
         run: npm run dist:win
 
       - name: Smoke Windows installer migration
-        timeout-minutes: 60
+        timeout-minutes: 120
         env:
           KUN_INSTALLER_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}\artifacts\windows-installer-smoke
         run: npm run smoke:windows-installer-migration -- -InstallerPath (Get-ChildItem dist/Kun-*-win-x64.exe | Select-Object -First 1 -ExpandProperty FullName)

--- a/scripts/smoke-windows-installer-manual-upgrade.ps1
+++ b/scripts/smoke-windows-installer-manual-upgrade.ps1
@@ -67,9 +67,9 @@ $script:manualUpgradeFixturePath = Join-Path $root 'manual-upgrade-fixture.exe'
 New-ManualUpgradeFixtureExecutable $script:manualUpgradeFixturePath
 
 Invoke-OldUninstallerBypassSmoke `
-  'manual overwrite bypasses non-zero old uninstaller' $custom 'exit2' 180
+  'manual overwrite bypasses non-zero old uninstaller' $custom 'exit2' 600
 Invoke-OldUninstallerBypassSmoke `
-  'manual overwrite bypasses hanging old uninstaller' $custom 'hang' 180
+  'manual overwrite bypasses hanging old uninstaller' $custom 'hang' 600
 
 $manualUserRoot = Join-Path $custom ($unicodeDirectoryName + '-user-files')
 $manualNestedRoot = Join-Path $manualUserRoot 'nested'
@@ -86,7 +86,7 @@ $selfInstaller = Join-Path $custom 'Kun-manual-upgrade-smoke.exe'
 Copy-Item -LiteralPath $script:InstallerPath -Destination $selfInstaller
 $selfInstallerHash = Get-FileSha256 $selfInstaller
 Invoke-Installer -Scenario 'installer runs from the previous application directory' `
-  -Arguments @('/S', '/currentuser') -TimeoutSeconds 300 -ExecutablePath $selfInstaller
+  -Arguments @('/S', '/currentuser') -TimeoutSeconds 600 -ExecutablePath $selfInstaller
 Assert-True (Test-Path -LiteralPath $selfInstaller -PathType Leaf) `
   'The running installer was removed from the previous application directory.'
 Assert-True ((Get-FileSha256 $selfInstaller) -eq $selfInstallerHash) `
@@ -110,7 +110,7 @@ try {
   }
   Assert-True (Test-Path -LiteralPath $resourceMarker) 'The installed resource blocker did not start.'
   Invoke-Installer -Scenario 'manual overwrite stops an installed resource process' `
-    -Arguments @('/S', '/currentuser') -TimeoutSeconds 300
+    -Arguments @('/S', '/currentuser') -TimeoutSeconds 600
   Assert-True ($resourceProcess.WaitForExit(10000)) `
     'The verified installed resource process remained alive after manual overwrite.'
 } finally {

--- a/scripts/smoke-windows-installer-migration.ps1
+++ b/scripts/smoke-windows-installer-migration.ps1
@@ -116,7 +116,8 @@ function Invoke-Installer(
 function Invoke-Uninstaller(
   [string]$Scenario,
   [string]$InstallLocation,
-  [ValidateSet('/currentuser', '/allusers')][string]$Mode
+  [ValidateSet('/currentuser', '/allusers')][string]$Mode,
+  [int]$TimeoutSeconds = 600
 ) {
   $script:currentScenario = $Scenario
   $source = Join-Path $InstallLocation 'Uninstall Kun.exe'
@@ -125,10 +126,15 @@ function Invoke-Uninstaller(
   try {
     # NSIS uninstallers normally launch a temporary child and let the original
     # process exit early. Running our own copy with _?= as the final, unquoted
-    # argument makes -Wait observe the real uninstall lifecycle.
+    # argument makes the spawned process represent the real uninstall lifecycle,
+    # so a bounded WaitForExit can observe it without hanging the whole CI step.
     $arguments = @('/S', $Mode, ('_?={0}' -f $InstallLocation))
     Write-Host "[$Scenario] Starting copied uninstaller: $($arguments -join ' ')"
-    $process = Start-Process -FilePath $copy -ArgumentList $arguments -Wait -PassThru
+    $process = Start-Process -FilePath $copy -ArgumentList $arguments -PassThru
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+      & "$env:SystemRoot\System32\taskkill.exe" /PID $process.Id /T /F | Out-Null
+      throw "[$Scenario] Uninstaller PID $($process.Id) did not exit within $TimeoutSeconds seconds."
+    }
     Assert-True ($process.ExitCode -eq 0) "Uninstaller exited with $($process.ExitCode)."
   } finally {
     Remove-Item -LiteralPath $copy -Force -ErrorAction SilentlyContinue
@@ -477,6 +483,14 @@ try {
   Remove-Item -LiteralPath $conflictTarget -Recurse -Force
   Invoke-Installer 'conflict retry migration' @('/S', '/currentuser')
   Assert-RegisteredLocation $conflictTarget
+  $conflictManualUserRoot = Join-Path $conflictSource ($unicodeDirectoryName + '-user-files')
+  $conflictManualTextFile = Join-Path $conflictManualUserRoot 'notes.txt'
+  $conflictManualBinaryFile = Join-Path $conflictManualUserRoot 'nested\payload.bin'
+  Assert-True ((Get-FileSha256 $conflictManualTextFile) -eq $manualUserHashes[$manualTextFile]) `
+    'The conflict retry did not restore the Unicode user text to the old source.'
+  Assert-True ((Get-FileSha256 $conflictManualBinaryFile) -eq $manualUserHashes[$manualBinaryFile]) `
+    'The conflict retry did not restore the nested binary user file to the old source.'
+  Move-Item -LiteralPath $conflictManualUserRoot -Destination $conflictTarget
 
   $externalBacking = Join-Path $root 'external-drive'
   $script:substDrive = New-TemporarySubstDrive $externalBacking
@@ -523,15 +537,15 @@ try {
     'The all-users migration changed the preserved Unicode user text.'
   Assert-True ((Get-FileSha256 $externalManualBinaryFile) -eq $manualUserHashes[$manualBinaryFile]) `
     'The all-users migration changed the preserved nested binary user file.'
-  $allUsersPrepareDiagnostics = @(Get-Content -LiteralPath $diagnosticPath | Where-Object {
-    $_ -match 'START action=Prepare' -and
+  $allUsersMigrationDiagnostics = @(Get-Content -LiteralPath $diagnosticPath | Where-Object {
+    $_ -match 'START action=FallbackCleanup' -and
       $_ -match [regex]::Escape("source=$externalSource") -and
       $_ -match 'installMode=all' -and
       $_ -match 'uacInner=[01]'
   })
-  Assert-True ($allUsersPrepareDiagnostics.Count -gt 0) `
+  Assert-True ($allUsersMigrationDiagnostics.Count -gt 0) `
     'The all-users migration did not record its outer/inner installer evidence.'
-  $ranUacInner = [bool]($allUsersPrepareDiagnostics | Where-Object { $_ -match 'uacInner=1' })
+  $ranUacInner = [bool]($allUsersMigrationDiagnostics | Where-Object { $_ -match 'uacInner=1' })
   if ($env:KUN_INSTALLER_SMOKE_REQUIRE_UAC_INNER -eq '1') {
     Assert-True $ranUacInner 'This smoke environment required a real UAC inner installer instance.'
   } elseif (-not $ranUacInner) {

--- a/src/main/kun-process-ports.ts
+++ b/src/main/kun-process-ports.ts
@@ -240,7 +240,7 @@ async function windowsProcessIdentity(pid: number): Promise<ProcessIdentity | nu
       '-NoProfile',
       '-NonInteractive',
       '-Command',
-      `$process = Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}'; if ($process) { [pscustomobject]@{ ProcessId = $process.ProcessId; ExecutablePath = $process.ExecutablePath; CommandLine = $process.CommandLine; CreationDate = $process.CreationDate } | ConvertTo-Json -Compress }`
+      `$process = Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}'; if ($process) { $creationDate = if ($process.CreationDate) { $process.CreationDate.ToUniversalTime().ToString('o') } else { $null }; [pscustomobject]@{ ProcessId = $process.ProcessId; ExecutablePath = $process.ExecutablePath; CommandLine = $process.CommandLine; CreationDate = $creationDate } | ConvertTo-Json -Compress }`
     ],
     { windowsHide: true, timeout: 5_000 }
   )

--- a/src/main/kun-process.ports.test.ts
+++ b/src/main/kun-process.ports.test.ts
@@ -324,3 +324,21 @@ describe('terminateVerifiedPid', () => {
   })
 
 })
+
+describe('processIdentity', () => {
+  it.runIf(process.platform === 'win32')(
+    'reads a complete identity through Windows PowerShell 5.1',
+    async () => {
+      const { processIdentity } = await import('./kun-process-ports')
+
+      const identity = await processIdentity(process.pid)
+
+      expect(identity).toMatchObject({
+        pid: process.pid,
+        executablePath: expect.any(String),
+        commandLine: expect.any(String),
+        startedAtMs: expect.any(Number)
+      })
+    }
+  )
+})

--- a/src/main/windows-installer-manual-upgrade-smoke.test.ts
+++ b/src/main/windows-installer-manual-upgrade-smoke.test.ts
@@ -16,22 +16,28 @@ describe('Windows manual-upgrade packaged smoke contract', () => {
   it('proves old uninstallers cannot control manual overwrite', () => {
     expect(mainSmoke).toContain(". (Join-Path $PSScriptRoot 'smoke-windows-installer-manual-upgrade.ps1')")
     expect(manualSmoke).toContain("[ValidateSet('exit2', 'hang')]")
-    expect(manualSmoke).toContain("'manual overwrite bypasses non-zero old uninstaller'")
-    expect(manualSmoke).toContain("'manual overwrite bypasses hanging old uninstaller'")
+    expect(manualSmoke).toContain("'manual overwrite bypasses non-zero old uninstaller' $custom 'exit2' 600")
+    expect(manualSmoke).toContain("'manual overwrite bypasses hanging old uninstaller' $custom 'hang' 600")
     expect(manualSmoke).toContain("-Destination (Join-Path $Source 'Uninstall Kun.exe') -Force")
     expect(manualSmoke).toContain("Assert-True (-not (Test-Path -LiteralPath $marker))")
     expect(mainSmoke).toContain("'The elevated manual overwrite invoked the current-user old uninstaller fixture.'")
     expect(mainSmoke).toContain("$env:KUN_INSTALLER_SMOKE_REQUIRE_UAC_INNER -eq '1'")
+    expect(mainSmoke).toContain("$_ -match 'START action=FallbackCleanup'")
     expect(mainSmoke).toContain("$_ -match 'uacInner=1'")
   })
 
   it('covers bounded execution, installer self-location, real blockers, and user files', () => {
+    expect(mainSmoke).toContain('[int]$TimeoutSeconds = 600')
     expect(mainSmoke).toContain('$process.WaitForExit($TimeoutSeconds * 1000)')
-    expect(manualSmoke).toContain('-ExecutablePath $selfInstaller')
+    expect(manualSmoke).toContain('-TimeoutSeconds 600 -ExecutablePath $selfInstaller')
     expect(manualSmoke).toContain("'resources\\kun-installer-smoke-blocker.exe'")
     expect(manualSmoke).toContain("'manual overwrite stops an installed resource process'")
+    expect(manualSmoke).toContain("-Arguments @('/S', '/currentuser') -TimeoutSeconds 600")
     expect(manualSmoke).toContain('Assert-ManualUpgradeUserFiles $manualUserHashes')
     expect(manualSmoke).toContain('Get-FileSha256 $manualBinaryFile')
+    expect(mainSmoke).toContain(
+      'Move-Item -LiteralPath $conflictManualUserRoot -Destination $conflictTarget'
+    )
     expect(mainSmoke).toContain('Assert-KunShortcuts')
     expect(mainSmoke).toContain('Assert-PathReconciled')
   })
@@ -48,6 +54,27 @@ describe('Windows manual-upgrade packaged smoke contract', () => {
       expect(source).toContain('KUN_INSTALLER_SMOKE_ARTIFACT_DIR:')
       expect(source).toContain('artifacts/windows-installer-smoke/**')
       expect(source).toContain('if: always()')
+    }
+  })
+
+  it('gives the complete Windows migration matrix enough hosted-runner time', () => {
+    for (const [workflow, jobName] of [
+      ['.github/workflows/pr-checks.yml', 'package-windows'],
+      ['.github/workflows/daily-dev-prerelease.yml', 'build-windows'],
+      ['.github/workflows/release.yml', 'build-windows']
+    ]) {
+      const source = readFileSync(join(root, workflow), 'utf8')
+      const jobStart = source.indexOf(`\n  ${jobName}:`)
+      const nextJobPattern = /\n {2}[A-Za-z0-9_-]+:\r?\n/gu
+      nextJobPattern.lastIndex = jobStart + 1
+      const nextJob = nextJobPattern.exec(source)
+      const windowsJob = source.slice(jobStart, nextJob?.index)
+
+      expect(jobStart).toBeGreaterThanOrEqual(0)
+      expect(windowsJob).toContain('timeout-minutes: 180')
+      expect(windowsJob).toMatch(
+        /- name: Smoke Windows installer migration\s+timeout-minutes: 120/u
+      )
     }
   })
 })

--- a/src/main/windows-installer-migration.test.ts
+++ b/src/main/windows-installer-migration.test.ts
@@ -248,7 +248,10 @@ describe('Windows installer migration ACL contract', () => {
     const script = readFileSync(smokePath, 'utf8')
 
     expect(script).toContain("$arguments = @('/S', $Mode, ('_?={0}' -f $InstallLocation))")
-    expect(script).toContain('Start-Process -FilePath $copy -ArgumentList $arguments -Wait -PassThru')
+    expect(script).toContain('[int]$TimeoutSeconds = 600')
+    expect(script).toContain('Start-Process -FilePath $copy -ArgumentList $arguments -PassThru')
+    expect(script).toContain('$process.WaitForExit($TimeoutSeconds * 1000)')
+    expect(script).toContain('Uninstaller PID $($process.Id) did not exit within $TimeoutSeconds seconds.')
     expect(script).not.toMatch(/Start-Process -FilePath \$(?:unicode|machine)Uninstaller/u)
   })
 


### PR DESCRIPTION
## Summary

- give the complete Windows installer migration step 120 minutes and its enclosing job 180 minutes in PR, daily, and release workflows
- keep each installer and copied-uninstaller process bounded to 600 seconds with explicit PID/scenario failures
- keep restored manual-upgrade user files at their actual source until the external-drive fixture is staged
- assert all-users outer/inner installer evidence on the diagnostic action that records it
- normalize Win32 CIM process creation time to ISO-8601 before packaged handoff identity verification

## Why

Follow-up to #1257. Successive Windows runs exposed independent assumptions in the smoke path: the full migration matrix exceeds 60 minutes, individual clean installs can exceed 300 seconds, rollback restores unknown files to the legacy source, all-users source/UAC evidence is emitted by FallbackCleanup, and Windows PowerShell 5.1 serializes CIM CreationDate as /Date(...)/, which Date.parse() cannot verify.

The workflow remains bounded at every layer. The identity fix also keeps the fail-closed PID-generation checks intact; it only makes the PowerShell timestamp transport unambiguous.

## Tests

- npx vitest run src/main/windows-installer-manual-upgrade-smoke.test.ts src/main/windows-installer-migration.test.ts (39 passed)
- npx vitest run src/main/kun-process.ports.test.ts src/main/kun-process-identity.test.ts (20 passed)
- npm run typecheck
- ESLint on all changed TypeScript files
- Windows PowerShell 5.1 parser validation for changed smoke scripts
- parsed all three updated workflows and verified Windows budgets: job 180, migration 120, handoff 20
- npm run check:file-lines
- git diff --check
- configured Windows win-unpacked rebuild
- npm run smoke:packaged-update-handoff -- --resources dist/win-unpacked/resources (4 update paths and 2 fail-closed owner cases passed)
- GitHub run 33617817308 reached the penultimate long migration scenario before the old 60-minute step limit terminated it
