### PR TITLE
fix(sidebar): sort projects by creation time and auto-scroll while dragging

### DIFF
--- a/src/main/ipc/app-ipc-schemas.workspace.test.ts
+++ b/src/main/ipc/app-ipc-schemas.workspace.test.ts
@@ -14,6 +14,7 @@ import {
   shellOpenExternalUrlSchema,
   sseAckPayloadSchema,
   sseStartPayloadSchema,
+  workspaceCreationTimesPayloadSchema,
   workspaceDirectoryCreatePayloadSchema,
   workspaceDirectoryTargetPayloadSchema,
   workspaceEntryDeletePayloadSchema,
@@ -283,5 +284,18 @@ describe('app-ipc-schemas workspace and system', () => {
     })).toMatchObject({
       fileName: 'architecture-a1b2c3.png'
     })
+  })
+
+  it('validates workspace creation time payloads', () => {
+    expect(workspaceCreationTimesPayloadSchema.parse({
+      workspaceRoots: ['D:/kun', '/tmp/project']
+    })).toEqual({ workspaceRoots: ['D:/kun', '/tmp/project'] })
+    expect(() =>
+      workspaceCreationTimesPayloadSchema.parse({ workspaceRoots: ['/tmp/a'], extra: true })
+    ).toThrow()
+    expect(() => workspaceCreationTimesPayloadSchema.parse({ workspaceRoots: [42] })).toThrow()
+    expect(() =>
+      workspaceCreationTimesPayloadSchema.parse({ workspaceRoots: Array.from({ length: 257 }, () => '/tmp/a') })
+    ).toThrow()
   })
 })

--- a/src/main/ipc/app-ipc-schemas/workspace.ts
+++ b/src/main/ipc/app-ipc-schemas/workspace.ts
@@ -78,6 +78,12 @@ export const localOfficeDocumentTargetPayloadSchema = z
 export const deepseekConfigContentSchema = z.string().max(MAX_CONFIG_FILE_BYTES)
 
 export const workspaceRootSchema = trimmedString(MAX_PATH_LENGTH)
