### PR TITLE
fix(kun): route media generation through provider proxy for inline configs

### DIFF
--- a/kun/src/adapters/tool/image-gen-tool-provider.ts
+++ b/kun/src/adapters/tool/image-gen-tool-provider.ts
@@ -98,6 +98,12 @@ export type ImageGenToolProviderOptions = {
   attachmentStore?: AttachmentStore
   nowIso?: () => string
   resolveCredential?: ProviderCredentialResolver
+  /**
+   * Provider-level model proxy. Custom inline configs have no provider
+   * credential to resolve, so without this fallback their requests would
+   * bypass the proxy that chat model requests honor.
+   */
+  proxyUrl?: string
 }
 
 export type ProviderCredentialResolver = (providerId: string) => Promise<{
@@ -316,13 +322,19 @@ export function buildImageGenToolProviders(
           const credential = config.providerId && options.resolveCredential
             ? await options.resolveCredential(config.providerId)
             : undefined
+          // A resolved connection credential is authoritative: an empty proxyUrl
+          // means the connection explicitly bypasses the app proxy. Only inline
+          // configs without a providerId fall back to the provider-level proxy.
+          const proxyUrl = credential
+            ? credential.proxyUrl?.trim() || ''
+            : options.proxyUrl?.trim() || ''
           client = createImageGenClient({
             ...config,
             ...(credential ? {
               apiKey: credential.apiKey,
-              headers: { ...(config.headers ?? {}), ...(credential.headers ?? {}) },
-              ...(credential.proxyUrl ? { proxyUrl: credential.proxyUrl } : {})
-            } : {})
+              headers: { ...(config.headers ?? {}), ...(credential.headers ?? {}) }
+            } : {}),
+            ...(proxyUrl ? { proxyUrl } : {})
           })
         }
         const request = {

--- a/kun/src/adapters/tool/media-gen-proxy.test.ts
+++ b/kun/src/adapters/tool/media-gen-proxy.test.ts
@@ -17,6 +17,7 @@ const { createSpeechGenClient, createMusicGenClient } = await import('./media-ge
 const { createVideoGenClient } = await import('./media-gen-video-clients.js')
 const { createMediaFetch } = await import('./media-gen-client-support.js')
 const { buildImageGenToolProviders } = await import('./image-gen-tool-provider.js')
+const { buildSpeechGenToolProviders } = await import('./media-gen-tool-provider.js')
 
 const fakeGeneratedImage = {
   // Smallest detectable PNG payload so detectImage() accepts it and the tool
@@ -127,6 +128,95 @@ describe('media generation proxy fetch wiring', () => {
 
     const clientConfig = createImageGenClientMock.mock.calls[0][0] as Record<string, unknown>
     expect(clientConfig).not.toHaveProperty('proxyUrl')
+  })
+
+  it('falls back to the provider-level proxy for inline image configs without a providerId', async () => {
+    const { providers, available } = buildImageGenToolProviders({
+      ...imageGenConfigDefaults,
+      enabled: true,
+      protocol: 'openai-images',
+      baseUrl: 'https://images.example.test/v1',
+      apiKey: 'sk-inline',
+      model: 'test-model'
+    }, {
+      proxyUrl: 'http://proxy.lan:8080'
+    })
+
+    expect(available).toBe(true)
+    const tool = providers[0].tools.find((candidate) => candidate.name === 'generate_image')
+    const result = await tool!.execute({ prompt: 'a cat' }, minimalContext())
+    expect(result.isError).toBeFalsy()
+
+    const clientConfig = createImageGenClientMock.mock.calls[0][0] as Record<string, unknown>
+    expect(clientConfig.proxyUrl).toBe('http://proxy.lan:8080')
+    expect(clientConfig.apiKey).toBe('sk-inline')
+  })
+
+  it('prefers the resolved credential proxy over the provider-level fallback', async () => {
+    const { providers } = buildImageGenToolProviders({
+      ...imageGenConfigDefaults,
+      enabled: true,
+      protocol: 'openai-images',
+      baseUrl: 'https://images.example.test/v1',
+      model: 'test-model',
+      providerId: 'prov-1'
+    }, {
+      proxyUrl: 'http://fallback.lan:8080',
+      resolveCredential: async () => ({
+        apiKey: 'sk-test',
+        proxyUrl: 'http://proxy.lan:8080'
+      })
+    })
+
+    const tool = providers[0].tools.find((candidate) => candidate.name === 'generate_image')
+    await tool!.execute({ prompt: 'a cat' }, minimalContext())
+
+    const clientConfig = createImageGenClientMock.mock.calls[0][0] as Record<string, unknown>
+    expect(clientConfig.proxyUrl).toBe('http://proxy.lan:8080')
+  })
+
+  it('honors a connection that explicitly bypasses the proxy instead of falling back', async () => {
+    const { providers } = buildImageGenToolProviders({
+      ...imageGenConfigDefaults,
+      enabled: true,
+      protocol: 'openai-images',
+      baseUrl: 'https://images.example.test/v1',
+      model: 'test-model',
+      providerId: 'prov-direct'
+    }, {
+      proxyUrl: 'http://fallback.lan:8080',
+      resolveCredential: async () => ({ apiKey: 'sk-test' })
+    })
+
+    const tool = providers[0].tools.find((candidate) => candidate.name === 'generate_image')
+    await tool!.execute({ prompt: 'a cat' }, minimalContext())
+
+    const clientConfig = createImageGenClientMock.mock.calls[0][0] as Record<string, unknown>
+    expect(clientConfig).not.toHaveProperty('proxyUrl')
+  })
+
+  it('falls back to the provider-level proxy for inline speech configs without a providerId', async () => {
+    createProxyFetchMock.mockReturnValue(async () => {
+      throw new Error('proxied fetch invoked')
+    })
+    const { providers, available } = buildSpeechGenToolProviders({
+      enabled: true,
+      protocol: 'openai-speech',
+      baseUrl: 'https://speech.example.test/v1',
+      apiKey: 'sk-inline',
+      model: 'tts-test',
+      format: 'mp3',
+      timeoutMs: 30_000
+    }, {
+      proxyUrl: 'http://proxy.lan:8080'
+    })
+
+    expect(available).toBe(true)
+    const tool = providers[0].tools.find((candidate) => candidate.name === 'generate_speech')
+    const result = await tool!.execute({ text: 'hello' }, minimalContext())
+    expect(result.isError).toBe(true)
+
+    expect(createProxyFetchMock).toHaveBeenCalledWith('http://proxy.lan:8080')
   })
 })
 

--- a/kun/src/adapters/tool/media-gen-tool-provider.ts
+++ b/kun/src/adapters/tool/media-gen-tool-provider.ts
@@ -146,6 +146,12 @@ export type MediaGenToolProviderOptions = {
   videoClient?: VideoGenClient
   nowIso?: () => string
   resolveCredential?: ProviderCredentialResolver
+  /**
+   * Provider-level model proxy. Custom inline configs have no provider
+   * credential to resolve, so without this fallback their requests would
+   * bypass the proxy that chat model requests honor.
+   */
+  proxyUrl?: string
 }
 
 export type SpeechGenToolProviderBuildResult = {
@@ -214,7 +220,7 @@ export function buildSpeechGenToolProviders(
       const requestTelemetry = () => telemetry(startedAt, client?.id ?? 'speech-provider')
       try {
         if (!client) {
-          client = createSpeechGenClient(await resolveProviderCredential(config, options.resolveCredential))
+          client = createSpeechGenClient(await resolveProviderCredential(config, options.resolveCredential, options.proxyUrl))
         }
         const media = await client.generate({
           text,
@@ -308,7 +314,7 @@ export function buildMusicGenToolProviders(
       const requestTelemetry = () => telemetry(startedAt, client?.id ?? 'music-provider')
       try {
         if (!client) {
-          client = createMusicGenClient(await resolveProviderCredential(config, options.resolveCredential))
+          client = createMusicGenClient(await resolveProviderCredential(config, options.resolveCredential, options.proxyUrl))
         }
         const media = await client.generate({
           ...(prompt ? { prompt } : {}),
@@ -447,7 +453,7 @@ export function buildVideoGenToolProviders(
       const requestTelemetry = () => telemetry(startedAt, client?.id ?? 'video-provider')
       try {
         if (!client) {
-          client = createVideoGenClient(await resolveProviderCredential(config, options.resolveCredential))
+          client = createVideoGenClient(await resolveProviderCredential(config, options.resolveCredential, options.proxyUrl))
         }
         const media = await client.generate({
           prompt,
@@ -508,18 +514,28 @@ async function resolveProviderCredential<T extends {
   providerId?: string
   apiKey?: string
   headers?: Record<string, string>
-}>(config: T, resolveCredential?: ProviderCredentialResolver): Promise<T & {
+}>(
+  config: T,
+  resolveCredential?: ProviderCredentialResolver,
+  fallbackProxyUrl?: string
+): Promise<T & {
   apiKey?: string
   headers?: Record<string, string>
   proxyUrl?: string
 }> {
-  if (!config.providerId || !resolveCredential) return config
+  const fallbackProxy = fallbackProxyUrl?.trim() ?? ''
+  if (!config.providerId || !resolveCredential) {
+    return fallbackProxy ? { ...config, proxyUrl: fallbackProxy } : config
+  }
   const credential = await resolveCredential(config.providerId)
+  // A resolved connection credential is authoritative: an empty proxyUrl means
+  // the connection explicitly bypasses the app proxy, so do not fall back here.
+  const proxyUrl = credential.proxyUrl?.trim() || ''
   return {
     ...config,
     apiKey: credential.apiKey,
     headers: { ...(config.headers ?? {}), ...(credential.headers ?? {}) },
-    ...(credential.proxyUrl ? { proxyUrl: credential.proxyUrl } : {})
+    ...(proxyUrl ? { proxyUrl } : {})
   }
 }
 

--- a/kun/src/server/runtime-composition-config.ts
+++ b/kun/src/server/runtime-composition-config.ts
@@ -310,19 +310,19 @@ export function createRuntimeConfigController(
 	    const nextImageGenProviders = buildImageGenToolProviders(nextOptions.capabilities?.imageGen, {
 	      attachmentStore: nextAttachmentStore,
 	      nowIso,
-	      resolveCredential: resolveCapabilityProviderCredential
+	      resolveCredential: resolveCapabilityProviderCredential, proxyUrl: nextOptions.modelProxyUrl
 	    })
 	    const nextSpeechGenProviders = buildSpeechGenToolProviders(nextOptions.capabilities?.speechGen, {
 	      nowIso,
-	      resolveCredential: resolveCapabilityProviderCredential
+	      resolveCredential: resolveCapabilityProviderCredential, proxyUrl: nextOptions.modelProxyUrl
 	    })
 	    const nextMusicGenProviders = buildMusicGenToolProviders(nextOptions.capabilities?.musicGen, {
 	      nowIso,
-	      resolveCredential: resolveCapabilityProviderCredential
+	      resolveCredential: resolveCapabilityProviderCredential, proxyUrl: nextOptions.modelProxyUrl
 	    })
 	    const nextVideoGenProviders = buildVideoGenToolProviders(nextOptions.capabilities?.videoGen, {
 	      nowIso,
-	      resolveCredential: resolveCapabilityProviderCredential
+	      resolveCredential: resolveCapabilityProviderCredential, proxyUrl: nextOptions.modelProxyUrl
 	    })
 	    const nextComputerUseProviders = await buildComputerUseToolProviders(nextOptions.capabilities?.computerUse)
 	    const nextBrowserUseProviders = buildBrowserUseToolProviders(nextOptions.capabilities?.browserUse)

--- a/kun/src/server/runtime-composition-services.ts
+++ b/kun/src/server/runtime-composition-services.ts
@@ -317,19 +317,23 @@ export async function createRuntimeServices(
 	  let imageGenProviders = buildImageGenToolProviders(core.activeOptions.capabilities?.imageGen, {
 	    attachmentStore,
 	    nowIso,
-	    resolveCredential: resolveCapabilityProviderCredential
+	    resolveCredential: resolveCapabilityProviderCredential,
+	    proxyUrl: core.activeOptions.modelProxyUrl
 	  })
 	  let speechGenProviders = buildSpeechGenToolProviders(core.activeOptions.capabilities?.speechGen, {
 	    nowIso,
-	    resolveCredential: resolveCapabilityProviderCredential
+	    resolveCredential: resolveCapabilityProviderCredential,
+	    proxyUrl: core.activeOptions.modelProxyUrl
 	  })
 	  let musicGenProviders = buildMusicGenToolProviders(core.activeOptions.capabilities?.musicGen, {
 	    nowIso,
-	    resolveCredential: resolveCapabilityProviderCredential
+	    resolveCredential: resolveCapabilityProviderCredential,
+	    proxyUrl: core.activeOptions.modelProxyUrl
 	  })
 	  let videoGenProviders = buildVideoGenToolProviders(core.activeOptions.capabilities?.videoGen, {
 	    nowIso,
-	    resolveCredential: resolveCapabilityProviderCredential
+	    resolveCredential: resolveCapabilityProviderCredential,
+	    proxyUrl: core.activeOptions.modelProxyUrl
 	  })
 	  let computerUseProviders = await buildComputerUseToolProviders(core.activeOptions.capabilities?.computerUse)
 	  let browserUseProviders = buildBrowserUseToolProviders(core.activeOptions.capabilities?.browserUse)


### PR DESCRIPTION
## Summary
- Media generation tools (image / speech / music / video) built from custom inline configs (no `providerId`) never resolve a provider credential, so `createProxyFetch` received an empty `proxyUrl` and their requests silently bypassed the configured model-request proxy.
- Symptom: `generate_image` requests time out or fail in networks that require the provider proxy, while chat model requests through the same provider work fine.

## Changes
- `kun/src/adapters/tool/image-gen-tool-provider.ts`, `media-gen-tool-provider.ts`: accept a fallback `proxyUrl` option. Inline configs without a `providerId` fall back to the provider-level model proxy so media requests stay on the same proxied path as chat model requests.
- A resolved connection credential stays authoritative: when the connection explicitly bypasses the app proxy, its empty `proxyUrl` is honored instead of falling back, matching the chat model request routing (`runtime-factory-model.ts`).
- `kun/src/server/runtime-composition-services.ts`, `runtime-composition-config.ts`: pass `modelProxyUrl` from the active serve options into the four media tool builders, on both initial composition and hot config apply.
- `kun/src/adapters/tool/media-gen-proxy.test.ts`: cover the inline-config proxy fallback (image + speech), credential-proxy precedence over the fallback, and the explicit-bypass case (no fallback when a resolved credential carries no proxy).

## Tests
- `npx vitest run src/adapters/tool/media-gen-proxy.test.ts` — 9 passed
- `npx vitest run src/adapters/tool/image-gen-network-error.test.ts` — 6 passed
- kun `tsc --noEmit` — clean (rebased on latest `develop` including #1270)
- `eslint` on all touched files — clean
- File-size gate — all touched files under 700 lines