### PR TITLE
fix(design): cancel page orchestration before interrupt

### DIFF
--- a/src/renderer/src/components/design/DesignConversationContent.tsx
+++ b/src/renderer/src/components/design/DesignConversationContent.tsx
@@ -21,7 +21,7 @@ import type { ModelProviderModelGroup } from '@shared/kun-gui-api'
 import { useDesignWorkspaceStore } from '../../design/design-workspace-store'
 import { drawingHistoryMutationMatches } from '../../design/design-drawing-history'
 import { defaultFrameSizeForDesignTarget } from '../../design/design-context'
-import { cancelDesignPagesRun } from '../../design/design-pages-run'
+import { cancelDesignPagesRun, interruptDesignPagesRun } from '../../design/design-pages-run'
 import { LazyMessageTimeline } from '../chat/LazyMessageTimeline'
 import { FloatingComposer } from '../chat/FloatingComposer'
 import type { DesignComposerContext } from '../chat/FloatingComposer'
@@ -484,7 +484,7 @@ export function DesignConversationContent({
             onRemoveAttachment={onRemoveAttachment}
             onRemoveContextChip={onRemoveContextChip}
             onSend={onSend}
-            onInterrupt={onInterrupt}
+            onInterrupt={(options) => interruptDesignPagesRun(onInterrupt, options)}
             onConfigureProviders={onConfigureProviders}
           />
         )}