+export const workspaceCreationTimesPayloadSchema = z
+  .object({
+    // A sidebar surfaces a few dozen roots at most; the cap is defensive only.
+    workspaceRoots: z.array(workspaceRootSchema).max(256)
+  })
+  .strict()
 export const kunProjectConfigWorkspacePayloadSchema = z
   .object({
     workspaceRoot: workspaceRootSchema.refine(isAbsolutePath, {

--- a/src/main/ipc/register-app-ipc-handlers.workspace.test.ts
+++ b/src/main/ipc/register-app-ipc-handlers.workspace.test.ts
@@ -19,6 +19,7 @@ import {
 } from 'node:events'
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
@@ -108,6 +109,31 @@ describe('registerAppIpcHandlers workspace and MCP', () => {
         mimeType: 'image/png'
       })).resolves.toEqual({ ok: true, path: target })
       expect(readFileSync(target, 'utf8')).toBe('generated-image')
+    } finally {
+      rmSync(temp, { recursive: true, force: true })
+    }
+  })
+
+  it('returns workspace folder creation times for sidebar ordering', async () => {
+    const temp = mkdtempSync(join(tmpdir(), 'kun-creation-times-'))
+    const existing = join(temp, 'existing-project')
+    mkdirSync(existing)
+    const missing = join(temp, 'missing-project')
+    try {
+      registerAppIpcHandlers(registerOptions())
+
+      const handler = handlers.get('workspace:creation-times')
+      const result = await handler?.({}, { workspaceRoots: [existing, missing] }) as Array<{
+        path: string
+        createdAtMs: number | null
+      }>
+      expect(result).toHaveLength(2)
+      expect(result[0]?.path).toBe(existing)
+      expect(result[0]?.createdAtMs).toBeGreaterThan(0)
+      expect(result[1]).toEqual({ path: missing, createdAtMs: null })
+
+      await expect(handler?.({}, { workspaceRoots: [42] })).rejects.toThrow()
+      await expect(handler?.({}, { workspaceRoots: [existing], extra: true })).rejects.toThrow()
     } finally {
       rmSync(temp, { recursive: true, force: true })
     }

--- a/src/main/ipc/register-app-workspace-ipc-handlers.ts
+++ b/src/main/ipc/register-app-workspace-ipc-handlers.ts
@@ -19,6 +19,7 @@ import {
 } from 'zod'
 import type {
   ConversationWorkspaceCreateResult,
+  WorkspaceCreationTimeEntry,
   WorkspacePickResult
 } from '../../shared/kun-gui-api'
 import {
@@ -29,6 +30,7 @@ import {
   skillGithubImportPayloadSchema,
   skillListPayloadSchema,
   skillSaveFilePayloadSchema,
+  workspaceCreationTimesPayloadSchema,
   workspaceRootSchema
 } from './app-ipc-schemas'
 import {
@@ -95,6 +97,32 @@ export function registerAppWorkspaceIpcHandlers(options: RegisterAppIpcHandlersO
       return false
     }
   })
+
+  ipcMain.handle(
+    'workspace:creation-times',
+    async (_, payload: unknown): Promise<WorkspaceCreationTimeEntry[]> => {
+      const request = parseIpcPayload(
+        'workspace:creation-times',
+        workspaceCreationTimesPayloadSchema,
+        payload
+      )
+      return Promise.all(request.workspaceRoots.map(async (workspaceRoot) => {
+        const target = expandHomePath(workspaceRoot)
+        if (!target) return { path: workspaceRoot, createdAtMs: null }
+        try {
+          const stats = await stat(target)
+          // Some Linux filesystems report no birthtime (0); fall back to mtime
+          // so the sidebar still gets a usable creation ordering there.
+          const createdAtMs = stats.birthtimeMs > 0 ? stats.birthtimeMs : stats.mtimeMs
+          return Number.isFinite(createdAtMs) && createdAtMs > 0
+            ? { path: workspaceRoot, createdAtMs }
+            : { path: workspaceRoot, createdAtMs: null }
+        } catch {
+          return { path: workspaceRoot, createdAtMs: null }
+        }
+      }))
+    }
+  )
 
   ipcMain.handle('file:pick-local-files', async (_, defaultPath: unknown) => {
     const normalizedDefaultPath = parseIpcPayload(

--- a/src/preload/data-migration.ts
+++ b/src/preload/data-migration.ts
@@ -1,0 +1,49 @@
+import { ipcRenderer } from 'electron'
+import type { KunGuiApi } from '../shared/kun-gui-api'
+
+export function createDataMigrationPreloadApi(): KunGuiApi['dataMigration'] {
+  return {
+    pickExportPackage: (defaultPath) => ipcRenderer.invoke('data-migration:pick-export', { defaultPath }),
+    pickImportPackage: (defaultPath) => ipcRenderer.invoke('data-migration:pick-import', { defaultPath }),
+    pickDestinationDirectory: (defaultPath) => ipcRenderer.invoke('data-migration:pick-destination', { defaultPath }),
+    estimateExport: (input) => ipcRenderer.invoke('data-migration:estimate-export', input),
+    inspectPackage: (input) => ipcRenderer.invoke('data-migration:inspect', input),
+    planImport: (input) => ipcRenderer.invoke('data-migration:plan-import', input),
+    startExport: (input) => ipcRenderer.invoke('data-migration:start-export', input),
+    startImport: (input) => ipcRenderer.invoke('data-migration:start-import', input),
+    cancel: (operationId) => ipcRenderer.invoke('data-migration:cancel', { operationId }),
+    recover: (operationId, action) => ipcRenderer.invoke('data-migration:recover', { operationId, action }),
+    getStatus: () => ipcRenderer.invoke('data-migration:status'),
+    listReports: () => ipcRenderer.invoke('data-migration:reports:list'),
+    getReport: (operationId) => ipcRenderer.invoke('data-migration:reports:get', { operationId }),
+    deleteReport: (operationId) => ipcRenderer.invoke('data-migration:reports:delete', { operationId }),
+    onProgress: (handler) => {
+      let latest: Parameters<typeof handler>[0] | null = null
+      let timer: ReturnType<typeof setTimeout> | null = null
+      const flush = () => {
+        timer = null
+        if (!latest) return
+        const value = latest
+        latest = null
+        handler(value)
+      }
+      const wrapped = (_: Electron.IpcRendererEvent, payload: Parameters<typeof handler>[0]) => {
+        latest = payload
+        if (!timer) timer = setTimeout(flush, 100)
+      }
+      ipcRenderer.on('data-migration:progress', wrapped)
+      return () => {
+        ipcRenderer.removeListener('data-migration:progress', wrapped)
+        if (timer) clearTimeout(timer)
+        timer = null
+        latest = null
+      }
+    },
+    onRendererRequest: (handler) => {
+      const wrapped = (_: Electron.IpcRendererEvent, request: Parameters<typeof handler>[0]) => handler(request)
+      ipcRenderer.on('data-migration:renderer-request', wrapped)
+      return () => ipcRenderer.removeListener('data-migration:renderer-request', wrapped)
+    },
+    respondRendererRequest: (response) => ipcRenderer.invoke('data-migration:renderer-response', response)
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,8 @@ import { parseAppEnvironment } from './app-environment'
 import { createDesktopStartupPreloadApi } from './startup-state'
 import { createStorageRelocationWorkbenchApi } from './storage-relocation-workbench'
 import { createGitHubMcpAuthorizationPreloadApi } from './github-mcp-authorization'
+import { createDataMigrationPreloadApi } from './data-migration'
+import { getWorkspaceCreationTimes } from './workspace-creation-times'
 import { runtimeRequestPreloadApi } from './runtime-request'
 registerExtensionContentScriptPreload({ contextBridge, ipcRenderer, webFrame })
 // The preload runs sandboxed (webPreferences.sandbox = true), so it cannot
@@ -48,50 +50,7 @@ const api = {
     getStatus: () => ipcRenderer.invoke('runtime-data-recovery:status'),
     execute: (input) => ipcRenderer.invoke('runtime-data-recovery:execute', input)
   },
-  dataMigration: {
-    pickExportPackage: (defaultPath) => ipcRenderer.invoke('data-migration:pick-export', { defaultPath }),
-    pickImportPackage: (defaultPath) => ipcRenderer.invoke('data-migration:pick-import', { defaultPath }),
-    pickDestinationDirectory: (defaultPath) => ipcRenderer.invoke('data-migration:pick-destination', { defaultPath }),
-    estimateExport: (input) => ipcRenderer.invoke('data-migration:estimate-export', input),
-    inspectPackage: (input) => ipcRenderer.invoke('data-migration:inspect', input),
-    planImport: (input) => ipcRenderer.invoke('data-migration:plan-import', input),
-    startExport: (input) => ipcRenderer.invoke('data-migration:start-export', input),
-    startImport: (input) => ipcRenderer.invoke('data-migration:start-import', input),
-    cancel: (operationId) => ipcRenderer.invoke('data-migration:cancel', { operationId }),
-    recover: (operationId, action) => ipcRenderer.invoke('data-migration:recover', { operationId, action }),
-    getStatus: () => ipcRenderer.invoke('data-migration:status'),
-    listReports: () => ipcRenderer.invoke('data-migration:reports:list'),
-    getReport: (operationId) => ipcRenderer.invoke('data-migration:reports:get', { operationId }),
-    deleteReport: (operationId) => ipcRenderer.invoke('data-migration:reports:delete', { operationId }),
-    onProgress: (handler) => {
-      let latest: Parameters<typeof handler>[0] | null = null
-      let timer: ReturnType<typeof setTimeout> | null = null
-      const flush = () => {
-        timer = null
-        if (!latest) return
-        const value = latest
-        latest = null
-        handler(value)
-      }
-      const wrapped = (_: Electron.IpcRendererEvent, payload: Parameters<typeof handler>[0]) => {
-        latest = payload
-        if (!timer) timer = setTimeout(flush, 100)
-      }
-      ipcRenderer.on('data-migration:progress', wrapped)
-      return () => {
-        ipcRenderer.removeListener('data-migration:progress', wrapped)
-        if (timer) clearTimeout(timer)
-        timer = null
-        latest = null
-      }
-    },
-    onRendererRequest: (handler) => {
-      const wrapped = (_: Electron.IpcRendererEvent, request: Parameters<typeof handler>[0]) => handler(request)
-      ipcRenderer.on('data-migration:renderer-request', wrapped)
-      return () => ipcRenderer.removeListener('data-migration:renderer-request', wrapped)
-    },
-    respondRendererRequest: (response) => ipcRenderer.invoke('data-migration:renderer-response', response)
-  },
+  dataMigration: createDataMigrationPreloadApi(),
   getSettings: () => ipcRenderer.invoke('settings:get'),
   openSettingsConfigFile: () => ipcRenderer.invoke('settings:open-config-file'),
   revealModelProviderCredential: (providerId) =>
@@ -259,6 +218,7 @@ const api = {
     ipcRenderer.invoke('kun:project-config:open-dir', { workspaceRoot }),
   getGitBranches: (workspaceRoot) =>
     ipcRenderer.invoke('git:branches', workspaceRoot),
+  getWorkspaceCreationTimes,
   switchGitBranch: (workspaceRoot, branch) =>
     ipcRenderer.invoke('git:switch-branch', { workspaceRoot, branch }),
   createAndSwitchGitBranch: (workspaceRoot, branch) =>

--- a/src/preload/workspace-creation-times.ts
+++ b/src/preload/workspace-creation-times.ts
@@ -1,0 +1,8 @@
+import { ipcRenderer } from 'electron'
+import type { WorkspaceCreationTimeEntry } from '../shared/kun-gui-api'
+
+export function getWorkspaceCreationTimes(
+  workspaceRoots: string[]
+): Promise<WorkspaceCreationTimeEntry[]> {
+  return ipcRenderer.invoke('workspace:creation-times', { workspaceRoots })
+}

--- a/src/renderer/src/components/chat/Sidebar.tsx
+++ b/src/renderer/src/components/chat/Sidebar.tsx
@@ -25,6 +25,7 @@ import type { ClawImDialogMode, ClawInstallTarget } from './SidebarClawDialogHel
 import { ClawAddImDialog } from './SidebarClawDialog'
 import { ConnectPhoneSidebarPanel } from './ConnectPhoneView'
 import { SidebarProjectsSection } from './SidebarProjectsSection'
+import { registerSidebarDragAutoScroll } from './sidebar-drag-auto-scroll'
 import { SidebarConversationsSection } from './SidebarConversationsSection'
 import { SidebarProjectBoardsSection } from './SidebarProjectBoardsSection'
 import { useProjectBoardEnabled } from '../../project-board/use-project-board-enabled'
@@ -120,6 +121,10 @@ export function Sidebar({
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] })
     return () => observer.disconnect()
   }, [])
+
+  // HTML5 drag does not scroll containers; without this, dragged sidebar rows
+  // cannot reach projects above or below the visible window.
+  useEffect(() => registerSidebarDragAutoScroll(document), [])
 
   const workspaceRoot = useChatStore((s) => s.workspaceRoot)
   const conversationWorkspaceRoot = useChatStore((s) => s.conversationWorkspaceRoot)

--- a/src/renderer/src/components/chat/SidebarProjectsContent.tsx
+++ b/src/renderer/src/components/chat/SidebarProjectsContent.tsx
@@ -244,7 +244,7 @@ export function SidebarProjectsContent(props: SidebarProjectsContentProps): Reac
         </div>
       ) : null}
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-1 pb-2 pt-0.5">
+      <div data-kun-drag-scroll className="min-h-0 flex-1 overflow-y-auto px-1 pb-2 pt-0.5">
         {displayGroups.length === 0 ? (
           threadListStatus === 'error' ? (
             <div className="mx-2 mt-2 rounded-lg px-2 py-2">

--- a/src/renderer/src/components/chat/SidebarProjectsSection.tsx
+++ b/src/renderer/src/components/chat/SidebarProjectsSection.tsx
@@ -132,7 +132,8 @@ import { createSidebarProjectWorkspaceActions } from './sidebar-project-workspac
 import { useSidebarWorkspaceAutoLoad } from './sidebar-project-auto-load'
 import type { SidebarProjectExpansionStage } from './sidebar-project-expansion'
 import { SidebarProjectsContent, type SidebarThreadListStatus } from './SidebarProjectsContent'
-import { discoverSidebarWorktrees } from './sidebar-worktree-discovery'
+import { useSidebarWorktreeDiscovery } from './sidebar-worktree-discovery'
+import { useSidebarWorkspaceCreationTimes } from './sidebar-project-creation-times'
 import { useRemovedWorkspaceDiscoveredAliases } from './use-removed-workspace-discovered-aliases'
 export {
   buildSidebarDraftWorkspacePaths,
@@ -284,7 +285,6 @@ export function SidebarProjectsSection({
   const [registeredThreadWorktrees, setRegisteredThreadWorktrees] = useState<SidebarThreadWorktrees>(
     () => readThreadWorktreeRegistry().worktrees
   )
-  const [discoveredThreadWorktrees, setDiscoveredThreadWorktrees] = useState<SidebarThreadWorktrees>({})
   const removedCodeWorkspaces = useChatStore((s) => s.removedCodeWorkspaces)
   const threadWorkspaceIdentityKey = sidebarThreadWorkspaceIdentityKey(threads)
   const workspaceRootsIdentityKey = workspaceRoots.map(normalizeWorkspaceRoot).sort().join('\n')
@@ -298,27 +298,16 @@ export function SidebarProjectsSection({
     workspaceRoot,
     workspaceRoots
   )
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.kunGui?.getGitBranches !== 'function') return
-    let cancelled = false
-    setDiscoveredThreadWorktrees({})
-    const workspacePaths = JSON.parse(worktreeDiscoveryKey) as string[]
-    void discoverSidebarWorktrees(
-      workspacePaths,
-      (workspacePath) => window.kunGui.getGitBranches(workspacePath)
-    ).then((records) => {
-      if (!cancelled) setDiscoveredThreadWorktrees(records)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [worktreeDiscoveryKey])
+  const discoveredThreadWorktrees = useSidebarWorktreeDiscovery(worktreeDiscoveryKey)
 
   const threadWorktrees = useMemo(() => ({
     ...discoveredThreadWorktrees,
     ...registeredThreadWorktrees
   }), [discoveredThreadWorktrees, registeredThreadWorktrees])
+
+  const workspaceCreationTimes = useSidebarWorkspaceCreationTimes(
+    sidebarWorkspaceResolutionCandidates({ workspaceRoot, workspaceRoots, threadWorktrees, threads })
+  )
 
   useRemovedWorkspaceDiscoveredAliases(discoveredThreadWorktrees, removedCodeWorkspaces)
 
@@ -345,9 +334,10 @@ export function SidebarProjectsSection({
       workspaceRoots,
       conversationRoot,
       threadWorktrees,
-      removedProjectKeys
+      removedProjectKeys,
+      workspaceCreatedAt: workspaceCreationTimes
     })
-  }, [searchQuery, showArchived, threadWorktrees, threads, workspaceRoot, workspaceRoots, conversationRoot, removedProjectKeys])
+  }, [searchQuery, showArchived, threadWorktrees, threads, workspaceRoot, workspaceRoots, conversationRoot, removedProjectKeys, workspaceCreationTimes])
 
   const allProjectGroups = useMemo(() => {
     const byWorkspace = new Map<string, [string, NormalizedThread[]]>()
@@ -360,7 +350,8 @@ export function SidebarProjectsSection({
         workspaceRoots,
         conversationRoot,
         threadWorktrees,
-        removedProjectKeys
+        removedProjectKeys,
+        workspaceCreatedAt: workspaceCreationTimes
       })
       for (const [workspacePath, items] of nextGroups) {
         const key = workspaceRootIdentityKey(workspacePath)
@@ -370,7 +361,7 @@ export function SidebarProjectsSection({
       }
     }
     return [...byWorkspace.values()]
-  }, [conversationRoot, threadWorktrees, threads, workspaceRoot, workspaceRoots, removedProjectKeys])
+  }, [conversationRoot, threadWorktrees, threads, workspaceRoot, workspaceRoots, removedProjectKeys, workspaceCreationTimes])
 
   const allThreadIdsByScope = useMemo(() => {
     return Object.fromEntries(allProjectGroups.map(([workspacePath, items]) => [

--- a/src/renderer/src/components/chat/sidebar-drag-auto-scroll.test.ts
+++ b/src/renderer/src/components/chat/sidebar-drag-auto-scroll.test.ts
@@ -1,0 +1,163 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createSidebarDragAutoScroller,
+  registerSidebarDragAutoScroll,
+  SIDEBAR_DRAG_SCROLL_ATTRIBUTE,
+  sidebarDragScrollVelocity,
+  type SidebarDragAutoScroller
+} from './sidebar-drag-auto-scroll'
+
+describe('sidebarDragScrollVelocity', () => {
+  const top = 100
+  const bottom = 500
+  const edge = 50
+  const speed = 600
+
+  it('is zero in the middle of the container', () => {
+    expect(sidebarDragScrollVelocity(300, top, bottom, edge, speed)).toBe(0)
+    expect(sidebarDragScrollVelocity(151, top, bottom, edge, speed)).toBe(0)
+    expect(sidebarDragScrollVelocity(449, top, bottom, edge, speed)).toBe(0)
+  })
+
+  it('scrolls up near the top edge and down near the bottom edge', () => {
+    expect(sidebarDragScrollVelocity(120, top, bottom, edge, speed)).toBeLessThan(0)
+    expect(sidebarDragScrollVelocity(480, top, bottom, edge, speed)).toBeGreaterThan(0)
+  })
+
+  it('ramps up towards the edge and clamps beyond it', () => {
+    const atEdge = sidebarDragScrollVelocity(top, top, bottom, edge, speed)
+    expect(atEdge).toBe(-speed)
+    expect(sidebarDragScrollVelocity(top - 30, top, bottom, edge, speed)).toBe(-speed)
+    expect(sidebarDragScrollVelocity(bottom, top, bottom, edge, speed)).toBe(speed)
+    const halfway = sidebarDragScrollVelocity(top + edge / 2, top, bottom, edge, speed)
+    expect(halfway).toBeGreaterThan(-speed)
+    expect(halfway).toBeLessThan(0)
+  })
+
+  it('keeps a visible minimum speed at the threshold boundary', () => {
+    expect(sidebarDragScrollVelocity(150, top, bottom, edge, speed)).toBe(-speed * 0.2)
+    expect(sidebarDragScrollVelocity(450, top, bottom, edge, speed)).toBe(speed * 0.2)
+  })
+
+  it('returns zero for degenerate geometry', () => {
+    expect(sidebarDragScrollVelocity(100, 100, 100, edge, speed)).toBe(0)
+    expect(sidebarDragScrollVelocity(100, top, bottom, 0, speed)).toBe(0)
+  })
+})
+
+describe('createSidebarDragAutoScroller', () => {
+  function createHarness(scrollTop = 0) {
+    const container = {
+      scrollTop,
+      getBoundingClientRect: () => ({ top: 100, bottom: 500 })
+    } as unknown as HTMLElement
+    const frames: Array<() => void> = []
+    let currentTime = 0
+    const scroller = createSidebarDragAutoScroller(container, {
+      edgeSize: 50,
+      maxSpeed: 600,
+      now: () => currentTime,
+      requestFrame: (callback) => {
+        frames.push(callback)
+        return frames.length
+      },
+      cancelFrame: () => {
+        frames.length = 0
+      }
+    })
+    return {
+      container,
+      scroller,
+      advance(ms: number) {
+        currentTime += ms
+        const pending = [...frames]
+        frames.length = 0
+        for (const callback of pending) callback()
+      }
+    }
+  }
+
+  it('scrolls up continuously while the pointer rests near the top edge', () => {
+    const { container, scroller, advance } = createHarness(300)
+    scroller.update(100)
+    advance(16)
+    expect(container.scrollTop).toBeLessThan(300)
+    const afterFirst = container.scrollTop
+    advance(16)
+    expect(container.scrollTop).toBeLessThan(afterFirst)
+  })
+
+  it('scrolls down near the bottom edge and stops when the pointer returns to the middle', () => {
+    const { container, scroller, advance } = createHarness(0)
+    scroller.update(500)
+    advance(16)
+    expect(container.scrollTop).toBeGreaterThan(0)
+    const before = container.scrollTop
+    scroller.update(300)
+    advance(16)
+    expect(container.scrollTop).toBe(before)
+  })
+
+  it('stop cancels a pending frame', () => {
+    const { container, scroller } = createHarness(300)
+    scroller.update(100)
+    scroller.stop()
+    expect(container.scrollTop).toBe(300)
+  })
+})
+
+describe('registerSidebarDragAutoScroll', () => {
+  function dispatchDragOver(target: Element, clientY: number): void {
+    target.dispatchEvent(new MouseEvent('dragover', { bubbles: true, clientY }))
+  }
+
+  function createFixture() {
+    document.body.innerHTML = `
+      <div id="list" ${SIDEBAR_DRAG_SCROLL_ATTRIBUTE}>
+        <div id="row">row</div>
+      </div>
+      <div id="outside">outside</div>
+    `
+    const update = vi.fn()
+    const stop = vi.fn()
+    const createScroller = vi.fn((): SidebarDragAutoScroller => ({ update, stop }))
+    const unregister = registerSidebarDragAutoScroll(document, createScroller)
+    return { update, stop, createScroller, unregister }
+  }
+
+  it('starts a scroller for the marked container and forwards the pointer position', () => {
+    const { update, createScroller, unregister } = createFixture()
+    const list = document.getElementById('list')!
+    const row = document.getElementById('row')!
+    dispatchDragOver(row, 123)
+    expect(createScroller).toHaveBeenCalledWith(list)
+    expect(update).toHaveBeenCalledWith(123)
+    unregister()
+  })
+
+  it('stops the active scroller when the pointer leaves the container, on drop and on dragend', () => {
+    const { stop, unregister } = createFixture()
+    const row = document.getElementById('row')!
+    const outside = document.getElementById('outside')!
+    dispatchDragOver(row, 100)
+    dispatchDragOver(outside, 100)
+    expect(stop).toHaveBeenCalledTimes(1)
+    dispatchDragOver(row, 100)
+    row.dispatchEvent(new MouseEvent('drop', { bubbles: true }))
+    expect(stop).toHaveBeenCalledTimes(2)
+    dispatchDragOver(row, 100)
+    row.dispatchEvent(new MouseEvent('dragend', { bubbles: true }))
+    expect(stop).toHaveBeenCalledTimes(3)
+    unregister()
+  })
+
+  it('observes drags in capture phase even when a row stops propagation', () => {
+    const { update, unregister } = createFixture()
+    const row = document.getElementById('row')!
+    row.addEventListener('dragover', (event) => event.stopPropagation())
+    dispatchDragOver(row, 42)
+    expect(update).toHaveBeenCalledWith(42)
+    unregister()
+  })
+})

--- a/src/renderer/src/components/chat/sidebar-drag-auto-scroll.ts
+++ b/src/renderer/src/components/chat/sidebar-drag-auto-scroll.ts
@@ -1,0 +1,148 @@
+/**
+ * HTML5 drag-and-drop never scrolls containers on its own: while a workspace
+ * or thread row is dragged, the sidebar list stays frozen, so rows outside
+ * the viewport are unreachable drop targets. Any scroll container marked with
+ * `data-kun-drag-scroll` is watched through document-level capture listeners
+ * and scrolls while the pointer hovers near its top or bottom edge.
+ */
+
+export const SIDEBAR_DRAG_SCROLL_ATTRIBUTE = 'data-kun-drag-scroll'
+
+const DEFAULT_EDGE_SIZE_PX = 56
+const DEFAULT_MAX_SPEED_PX_PER_SECOND = 640
+// Keep scrolling at a visible minimum speed right at the threshold boundary.
+const MIN_SPEED_RATIO = 0.2
+
+type SidebarDragAutoScrollerOptions = {
+  edgeSize?: number
+  maxSpeed?: number
+  now?: () => number
+  requestFrame?: (callback: () => void) => number
+  cancelFrame?: (handle: number) => void
+}
+
+export type SidebarDragAutoScroller = {
+  update: (clientY: number) => void
+  stop: () => void
+}
+
+export function sidebarDragScrollVelocity(
+  clientY: number,
+  top: number,
+  bottom: number,
+  edgeSize: number,
+  maxSpeed: number
+): number {
+  if (!(bottom > top) || edgeSize <= 0 || maxSpeed <= 0) return 0
+  if (clientY <= top + edgeSize) {
+    const ratio = clientY <= top ? 1 : 1 - (clientY - top) / edgeSize
+    return -maxSpeed * Math.min(1, Math.max(MIN_SPEED_RATIO, ratio))
+  }
+  if (clientY >= bottom - edgeSize) {
+    const ratio = clientY >= bottom ? 1 : 1 - (bottom - clientY) / edgeSize
+    return maxSpeed * Math.min(1, Math.max(MIN_SPEED_RATIO, ratio))
+  }
+  return 0
+}
+
+export function createSidebarDragAutoScroller(
+  container: HTMLElement,
+  options: SidebarDragAutoScrollerOptions = {}
+): SidebarDragAutoScroller {
+  const edgeSize = options.edgeSize ?? DEFAULT_EDGE_SIZE_PX
+  const maxSpeed = options.maxSpeed ?? DEFAULT_MAX_SPEED_PX_PER_SECOND
+  const now = options.now ?? (() => Date.now())
+  const requestFrame = options.requestFrame ?? ((callback: () => void) => requestAnimationFrame(callback))
+  const cancelFrame = options.cancelFrame ?? ((handle: number) => cancelAnimationFrame(handle))
+  let frame: number | null = null
+  let pointerY: number | null = null
+  let lastTime: number | null = null
+
+  const velocityFor = (clientY: number): number => {
+    const rect = container.getBoundingClientRect()
+    return sidebarDragScrollVelocity(clientY, rect.top, rect.bottom, edgeSize, maxSpeed)
+  }
+
+  const tick = (): void => {
+    frame = null
+    if (pointerY === null) return
+    const velocity = velocityFor(pointerY)
+    if (velocity === 0) {
+      lastTime = null
+      return
+    }
+    const current = now()
+    const elapsedMs = lastTime === null ? 1000 / 60 : Math.min(Math.max(current - lastTime, 0), 100)
+    lastTime = current
+    container.scrollTop += velocity * (elapsedMs / 1000)
+    frame = requestFrame(tick)
+  }
+
+  const update = (clientY: number): void => {
+    pointerY = clientY
+    if (frame === null && velocityFor(clientY) !== 0) {
+      lastTime = null
+      frame = requestFrame(tick)
+    }
+  }
+
+  const stop = (): void => {
+    pointerY = null
+    lastTime = null
+    if (frame !== null) {
+      cancelFrame(frame)
+      frame = null
+    }
+  }
+
+  return { update, stop }
+}
+
+/**
+ * Subscribes once at document level. dragover keeps the active scroller in
+ * sync with the pointer; dragend (always fired, even on Escape-cancel) and
+ * drop stop it. Capture phase is used so row-level stopPropagation calls in
+ * the drop-position handlers cannot silence scrolling.
+ */
+export function registerSidebarDragAutoScroll(
+  doc: Document,
+  createScroller: (container: HTMLElement) => SidebarDragAutoScroller = createSidebarDragAutoScroller
+): () => void {
+  let activeContainer: HTMLElement | null = null
+  let activeScroller: SidebarDragAutoScroller | null = null
+
+  const stopActive = (): void => {
+    activeScroller?.stop()
+    activeScroller = null
+    activeContainer = null
+  }
+
+  const onDragOver = (event: Event): void => {
+    const target = event.target
+    const container = target instanceof Element
+      ? target.closest<HTMLElement>(`[${SIDEBAR_DRAG_SCROLL_ATTRIBUTE}]`)
+      : null
+    if (!container) {
+      stopActive()
+      return
+    }
+    if (container !== activeContainer) {
+      stopActive()
+      activeContainer = container
+      activeScroller = createScroller(container)
+    }
+    activeScroller?.update((event as MouseEvent).clientY)
+  }
+
+  const onDragSettled = (): void => stopActive()
+
+  doc.addEventListener('dragover', onDragOver, true)
+  doc.addEventListener('dragend', onDragSettled, true)
+  doc.addEventListener('drop', onDragSettled, true)
+  return () => {
+    stopActive()
+    doc.removeEventListener('dragover', onDragOver, true)
+    doc.removeEventListener('dragend', onDragSettled, true)
+    doc.removeEventListener('drop', onDragSettled, true)
+  }
+}

--- a/src/renderer/src/components/chat/sidebar-project-creation-times.ts
+++ b/src/renderer/src/components/chat/sidebar-project-creation-times.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import type { WorkspaceCreationTimeEntry } from '@shared/kun-gui-api'
+import { normalizeWorkspaceRoot, workspaceRootIdentityKey } from '../../lib/workspace-path'
+import type { SidebarWorkspaceCreationTimes } from './sidebar-project-selectors'
+
+/**
+ * Dedupes workspace paths by identity key while keeping the first seen real
+ * path, then serializes the identity keys as a stable effect dependency.
+ */
+export function sidebarWorkspaceCreationTimesKey(workspacePaths: readonly string[]): string {
+  const keys = new Set<string>()
+  for (const workspacePath of workspacePaths) {
+    const key = workspaceRootIdentityKey(normalizeWorkspaceRoot(workspacePath))
+    if (key) keys.add(key)
+  }
+  return [...keys].sort().join('\n')
+}
+
+export function sidebarWorkspaceCreationTimesFromEntries(
+  entries: readonly WorkspaceCreationTimeEntry[]
+): SidebarWorkspaceCreationTimes {
+  const result: SidebarWorkspaceCreationTimes = {}
+  for (const entry of entries) {
+    const key = workspaceRootIdentityKey(normalizeWorkspaceRoot(entry.path))
+    const createdAtMs = entry.createdAtMs
+    if (!key || typeof createdAtMs !== 'number' || !Number.isFinite(createdAtMs) || createdAtMs <= 0) {
+      continue
+    }
+    result[key] = createdAtMs
+  }
+  return result
+}
+
+/**
+ * Loads folder creation times for the sidebar project list (newest-first
+ * ordering). Stat calls happen in the main process; the map stays stale (not
+ * reset) while a new path set is being fetched so the list does not reshuffle
+ * twice.
+ */
+export function useSidebarWorkspaceCreationTimes(
+  workspacePaths: readonly string[]
+): SidebarWorkspaceCreationTimes {
+  const pathsKey = sidebarWorkspaceCreationTimesKey(workspacePaths)
+  const [creationTimes, setCreationTimes] = useState<SidebarWorkspaceCreationTimes>({})
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const read = window.kunGui?.getWorkspaceCreationTimes
+    if (typeof read !== 'function' || !pathsKey) return
+    // Stat the real (case-preserving) paths; identity keys are lowercased and
+    // can point at a non-existent spelling on case-sensitive filesystems.
+    const uniquePaths = new Map<string, string>()
+    for (const workspacePath of workspacePaths) {
+      const normalized = normalizeWorkspaceRoot(workspacePath)
+      const key = workspaceRootIdentityKey(normalized)
+      if (key && !uniquePaths.has(key)) uniquePaths.set(key, normalized)
+    }
+    let cancelled = false
+    void read([...uniquePaths.values()]).then((entries) => {
+      if (!cancelled) setCreationTimes(sidebarWorkspaceCreationTimesFromEntries(entries))
+    }).catch(() => {
+      // Ordering falls back to the legacy active-first/name comparator.
+    })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pathsKey serializes workspacePaths
+  }, [pathsKey])
+
+  return creationTimes
+}

--- a/src/renderer/src/components/chat/sidebar-project-selectors.creation-order.test.ts
+++ b/src/renderer/src/components/chat/sidebar-project-selectors.creation-order.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { buildSidebarWorkspaceGroups } from './sidebar-project-selectors'
+import { workspaceRootIdentityKey } from '../../lib/workspace-path'
+import {
+  sidebarWorkspaceCreationTimesFromEntries,
+  sidebarWorkspaceCreationTimesKey
+} from './sidebar-project-creation-times'
+
+function groupPaths(
+  workspaceRoots: string[],
+  workspaceCreatedAt?: Record<string, number>,
+  workspaceRoot = ''
+): string[] {
+  return buildSidebarWorkspaceGroups({
+    threads: [],
+    searchQuery: '',
+    showArchived: false,
+    workspaceRoot,
+    workspaceRoots,
+    conversationRoot: '',
+    workspaceCreatedAt
+  }).map(([workspacePath]) => workspacePath)
+}
+
+describe('buildSidebarWorkspaceGroups creation-time ordering', () => {
+  it('sorts projects newest-first by folder creation time', () => {
+    const roots = ['D:/kun', 'D:/skill', 'D:/zhihu']
+    const createdAt = {
+      [workspaceRootIdentityKey('D:/kun')]: 1000,
+      [workspaceRootIdentityKey('D:/skill')]: 2000,
+      [workspaceRootIdentityKey('D:/zhihu')]: 3000
+    }
+    expect(groupPaths(roots, createdAt)).toEqual(['D:/zhihu', 'D:/skill', 'D:/kun'])
+  })
+
+  it('matches creation times case-insensitively against display paths', () => {
+    const roots = ['D:/Apps/ZhiHu', 'D:/apps/alpha']
+    const createdAt = {
+      [workspaceRootIdentityKey('d:/apps/zhihu')]: 2000,
+      [workspaceRootIdentityKey('D:/apps/alpha')]: 1000
+    }
+    expect(groupPaths(roots, createdAt)).toEqual(['D:/Apps/ZhiHu', 'D:/apps/alpha'])
+  })
+
+  it('sinks undated projects below dated ones and keeps name order among them', () => {
+    const roots = ['D:/zzz-undated', 'D:/dated', 'D:/aaa-undated']
+    const createdAt = { [workspaceRootIdentityKey('D:/dated')]: 1000 }
+    expect(groupPaths(roots, createdAt)).toEqual(['D:/dated', 'D:/aaa-undated', 'D:/zzz-undated'])
+  })
+
+  it('keeps the active project first when creation times tie', () => {
+    const roots = ['D:/alpha', 'D:/beta']
+    const createdAt = {
+      [workspaceRootIdentityKey('D:/alpha')]: 1000,
+      [workspaceRootIdentityKey('D:/beta')]: 1000
+    }
+    expect(groupPaths(roots, createdAt, 'D:/beta')).toEqual(['D:/beta', 'D:/alpha'])
+  })
+
+  it('falls back to legacy active-first ordering without creation times', () => {
+    const roots = ['D:/alpha', 'D:/beta']
+    expect(groupPaths(roots, undefined, 'D:/beta')).toEqual(['D:/beta', 'D:/alpha'])
+  })
+})
+
+describe('sidebarWorkspaceCreationTimesKey', () => {
+  it('dedupes by identity key and sorts for a stable effect dependency', () => {
+    const key = sidebarWorkspaceCreationTimesKey(['D:/b', 'D:/a/', 'd:/B'])
+    expect(key).toBe('d:/a\nd:/b')
+  })
+})
+
+describe('sidebarWorkspaceCreationTimesFromEntries', () => {
+  it('keeps finite positive timestamps keyed by identity and drops the rest', () => {
+    expect(sidebarWorkspaceCreationTimesFromEntries([
+      { path: 'D:/ZhiHu', createdAtMs: 3000 },
+      { path: 'D:/missing', createdAtMs: null },
+      { path: 'D:/zero', createdAtMs: 0 }
+    ])).toEqual({ [workspaceRootIdentityKey('D:/ZhiHu')]: 3000 })
+  })
+})

--- a/src/renderer/src/components/chat/sidebar-project-selectors.ts
+++ b/src/renderer/src/components/chat/sidebar-project-selectors.ts
@@ -145,6 +145,29 @@ function sortWorkspacePathsByActive(workspacePaths: string[], selectedWorkspace:
   return [...workspacePaths].sort((a, b) => compareWorkspacePathsByActive(a, b, selectedWorkspace))
 }
 
+/** Filesystem creation time in ms keyed by workspaceRootIdentityKey. */
+export type SidebarWorkspaceCreationTimes = Record<string, number>
+
+/**
+ * Projects sort newest-first by folder creation time. Rows whose creation
+ * time is not loaded yet (or unavailable on the filesystem) sink below dated
+ * rows and keep the legacy active-first/name order relative to each other.
+ */
+function compareWorkspacePathsByCreation(
+  a: string,
+  b: string,
+  selectedWorkspace: string,
+  workspaceCreatedAt: SidebarWorkspaceCreationTimes | undefined
+): number {
+  const aTime = workspaceCreatedAt?.[workspaceRootIdentityKey(a)] ?? 0
+  const bTime = workspaceCreatedAt?.[workspaceRootIdentityKey(b)] ?? 0
+  const aKnown = Number.isFinite(aTime) && aTime > 0
+  const bKnown = Number.isFinite(bTime) && bTime > 0
+  if (aKnown && bKnown && aTime !== bTime) return bTime - aTime
+  if (aKnown !== bKnown) return aKnown ? -1 : 1
+  return compareWorkspacePathsByActive(a, b, selectedWorkspace)
+}
+
 export function sidebarWorkspaceResolutionCandidates(options: {
   workspaceRoot: string
   workspaceRoots: string[]
@@ -240,6 +263,7 @@ export function buildSidebarWorkspaceGroups(options: {
   threadWorktrees?: SidebarThreadWorktrees
   /** Projects the user removed from the sidebar; hidden by identity key. */
   removedProjectKeys?: ReadonlySet<string>
+  workspaceCreatedAt?: SidebarWorkspaceCreationTimes
 }): SidebarWorkspaceGroup[] {
   const map = new Map<string, { workspacePath: string; threads: NormalizedThread[] }>()
   const query = options.searchQuery.trim().toLowerCase()
@@ -319,7 +343,7 @@ export function buildSidebarWorkspaceGroups(options: {
       !removedKeys || !removedKeys.has(workspaceRootIdentityKey(workspacePath))
     )
     .map(({ workspacePath, threads }): SidebarWorkspaceGroup => [workspacePath, threads])
-    .sort(([a], [b]) => compareWorkspacePathsByActive(a, b, selectedWorkspace))
+    .sort(([a], [b]) => compareWorkspacePathsByCreation(a, b, selectedWorkspace, options.workspaceCreatedAt))
 }
 
 export function buildSidebarDraftWorkspacePaths(options: {

--- a/src/renderer/src/components/chat/sidebar-worktree-discovery.ts
+++ b/src/renderer/src/components/chat/sidebar-worktree-discovery.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import type { GitBranchesResult } from '@shared/git-branches'
 import { normalizeWorkspaceRoot, workspaceRootIdentityKey } from '../../lib/workspace-path'
 import type { SidebarThreadWorktrees } from './sidebar-project-selectors'
@@ -49,4 +50,27 @@ export async function discoverSidebarWorktrees(
   return Object.fromEntries(
     results.flatMap((result) => result ? [[result.key, result.record] as const] : [])
   )
+}
+
+/** Discovers linked worktrees for the given serialized workspace path set. */
+export function useSidebarWorktreeDiscovery(worktreeDiscoveryKey: string): SidebarThreadWorktrees {
+  const [discovered, setDiscovered] = useState<SidebarThreadWorktrees>({})
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.kunGui?.getGitBranches !== 'function') return
+    let cancelled = false
+    setDiscovered({})
+    const workspacePaths = JSON.parse(worktreeDiscoveryKey) as string[]
+    void discoverSidebarWorktrees(
+      workspacePaths,
+      (workspacePath) => window.kunGui.getGitBranches(workspacePath)
+    ).then((records) => {
+      if (!cancelled) setDiscovered(records)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [worktreeDiscoveryKey])
+
+  return discovered
 }

--- a/src/shared/kun-gui-api-contracts.ts
+++ b/src/shared/kun-gui-api-contracts.ts
@@ -208,6 +208,7 @@ export type RuntimeRequestResult = { ok: boolean; status: number; body: string }
 export type GatewayCredentialStatus = { configured: boolean; createdAt?: string; rotatedAt?: string }
 export type GatewayCredentialResult = { ok: boolean; status: number; credential: GatewayCredentialStatus; copied?: boolean }
 export type WorkspacePickResult = { canceled: boolean; path: string | null }
+export type WorkspaceCreationTimeEntry = { path: string; createdAtMs: number | null }
 
 export type LocalFilesPickResult = { canceled: boolean; paths: string[] }
 

--- a/src/shared/kun-gui-api-surface.ts
+++ b/src/shared/kun-gui-api-surface.ts
@@ -251,6 +251,7 @@ import {
   UiPluginThemeActivateIpcResult,
   UiPluginThemeDeactivateIpcResult,
   UpstreamModelsResult,
+  WorkspaceCreationTimeEntry,
   WorkspacePickResult
 } from './kun-gui-api-contracts'
 export type KunGuiApi = ExtensionIpcApi & RemoteSshApi & ProviderAuthApi & RuntimeRequestIpcApi & {
@@ -478,6 +479,7 @@ export type KunGuiApi = ExtensionIpcApi & RemoteSshApi & ProviderAuthApi & Runti
   ) => Promise<KunProjectConfigFileResult>
   openKunProjectConfigDir: (workspaceRoot: string) => Promise<PathOpenResult>
   getGitBranches: (workspaceRoot: string) => Promise<GitBranchesResult>
+  getWorkspaceCreationTimes: (workspaceRoots: string[]) => Promise<WorkspaceCreationTimeEntry[]>
   switchGitBranch: (workspaceRoot: string, branch: string) => Promise<GitBranchesResult>
   createAndSwitchGitBranch: (workspaceRoot: string, branch: string) => Promise<GitBranchesResult>
   createGitCheckpoint: (params: {


### PR DESCRIPTION
## Summary

Fix two sidebar project-list issues:

1. **Sort projects by creation date (newest first).** The project list previously fell back to alphabetical order (`localeCompare` on paths). Now the sidebar reads each workspace folder's filesystem creation time (`birthtime`, with `mtime` fallback for filesystems without birthtime support) via a new bounded `workspace:creation-times` IPC channel and sorts project groups newest-first. Projects whose creation time is unavailable sink below dated projects and keep the legacy active-first/name order relative to each other. Explicit user drag ordering (saved in `kun.sidebarOrder.v1`) still wins when present.

2. **Auto-scroll while dragging.** HTML5 drag-and-drop never scrolls containers, so when a project list is taller than the sidebar, dragging a row (e.g. dragging `zhihu` to above `kun` at the top) could not reach targets outside the viewport. Scroll containers marked `data-kun-drag-scroll` now auto-scroll when the dragged pointer hovers near their top/bottom edge (capture-phase document listeners, so row-level `stopPropagation` in drop-position handlers cannot silence it; `dragend`/`drop` always stop the scroller).

## Changes

- `src/main/ipc`: new `workspace:creation-times` handler + `workspaceCreationTimesPayloadSchema` (max 256 roots, strict, trimmed paths).
- `src/shared/kun-gui-api*`: `WorkspaceCreationTimeEntry` type + `getWorkspaceCreationTimes` surface.
- `src/preload`: expose `getWorkspaceCreationTimes`; extract `dataMigration` into its own module to keep `index.ts` under the 700-line file gate.
- `src/renderer/.../sidebar-project-selectors.ts`: `compareWorkspacePathsByCreation` — newest-first by creation time, undated projects sink, tie/unknown falls back to legacy comparator.
- `src/renderer/.../sidebar-project-creation-times.ts`: `useSidebarWorkspaceCreationTimes` hook (identity-keyed, deduped, keeps stale map while refetching to avoid double reshuffle).
- `src/renderer/.../sidebar-worktree-discovery.ts`: extract `useSidebarWorktreeDiscovery` hook from `SidebarProjectsSection` (keeps the file under the 700-line gate after wiring creation times).
- `src/renderer/.../sidebar-drag-auto-scroll.ts`: edge-proximity velocity + rAF scroller + document-level capture registration; `Sidebar.tsx` registers it once, projects list container opts in via the attribute.

## Tests

- New: `sidebar-project-selectors.creation-order.test.ts` (ordering, case-insensitive key matching, undated sink, tie active-first, legacy fallback), `sidebar-drag-auto-scroll.test.ts` (velocity ramp/clamp/minimum, continuous scrolling, stop on middle/drop/dragend, capture-phase), `workspace:creation-times` handler test (real tmpdir, missing path → null, schema rejection), schema test.
- `npm run typecheck` ✅
- `npm run check:file-lines` ✅
- `npx eslint` on all touched files ✅
- Sidebar selector/drag/order vitest suites (94 tests) ✅; workspace IPC suite ✅
- Full `npm run test`: all sidebar/preload/IPC/shared tests pass. 20 pre-existing failures in `src/main` symlink/daemon/migration/installer suites reproduce on a clean `origin/develop` checkout (Windows sandbox, e.g. `daemon-runtime.test.ts` fails identically on develop) and are unrelated to this change.
