### PR TITLE
release: v0.3.8 retry with native dependency download fix

### DIFF
--- a/kun/src/services/model-connection-probe.test.ts
+++ b/kun/src/services/model-connection-probe.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { probeModels } from './model-connection-probe.js'
+import { CODEX_CLI_VERSION } from '../adapters/model/provider-cli-identity.js'
+
+afterEach(() => vi.unstubAllGlobals())
+
+const input = {
+  kind: 'http' as const,
+  baseUrl: 'https://chatgpt.com/backend-api/codex/responses',
+  endpointFormat: 'custom_endpoint' as const,
+  apiKey: 'test-token',
+  headers: { 'ChatGPT-Account-Id': 'test-account', originator: 'codex_cli_rs' },
+  fallbackModels: ['gpt-5.5'],
+  proxyUrl: ''
+}
+
+it('discovers Codex models through the registry custom endpoint path', async () => {
+  const fetcher = vi.fn(async () => Response.json({ models: [
+    { slug: 'gpt-6-astra', visibility: 'list' },
+    { slug: 'gpt-5.3-codex-spark', visibility: 'list', supported_in_api: false },
+    { slug: 'hidden', visibility: 'hide' },
+    { slug: 'gpt-6-astra', visibility: 'list' }
+  ] }))
+  vi.stubGlobal('fetch', fetcher)
+  expect(await probeModels(input)).toEqual(['gpt-6-astra', 'gpt-5.3-codex-spark'])
+  expect(fetcher).toHaveBeenCalledWith(
+    `https://chatgpt.com/backend-api/codex/models?client_version=${CODEX_CLI_VERSION}`,
+    expect.objectContaining({ headers: expect.objectContaining({
+      authorization: 'Bearer test-token', 'ChatGPT-Account-Id': 'test-account'
+    }) })
+  )
+})
+
+it('does not report configured models as a successful discovery on API failure', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 401 })))
+  await expect(probeModels(input)).rejects.toThrow('HTTP 401')
+  vi.stubGlobal('fetch', vi.fn(async () => Response.json({ data: [] })))
+  await expect(probeModels(input)).rejects.toThrow('invalid model catalog')
+})
+
+it('keeps the configured-model behavior for other custom inference endpoints', async () => {
+  const fetcher = vi.fn()
+  vi.stubGlobal('fetch', fetcher)
+  expect(await probeModels({ ...input, baseUrl: 'https://example.com/inference' })).toEqual(['gpt-5.5'])
+  expect(fetcher).not.toHaveBeenCalled()
+})

