### PR TITLE
fix(kun): align proxied stream types

### DIFF
--- a/kun/src/adapters/model/proxy-fetch.test.ts
+++ b/kun/src/adapters/model/proxy-fetch.test.ts
@@ -114,7 +114,7 @@ describe('proxy fetch streaming bodies', () => {
         method: 'POST',
         body: bodyStream,
         duplex: 'half'
-      })).text()
+      } as RequestInit & { duplex: 'half' })).text()
 
       expect(requests).toHaveLength(1)
       const captured = requests[0]
@@ -144,7 +144,7 @@ describe('proxy fetch streaming bodies', () => {
         body: bodyStream,
         duplex: 'half',
         headers: { 'content-length': String(bytes.length) }
-      })).text()
+      } as RequestInit & { duplex: 'half' })).text()
 
       expect(requests).toHaveLength(1)
       expect(requests[0].headers['content-length']).toBe(String(bytes.length))
@@ -173,7 +173,7 @@ describe('proxy fetch streaming bodies', () => {
         body: bodyStream,
         duplex: 'half',
         signal: controller.signal
-      })
+      } as RequestInit & { duplex: 'half' })
       await new Promise((resolve) => setTimeout(resolve, 20))
       controller.abort()
       await expect(pending).rejects.toThrow('The operation was aborted.')


### PR DESCRIPTION
## Summary

- Align the Kun proxy body stream bridge with the existing Electron main-process implementation.
- Type Node's request-only `duplex` option explicitly in the Kun proxy tests.

## Changes

- Cast the DOM `ReadableStream` through `node:stream/web` before calling `Readable.fromWeb`.
- Preserve the streaming request behavior and test coverage without changing runtime logic.

## Tests

- `npm --prefix kun run typecheck`
- `npm run build:kun`
- `npm run typecheck`
- `vitest run src/adapters/model/proxy-fetch.test.ts` (6/6 passed)
- changed-file ESLint
- `git diff --check`
