### PR TITLE
fix(updater): keep upgrades visible and use the checked download source

### DIFF
--- a/src/main/gui-updater.test.ts
+++ b/src/main/gui-updater.test.ts
@@ -582,6 +582,33 @@ describe('installGuiUpdate', () => {
 })
 
 describe('downloadGuiUpdate recovery', () => {
+  it('downloads from the checked feed even when a different mirror becomes faster', async () => {
+    process.env.DEEPSEEK_GUI_ALLOW_UNSIGNED_UPDATES = '1'
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    updater.checkForUpdates.mockResolvedValue({
+      updateInfo: { version: '0.3.9' }, isUpdateAvailable: true
+    })
+    const module = await import('./gui-updater')
+    module.initializeGuiUpdater(() => null, () => 'stable')
+    await expect(module.checkGuiUpdate('stable')).resolves.toMatchObject({ ok: true, hasUpdate: true })
+    const checkedFeed = updater.setFeedURL.mock.lastCall?.[0]
+    fetchMock.mockImplementation(async (url: string) => ({
+      ok: !url.startsWith(checkedFeed.url), status: 503
+    }))
+    updater.setFeedURL.mockClear()
+    updater.downloadUpdate.mockImplementation(async () => {
+      expect(module.getGuiUpdateState()).toMatchObject({
+        status: 'downloading', info: { latestVersion: '0.3.9' }, progress: { percent: 0 }
+      })
+      return ['/tmp/Kun-0.3.9.zip']
+    })
+
+    await expect(module.downloadGuiUpdate('stable')).resolves.toEqual({ ok: true, paths: ['/tmp/Kun-0.3.9.zip'] })
+    expect(updater.downloadUpdate).toHaveBeenCalledOnce()
+    expect(updater.setFeedURL).not.toHaveBeenCalled()
+  })
+
   it('clears stale download state so an interrupted download can be retried', async () => {
     process.env.KUN_UPDATE_URL = 'https://updates.example.test/'
     process.env.DEEPSEEK_GUI_ALLOW_UNSIGNED_UPDATES = '1'

--- a/src/main/gui-updater.ts
+++ b/src/main/gui-updater.ts
@@ -512,16 +512,9 @@ export async function downloadGuiUpdate(channel?: GuiUpdateChannel): Promise<Gui
         message: 'The update channel changed before download.'
       }
     }
-    const feedConfiguration = await resolveConfiguredUpdateChannel(selectedChannel, requestGeneration)
-    if (feedConfiguration !== 'configured') {
-      if (feedConfiguration !== 'stale') return feedConfiguration
-      return {
-        ok: false,
-        currentVersion: app.getVersion(),
-        code: 'download_failed',
-        message: 'The update channel changed before download.'
-      }
-    }
+    // The checked metadata belongs to configuredFeedUrl. Racing mirrors again here
+    // can select another URL, invalidate lastInfo, and silently cancel the update.
+    // Keep that source for the download; a later check can discover another mirror.
     if (!macAutoUpdateAllowed()) {
       return { ok: false, currentVersion: app.getVersion(), code: 'unsupported', message: unsupportedMessage() }
     }
@@ -532,6 +525,11 @@ export async function downloadGuiUpdate(channel?: GuiUpdateChannel): Promise<Gui
     operation.targetVersion = lastInfo.latestVersion
     eventOperation = operation
     clearDownloadedInstaller()
+    emitGuiUpdateState({
+      status: 'downloading',
+      info: lastInfo,
+      progress: { total: 0, delta: 0, transferred: 0, percent: 0, bytesPerSecond: 0 }
+    })
     try {
       let tracked: Promise<string[]>
       tracked = autoUpdater.downloadUpdate().finally(() => {

--- a/src/renderer/src/components/chat/WorkbenchGuiUpdateButton.tsx
+++ b/src/renderer/src/components/chat/WorkbenchGuiUpdateButton.tsx
@@ -1,0 +1,176 @@
+import type { ReactElement } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { GuiUpdateState } from '@shared/gui-update'
+import { ArrowUpCircle, Download, ExternalLink, Loader2, RefreshCw, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+export function WorkbenchGuiUpdateButton(): ReactElement | null {
+  const { t } = useTranslation(['common', 'settings'])
+  const [guiUpdateState, setGuiUpdateState] = useState<GuiUpdateState>({ status: 'idle' })
+  const [applyingGuiUpdate, setApplyingGuiUpdate] = useState(false)
+  const [guiUpdateError, setGuiUpdateError] = useState('')
+  const applyingRef = useRef(false)
+
+  useEffect(() => {
+    if (typeof window.kunGui?.onGuiUpdateState !== 'function') return
+    let receivedEvent = false
+    let cancelled = false
+    const applyEvent = (state: GuiUpdateState): void => {
+      if (cancelled) return
+      receivedEvent = true
+      setGuiUpdateError(state.status === 'error' ? state.message : '')
+      setGuiUpdateState((previous) => {
+        // A transient check failure must not discard the known update action.
+        const known = previous.info
+        if ((state.status === 'checking' || state.status === 'error') &&
+          !state.info?.ok && known?.ok && known.hasUpdate &&
+          (!state.info?.channel || state.info.channel === known.channel)) {
+          return { ...state, info: known }
+        }
+        return state
+      })
+    }
+    const unsubscribe = window.kunGui.onGuiUpdateState(applyEvent)
+    if (typeof window.kunGui?.getGuiUpdateState === 'function') {
+      void window.kunGui.getGuiUpdateState().then((state) => {
+        if (!cancelled && !receivedEvent) applyEvent(state)
+      }).catch(() => undefined)
+    }
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [])
+
+  const guiUpdateAction = useMemo(() => {
+    if (guiUpdateState.status === 'idle' || guiUpdateState.status === 'not_available') return null
+    return guiUpdateState.info?.ok && guiUpdateState.info.hasUpdate ? guiUpdateState.info : null
+  }, [guiUpdateState])
+  const guiUpdateBusy =
+    applyingGuiUpdate || guiUpdateState.status === 'checking' ||
+    guiUpdateState.status === 'downloading' || guiUpdateState.status === 'installing'
+  const guiUpdateLabel = useMemo(() => {
+    if (!guiUpdateAction) return ''
+    if (guiUpdateState.status === 'checking') return t('settings:guiUpdateChecking')
+    if (guiUpdateState.status === 'downloading') {
+      return t('guiUpdateTopbarDownloading', {
+        percent: Math.max(0, Math.round(guiUpdateState.progress.percent))
+      })
+    }
+    if (guiUpdateState.status === 'installing') {
+      return t('guiUpdateTopbarInstalling')
+    }
+    if (applyingGuiUpdate && !guiUpdateAction.manualOnly) {
+      return guiUpdateAction.downloaded || guiUpdateState.status === 'downloaded'
+        ? t('guiUpdateTopbarInstalling')
+        : t('guiUpdateTopbarDownloading', { percent: 0 })
+    }
+    if (guiUpdateAction.downloaded || guiUpdateState.status === 'downloaded') {
+      return t('settings:guiUpdateInstall')
+    }
+    if (guiUpdateAction.manualOnly) {
+      return t('guiUpdateTopbarManual', { version: guiUpdateAction.latestVersion })
+    }
+    return t('guiUpdateTopbarAvailable', { version: guiUpdateAction.latestVersion })
+  }, [applyingGuiUpdate, guiUpdateAction, guiUpdateState, t])
+  const guiUpdateTitle = useMemo(() => {
+    if (!guiUpdateAction) return ''
+    return guiUpdateAction.manualOnly
+      ? t('settings:guiUpdateAvailableManual', {
+          current: guiUpdateAction.currentVersion,
+          latest: guiUpdateAction.latestVersion
+        })
+      : t('settings:guiUpdateAvailable', {
+          current: guiUpdateAction.currentVersion,
+          latest: guiUpdateAction.latestVersion
+        })
+  }, [guiUpdateAction, t])
+
+  const runGuiUpdateAction = async (): Promise<void> => {
+    if (!guiUpdateAction || guiUpdateBusy || applyingRef.current) return
+    if (!guiUpdateAction.manualOnly && (
+      typeof window.kunGui?.downloadGuiUpdate !== 'function' ||
+      typeof window.kunGui?.installGuiUpdate !== 'function'
+    )) {
+      return
+    }
+
+    applyingRef.current = true
+    setApplyingGuiUpdate(true)
+    setGuiUpdateError('')
+    try {
+      if (guiUpdateAction.manualOnly) {
+        await window.kunGui.openExternal?.(guiUpdateAction.releaseUrl)
+        return
+      }
+      if (!guiUpdateAction.downloaded && guiUpdateState.status !== 'downloaded') {
+        const downloadResult = await window.kunGui.downloadGuiUpdate(guiUpdateAction.channel)
+        if (!downloadResult.ok) throw new Error(downloadResult.message)
+      }
+      const installResult = await window.kunGui.installGuiUpdate()
+      if (!installResult.ok) throw new Error(installResult.message)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setGuiUpdateError(message)
+      setGuiUpdateState((current) => {
+        if (current.status === 'idle' || current.status === 'not_available' ||
+          current.info?.channel !== guiUpdateAction.channel) return current
+        return { status: 'error', info: current.info, message }
+      })
+      if (typeof window.kunGui?.logError === 'function') {
+        await window.kunGui.logError('gui-update', 'Failed to apply GUI update from workbench top bar', {
+          version: guiUpdateAction.latestVersion,
+          message
+        }).catch(() => undefined)
+      }
+    } finally {
+      applyingRef.current = false
+      setApplyingGuiUpdate(false)
+    }
+  }
+
+  const renderGuiUpdateIcon = (): ReactElement => {
+    if (guiUpdateBusy) {
+      return <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2} />
+    }
+    if (guiUpdateAction?.downloaded || guiUpdateState.status === 'downloaded') {
+      return <RefreshCw className="h-4 w-4" strokeWidth={1.85} />
+    }
+    if (guiUpdateAction?.manualOnly) {
+      return <ExternalLink className="h-4 w-4" strokeWidth={1.85} />
+    }
+    if (guiUpdateAction) {
+      return <ArrowUpCircle className="h-4 w-4" strokeWidth={1.85} />
+    }
+    return <Download className="h-4 w-4" strokeWidth={1.85} />
+  }
+
+  if (!guiUpdateAction) return null
+
+  return (
+    <span className="relative inline-flex shrink-0">
+      <button
+        type="button"
+        onClick={() => void runGuiUpdateAction()}
+        disabled={guiUpdateBusy}
+        className={`${guiUpdateError && !guiUpdateBusy ? '' : 'ds-topbar-action-button '}relative inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border border-amber-300/75 bg-amber-50/92 text-amber-950 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] transition hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-700/70 dark:bg-amber-950/35 dark:text-amber-100 dark:hover:bg-amber-900/45`}
+        data-tooltip={guiUpdateBusy ? guiUpdateLabel : guiUpdateError || guiUpdateTitle}
+        aria-label={guiUpdateBusy ? guiUpdateLabel : guiUpdateError || guiUpdateTitle}
+      >
+        {renderGuiUpdateIcon()}
+        {!guiUpdateBusy ? (
+          <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-amber-500 shadow-[0_0_0_2px_rgba(245,158,11,0.18)]" />
+        ) : null}
+      </button>
+      {guiUpdateError && !guiUpdateBusy ? (
+        <span role="alert" className="absolute right-0 top-10 z-50 flex w-72 max-w-[calc(100vw-2rem)] items-start gap-2 break-words rounded-lg border border-ds-border bg-ds-card p-3 text-xs text-ds-danger shadow-lg">
+          <span className="min-w-0 flex-1">{guiUpdateError}</span>
+          <button type="button" onClick={() => setGuiUpdateError('')} aria-label={t('close')}
+            className="shrink-0 rounded text-ds-muted hover:text-ds-ink">
+            <X className="h-4 w-4" />
+          </button>
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/src/renderer/src/components/chat/WorkbenchTopBar.tsx
+++ b/src/renderer/src/components/chat/WorkbenchTopBar.tsx
@@ -1,16 +1,13 @@
 import type { ReactElement } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { EditorInfo } from '@shared/editor'
-import type { GuiUpdateState } from '@shared/gui-update'
+import { WorkbenchGuiUpdateButton } from './WorkbenchGuiUpdateButton'
 import {
-  ArrowUpCircle,
   Blocks,
   Bot,
   Check,
   Code2,
   ClipboardList,
-  Download,
-  ExternalLink,
   FileEdit,
   Folders,
   FolderOpen,
@@ -101,8 +98,6 @@ export function WorkbenchTopActions({
   const [selectedEditorId, setSelectedEditorId] = useState(() => readPreferredEditorId() ?? '')
   const [editorMenuOpen, setEditorMenuOpen] = useState(false)
   const [failedIconIds, setFailedIconIds] = useState<Set<string>>(() => new Set())
-  const [guiUpdateState, setGuiUpdateState] = useState<GuiUpdateState>({ status: 'idle' })
-  const [applyingGuiUpdate, setApplyingGuiUpdate] = useState(false)
   const [restartingKunServe, setRestartingKunServe] = useState(false)
   const [restartKunServeError, setRestartKunServeError] = useState('')
   const restartKunServeAvailable =
@@ -151,71 +146,6 @@ export function WorkbenchTopActions({
     return () => window.removeEventListener('pointerdown', onPointerDown)
   }, [editorMenuOpen])
 
-  useEffect(() => {
-    if (typeof window.kunGui?.onGuiUpdateState !== 'function') return
-    let receivedEvent = false
-    let cancelled = false
-    const applyEvent = (state: GuiUpdateState): void => {
-      receivedEvent = true
-      setGuiUpdateState(state)
-    }
-    const unsubscribe = window.kunGui.onGuiUpdateState(applyEvent)
-    if (typeof window.kunGui?.getGuiUpdateState === 'function') {
-      void window.kunGui.getGuiUpdateState().then((state) => {
-        if (!cancelled && !receivedEvent) setGuiUpdateState(state)
-      }).catch(() => undefined)
-    }
-    return () => {
-      cancelled = true
-      unsubscribe()
-    }
-  }, [])
-
-  const guiUpdateAction = useMemo(() => {
-    if (guiUpdateState.status === 'available' || guiUpdateState.status === 'downloaded') {
-      return guiUpdateState.info.hasUpdate ? guiUpdateState.info : null
-    }
-    if (guiUpdateState.status === 'downloading' || guiUpdateState.status === 'installing') {
-      return guiUpdateState.info?.hasUpdate ? guiUpdateState.info : null
-    }
-    if (guiUpdateState.status === 'error' && guiUpdateState.info?.ok && guiUpdateState.info.hasUpdate) {
-      return guiUpdateState.info
-    }
-    return null
-  }, [guiUpdateState])
-  const guiUpdateBusy =
-    applyingGuiUpdate || guiUpdateState.status === 'downloading' || guiUpdateState.status === 'installing'
-  const guiUpdateLabel = useMemo(() => {
-    if (!guiUpdateAction) return ''
-    if (guiUpdateState.status === 'downloading') {
-      return t('guiUpdateTopbarDownloading', {
-        percent: Math.max(0, Math.round(guiUpdateState.progress.percent))
-      })
-    }
-    if (guiUpdateState.status === 'installing') {
-      return t('guiUpdateTopbarInstalling')
-    }
-    if (guiUpdateAction.downloaded || guiUpdateState.status === 'downloaded') {
-      return t('settings:guiUpdateInstall')
-    }
-    if (guiUpdateAction.manualOnly) {
-      return t('guiUpdateTopbarManual', { version: guiUpdateAction.latestVersion })
-    }
-    return t('guiUpdateTopbarAvailable', { version: guiUpdateAction.latestVersion })
-  }, [guiUpdateAction, guiUpdateState, t])
-  const guiUpdateTitle = useMemo(() => {
-    if (!guiUpdateAction) return ''
-    return guiUpdateAction.manualOnly
-      ? t('settings:guiUpdateAvailableManual', {
-          current: guiUpdateAction.currentVersion,
-          latest: guiUpdateAction.latestVersion
-        })
-      : t('settings:guiUpdateAvailable', {
-          current: guiUpdateAction.currentVersion,
-          latest: guiUpdateAction.latestVersion
-        })
-  }, [guiUpdateAction, t])
-
   const chooseEditor = (editor: EditorInfo): void => {
     setSelectedEditorId(editor.id)
     writePreferredEditorId(editor.id)
@@ -250,46 +180,6 @@ export function WorkbenchTopActions({
     return <Icon className={`${className} shrink-0`} strokeWidth={1.8} />
   }
 
-  const runGuiUpdateAction = async (): Promise<void> => {
-    if (!guiUpdateAction || guiUpdateBusy) return
-    if (guiUpdateAction.manualOnly) {
-      if (typeof window.kunGui?.openExternal === 'function') {
-        await window.kunGui.openExternal(guiUpdateAction.releaseUrl)
-      }
-      return
-    }
-    if (
-      typeof window.kunGui?.downloadGuiUpdate !== 'function' ||
-      typeof window.kunGui?.installGuiUpdate !== 'function'
-    ) {
-      return
-    }
-
-    setApplyingGuiUpdate(true)
-    try {
-      if (!guiUpdateAction.downloaded && guiUpdateState.status !== 'downloaded') {
-        const downloadResult = await window.kunGui.downloadGuiUpdate(guiUpdateAction.channel)
-        if (!downloadResult.ok) return
-      }
-      const installResult = await window.kunGui.installGuiUpdate()
-      if (!installResult.ok && typeof window.kunGui?.logError === 'function') {
-        await window.kunGui.logError('gui-update', 'Failed to install GUI update from workbench top bar', {
-          version: guiUpdateAction.latestVersion,
-          message: installResult.message
-        })
-      }
-    } catch (error) {
-      if (typeof window.kunGui?.logError === 'function') {
-        await window.kunGui.logError('gui-update', 'Failed to apply GUI update from workbench top bar', {
-          version: guiUpdateAction.latestVersion,
-          message: error instanceof Error ? error.message : String(error)
-        })
-      }
-    } finally {
-      setApplyingGuiUpdate(false)
-    }
-  }
-
   const restartKunServe = async (): Promise<void> => {
     if (restartingKunServe || !restartKunServeAvailable) return
     setRestartKunServeError('')
@@ -308,22 +198,6 @@ export function WorkbenchTopActions({
     }
   }
 
-  const renderGuiUpdateIcon = (): ReactElement => {
-    if (guiUpdateState.status === 'downloading' || guiUpdateState.status === 'installing' || applyingGuiUpdate) {
-      return <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2} />
-    }
-    if (guiUpdateAction?.downloaded || guiUpdateState.status === 'downloaded') {
-      return <RefreshCw className="h-4 w-4" strokeWidth={1.85} />
-    }
-    if (guiUpdateAction?.manualOnly) {
-      return <ExternalLink className="h-4 w-4" strokeWidth={1.85} />
-    }
-    if (guiUpdateAction) {
-      return <ArrowUpCircle className="h-4 w-4" strokeWidth={1.85} />
-    }
-    return <Download className="h-4 w-4" strokeWidth={1.85} />
-  }
-
   return (
     <div className="ds-workbench-top-actions ds-no-drag relative flex shrink-0 items-center gap-1.5">
       {onOpenCommandPalette ? (
@@ -338,21 +212,7 @@ export function WorkbenchTopActions({
         </button>
       ) : null}
 
-      {guiUpdateAction ? (
-        <button
-          type="button"
-          onClick={() => void runGuiUpdateAction()}
-          disabled={guiUpdateBusy}
-          className="ds-topbar-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-[0.9rem] border border-amber-300/75 bg-amber-50/92 text-amber-950 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] transition hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-700/70 dark:bg-amber-950/35 dark:text-amber-100 dark:hover:bg-amber-900/45"
-          data-tooltip={guiUpdateBusy ? guiUpdateLabel : guiUpdateTitle}
-          aria-label={guiUpdateBusy ? guiUpdateLabel : guiUpdateTitle}
-        >
-          {renderGuiUpdateIcon()}
-          {!guiUpdateBusy ? (
-            <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-amber-500 shadow-[0_0_0_2px_rgba(245,158,11,0.18)]" />
-          ) : null}
-        </button>
-      ) : null}
+      <WorkbenchGuiUpdateButton />
 
       <div ref={editorMenuRef} className="relative">
         <button

--- a/src/renderer/src/components/chat/WorkbenchTopBar.update.test.ts
+++ b/src/renderer/src/components/chat/WorkbenchTopBar.update.test.ts
@@ -1,0 +1,140 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GuiUpdateInfo, GuiUpdateState } from '@shared/gui-update'
+import i18n from '../../i18n'
+import { WorkbenchTopActions } from './WorkbenchTopBar'
+
+const info: Extract<GuiUpdateInfo, { ok: true }> = {
+  ok: true, currentVersion: '0.3.8', latestVersion: '0.3.9', hasUpdate: true,
+  releaseUrl: 'https://example.test/releases/0.3.9', channel: 'stable'
+}
+let renderer: ReactTestRenderer
+let emit: (state: GuiUpdateState) => void
+let download: ReturnType<typeof vi.fn>
+let install: ReturnType<typeof vi.fn>
+
+async function mount(initial: GuiUpdateState = { status: 'available', info }): Promise<void> {
+  vi.stubGlobal('window', { kunGui: {
+    getGuiUpdateState: vi.fn(async () => initial),
+    onGuiUpdateState: (listener: typeof emit) => { emit = listener; return vi.fn() },
+    downloadGuiUpdate: download,
+    installGuiUpdate: install,
+    logError: vi.fn(async () => undefined),
+    openExternal: vi.fn(async () => undefined)
+  } })
+  await act(async () => { renderer = create(createElement(WorkbenchTopActions)) })
+}
+
+function updateButton() {
+  return renderer.root.find((node) =>
+    node.type === 'button' && node.props.className.includes('border-amber-300/75'))
+}
+
+function errorText() {
+  return renderer.root.findByProps({ role: 'alert' }).findAllByType('span')
+    .flatMap((node) => node.children.filter((child) => typeof child === 'string')).join('')
+}
+
+beforeEach(async () => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  await i18n.changeLanguage('en')
+  download = vi.fn(async () => ({ ok: true, paths: ['/tmp/Kun.zip'] }))
+  install = vi.fn(async () => ({ ok: true }))
+})
+
+afterEach(() => {
+  act(() => renderer?.unmount())
+  vi.unstubAllGlobals()
+})
+
+describe('workbench GUI update action', () => {
+  it('keeps a known update visible during a recheck and reports check failures', async () => {
+    await mount()
+    await act(async () => { emit({ status: 'checking', info }) })
+    expect(updateButton().props.disabled).toBe(true)
+    expect(updateButton().props['aria-label']).toBe('Checking for GUI updates…')
+    await act(async () => {
+      emit({ status: 'error', info: {
+        ok: false, currentVersion: '0.3.8', channel: 'stable', message: 'feed unavailable'
+      }, message: 'feed unavailable' })
+    })
+    expect(updateButton().props.disabled).toBe(false)
+    expect(errorText()).toContain('feed unavailable')
+    await act(async () => { emit({ status: 'idle' }) })
+    expect(renderer.root.findAllByProps({ role: 'alert' })).toHaveLength(0)
+    expect(() => updateButton()).toThrow()
+  })
+
+  it('keeps the button busy through download and install without duplicate requests', async () => {
+    let finishDownload!: (result: unknown) => void
+    let finishInstall!: (result: unknown) => void
+    download.mockImplementation(() => new Promise((resolve) => { finishDownload = resolve }))
+    install.mockImplementation(() => new Promise((resolve) => { finishInstall = resolve }))
+    await mount()
+    await act(async () => { updateButton().props.onClick() })
+    expect(updateButton().props.disabled).toBe(true)
+    await act(async () => {
+      emit({ status: 'downloading', info, progress: {
+        total: 100, delta: 42, transferred: 42, percent: 42, bytesPerSecond: 10
+      } })
+      updateButton().props.onClick()
+    })
+    expect(updateButton().props['aria-label']).toBe('Updating 42%')
+    expect(download).toHaveBeenCalledExactlyOnceWith('stable')
+    expect(install).not.toHaveBeenCalled()
+    await act(async () => {
+      emit({ status: 'downloaded', info: { ...info, downloaded: true } })
+      finishDownload({ ok: true, paths: ['/tmp/Kun.zip'] })
+    })
+    expect(install).toHaveBeenCalledOnce()
+    expect(updateButton().props.disabled).toBe(true)
+    await act(async () => {
+      emit({ status: 'installing', info })
+      finishInstall({ ok: true })
+    })
+    expect(updateButton().props['aria-label']).toBe('Installing…')
+    expect(updateButton().props.disabled).toBe(true)
+  })
+
+  it.each(['result', 'exception'])('shows a download %s failure and allows retry', async (failure) => {
+    if (failure === 'result') {
+      download.mockResolvedValueOnce({ ok: false, message: 'connection reset', code: 'download_failed' })
+    } else {
+      download.mockRejectedValueOnce(new Error('connection reset'))
+    }
+    await mount()
+    await act(async () => { updateButton().props.onClick() })
+    expect(install).not.toHaveBeenCalled()
+    expect(updateButton().props.disabled).toBe(false)
+    expect(updateButton().props['data-tooltip']).toContain('connection reset')
+    expect(errorText()).toContain('connection reset')
+    expect(updateButton().props.className).not.toContain('ds-topbar-action-button')
+    await act(async () => { renderer.root.findByProps({ 'aria-label': 'Close' }).props.onClick() })
+    expect(renderer.root.findAllByProps({ role: 'alert' })).toHaveLength(0)
+    expect(updateButton().props.className).toContain('ds-topbar-action-button')
+    await act(async () => { updateButton().props.onClick() })
+    expect(download).toHaveBeenCalledTimes(2)
+    expect(install).toHaveBeenCalledOnce()
+    expect(renderer.root.findAllByProps({ role: 'alert' })).toHaveLength(0)
+  })
+
+  it('reports install failures and retries a downloaded update without downloading again', async () => {
+    install.mockResolvedValueOnce({ ok: false, message: 'installation deferred' })
+    await mount({ status: 'downloaded', info: { ...info, downloaded: true } })
+    await act(async () => { updateButton().props.onClick() })
+    expect(errorText()).toContain('installation deferred')
+    expect(updateButton().props.disabled).toBe(false)
+    await act(async () => { updateButton().props.onClick() })
+    expect(download).not.toHaveBeenCalled()
+    expect(install).toHaveBeenCalledTimes(2)
+  })
+
+  it('opens manual updates without downloading or installing', async () => {
+    await mount({ status: 'available', info: { ...info, manualOnly: true } })
+    await act(async () => { updateButton().props.onClick() })
+    expect(window.kunGui.openExternal).toHaveBeenCalledWith(info.releaseUrl)
+    expect(download).not.toHaveBeenCalled()
+    expect(install).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Clicking the workbench update button could cancel an available upgrade and hide the button. Download startup raced the update mirrors again; a different winner invalidated the previously checked metadata as if the user had changed channels.

## Changes

- Download from the source associated with the checked update metadata and emit the downloading state immediately.
- Keep known updates visible while rechecking and show download/install failures with a dismissible error and a retryable button.
- Isolate the update button from the other workbench actions and add regression coverage for mirror changes, progress, failures, retries, and manual updates.

## Tests

- 72 relevant Vitest tests passed across the updater and workbench/settings update suites.
- npm run typecheck
- npm run build
- npm run check:file-lines
- ESLint for all changed source and test files; git diff --check
- Chromium UI verification at 2x scale: button position, busy states, failure/retry, dismissible errors, and light/dark layouts.
- Final renderer tests, TypeScript check, and Electron Vite build passed after the tooltip adjustment.

The installed application was not replaced during validation.
