### PR TITLE
fix(shell): size the initial main window within the work area

### DIFF
--- a/src/main/main-window-initial-bounds.test.ts
+++ b/src/main/main-window-initial-bounds.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAIN_WINDOW_DEFAULT_HEIGHT,
+  MAIN_WINDOW_DEFAULT_WIDTH,
+  MAIN_WINDOW_MIN_HEIGHT,
+  MAIN_WINDOW_MIN_WIDTH,
+  resolveMainWindowInitialBounds
+} from './main-window-initial-bounds'
+
+describe('resolveMainWindowInitialBounds', () => {
+  it('keeps the default size centered on large work areas', () => {
+    expect(resolveMainWindowInitialBounds({ x: 0, y: 0, width: 1920, height: 1040 })).toEqual({
+      x: 320,
+      y: 100,
+      width: MAIN_WINDOW_DEFAULT_WIDTH,
+      height: MAIN_WINDOW_DEFAULT_HEIGHT
+    })
+  })
+
+  it('shrinks below the work area on small or scaled displays so restore stays visible', () => {
+    // 1280x800 panel at 150% scaling: work area is smaller than the default
+    // window, so the unclamped default would make restore look like a no-op.
+    const bounds = resolveMainWindowInitialBounds({ x: 0, y: 0, width: 1280, height: 752 })
+    expect(bounds).toEqual({ x: 96, y: 56, width: 1088, height: 640 })
+    expect(bounds.width).toBeLessThan(1280)
+    expect(bounds.height).toBeLessThan(752)
+  })
+
+  it('never goes below the minimum window size on tiny work areas', () => {
+    expect(resolveMainWindowInitialBounds({ x: 0, y: 0, width: 800, height: 600 })).toEqual({
+      x: 0,
+      y: 0,
+      width: MAIN_WINDOW_MIN_WIDTH,
+      height: MAIN_WINDOW_MIN_HEIGHT
+    })
+  })
+
+  it('respects the work area offset of non-primary displays', () => {
+    expect(resolveMainWindowInitialBounds({ x: 1920, y: 40, width: 1920, height: 1040 })).toEqual({
+      x: 2240,
+      y: 140,
+      width: MAIN_WINDOW_DEFAULT_WIDTH,
+      height: MAIN_WINDOW_DEFAULT_HEIGHT
+    })
+  })
+})

--- a/src/main/main-window-initial-bounds.ts
+++ b/src/main/main-window-initial-bounds.ts
@@ -1,0 +1,34 @@
+// Initial main-window bounds.
+//
+// The fixed 1280x840 default fills the whole work area on small or
+// high-DPI-scaled displays (for example a 1280x800 panel at 150% scaling
+// has a 1280x752 work area). There the window opens effectively
+// full-screen, so restoring from maximize returns to bounds that match the
+// maximized size and the restore button looks like a no-op. Keep the
+// initial window at most 85% of the work area so restore always shrinks
+// visibly, and center it.
+
+export const MAIN_WINDOW_MIN_WIDTH = 960
+export const MAIN_WINDOW_MIN_HEIGHT = 640
+export const MAIN_WINDOW_DEFAULT_WIDTH = 1280
+export const MAIN_WINDOW_DEFAULT_HEIGHT = 840
+const MAX_WORK_AREA_FRACTION = 0.85
+
+export type MainWindowBounds = { x: number; y: number; width: number; height: number }
+
+export function resolveMainWindowInitialBounds(workArea: MainWindowBounds): MainWindowBounds {
+  const width = Math.min(
+    MAIN_WINDOW_DEFAULT_WIDTH,
+    Math.max(MAIN_WINDOW_MIN_WIDTH, Math.floor(workArea.width * MAX_WORK_AREA_FRACTION))
+  )
+  const height = Math.min(
+    MAIN_WINDOW_DEFAULT_HEIGHT,
+    Math.max(MAIN_WINDOW_MIN_HEIGHT, Math.floor(workArea.height * MAX_WORK_AREA_FRACTION))
+  )
+  return {
+    x: workArea.x + Math.max(0, Math.floor((workArea.width - width) / 2)),
+    y: workArea.y + Math.max(0, Math.floor((workArea.height - height) / 2)),
+    width,
+    height
+  }
+}

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron'
+import { BrowserWindow, screen } from 'electron'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -13,6 +13,11 @@ import {
   shouldRecoverRendererProcess
 } from './main-window-renderer-recovery'
 import { logError, logInfo, logWarn } from './logger'
+import {
+  MAIN_WINDOW_MIN_HEIGHT,
+  MAIN_WINDOW_MIN_WIDTH,
+  resolveMainWindowInitialBounds
+} from './main-window-initial-bounds'
 import { appWindowTitleForFlavor } from '../shared/app-environment'
 import { resolveDesktopTitleBarMode } from '../shared/desktop-title-bar'
 import {
@@ -62,11 +67,14 @@ export function createWindow(options: {
   )
   const usesCustomDesktopTitleBar = desktopTitleBarMode === 'custom'
   const windowTitle = appWindowTitleForFlavor(appEnvironment.flavor)
+  const initialBounds = resolveMainWindowInitialBounds(screen.getPrimaryDisplay().workArea)
   const window = new BrowserWindow({
-    width: 1280,
-    height: 840,
-    minWidth: 960,
-    minHeight: 640,
+    x: initialBounds.x,
+    y: initialBounds.y,
+    width: initialBounds.width,
+    height: initialBounds.height,
+    minWidth: MAIN_WINDOW_MIN_WIDTH,
+    minHeight: MAIN_WINDOW_MIN_HEIGHT,
     title: windowTitle,
     icon: appIcon.isEmpty() ? undefined : appIcon,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : usesCustomDesktopTitleBar ? 'hidden' : 'default',


### PR DESCRIPTION
## Summary

Fixes the title-bar **restore button appearing to do nothing** on small or high-DPI-scaled displays.

- Root cause: the main window always opened at a fixed `1280x840`. On displays whose work area is smaller than that (e.g. a 1280x800 panel at 150% scaling, work area 1280x752), Windows clamps the new window to fill the work area. The window therefore opens effectively full-screen, and restoring from maximize returns to bounds that match the maximized size — the window visibly never shrinks.
- Fix: derive the initial window bounds from the primary display work area. Large screens keep the `1280x840` default; smaller work areas get at most 85% of the work area (never below the `960x640` minimum), centered, so restore-from-maximize always shrinks visibly.

## Changes

- `src/main/main-window-initial-bounds.ts` (new): pure `resolveMainWindowInitialBounds(workArea)` helper plus the exported min/default size constants.
- `src/main/main-window.ts`: `createWindow` now positions and sizes the window from the primary display work area instead of hardcoding `width: 1280, height: 840`.
- `src/main/main-window-initial-bounds.test.ts` (new): unit tests for large, small/scaled, tiny, and offset work areas.

## Tests

- `npx vitest run src/main/main-window-initial-bounds.test.ts src/main/main-window.auxiliary.test.ts` — 6 passed
- `npx vitest run` on adjacent main-window suites (activation, renderer-recovery, storage-relocation, runtime-data-recovery) — 12 passed
- `npm run typecheck` — passed
- Real Electron verification on a 1280x800 @150% display (work area 1280x752), simulating `createWindow` then maximize → restore:
  - before: restored bounds 1284x753 vs maximized 1296x768 (Δ 12x15 px — invisible, the reported bug)
  - after: restored bounds 1091x643 vs maximized 1296x768 (Δ 205x125 px — clearly visible)