--- a/src/renderer/src/components/design/DesignDrawingStart.tsx
+++ b/src/renderer/src/components/design/DesignDrawingStart.tsx
@@ -8,6 +8,7 @@ import type {
 import type { ModelProviderModelGroup } from '@shared/kun-gui-api'
 import type { QueuedUserMessage } from '../../store/chat-store-types'
 import { useDesignWorkspaceStore } from '../../design/design-workspace-store'
+import { interruptDesignPagesRun } from '../../design/design-pages-run'
 import { FloatingComposer, type DesignComposerContext } from '../chat/FloatingComposer'
 import type { ComposerReasoningEffort } from '../chat/FloatingComposerModelPicker'
 import { SidebarTitlebarToggleButton } from '../sidebar/SidebarPrimitives'
@@ -181,7 +182,7 @@ export function DesignDrawingStart({
               onRemoveAttachment={onRemoveAttachment}
               onRemoveContextChip={onRemoveContextChip}
               onSend={onSend}
-              onInterrupt={onInterrupt}
+              onInterrupt={(options) => interruptDesignPagesRun(onInterrupt, options)}
               onConfigureProviders={onConfigureProviders}
             />
           </div>

--- a/src/renderer/src/components/design/DesignImplementPanel.tsx
+++ b/src/renderer/src/components/design/DesignImplementPanel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import type { AttachmentReference, RuntimeConnectionStatus, ChatBlock } from '../../agent/types'
 import type { QueuedUserMessage } from '../../store/chat-store-types'
 import type { ModelProviderModelGroup } from '@shared/kun-gui-api'
+import { interruptDesignPagesRun } from '../../design/design-pages-run'
 import { LazyMessageTimeline } from '../chat/LazyMessageTimeline'
 import { FloatingComposer } from '../chat/FloatingComposer'
 import type { ComposerReasoningEffort } from '../chat/FloatingComposerModelPicker'
@@ -181,7 +182,7 @@ export function DesignImplementPanel({
           onPasteClipboardImage={onPasteClipboardImage}
           onRemoveAttachment={onRemoveAttachment}
           onSend={onSend}
-          onInterrupt={onInterrupt}
+          onInterrupt={(options) => interruptDesignPagesRun(onInterrupt, options)}
           onConfigureProviders={onConfigureProviders}
         />
       </div>

--- a/src/renderer/src/design/design-pages-run.test.ts
+++ b/src/renderer/src/design/design-pages-run.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useChatStore } from '../store/chat-store'
 import { useDesignWorkspaceStore } from './design-workspace-store'
-import { runDesignPages } from './design-pages-run'
+import { interruptDesignPagesRun, isDesignPagesRunActive, runDesignPages } from './design-pages-run'
+import { beginDesignPagesRun, finishDesignPagesRun } from './design-pages-run/orchestration-support'
 import type { ChatBlock } from '../agent/types'
 import type { DesignArtifact, DesignDocument } from './design-types'
 import type { SendMessageOverrides } from '../store/chat-store-types'
@@ -83,6 +84,65 @@ describe('runDesignPages parallel fanout', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+  })
+
+  it('cancels the local orchestration before interrupting the runtime turn', () => {
+    const signal = { cancelled: false }
+    expect(beginDesignPagesRun(signal)).toBe(true)
+    const order: string[] = []
+    try {
+      interruptDesignPagesRun(() => {
+        order.push('runtime-interrupt')
+        expect(signal.cancelled).toBe(true)
+      })
+      expect(order).toEqual(['runtime-interrupt'])
+      expect(signal.cancelled).toBe(true)
+    } finally {
+      finishDesignPagesRun(signal)
+    }
+  })
+
+  it('stops a live fanout without scheduling another design turn', async () => {
+    let fanoutStarted!: () => void
+    const fanoutReady = new Promise<void>((resolve) => {
+      fanoutStarted = resolve
+    })
+    const sendMessage = vi.fn(async (prompt: string) => {
+      if (prompt.includes('PLAN a multi-page')) {
+        pushRuntimeTurn(prompt, [{
+          kind: 'assistant',
+          id: 'assistant_cancel_plan',
+          text: '```pages\n[{"title":"Home","brief":"Home page"},{"title":"Settings","brief":"Settings page"}]\n```',
+          createdAt
+        }])
+        return true
+      }
+      fanoutStarted()
+      useChatStore.setState({ currentTurnId: 'turn_fanout', busy: true })
+      return true
+    })
+
+    const runPromise = runDesignPages({
+      brief: 'Cancelable project',
+      workspaceRoot: '/workspace',
+      sendMessage,
+      foundation: false,
+      expectedThreadId: 'thr_design'
+    })
+    await fanoutReady
+    expect(isDesignPagesRunActive()).toBe(true)
+
+    interruptDesignPagesRun(() => {
+      useChatStore.setState({ currentTurnId: null, busy: false })
+    })
+    await runPromise
+
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+    expect(isDesignPagesRunActive()).toBe(false)
+    expect(useDesignWorkspaceStore.getState().pagesRun).toBeNull()
+    expect(writeWorkspaceFile.mock.calls.some((call) => (
+      call[0] as { path?: string } | undefined
+    )?.path === '.kun-design/HANDOFF.md')).toBe(false)
   })
 
   it('pre-creates all pages and sends one fanout turn for page generation', async () => {

--- a/src/renderer/src/design/design-pages-run.ts
+++ b/src/renderer/src/design/design-pages-run.ts
@@ -1,3 +1,18 @@
 export type { RunDesignPagesDeps } from './design-pages-run/orchestration-support'
 export { cancelDesignPagesRun, deriveParallelDesignPageStatesFromBlocks, isDesignPagesRunActive } from './design-pages-run/orchestration-support'
 export { runDesignPages } from './design-pages-run/runner'
+import { cancelDesignPagesRun } from './design-pages-run/orchestration-support'
+
+/**
+ * Stop the renderer-owned multi-step Design orchestration before interrupting
+ * the current runtime turn. The runtime can become idle immediately after an
+ * interrupt; cancelling first prevents that idle transition from being
+ * mistaken for a normally completed step and scheduling the next one.
+ */
+export function interruptDesignPagesRun(
+  interrupt: (options?: { discard?: boolean }) => void,
+  options?: { discard?: boolean }
+): void {
+  cancelDesignPagesRun()
+  interrupt(options)
+}


### PR DESCRIPTION
## Summary\nCancel the renderer-owned Design multi-page orchestration before forwarding a runtime interrupt, preventing an interrupted turn's idle transition from scheduling later Design stages.\n\n## Changes\n- Add a Design-scoped interrupt wrapper that cancels local orchestration before invoking the runtime callback.\n- Wire the wrapper only to DesignConversationContent.\n- Cover callback ordering and a live fanout cancellation regression.\n\n## Validation\n- npm.cmd exec vitest run src/renderer/src/design/design-pages-run.test.ts src/renderer/src/design/design-pages-dispatch.test.ts\n- npm.cmd exec eslint -- src/renderer/src/design/design-pages-run.ts src/renderer/src/design/design-pages-run.test.ts src/renderer/src/components/design/DesignConversationContent.tsx\n- npm.cmd run check:file-lines\n- npm.cmd run typecheck\n- npm.cmd run build\n- git diff --check\n\nAll local checks passed. Build emitted only pre-existing Rollup circular dependency warnings.\n\nRelated to #1233 (issue is already closed; no auto-close keyword).