--- a/kun/src/services/model-connection-probe.ts
+++ b/kun/src/services/model-connection-probe.ts
@@ -1,0 +1,109 @@
+import type { ModelConnectionProfile } from '../contracts/model-connections.js'
+import { createProxyFetch } from '../adapters/model/proxy-fetch.js'
+import { CODEX_CLI_VERSION } from '../adapters/model/provider-cli-identity.js'
+
+function uniqueModels(models: readonly string[]): string[] {
+  return [...new Set(models.map((model) => model.trim()).filter(Boolean))]
+}
+
+export async function probeModels(input: {
+  kind: ModelConnectionProfile['kind']
+  baseUrl?: string
+  endpointFormat?: ModelConnectionProfile['endpointFormat']
+  apiKey: string
+  headers?: Record<string, string>
+  fallbackModels: readonly string[]
+  proxyUrl: string
+}): Promise<string[]> {
+  if (input.kind !== 'http') return uniqueModels(input.fallbackModels)
+  if (!input.baseUrl) throw new Error('provider probe failed: HTTP provider has no base URL')
+  const endpoint = new URL(input.baseUrl)
+  if (endpoint.protocol === 'https:' && endpoint.hostname === 'chatgpt.com' &&
+      /^\/backend-api\/codex(?:\/|$)/u.test(endpoint.pathname)) {
+    if (!input.apiKey.trim()) throw new Error('provider probe failed: Codex requires a credential')
+    const fetchImpl = createProxyFetch(input.proxyUrl) ?? fetch
+    const response = await fetchImpl(
+      `https://chatgpt.com/backend-api/codex/models?client_version=${CODEX_CLI_VERSION}`,
+      {
+        headers: { ...input.headers, Accept: 'application/json', authorization: `Bearer ${input.apiKey}` },
+        signal: AbortSignal.timeout(15_000)
+      }
+    )
+    if (!response.ok) throw new Error(`provider probe failed with HTTP ${response.status}`)
+    const catalog = await response.json() as { models?: unknown }
+    if (!catalog || !Array.isArray(catalog.models)) throw new Error('Codex returned an invalid model catalog')
+    return uniqueModels(catalog.models.slice(0, 2_000).flatMap((row) =>
+      row && row.visibility === 'list' && typeof row.slug === 'string' && row.slug.length <= 512
+        ? [row.slug] : []
+    ))
+  }
+  // Custom full inference endpoints have no discoverable /models URL. When the
+  // profile already lists models (coding-plan gateways, user custom
+  // paths), treat an explicit credential + catalog as a successful probe.
+  if (input.endpointFormat === 'custom_endpoint') {
+    const configured = uniqueModels(input.fallbackModels)
+    if (configured.length === 0) {
+      throw new Error(
+        'provider probe failed: custom_endpoint does not define a models URL; configure models explicitly with probe disabled'
+      )
+    }
+    if (!input.apiKey.trim()) {
+      throw new Error('provider probe failed: custom_endpoint requires a credential when probing configured models')
+    }
+    return configured
+  }
+  const url = modelsUrl(input.baseUrl, input.endpointFormat)
+  const usesAnthropicHeaders = input.endpointFormat === 'messages'
+  const authHeaders: Record<string, string> = input.apiKey
+    ? usesAnthropicHeaders
+      ? { 'x-api-key': input.apiKey, 'anthropic-version': '2023-06-01' }
+      : { authorization: `Bearer ${input.apiKey}` }
+    : {}
+  const fetchImpl = createProxyFetch(input.proxyUrl) ?? fetch
+  const response = await fetchImpl(url, {
+    headers: { ...(input.headers ?? {}), ...authHeaders },
+    signal: AbortSignal.timeout(15_000)
+  })
+  if (!response.ok) throw new Error(`provider probe failed with HTTP ${response.status}`)
+  const value = await response.json().catch(() => ({})) as { data?: Array<{ id?: unknown }>; models?: unknown[] }
+  const discovered = Array.isArray(value.data)
+    ? value.data.flatMap((entry) => typeof entry?.id === 'string' ? [entry.id] : [])
+    : Array.isArray(value.models)
+      ? value.models.flatMap((entry) => typeof entry === 'string' ? [entry] : [])
+      : []
+  return uniqueModels([...discovered, ...input.fallbackModels])
+}
+
+export function modelsUrl(
+  baseUrl: string,
+  endpointFormat: ModelConnectionProfile['endpointFormat'] | undefined
+): string {
+  if (endpointFormat === 'custom_endpoint') {
+    throw new Error(
+      'provider probe failed: custom_endpoint does not define a models URL; configure models explicitly with probe disabled'
+    )
+  }
+  const url = new URL(baseUrl)
+  url.search = ''
+  url.hash = ''
+  const segments = url.pathname.split('/').filter(Boolean)
+  const last = segments.at(-1)?.toLowerCase()
+  if (last === 'models') {
+    url.pathname = `/${segments.join('/')}`
+    return url.toString()
+  }
+  if (last === 'responses' || last === 'messages') {
+    segments.pop()
+  } else if (last === 'completions' && segments.at(-2)?.toLowerCase() === 'chat') {
+    segments.splice(-2)
+  }
+  const version = segments.at(-1)?.toLowerCase()
+  if (version === 'beta') {
+    segments[segments.length - 1] = 'v1'
+  } else if (!version || !/^v\d+$/u.test(version)) {
+    segments.push('v1')
+  }
+  if (segments.at(-1)?.toLowerCase() !== 'models') segments.push('models')
+  url.pathname = `/${segments.join('/')}`
+  return url.toString()
+}

