### PR TITLE
fix(workbench): collapse the right panel when its active rail button is clicked again

### DIFF
--- a/src/renderer/src/components/Workbench.tsx
+++ b/src/renderer/src/components/Workbench.tsx
@@ -390,7 +390,7 @@ export function Workbench(): ReactElement {
   } = useWorkbenchRightTools({
     input, inputRef, prevThreadId, activeThreadId,
     activeThreadDesignDocumentId: lockedDesignProfile?.documentTarget.documentId,
-    activeGuiPlan, sidePanel,
+    activeGuiPlan, rightPanelMode, sidePanel,
     currentSideConversations, designWorkspaceRoot, workspaceRoot, fileTreeWorkspaceRoot,
     filePreviewTarget, codeRightTabs, openSideConversationDraft, selectSideConversation,
     setSidePanelOpen, openFileTreeSidePanel, openDesignFileTreeSidePanel, openRightPanelTab,

--- a/src/renderer/src/components/workbench/useWorkbenchExtensionSurfaces.ts
+++ b/src/renderer/src/components/workbench/useWorkbenchExtensionSurfaces.ts
@@ -32,6 +32,7 @@ import {
 import { readBrowserStorageItem, removeBrowserStorageItem, writeBrowserStorageItem } from '../../lib/browser-storage'
 import type { useWorkbenchChatStoreState } from './useWorkbenchChatStoreState'
 import type { ComposerTaskSurface } from '../chat/FloatingComposerTaskSurfacePicker'
+import { resolveCodeRightToolClick } from './useWorkbenchRightTools'
 
 type WorkbenchState = ReturnType<typeof useWorkbenchChatStoreState>
 const extensionSurfaceLayoutStorage = {
@@ -205,7 +206,14 @@ export function useWorkbenchExtensionSurfaces({
   const selectRightRailExtension = useCallback((entry: ExtensionRightRailViewEntry): boolean => {
     const runnable = workbenchContributionRegistry.get(entry.id, contributionContext)
     if (isExtensionWorkbenchView(runnable) && runnable.point === 'views.rightSidebar') {
-      openExtensionSurface(runnable)
+      if (
+        isExtensionContributionId(entry.id) &&
+        resolveCodeRightToolClick(entry.id, rightPanelMode) === 'collapse'
+      ) {
+        setRightPanelMode(null)
+      } else {
+        openExtensionSurface(runnable)
+      }
       return true
     }
     if (entry.owner.kind !== 'extension' || entry.workspaceTrusted || !extensionWorkspaceRoot) {
@@ -254,7 +262,7 @@ export function useWorkbenchExtensionSurfaces({
     return true
   }, [
     contributionContext, extensionContributionLoadContext, extensionContributionLoadContextRef,
-    extensionWorkspaceRoot, openExtensionSurface, setError, t
+    extensionWorkspaceRoot, openExtensionSurface, rightPanelMode, setError, setRightPanelMode, t
   ])
 
   const openManagedExtensionView = useCallback(async (contributionId: string): Promise<void> => {

--- a/src/renderer/src/components/workbench/useWorkbenchRightTools.test.ts
+++ b/src/renderer/src/components/workbench/useWorkbenchRightTools.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { BUILTIN_RIGHT_PANEL_IDS } from '../../extensions/contribution-ids'
+import { resolveCodeRightToolClick } from './useWorkbenchRightTools'
+
+describe('resolveCodeRightToolClick', () => {
+  it('collapses the panel when the clicked tool is already visible', () => {
+    expect(resolveCodeRightToolClick(
+      BUILTIN_RIGHT_PANEL_IDS.providerQuotas,
+      BUILTIN_RIGHT_PANEL_IDS.providerQuotas
+    )).toBe('collapse')
+    expect(resolveCodeRightToolClick(
+      BUILTIN_RIGHT_PANEL_IDS.changes,
+      BUILTIN_RIGHT_PANEL_IDS.changes
+    )).toBe('collapse')
+  })
+
+  it('opens the tool when another tool or no tool is visible', () => {
+    expect(resolveCodeRightToolClick(
+      BUILTIN_RIGHT_PANEL_IDS.providerQuotas,
+      BUILTIN_RIGHT_PANEL_IDS.changes
+    )).toBe('open')
+    expect(resolveCodeRightToolClick(
+      BUILTIN_RIGHT_PANEL_IDS.providerQuotas,
+      null
+    )).toBe('open')
+  })
+
+  it('keeps the terminal on its own toggle path', () => {
+    expect(resolveCodeRightToolClick(BUILTIN_RIGHT_PANEL_IDS.terminal, null)).toBe('toggle-terminal')
+    expect(resolveCodeRightToolClick(
+      BUILTIN_RIGHT_PANEL_IDS.terminal,
+      BUILTIN_RIGHT_PANEL_IDS.providerQuotas
+    )).toBe('toggle-terminal')
+  })
+
+  it('collapses an active extension right-rail view', () => {
+    const extensionId = 'extension:example/right-panel' as const
+    expect(resolveCodeRightToolClick(extensionId, extensionId)).toBe('collapse')
+  })
+})

--- a/src/renderer/src/components/workbench/useWorkbenchRightTools.ts
+++ b/src/renderer/src/components/workbench/useWorkbenchRightTools.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, type RefObject } from 'react'
-import { BUILTIN_RIGHT_PANEL_IDS, type RightPanelContributionId } from '../../extensions/contribution-ids'
+import {
+  BUILTIN_RIGHT_PANEL_IDS,
+  type RightPanelContributionId,
+  type RightPanelMode
+} from '../../extensions/contribution-ids'
 import { normalizeWorkspaceRoot } from '../../lib/workspace-path'
 import { useCodeCanvasDesignSurface } from '../../design/code-canvas-design-surface'
 import { requestCodeCanvasPanelOpen } from '../../lib/code-canvas-panel-event'
@@ -11,6 +15,7 @@ type Params = {
   activeThreadId: string | null
   activeThreadDesignDocumentId?: string
   activeGuiPlan: unknown
+  rightPanelMode: RightPanelMode
   sidePanel: { open: boolean }
   currentSideConversations: Array<{ threadId: string }>
   designWorkspaceRoot: string
@@ -30,6 +35,21 @@ type Params = {
   expandRightPanel: () => void
 }
 
+export type CodeRightToolClick = 'open' | 'collapse' | 'toggle-terminal'
+
+/**
+ * Decides what a side-rail button click does. Clicking the button of the
+ * tool that is already visible collapses the right panel instead of
+ * re-opening the same tab, so the rail acts as a toggle.
+ */
+export function resolveCodeRightToolClick(
+  id: RightPanelContributionId,
+  rightPanelMode: RightPanelMode
+): CodeRightToolClick {
+  if (id === BUILTIN_RIGHT_PANEL_IDS.terminal) return 'toggle-terminal'
+  return rightPanelMode === id ? 'collapse' : 'open'
+}
+
 export function useWorkbenchRightTools({
   input,
   inputRef,
@@ -37,6 +57,7 @@ export function useWorkbenchRightTools({
   activeThreadId,
   activeThreadDesignDocumentId,
   activeGuiPlan,
+  rightPanelMode,
   sidePanel,
   currentSideConversations,
   designWorkspaceRoot,
@@ -95,14 +116,28 @@ export function useWorkbenchRightTools({
   }, [activeThreadDesignDocumentId, activeThreadId, designWorkspaceRoot, workspaceRoot])
 
   const openCodeRightTool = useCallback((id: RightPanelContributionId): void => {
-    if (id === BUILTIN_RIGHT_PANEL_IDS.terminal) {
+    const action = resolveCodeRightToolClick(id, rightPanelMode)
+    if (action === 'toggle-terminal') {
       toggleTerminal()
+      return
+    }
+    if (action === 'collapse') {
+      if (id === BUILTIN_RIGHT_PANEL_IDS.sideConversations) setSidePanelOpen(false)
+      collapseRightPanel()
       return
     }
     if (id === BUILTIN_RIGHT_PANEL_IDS.sideConversations) openSideChat()
     if (id === BUILTIN_RIGHT_PANEL_IDS.files) openFileTreeSidePanel()
     openRightPanelTab(id)
-  }, [openFileTreeSidePanel, openRightPanelTab, openSideChat, toggleTerminal])
+  }, [
+    collapseRightPanel,
+    openFileTreeSidePanel,
+    openRightPanelTab,
+    openSideChat,
+    rightPanelMode,
+    setSidePanelOpen,
+    toggleTerminal
+  ])
 
   const closeCodeRightTool = useCallback((id: RightPanelContributionId): void => {
     if (id === BUILTIN_RIGHT_PANEL_IDS.sideConversations) setSidePanelOpen(false)


### PR DESCRIPTION
## Summary

Clicking a button in the right side rail (e.g. 用量与额度 / Provider quotas) always re-opened the same tab and there was no way to collapse the panel from the rail. This makes the rail buttons act as toggles: clicking the button of the tool that is currently visible collapses the right panel; clicking any other button (or clicking again while collapsed) opens it.

## Changes

- Add `resolveCodeRightToolClick(id, rightPanelMode)` in `useWorkbenchRightTools.ts` that maps a rail click to `open` / `collapse` / `toggle-terminal`.
- `openCodeRightTool` now routes through that decision: when the clicked tool is already visible it collapses the panel (closing the side conversation surface when applicable) instead of re-opening the same tab; the terminal keeps its own separate toggle path.
- Pass the resolved `rightPanelMode` from `Workbench.tsx` into the hook so the decision uses exactly what the rail highlights as active.

## Tests

- Added `useWorkbenchRightTools.test.ts` covering: clicking the visible tool collapses, clicking another tool or while collapsed opens, and the terminal keeps its toggle path.
- `npx vitest run src/renderer/src/components/workbench src/renderer/src/components/chat/WorkbenchTopBar.test.ts` - 42 files / 268 tests passed.
- `npm run typecheck` passed.
- `npm run check:file-lines` passed.