### PR TITLE
fix(renderer): restore quality gate baseline

### DIFF
--- a/src/renderer/src/components/chat/BackgroundShellOverlay.tsx
+++ b/src/renderer/src/components/chat/BackgroundShellOverlay.tsx
@@ -19,7 +19,10 @@ const SHELL_POPOVER_WIDTH = 736
 const SHELL_POPOVER_MAX_HEIGHT = 620
 const SHELL_POPOVER_ESTIMATED_HEIGHT = 560
 
-const ANSI_ESCAPE_SEQUENCE = /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g
+const ANSI_ESCAPE_SEQUENCE = new RegExp(
+  `${String.fromCharCode(27)}(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])`,
+  'g'
+)
 
 export function stripAnsiSequences(value: string): string {
   return value.replace(ANSI_ESCAPE_SEQUENCE, '')

--- a/src/renderer/src/components/workbench/UsageQuotaPanel.test.ts
+++ b/src/renderer/src/components/workbench/UsageQuotaPanel.test.ts
@@ -156,7 +156,7 @@ describe('UsageQuotaPanel', () => {
     expect(renderer.root.findByProps({ 'data-usage-range': '30d' }).props['aria-pressed']).toBe(false)
     expect(renderer.root.findByProps({ 'data-usage-range': '90d' }).props['aria-pressed']).toBe(false)
     expect(renderer.root.findByProps({ 'data-usage-range': 'all' }).props['aria-pressed']).toBe(false)
-    expectUsageRange(runtimeRequest, 'day', 7)
+    expectUsageRange(runtimeRequest, 'day', 84)
     expectUsageRange(runtimeRequest, 'model', 7)
     expect(listProviderQuotas).not.toHaveBeenCalled()
     const output = JSON.stringify(renderer.toJSON())
@@ -191,19 +191,19 @@ describe('UsageQuotaPanel', () => {
     await act(async () => {
       renderer.root.findByProps({ 'data-usage-range': '30d' }).props.onClick()
     })
-    expectUsageRange(runtimeRequest, 'day', 30)
+    expectUsageRange(runtimeRequest, 'day', 84)
     expectUsageRange(runtimeRequest, 'model', 30)
 
     await act(async () => {
       renderer.root.findByProps({ 'data-usage-range': '90d' }).props.onClick()
     })
-    expectUsageRange(runtimeRequest, 'day', 90)
+    expectUsageRange(runtimeRequest, 'day', 84)
     expectUsageRange(runtimeRequest, 'model', 90)
 
     await act(async () => {
       renderer.root.findByProps({ 'data-usage-range': 'all' }).props.onClick()
     })
-    expectUsageRange(runtimeRequest, 'day', 365)
+    expectUsageRange(runtimeRequest, 'day', 84)
     expectUsageRange(runtimeRequest, 'model', 365)
 
     const resetPage = JSON.stringify(renderer.toJSON())


### PR DESCRIPTION
## Summary / 概要

Restore the renderer quality-gate baseline on the current `develop` branch by fixing two independent stale representations:

1. Express the existing ANSI escape-sequence matcher in a lint-safe form.
2. Align `UsageQuotaPanel` test expectations with the new fixed 12-week daily-history design.

恢复当前 `develop` 的 renderer 质量门禁基线：一项修复 lint 表达方式，另一项修复 Usage 12 周历史重构后遗漏更新的测试断言。

## Why / 背景

### 1. Intentional ANSI matching triggered `no-control-regex`

`stripAnsiSequences()` intentionally matches ESC (U+001B) so terminal color and control sequences are removed before background-shell output is rendered.

The previous regex literal was functionally correct, but ESLint's `no-control-regex` rule rejects control characters written in regex literals. This caused the full `npm run lint` quality gate to fail even though the runtime behavior was correct.

The pattern is now constructed with `new RegExp()` and `String.fromCharCode(27)`, following the existing convention in `src/main/claude-subscription-auth.ts`. The pattern branches and global matching behavior remain unchanged.

### 2. The 12-week Usage history refactor left stale range assertions

Upstream commit `586283f3` introduced `SidebarUsageHistoryCard` and intentionally changed daily usage loading to a fixed `HISTORY_RANGE_DAYS = 84`, allowing the card to render 12 weeks × 7 days.

The range selector now has two distinct responsibilities:

- Daily history always loads 84 days for the fixed 12-week card.
- Model usage continues to follow the selected `7d`, `30d`, `90d`, or `all` range.

The existing `UsageQuotaPanel.test.ts` still expected both requests to follow the selector. The first #1264 quality-gate run therefore failed at the daily-range assertion with:

`expected 84 to be 7`

This was a deterministic stale-test failure in the current base rather than a runtime regression caused by the ANSI change.

Failure evidence:
https://github.com/KunAgent/Kun/actions/runs/33708795909/job/100503661816?pr=1264

## Changes / 变更

- Replace the ANSI regex literal with an equivalent lint-safe `RegExp` construction.
- Preserve ANSI stripping behavior without adding dependencies.
- Update all four daily-history expectations to 84 days.
- Keep model-usage expectations unchanged at 7, 30, 90, and 365 days.
- Keep the change intentionally narrow: 2 files, no UI, layout, or product-behavior change.

## Media / 截图或录屏

Not applicable. There is no visual or interaction change.

## Tests / 测试

Focused tests:

- `BackgroundShellOverlay.test.ts`
- `UsageQuotaPanel.test.ts`
- Result: **14/14 passed**

Coverage includes:

- ANSI sequence stripping.
- Plain-text preservation.
- Fixed 84-day daily history.
- Selector-driven model ranges.
- Equivalent output between the old and new ANSI patterns for representative plain text, SGR color, and erase-line sequences.

## Validation / 验证

- [x] I agree that this contribution is submitted under the [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md). / 我同意本贡献遵循 [Contributor License Agreement](https://github.com/KunAgent/Kun/blob/develop/CLA.md) 提交。
- [ ] `npm run test` — the local full-suite command did not return a conclusive exit code within the available execution window; GitHub Actions is the authoritative full-suite validation.
- [x] `npm run typecheck`
- [ ] `npm run build` — not required because no runtime or packaging behavior changed.
- [ ] `npm run dev` — not applicable because no runtime/UI behavior changed.
- [ ] UI change: video or GIF attached — not applicable.
- [x] Logic change: existing unit-test expectations were updated to match the intended 12-week history behavior.
- [x] `npm run lint` — passed with **0 errors** and 30 pre-existing warnings.
- [x] `git diff --check`

## Notes / 备注

This PR contains only renderer quality-gate baseline repairs. It remains separate from the Memory/P1 work so the feature PR stays focused.

After CI identified the stale Usage assertion, the original #1264 commit was amended into one clean commit:

`ff1e1ed16478c1cd43aba6e1c37f9da15a5ddc39`