### PR TITLE
feat(chat): 语音输入边说边出字(流式听写)

### DIFF
--- a/src/renderer/src/components/chat/FloatingComposer.tsx
+++ b/src/renderer/src/components/chat/FloatingComposer.tsx
@@ -291,8 +291,15 @@ export function FloatingComposer({
   const dictation = useVoiceDictation({
     speechToText: speechToTextSettings,
     onText: (text, intent) => {
-      const existing = dictationInputRef.current.replace(/\s+$/, '')
-      setInput(existing ? `${existing} ${text}` : text)
+      const trimmed = text.trim()
+      if (trimmed) {
+        // 流式听写会连续多次回调:手动同步 ref,避免后一个分片读到
+        // 重渲染生效前的旧文本而丢掉刚插入的内容。
+        const existing = dictationInputRef.current.replace(/\s+$/, '')
+        const next = existing ? `${existing} ${trimmed}` : trimmed
+        dictationInputRef.current = next
+        setInput(next)
+      }
       if (intent === 'send') {
         // 等 setInput 的重渲染落地后再走正常的发送路径,
         // 这样语音直发和手动点发送行为完全一致。

--- a/src/renderer/src/components/chat/use-voice-dictation.ts
+++ b/src/renderer/src/components/chat/use-voice-dictation.ts
@@ -15,13 +15,23 @@ import {
   fetchSharedModelConnectionCredentialStates,
   providerHasUsableCredential
 } from '../../lib/provider-credential-readiness'
+import {
+  createPcmCaptureWorkletUrl,
+  isSilentChunk,
+  PCM_CAPTURE_PROCESSOR_NAME,
+  PcmChunkAccumulator,
+  resampleTo16k,
+  SerialTranscriptionQueue,
+  VOICE_REALTIME_FLUSH_INTERVAL_MS,
+  VOICE_REALTIME_MIN_TAIL_MS,
+  VOICE_TRANSCRIPTION_SAMPLE_RATE
+} from './voice-dictation-realtime'
 
 export type VoiceDictationStatus = 'idle' | 'recording' | 'transcribing'
 
 /** What to do with the transcript once it lands: insert into the input, or send right away. */
 export type VoiceDictationIntent = 'insert' | 'send'
 
-const TRANSCRIPTION_SAMPLE_RATE = 16_000
 const MIN_RECORDING_MS = 500
 const VOICE_ERROR_AUTO_DISMISS_MS = 10_000
 const RECORDER_MIME_CANDIDATES = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4']
@@ -155,11 +165,20 @@ export function useVoiceDictation({
   const audioContextRef = useRef<AudioContext | null>(null)
   const analyserRef = useRef<AnalyserNode | null>(null)
   const levelDataRef = useRef<Uint8Array<ArrayBuffer> | null>(null)
+  const workletNodeRef = useRef<AudioWorkletNode | null>(null)
+  const pcmAccumulatorRef = useRef<PcmChunkAccumulator | null>(null)
+  const chunkFlushTimerRef = useRef<number | null>(null)
+  const transcriptionQueueRef = useRef<SerialTranscriptionQueue | null>(null)
+  const sourceSampleRateRef = useRef(0)
+  const producedTextRef = useRef(false)
+  /** Incremented per dictation so stale async results from a previous run are dropped. */
+  const sessionIdRef = useRef(0)
   const stopIntentRef = useRef<VoiceDictationIntent>('insert')
   const maxDurationTimerRef = useRef<number | null>(null)
   const errorTimerRef = useRef<number | null>(null)
   const startedAtRef = useRef(0)
   const onTextRef = useRef(onText)
+  const stopRef = useRef<(intent?: VoiceDictationIntent) => void>(() => undefined)
   const mountedRef = useRef(true)
 
   useEffect(() => {
@@ -189,6 +208,13 @@ export function useVoiceDictation({
       window.clearTimeout(maxDurationTimerRef.current)
       maxDurationTimerRef.current = null
     }
+    if (chunkFlushTimerRef.current != null) {
+      window.clearInterval(chunkFlushTimerRef.current)
+      chunkFlushTimerRef.current = null
+    }
+    workletNodeRef.current?.disconnect()
+    workletNodeRef.current = null
+    pcmAccumulatorRef.current = null
     streamRef.current?.getTracks().forEach((track) => track.stop())
     streamRef.current = null
     recorderRef.current = null
@@ -216,6 +242,8 @@ export function useVoiceDictation({
     return () => {
       mountedRef.current = false
       recorderRef.current?.stop()
+      transcriptionQueueRef.current?.abort()
+      sessionIdRef.current += 1
       releaseStream()
       if (errorTimerRef.current != null) {
         window.clearTimeout(errorTimerRef.current)
@@ -223,6 +251,90 @@ export function useVoiceDictation({
       }
     }
   }, [releaseStream])
+
+  /** True only for async work belonging to the live dictation run. */
+  const isLiveSession = useCallback((sessionId: number): boolean => (
+    mountedRef.current && sessionIdRef.current === sessionId
+  ), [])
+
+  const abortSession = useCallback((message: string, sessionId: number): void => {
+    if (!isLiveSession(sessionId)) return
+    showError(t('composerVoiceFailed', { message }))
+    transcriptionQueueRef.current?.abort()
+    sessionIdRef.current += 1
+    // 转写链路出错后继续录只会产生带断层的文本,直接结束本次听写;
+    // 已经插入输入框的分片文本保留,由用户决定去留。
+    releaseStream()
+    setStatus('idle')
+  }, [isLiveSession, releaseStream, showError, t])
+
+  const runChunkTranscription = useCallback(async (
+    pcm16k: Float32Array,
+    durationMs: number,
+    sessionId: number
+  ): Promise<void> => {
+    try {
+      const wavBytes = encodeWavPcm16(pcm16k, VOICE_TRANSCRIPTION_SAMPLE_RATE)
+      const result = await window.kunGui.transcribeSpeech({
+        audioBase64: bytesToBase64(wavBytes),
+        mimeType: 'audio/wav',
+        durationMs,
+        ...(speechToText ? { speechToText } : {})
+      })
+      if (!isLiveSession(sessionId)) return
+      if (result.ok) {
+        const text = result.text.trim()
+        if (text) {
+          producedTextRef.current = true
+          onTextRef.current(text, 'insert')
+        }
+      } else {
+        abortSession(result.message, sessionId)
+      }
+    } catch (cause) {
+      abortSession(cause instanceof Error ? cause.message : String(cause), sessionId)
+    }
+  }, [abortSession, isLiveSession, speechToText])
+
+  const enqueueSpeechChunk = useCallback((samples: Float32Array, sessionId: number): void => {
+    const queue = transcriptionQueueRef.current
+    const sourceRate = sourceSampleRateRef.current
+    if (!queue || sourceRate <= 0) return
+    const pcm16k = resampleTo16k(samples, sourceRate)
+    // 整段静音的分片直接跳过:省配额,也避免提供方对背景噪声幻觉出文本。
+    if (isSilentChunk(pcm16k)) return
+    const durationMs = Math.round((pcm16k.length / VOICE_TRANSCRIPTION_SAMPLE_RATE) * 1000)
+    queue.enqueue(() => runChunkTranscription(pcm16k, durationMs, sessionId))
+  }, [runChunkTranscription])
+
+  const flushFullChunks = useCallback((sessionId: number): void => {
+    const accumulator = pcmAccumulatorRef.current
+    if (!accumulator) return
+    for (const chunk of accumulator.takeFullChunks()) {
+      enqueueSpeechChunk(chunk, sessionId)
+    }
+  }, [enqueueSpeechChunk])
+
+  /**
+   * Runs after every queued chunk resolves. A "send" intent fires exactly once
+   * here (with empty text) so the composer sends whatever the stream inserted,
+   * mirroring the single-shot batch flow even when the tail chunk was silent.
+   */
+  const enqueueSessionFinalizer = useCallback((intent: VoiceDictationIntent, sessionId: number): void => {
+    const queue = transcriptionQueueRef.current
+    if (!queue) return
+    queue.enqueue(async () => {
+      if (!isLiveSession(sessionId)) return
+      if (!producedTextRef.current) {
+        if (Date.now() - startedAtRef.current < MIN_RECORDING_MS) {
+          showError(t('composerVoiceTooShort'))
+        }
+        // 全程静音:静默结束,不触碰输入框。
+        return
+      }
+      if (intent === 'send') onTextRef.current('', 'send')
+    })
+  }, [isLiveSession, showError, t])
 
   const transcribeBlob = useCallback(async (blob: Blob, durationMs: number, intent: VoiceDictationIntent): Promise<void> => {
     try {
@@ -249,7 +361,7 @@ export function useVoiceDictation({
   }, [showError, speechToText, t])
 
   const start = useCallback((): void => {
-    if (recorderRef.current) return
+    if (recorderRef.current || workletNodeRef.current) return
     clearError()
     void (async () => {
       let stream: MediaStream
@@ -269,59 +381,138 @@ export function useVoiceDictation({
         stream.getTracks().forEach((track) => track.stop())
         return
       }
-      const mimeType = RECORDER_MIME_CANDIDATES.find((candidate) =>
-        MediaRecorder.isTypeSupported(candidate)
-      )
-      const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
-      const chunks: Blob[] = []
-      recorder.ondataavailable = (event) => {
-        if (event.data.size > 0) chunks.push(event.data)
-      }
-      recorder.onstop = () => {
-        const durationMs = Date.now() - startedAtRef.current
-        const intent = stopIntentRef.current
-        const blob = new Blob(chunks, { type: recorder.mimeType || 'audio/webm' })
-        releaseStream()
-        if (!mountedRef.current) return
-        if (durationMs < MIN_RECORDING_MS || blob.size === 0) {
-          setStatus('idle')
-          showError(t('composerVoiceTooShort'))
-          return
-        }
-        setStatus('transcribing')
-        void transcribeBlob(blob, durationMs, intent)
-      }
+      const sessionId = sessionIdRef.current + 1
+      sessionIdRef.current = sessionId
+      producedTextRef.current = false
+      transcriptionQueueRef.current = new SerialTranscriptionQueue()
+
+      let audioContext: AudioContext | null = null
+      let source: MediaStreamAudioSourceNode | null = null
       try {
-        const audioContext = new AudioContext()
+        audioContext = new AudioContext()
         const analyser = audioContext.createAnalyser()
         analyser.fftSize = 512
         analyser.smoothingTimeConstant = 0.55
-        audioContext.createMediaStreamSource(stream).connect(analyser)
+        source = audioContext.createMediaStreamSource(stream)
+        source.connect(analyser)
         audioContextRef.current = audioContext
         analyserRef.current = analyser
         levelDataRef.current = new Uint8Array(new ArrayBuffer(analyser.fftSize))
+        sourceSampleRateRef.current = audioContext.sampleRate
       } catch {
         // 波形只是视觉反馈,拿不到 analyser 也不影响录音本身。
       }
-      streamRef.current = stream
-      recorderRef.current = recorder
-      stopIntentRef.current = 'insert'
+
+      let realtimeReady = false
+      if (audioContext && source) {
+        try {
+          const workletUrl = createPcmCaptureWorkletUrl()
+          try {
+            await audioContext.audioWorklet.addModule(workletUrl)
+          } finally {
+            URL.revokeObjectURL(workletUrl)
+          }
+          const workletNode = new AudioWorkletNode(audioContext, PCM_CAPTURE_PROCESSOR_NAME)
+          const accumulator = PcmChunkAccumulator.forSourceRate(audioContext.sampleRate)
+          workletNode.port.onmessage = (event: MessageEvent<Float32Array>) => {
+            if (event.data instanceof Float32Array) accumulator.push(event.data)
+          }
+          source.connect(workletNode)
+          // The processor never writes its outputs, so this edge plays silence;
+          // connecting to the destination keeps the graph pulled everywhere.
+          workletNode.connect(audioContext.destination)
+          void audioContext.resume().catch(() => undefined)
+          workletNodeRef.current = workletNode
+          pcmAccumulatorRef.current = accumulator
+          realtimeReady = true
+        } catch {
+          // AudioWorklet 不可用时回退到整段录制,停止后一次性转写依旧可用。
+          realtimeReady = false
+        }
+      }
+
       startedAtRef.current = Date.now()
       setStartedAtMs(startedAtRef.current)
-      recorder.start()
+      streamRef.current = stream
       setStatus('recording')
+
+      if (realtimeReady) {
+        chunkFlushTimerRef.current = window.setInterval(() => {
+          flushFullChunks(sessionId)
+        }, VOICE_REALTIME_FLUSH_INTERVAL_MS)
+      } else {
+        const mimeType = RECORDER_MIME_CANDIDATES.find((candidate) =>
+          MediaRecorder.isTypeSupported(candidate)
+        )
+        const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
+        const chunks: Blob[] = []
+        recorder.ondataavailable = (event) => {
+          if (event.data.size > 0) chunks.push(event.data)
+        }
+        recorder.onstop = () => {
+          const durationMs = Date.now() - startedAtRef.current
+          const intent = stopIntentRef.current
+          const blob = new Blob(chunks, { type: recorder.mimeType || 'audio/webm' })
+          releaseStream()
+          if (!mountedRef.current) return
+          if (durationMs < MIN_RECORDING_MS || blob.size === 0) {
+            setStatus('idle')
+            showError(t('composerVoiceTooShort'))
+            return
+          }
+          setStatus('transcribing')
+          void transcribeBlob(blob, durationMs, intent)
+        }
+        recorderRef.current = recorder
+        stopIntentRef.current = 'insert'
+        recorder.start()
+      }
+
       maxDurationTimerRef.current = window.setTimeout(() => {
-        if (recorderRef.current?.state === 'recording') recorderRef.current.stop()
+        stopRef.current('insert')
       }, SPEECH_TRANSCRIPTION_MAX_DURATION_MS)
     })()
-  }, [clearError, releaseStream, showError, t, transcribeBlob])
+  }, [clearError, flushFullChunks, releaseStream, showError, t, transcribeBlob])
 
   const stop = useCallback((intent: VoiceDictationIntent = 'insert'): void => {
+    // Batch fallback: MediaRecorder.onstop carries on with the single-shot flow.
     if (recorderRef.current?.state === 'recording') {
       stopIntentRef.current = intent
       recorderRef.current.stop()
+      return
     }
-  }, [])
+    if (!workletNodeRef.current) return
+    const sessionId = sessionIdRef.current
+    const queue = transcriptionQueueRef.current
+    // Flush complete windows still sitting in the accumulator, then cut the tail.
+    flushFullChunks(sessionId)
+    const remainder = pcmAccumulatorRef.current?.takeRemainder() ?? null
+    const sourceRate = sourceSampleRateRef.current
+    releaseStream()
+    if (!queue) {
+      setStatus('idle')
+      return
+    }
+    if (remainder && sourceRate > 0) {
+      const tailDurationMs = Math.round((remainder.length / sourceRate) * 1000)
+      if (tailDurationMs >= VOICE_REALTIME_MIN_TAIL_MS) {
+        enqueueSpeechChunk(remainder, sessionId)
+      }
+    }
+    enqueueSessionFinalizer(intent, sessionId)
+    if (queue.pending > 0) {
+      setStatus('transcribing')
+      void queue.drain().then(() => {
+        if (isLiveSession(sessionId)) setStatus('idle')
+      })
+    } else {
+      setStatus('idle')
+    }
+  }, [enqueueSessionFinalizer, enqueueSpeechChunk, flushFullChunks, isLiveSession, releaseStream])
+
+  useEffect(() => {
+    stopRef.current = stop
+  }, [stop])
 
   const toggle = useCallback((): void => {
     if (status === 'recording') {
@@ -348,14 +539,14 @@ async function encodeBlobAsWav(blob: Blob): Promise<{ base64: string }> {
   } finally {
     void decodeContext.close()
   }
-  const frameCount = Math.max(1, Math.ceil(decoded.duration * TRANSCRIPTION_SAMPLE_RATE))
-  const offline = new OfflineAudioContext(1, frameCount, TRANSCRIPTION_SAMPLE_RATE)
+  const frameCount = Math.max(1, Math.ceil(decoded.duration * VOICE_TRANSCRIPTION_SAMPLE_RATE))
+  const offline = new OfflineAudioContext(1, frameCount, VOICE_TRANSCRIPTION_SAMPLE_RATE)
   const source = offline.createBufferSource()
   source.buffer = decoded
   source.connect(offline.destination)
   source.start()
   const rendered = await offline.startRendering()
-  const wavBytes = encodeWavPcm16(rendered.getChannelData(0), TRANSCRIPTION_SAMPLE_RATE)
+  const wavBytes = encodeWavPcm16(rendered.getChannelData(0), VOICE_TRANSCRIPTION_SAMPLE_RATE)
   return { base64: bytesToBase64(wavBytes) }
 }
 

--- a/src/renderer/src/components/chat/voice-dictation-realtime.test.ts
+++ b/src/renderer/src/components/chat/voice-dictation-realtime.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSilentChunk,
+  PcmChunkAccumulator,
+  resampleTo16k,
+  rmsLevel,
+  SerialTranscriptionQueue,
+  VOICE_REALTIME_CHUNK_MS,
+  VOICE_SILENCE_RMS_THRESHOLD,
+  VOICE_TRANSCRIPTION_SAMPLE_RATE
+} from './voice-dictation-realtime'
+
+function constantFrames(length: number, value: number): Float32Array {
+  return new Float32Array(length).fill(value)
+}
+
+describe('PcmChunkAccumulator', () => {
+  it('cuts full chunks in arrival order across push boundaries', () => {
+    const accumulator = new PcmChunkAccumulator(4)
+    accumulator.push(new Float32Array([1, 2, 3]))
+    accumulator.push(new Float32Array([4, 5, 6, 7]))
+    accumulator.push(new Float32Array([8, 9]))
+
+    const chunks = accumulator.takeFullChunks()
+    expect(chunks).toHaveLength(2)
+    expect(Array.from(chunks[0])).toEqual([1, 2, 3, 4])
+    expect(Array.from(chunks[1])).toEqual([5, 6, 7, 8])
+    expect(accumulator.pendingFrames).toBe(1)
+    expect(Array.from(accumulator.takeRemainder() ?? [])).toEqual([9])
+    expect(accumulator.pendingFrames).toBe(0)
+    expect(accumulator.takeRemainder()).toBeNull()
+  })
+
+  it('sizes chunks from the audio context sample rate', () => {
+    const accumulator = PcmChunkAccumulator.forSourceRate(48_000)
+    accumulator.push(constantFrames(48_000 * (VOICE_REALTIME_CHUNK_MS / 1000) - 1, 0.5))
+    expect(accumulator.takeFullChunks()).toHaveLength(0)
+    accumulator.push(constantFrames(2, 0.5))
+    expect(accumulator.takeFullChunks()).toHaveLength(1)
+    expect(accumulator.pendingFrames).toBe(1)
+  })
+
+  it('rejects a non-positive chunk size', () => {
+    expect(() => new PcmChunkAccumulator(0)).toThrow()
+  })
+})
+
+describe('resampleTo16k', () => {
+  it('returns the input unchanged when already at 16 kHz', () => {
+    const samples = new Float32Array([0.1, -0.2, 0.3])
+    expect(resampleTo16k(samples, VOICE_TRANSCRIPTION_SAMPLE_RATE)).toBe(samples)
+  })
+
+  it('halves the frame count for 32 kHz input', () => {
+    // ratio 2: decimation keeps even indices 0, 2, 4, 6.
+    const samples = new Float32Array([0, 0.5, 1, 0.5, 0, -0.5, -1, -0.5])
+    const out = resampleTo16k(samples, 32_000)
+    expect(out).toHaveLength(4)
+    expect(Array.from(out)).toEqual([0, 1, 0, -1])
+  })
+
+  it('downsamples 48 kHz audio to one third of the frames', () => {
+    const samples = constantFrames(4_800, 0.25)
+    const out = resampleTo16k(samples, 48_000)
+    expect(out).toHaveLength(1_600)
+    expect(out[0]).toBeCloseTo(0.25)
+    expect(out[out.length - 1]).toBeCloseTo(0.25)
+  })
+
+  it('interpolates between neighbouring samples', () => {
+    // ratio 1.5: floor(4 / 1.5) = 2 output frames at positions 0 and 1.5.
+    const out = resampleTo16k(new Float32Array([0, 1, 2, 3]), 24_000)
+    expect(out).toHaveLength(2)
+    expect(Array.from(out)).toEqual([0, 1.5])
+  })
+})
+
+describe('silence gating', () => {
+  it('measures RMS of a constant signal', () => {
+    expect(rmsLevel(constantFrames(100, 0.5))).toBeCloseTo(0.5)
+    expect(rmsLevel(new Float32Array(0))).toBe(0)
+  })
+
+  it('flags quiet chunks as silent and keeps speech-level chunks', () => {
+    expect(isSilentChunk(constantFrames(1_000, VOICE_SILENCE_RMS_THRESHOLD / 2))).toBe(true)
+    expect(isSilentChunk(constantFrames(1_000, VOICE_SILENCE_RMS_THRESHOLD * 4))).toBe(false)
+  })
+})
+
+describe('SerialTranscriptionQueue', () => {
+  it('runs tasks one at a time in enqueue order', async () => {
+    const queue = new SerialTranscriptionQueue()
+    const order: string[] = []
+    let running = 0
+    let maxRunning = 0
+    const task = (label: string, delayMs: number) => async (): Promise<void> => {
+      running += 1
+      maxRunning = Math.max(maxRunning, running)
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      order.push(label)
+      running -= 1
+    }
+    // The later task answers faster; the queue must still keep spoken order.
+    queue.enqueue(task('first', 30))
+    queue.enqueue(task('second', 1))
+    await queue.drain()
+    expect(order).toEqual(['first', 'second'])
+    expect(maxRunning).toBe(1)
+    expect(queue.pending).toBe(0)
+  })
+
+  it('keeps the chain alive when a task throws', async () => {
+    const queue = new SerialTranscriptionQueue()
+    const order: string[] = []
+    queue.enqueue(async () => {
+      order.push('boom')
+      throw new Error('provider down')
+    })
+    queue.enqueue(async () => {
+      order.push('after')
+    })
+    await queue.drain()
+    expect(order).toEqual(['boom', 'after'])
+    expect(queue.pending).toBe(0)
+  })
+
+  it('skips tasks enqueued before an abort but still resolves drain', async () => {
+    const queue = new SerialTranscriptionQueue()
+    const order: string[] = []
+    queue.enqueue(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      order.push('slow')
+      queue.abort()
+    })
+    queue.enqueue(async () => {
+      order.push('skipped')
+    })
+    await queue.drain()
+    expect(order).toEqual(['slow'])
+    queue.enqueue(async () => {
+      order.push('ignored')
+    })
+    await queue.drain()
+    expect(order).toEqual(['slow'])
+  })
+})

--- a/src/renderer/src/components/chat/voice-dictation-realtime.ts
+++ b/src/renderer/src/components/chat/voice-dictation-realtime.ts
@@ -1,0 +1,189 @@
+/**
+ * Realtime dictation pipeline: capture raw microphone PCM through an
+ * AudioWorklet, cut the stream into fixed-size windows, and hand each window
+ * to the existing batch speech-to-text endpoint one at a time. Transcript
+ * fragments therefore land in the composer while the user is still speaking,
+ * instead of only after the recording stops.
+ */
+
+/** Audio duration packed into one streaming transcription request. */
+export const VOICE_REALTIME_CHUNK_MS = 4_000
+
+/** How often the recorder checks the accumulator for complete chunks. */
+export const VOICE_REALTIME_FLUSH_INTERVAL_MS = 250
+
+/** Minimum tail audio worth transcribing when a dictation stops. */
+export const VOICE_REALTIME_MIN_TAIL_MS = 500
+
+/** Sample rate shared with every transcription provider (16 kHz mono WAV). */
+export const VOICE_TRANSCRIPTION_SAMPLE_RATE = 16_000
+
+/**
+ * RMS floor (16-bit PCM, full scale = 1.0) under which a chunk counts as
+ * silence. Skipping silent windows avoids burning transcription quota and
+ * prevents providers from hallucinating text for background noise.
+ */
+export const VOICE_SILENCE_RMS_THRESHOLD = 0.012
+
+/** AudioWorklet processor name registered by the capture module source. */
+export const PCM_CAPTURE_PROCESSOR_NAME = 'kun-pcm-capture'
+
+const PCM_WORKLET_SOURCE = [
+  'class KunPcmCaptureProcessor extends AudioWorkletProcessor {',
+  '  process(inputs) {',
+  '    const channel = inputs[0] && inputs[0][0]',
+  '    if (channel && channel.length > 0) {',
+  '      this.port.postMessage(new Float32Array(channel))',
+  '    }',
+  '    return true',
+  '  }',
+  '}',
+  `registerProcessor('${PCM_CAPTURE_PROCESSOR_NAME}', KunPcmCaptureProcessor)`
+].join('\n')
+
+/**
+ * Worklet modules must load from a URL; an inline Blob keeps the processor
+ * self-contained so no extra bundle asset or server route is needed. Callers
+ * should revoke the URL once `audioWorklet.addModule` settles.
+ */
+export function createPcmCaptureWorkletUrl(): string {
+  return URL.createObjectURL(new Blob([PCM_WORKLET_SOURCE], { type: 'application/javascript' }))
+}
+
+/**
+ * Accumulates raw PCM frames pushed by the capture worklet and cuts them
+ * into fixed-size windows in arrival order.
+ */
+export class PcmChunkAccumulator {
+  private parts: Float32Array[] = []
+  private frames = 0
+
+  constructor(private readonly framesPerChunk: number) {
+    if (framesPerChunk <= 0) throw new Error('framesPerChunk must be positive')
+  }
+
+  static forSourceRate(sourceRate: number, chunkMs: number = VOICE_REALTIME_CHUNK_MS): PcmChunkAccumulator {
+    return new PcmChunkAccumulator(Math.max(1, Math.floor((sourceRate * chunkMs) / 1000)))
+  }
+
+  get pendingFrames(): number {
+    return this.frames
+  }
+
+  push(frames: Float32Array): void {
+    if (frames.length === 0) return
+    this.parts.push(frames)
+    this.frames += frames.length
+  }
+
+  /** Detach every complete chunk currently buffered, oldest first. */
+  takeFullChunks(): Float32Array[] {
+    const chunks: Float32Array[] = []
+    while (this.frames >= this.framesPerChunk) {
+      chunks.push(this.takeFrames(this.framesPerChunk))
+    }
+    return chunks
+  }
+
+  /** Detach everything that is left, used when the dictation stops. */
+  takeRemainder(): Float32Array | null {
+    if (this.frames === 0) return null
+    return this.takeFrames(this.frames)
+  }
+
+  private takeFrames(count: number): Float32Array {
+    const out = new Float32Array(count)
+    let written = 0
+    while (written < count) {
+      const head = this.parts[0]
+      const needed = count - written
+      if (head.length <= needed) {
+        out.set(head, written)
+        written += head.length
+        this.parts.shift()
+      } else {
+        out.set(head.subarray(0, needed), written)
+        this.parts[0] = head.subarray(needed)
+        written += needed
+      }
+    }
+    this.frames -= count
+    return out
+  }
+}
+
+/**
+ * Resample mono PCM to 16 kHz with linear interpolation. Speech transcription
+ * does not need band-limited sinc filtering, and linear interpolation keeps
+ * this dependency-free and fast enough for real-time slicing.
+ */
+export function resampleTo16k(samples: Float32Array, sourceRate: number): Float32Array {
+  if (sourceRate === VOICE_TRANSCRIPTION_SAMPLE_RATE) return samples
+  const ratio = sourceRate / VOICE_TRANSCRIPTION_SAMPLE_RATE
+  const outLength = Math.floor(samples.length / ratio)
+  const out = new Float32Array(outLength)
+  for (let i = 0; i < outLength; i += 1) {
+    const position = i * ratio
+    const index = Math.floor(position)
+    const fraction = position - index
+    const a = samples[index]
+    const b = samples[Math.min(index + 1, samples.length - 1)]
+    out[i] = a + (b - a) * fraction
+  }
+  return out
+}
+
+export function rmsLevel(samples: Float32Array): number {
+  if (samples.length === 0) return 0
+  let sumSquares = 0
+  for (let i = 0; i < samples.length; i += 1) {
+    sumSquares += samples[i] * samples[i]
+  }
+  return Math.sqrt(sumSquares / samples.length)
+}
+
+export function isSilentChunk(
+  samples: Float32Array,
+  threshold: number = VOICE_SILENCE_RMS_THRESHOLD
+): boolean {
+  return rmsLevel(samples) < threshold
+}
+
+/**
+ * Runs transcription tasks strictly one at a time so partial transcripts are
+ * inserted in spoken order even when providers answer at different speeds.
+ * `abort()` skips every task that has not started yet; `drain()` still
+ * resolves so callers can reset state after an abort.
+ */
+export class SerialTranscriptionQueue {
+  private chain: Promise<void> = Promise.resolve()
+  private aborted = false
+  private pendingCount = 0
+
+  get pending(): number {
+    return this.pendingCount
+  }
+
+  enqueue(task: () => Promise<void>): void {
+    if (this.aborted) return
+    this.pendingCount += 1
+    const run = async (): Promise<void> => {
+      try {
+        if (!this.aborted) await task()
+      } catch {
+        // Tasks report their own errors; the chain itself must keep moving.
+      } finally {
+        this.pendingCount -= 1
+      }
+    }
+    this.chain = this.chain.then(run)
+  }
+
+  abort(): void {
+    this.aborted = true
+  }
+
+  drain(): Promise<void> {
+    return this.chain
+  }
+}


### PR DESCRIPTION
## Summary

为会话输入框的语音输入增加**边说边出字**的流式转写:录音过程中文字实时逐段出现在输入框里,不再等到停止录音后才一次性插入。麦克风按钮位置、录音波形条、停止/发送按钮等现有交互不变。

## Changes

- 新增 `voice-dictation-realtime.ts`:AudioWorklet 采集原始 PCM → 每 4 秒切一个音频窗口 → 重采样到 16kHz 单声道 → 串行队列依次调用现有 STT 接口,保证识别结果按说话顺序落地;RMS 静音门控跳过安静片段(省配额、避免对背景噪声幻觉出文本)。
- 改造 `use-voice-dictation.ts`:默认走实时流式路径,每个分片转写完成即插入输入框;停止时冲刷尾段音频,全部落地后收尾回调统一携带 `insert`/`send` 意图(`send` 语义与原整段转写一致);任一分片失败即终止本次听写并提示,已插入文字保留;AudioWorklet 不可用时自动回退原 MediaRecorder 整段转写。
- `FloatingComposer.tsx`:`onText` 支持流式多次回调与空文本收尾(仅触发发送、不改动输入框),并手动同步输入 ref,避免连续分片读到重渲染前的旧文本。

## Tests

- 新增 `voice-dictation-realtime.test.ts`:12 个用例覆盖分块切割(跨 push 边界保序)、按采样率定帧、32k/48k/24k 重采样与插值、RMS 静音门控、串行队列顺序/并发上限/异常不断链/中止语义。
- 本地验证:`npm run typecheck` 全仓通过;`src/renderer/src/components/chat/` 123 个测试文件 920 个用例全部通过;`npm run check:file-lines` 通过;改动文件 ESLint 无告警。