--- a/kun/src/services/model-connection-registry-core.ts
+++ b/kun/src/services/model-connection-registry-core.ts
@@ -23,7 +23,7 @@ import {
 } from '../contracts/model-connections.js'
 import { materializeLegacyProviderCredential } from './legacy-provider-credential-migration.js'
 import type { ExtensionCredentialStore } from './extension-credential-store.js'
-import { createProxyFetch } from '../adapters/model/proxy-fetch.js'
+export { probeModels, modelsUrl } from './model-connection-probe.js'
 import { installServiceOperations } from './service-operation-install.js'
 import { modelConnectionRegistryConnectionOperations } from './model-connection-registry-connection-operations.js'
 import { modelConnectionRegistryCredentialMutationOperations } from './model-connection-registry-credential-mutation-operations.js'
@@ -615,86 +615,4 @@ export function uniqueModels(models: readonly string[]): string[] {
 
 export function sameModels(left: readonly string[], right: readonly string[]): boolean {
   return left.length === right.length && left.every((model, index) => model === right[index])
-}
-
-export async function probeModels(input: {
-  kind: ModelConnectionProfile['kind']
-  baseUrl?: string
-  endpointFormat?: ModelConnectionProfile['endpointFormat']
-  apiKey: string
-  headers?: Record<string, string>
-  fallbackModels: readonly string[]
-  proxyUrl: string
-}): Promise<string[]> {
-  if (input.kind !== 'http') return uniqueModels(input.fallbackModels)
-  if (!input.baseUrl) throw new Error('provider probe failed: HTTP provider has no base URL')
-  // Custom full inference endpoints have no discoverable /models URL. When the
-  // profile already lists models (Codex, coding-plan gateways, user custom
-  // paths), treat an explicit credential + catalog as a successful probe.
-  if (input.endpointFormat === 'custom_endpoint') {
-    const configured = uniqueModels(input.fallbackModels)
-    if (configured.length === 0) {
-      throw new Error(
-        'provider probe failed: custom_endpoint does not define a models URL; configure models explicitly with probe disabled'
-      )
-    }
-    if (!input.apiKey.trim()) {
-      throw new Error('provider probe failed: custom_endpoint requires a credential when probing configured models')
-    }
-    return configured
-  }
-  const url = modelsUrl(input.baseUrl, input.endpointFormat)
-  const usesAnthropicHeaders = input.endpointFormat === 'messages'
-  const authHeaders: Record<string, string> = input.apiKey
-    ? usesAnthropicHeaders
-      ? { 'x-api-key': input.apiKey, 'anthropic-version': '2023-06-01' }
-      : { authorization: `Bearer ${input.apiKey}` }
-    : {}
-  const fetchImpl = createProxyFetch(input.proxyUrl) ?? fetch
-  const response = await fetchImpl(url, {
-    headers: { ...(input.headers ?? {}), ...authHeaders },
-    signal: AbortSignal.timeout(15_000)
-  })
-  if (!response.ok) throw new Error(`provider probe failed with HTTP ${response.status}`)
-  const value = await response.json().catch(() => ({})) as { data?: Array<{ id?: unknown }>; models?: unknown[] }
-  const discovered = Array.isArray(value.data)
-    ? value.data.flatMap((entry) => typeof entry?.id === 'string' ? [entry.id] : [])
-    : Array.isArray(value.models)
-      ? value.models.flatMap((entry) => typeof entry === 'string' ? [entry] : [])
-      : []
-  return uniqueModels([...discovered, ...input.fallbackModels])
-}
-
-export function modelsUrl(
-  baseUrl: string,
-  endpointFormat: ModelConnectionProfile['endpointFormat'] | undefined
-): string {
-  if (endpointFormat === 'custom_endpoint') {
-    throw new Error(
-      'provider probe failed: custom_endpoint does not define a models URL; configure models explicitly with probe disabled'
-    )
-  }
-  const url = new URL(baseUrl)
-  url.search = ''
-  url.hash = ''
-  const segments = url.pathname.split('/').filter(Boolean)
-  const last = segments.at(-1)?.toLowerCase()
-  if (last === 'models') {
-    url.pathname = `/${segments.join('/')}`
-    return url.toString()
-  }
-  if (last === 'responses' || last === 'messages') {
-    segments.pop()
-  } else if (last === 'completions' && segments.at(-2)?.toLowerCase() === 'chat') {
-    segments.splice(-2)
-  }
-  const version = segments.at(-1)?.toLowerCase()
-  if (version === 'beta') {
-    segments[segments.length - 1] = 'v1'
-  } else if (!version || !/^v\d+$/u.test(version)) {
-    segments.push('v1')
-  }
-  if (segments.at(-1)?.toLowerCase() !== 'models') segments.push('models')
-  url.pathname = `/${segments.join('/')}`
-  return url.toString()
 }

--- a/kun/src/services/model-connection-registry.test.ts
+++ b/kun/src/services/model-connection-registry.test.ts
@@ -295,8 +295,10 @@ describe('ModelConnectionRegistry', () => {
       expect(fetchMock).not.toHaveBeenCalled()
     })
 
-  it('probes Codex with configured models without requesting a models URL', async () => {
-      const fetchMock = vi.fn()
+  it('discovers live Codex models using the Registry OAuth credential', async () => {
+      const fetchMock = vi.fn(async () => Response.json({
+        models: [{ slug: 'gpt-6-astra', visibility: 'list' }]
+      }))
       vi.stubGlobal('fetch', fetchMock)
       const { value } = await registry()
       await value.connect({
@@ -322,9 +324,16 @@ describe('ModelConnectionRegistry', () => {
 
       await expect(value.probe('codex')).resolves.toEqual({
         ok: true,
-        models: ['gpt-5.5', 'gpt-5.4']
+        models: ['gpt-6-astra']
       })
-      expect(fetchMock).not.toHaveBeenCalled()
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('https://chatgpt.com/backend-api/codex/models?client_version='),
+        expect.objectContaining({ headers: expect.objectContaining({
+          authorization: 'Bearer access-token',
+          'ChatGPT-Account-Id': 'account-1',
+          originator: 'codex_cli_rs'
+        }) })
+      )
     })
 
   it('probes Messages providers with the Registry credential and Anthropic headers', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19062,13 +19062,13 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmmirror.com/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/node-gyp/node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:kun": "npm run build --workspace @kun/provider-catalog && npm run build --workspace @kun/extension-api && node ./scripts/ensure-kun-install.cjs && npm --prefix kun run build",
     "smoke:dual-runtime": "npm run build:kun && node ./scripts/smoke-dual-runtime.mjs",
     "test:packaging": "node --test ./scripts/publish-r2.test.mjs ./scripts/smoke-packaged-cli.test.cjs",
-    "test:release-workflows": "node --test ./scripts/daily-dev-prerelease-workflow.test.cjs ./scripts/release-workflow-guardrails.test.cjs ./scripts/gui-upgrade-feed.test.cjs ./scripts/verify-public-release.test.mjs ./scripts/smoke-gui-upgrade.test.cjs",
+    "test:release-workflows": "node --test ./scripts/daily-dev-prerelease-workflow.test.cjs ./scripts/release-workflow-guardrails.test.cjs ./scripts/node-gyp-download.test.cjs ./scripts/gui-upgrade-feed.test.cjs ./scripts/verify-public-release.test.mjs ./scripts/smoke-gui-upgrade.test.cjs",
     "build:extensions": "npm run build --workspace @kun/provider-catalog && npm run build --workspace @kun/extension-api && npm run build --workspace @kun/extension-react && npm run build --workspace @kun/extension-test && npm run build --workspace create-kun-extension",
     "test:extensions": "npm run test --workspace @kun/provider-catalog && npm run test --workspace @kun/extension-api && npm run test --workspace @kun/extension-react && npm run test --workspace @kun/extension-test && npm run test --workspace create-kun-extension",
     "check:extension-schema": "npm run schema:check --workspace @kun/extension-api",
@@ -212,6 +212,9 @@
     "hono": "4.13.0",
     "ip-address": "10.4.0",
     "js-yaml": "4.3.1",
+    "node-gyp": {
+      "undici": "8.10.2"
+    },
     "qs": "6.16.0"
   },
   "author": "Kun Contributors",

--- a/scripts/node-gyp-download.test.cjs
+++ b/scripts/node-gyp-download.test.cjs
@@ -1,0 +1,50 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const { join } = require('node:path')
+const test = require('node:test')
+
+// Exercise node-gyp's actual download stack in isolation: an uncaught parser
+// assertion must fail this test without terminating the rest of the test suite.
+// Regression: https://github.com/nodejs/undici/issues/5360
+test('node-gyp consumes a complete download after backpressure and socket EOF', () => {
+  const result = spawnSync(process.execPath, ['-e', `
+    const assert = require('node:assert/strict')
+    const { createServer } = require('node:net')
+    const { download } = require('node-gyp/lib/download.js')
+    const body = Buffer.alloc(64 * 1024, 97)
+    const server = createServer(socket => {
+      socket.once('data', () => socket.end(Buffer.concat([
+        Buffer.from('HTTP/1.1 200 OK\\r\\nContent-Length: ' + body.length +
+          '\\r\\nConnection: close\\r\\n\\r\\n'),
+        body
+      ])))
+    })
+    server.listen(0, '127.0.0.1', async () => {
+      try {
+        const response = await download({ version: 'test', opts: {} },
+          'http://127.0.0.1:' + server.address().port + '/headers.tar.gz')
+        assert.equal(response.status, 200)
+        // Let the body pause the parser before the peer's FIN is processed.
+        await new Promise(resolve => setTimeout(resolve, 200))
+        const chunks = []
+        for await (const chunk of response.body) chunks.push(chunk)
+        assert.deepEqual(Buffer.concat(chunks), body)
+      } catch (error) {
+        console.error(error)
+        process.exitCode = 1
+      } finally {
+        server.close()
+      }
+    })
+  `], {
+    cwd: join(__dirname, '..'),
+    encoding: 'utf8',
+    timeout: 10_000,
+    env: { ...process.env, NO_PROXY: '*', no_proxy: '*' }
+  })
+
+  assert.equal(result.error, undefined, result.error?.message)
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+})


### PR DESCRIPTION
## Summary
Release Kun v0.3.8 from develop, including the fix for the dependency installation failure in the previous release run.

## Changes
- Pin node-gyp's Undici dependency to 8.10.2 so paused HTTP downloads complete without crashing during native dependency installation.
- Add a regression test using node-gyp's actual download stack.
- Include the latest model discovery and connection probing changes already on develop.

## Tests
- Clean npm ci on Node 22.23.2 passed.
- Node-gyp downloaded and verified Node 22.23.2 headers successfully.
- Release workflow tests: 17 passed, including the download regression.
- Typecheck and application build passed.
- Changed-file lint, file line limit, and git diff --check passed.
- Release version computation selects v0.3.8; no existing v0.3.8 tag or release was found.

Merging this develop-to-master release PR triggers the stable release workflow, including quality gates, platform packaging, GUI upgrade acceptance, and publication.
