### PR TITLE
fix(installer): Windows 更新因失效旧安装残留而反复回滚的问题

### DIFF
--- a/.github/workflows/daily-dev-prerelease.yml
+++ b/.github/workflows/daily-dev-prerelease.yml
@@ -155,6 +155,9 @@ jobs:
           KUN_INSTALLER_TEST_ARTIFACT_ROOT: ${{ github.workspace }}\artifacts\windows-installer-transaction
         run: npx vitest run src/main/windows-installer-migration.transaction.test.ts
 
+      - name: Test Windows installer recovery safety
+        run: npx vitest run src/main/windows-installer-migration.recovery-safety.test.ts
+
       - name: Upload Windows transaction diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -242,6 +242,9 @@ jobs:
           KUN_INSTALLER_TEST_ARTIFACT_ROOT: ${{ github.workspace }}\artifacts\windows-installer-transaction
         run: npx vitest run src/main/windows-installer-migration.transaction.test.ts
 
+      - name: Test Windows installer recovery safety
+        run: npx vitest run src/main/windows-installer-migration.recovery-safety.test.ts
+
       - name: Upload Windows transaction diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,9 @@ jobs:
           KUN_INSTALLER_TEST_ARTIFACT_ROOT: ${{ github.workspace }}\artifacts\windows-installer-transaction
         run: npx vitest run src/main/windows-installer-migration.transaction.test.ts
 
+      - name: Test Windows installer recovery safety
+        run: npx vitest run src/main/windows-installer-migration.recovery-safety.test.ts
+
       - name: Upload Windows transaction diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/build/windows-installer-migration-actions.ps1
+++ b/build/windows-installer-migration-actions.ps1
@@ -200,11 +200,14 @@ function Invoke-Prepare {
     }
 
     if ((Test-PathEqual $source $secondarySource) -and
+        (-not (Test-PathEqual $source $primarySource)) -and
         (-not (Test-RecoverableApplicationSource $source) -or
          -not (Test-PackagedApplicationPayload $source))) {
       # A leftover current-user installation that can no longer be verified as
       # a packaged Kun payload must not block the update. Retire its stale
-      # registration and shortcuts, but leave its files untouched.
+      # registration and shortcuts, but leave its files untouched. When the
+      # primary and secondary registrations share one directory, keep the
+      # stricter primary-source checks instead of skipping the only source.
       Write-InstallerDiagnostic "Retiring the unverifiable current-user installation registration without modifying its files: $source"
       $staleSourceMask = $staleSourceMask -bor 2
       continue

--- a/build/windows-installer-migration-actions.ps1
+++ b/build/windows-installer-migration-actions.ps1
@@ -13,7 +13,10 @@ function Get-InstallSources(
     } elseif (-not (Test-Path -LiteralPath $secondary -PathType Container)) {
       throw "The current-user installation source exists but is not a directory: $secondary"
     } elseif ($ValidateSecondary) {
-      Assert-TrustedSecondarySource $secondary
+      # Only the safe-root invariant is enforced while gathering sources.
+      # Invoke-Prepare classifies an unverifiable current-user source as a
+      # stale registration instead of aborting the whole installation.
+      Assert-SafeInstallRoot $secondary 'External current-user installation source'
     }
   }
   $sources = @($primary, $secondary)
@@ -193,6 +196,17 @@ function Invoke-Prepare {
       if (Test-PathEqual $source $secondarySource) {
         $staleSourceMask = $staleSourceMask -bor 2
       }
+      continue
+    }
+
+    if ((Test-PathEqual $source $secondarySource) -and
+        (-not (Test-RecoverableApplicationSource $source) -or
+         -not (Test-PackagedApplicationPayload $source))) {
+      # A leftover current-user installation that can no longer be verified as
+      # a packaged Kun payload must not block the update. Retire its stale
+      # registration and shortcuts, but leave its files untouched.
+      Write-InstallerDiagnostic "Retiring the unverifiable current-user installation registration without modifying its files: $source"
+      $staleSourceMask = $staleSourceMask -bor 2
       continue
     }
 

--- a/build/windows-installer-migration-filesystem.ps1
+++ b/build/windows-installer-migration-filesystem.ps1
@@ -374,12 +374,6 @@ function Test-PackagedApplicationPayload([string]$Source) {
   return (Test-Path -LiteralPath $packagedPayload -PathType Leaf)
 }
 
-function Assert-PackagedApplicationPayload([string]$Source) {
-  if (-not (Test-PackagedApplicationPayload $Source)) {
-    throw "The external current-user installation source is not a recognized packaged Kun installation: $Source"
-  }
-}
-
 function Get-ExpectedApplicationExecutable {
   $configured = (Get-EnvironmentValue 'KUN_INSTALLER_APP_EXECUTABLE').Trim()
   $executable = if ([string]::IsNullOrWhiteSpace($configured)) {
@@ -664,19 +658,4 @@ function Assert-RecoverableApplicationSource([string]$Source) {
       'No files or registration were changed.'
     )
   }
-}
-
-function Assert-TrustedSecondarySource([string]$Source) {
-  $profile = Normalize-FullPath $env:USERPROFILE
-  if (-not [string]::IsNullOrWhiteSpace($profile) -and (Test-PathWithin $Source $profile) -and
-      -not (Test-PathEqual $Source $profile)) {
-    return
-  }
-
-  Assert-SafeInstallRoot $Source 'External current-user installation source'
-  if (@(Get-ChildItem -LiteralPath $Source -Force).Count -eq 0) {
-    return
-  }
-  Assert-RecoverableApplicationSource $Source
-  Assert-PackagedApplicationPayload $Source
 }

--- a/src/main/packaging-config.hooks.test.ts
+++ b/src/main/packaging-config.hooks.test.ts
@@ -505,8 +505,13 @@ it('passes the nested OfficeCLI executable through the Windows signing manager',
     expect(migrationScript).toContain("Get-EnvironmentValue 'KUN_INSTALLER_DIAGNOSTIC_PATH'")
     expect(migrationScript).toContain('$preparedSources += @{')
     expect(migrationScript).toContain('if ($set.Unknown.Count -eq 0)')
-    expect(migrationScript).toContain('function Assert-TrustedSecondarySource')
-    expect(migrationScript).toContain('function Assert-PackagedApplicationPayload')
+    expect(migrationScript).toContain('function Test-PackagedApplicationPayload')
+    expect(migrationScript).toContain('(-not (Test-PathEqual $source $primarySource))')
+    expect(migrationScript).toContain(
+      'Retiring the unverifiable current-user installation registration without modifying its files'
+    )
+    expect(migrationScript).not.toContain('function Assert-TrustedSecondarySource')
+    expect(migrationScript).not.toContain('function Assert-PackagedApplicationPayload')
     expect(migrationScript).toContain("Join-Path $Source 'resources'")
     expect(migrationScript).toContain("'app.asar'")
     expect(migrationScript).toContain('Ignoring missing current-user installation source')

--- a/src/main/windows-installer-migration.recovery-safety.test.ts
+++ b/src/main/windows-installer-migration.recovery-safety.test.ts
@@ -293,8 +293,9 @@ it('preserves unknown top-level content and restores it after fallback cleanup',
     const secondary = join(root, 'User Kun')
     const journal = join(root, 'recovery', 'journal.json')
     for (const directory of [source, secondary]) {
-      mkdirSync(directory, { recursive: true })
+      mkdirSync(join(directory, 'resources'), { recursive: true })
       writeFileSync(join(directory, 'Kun.exe'), 'app')
+      writeFileSync(join(directory, 'resources', 'app.asar'), 'packaged app')
       writeFileSync(join(directory, 'personal.txt'), directory)
     }
 
@@ -348,27 +349,62 @@ it('preserves unknown top-level content and restores it after fallback cleanup',
     expect(existsSync(journal)).toBe(false)
   })
 
-  it('rejects a misleading external current-user source without packaged payload', () => {
+  it('retires an unverifiable current-user source as a stale registration', () => {
     const root = makeTempRoot()
     const userProfile = join(root, 'profile')
     const source = join(root, 'Machine Kun')
     const secondary = join(root, 'other-app')
     const journal = join(root, 'recovery', 'journal.json')
+    const resultPath = join(root, 'prepare-result.txt')
     mkdirSync(userProfile, { recursive: true })
-    for (const directory of [source, secondary]) {
-      mkdirSync(join(directory, 'resources'), { recursive: true })
-      writeFileSync(join(directory, 'Kun.exe'), 'app')
-      writeFileSync(join(directory, 'resources', 'keep.txt'), 'keep')
-    }
+    mkdirSync(join(source, 'resources'), { recursive: true })
+    writeFileSync(join(source, 'Kun.exe'), 'app')
+    writeFileSync(join(source, 'resources', 'app.asar'), 'packaged app')
+    mkdirSync(join(secondary, 'resources'), { recursive: true })
+    writeFileSync(join(secondary, 'Kun.exe'), 'app')
+    writeFileSync(join(secondary, 'resources', 'keep.txt'), 'keep')
 
     const result = runHelper({
-      action: 'Prepare', source, target: source, journal, secondary, userProfile
+      action: 'Prepare', source, target: source, journal, secondary, userProfile, resultPath
     })
 
-    expect(result.status).not.toBe(0)
-    expect(result.stderr).toContain('not a recognized packaged Kun installation')
+    expect(result.status, processError(result)).toBe(0)
+    expect(readFileSync(resultPath, 'utf16le')).toBe('2')
+    expect(readFileSync(join(secondary, 'Kun.exe'), 'utf8')).toBe('app')
     expect(readFileSync(join(secondary, 'resources', 'keep.txt'), 'utf8')).toBe('keep')
-    expect(existsSync(journal)).toBe(false)
+  })
+
+  it('keeps primary-source validation when primary and secondary share one directory', () => {
+    const root = makeTempRoot()
+    const userProfile = join(root, 'profile')
+    const source = join(root, 'Shared Kun')
+    const journal = join(root, 'recovery', 'journal.json')
+    const resultPath = join(root, 'prepare-result.txt')
+    mkdirSync(userProfile, { recursive: true })
+    mkdirSync(source, { recursive: true })
+    writeFileSync(join(source, 'Kun.exe'), 'app')
+    writeFileSync(join(source, 'personal.txt'), 'keep shared content')
+
+    const prepared = runHelper({
+      action: 'Prepare',
+      source,
+      secondary: source,
+      target: source,
+      journal,
+      userProfile,
+      resultPath
+    })
+
+    expect(prepared.status, processError(prepared)).toBe(0)
+    expect(readFileSync(resultPath, 'utf16le')).toBe('0')
+    expect(existsSync(join(source, 'personal.txt'))).toBe(false)
+    expect(readFileSync(join(source, 'Kun.exe'), 'utf8')).toBe('app')
+
+    const restored = runHelper({
+      action: 'Restore', source, secondary: source, target: source, journal, userProfile
+    })
+    expect(restored.status, processError(restored)).toBe(0)
+    expect(readFileSync(join(source, 'personal.txt'), 'utf8')).toBe('keep shared content')
   })
 
   it('rejects a verified-looking external secondary source reached through a reparse point', () => {


### PR DESCRIPTION
## 问题

Windows 上点击"重新安装"更新后，重新打开的仍是旧版本——更新每次都在安装器阶段失败并被自动回滚。

**根因**：当注册表里残留一条指向"已损坏/已部分删除的旧安装目录"的 current-user 安装记录时（例如旧目录里还留着 `Kun.exe` 但 `resources\app.asar` 已丢失，目录内容不再是可验证的 Kun 安装），`Invoke-Prepare` 通过 `Get-InstallSources` 调用 `Assert-TrustedSecondarySource`，对无法验证的 secondary source 直接抛错，整个 Prepare 中止 → `KunAbortAutomaticUpdate` 回滚 → 旧版本重新启动。用户永远无法完成更新。

真实用户日志（`%TEMP%\Kun-installer-migration-*.log`）：

```
FAIL action=Prepare ... error=
The external current-user installation source is not a recognized packaged Kun installation: D:\kun_app\Kun
```

## 修复

把"无法验证的 current-user 次要安装源"按**失效注册（stale registration）**处理，而不是中止安装：

- `Get-InstallSources` 收集阶段只保留 `Assert-SafeInstallRoot` 安全根校验（防止把危险根目录当作安装源），不再对无法验证的 secondary 抛错。
- `Invoke-Prepare` validate-sources 阶段：非空 secondary 若不能通过 `Test-RecoverableApplicationSource` 或 `Test-PackagedApplicationPayload`，置 stale mask 第 2 位并跳过——NSIS 侧已有对应处理：注销其注册表项与快捷方式、**不改动其文件**，与"目录不存在/为空"的既有 stale 行为完全一致，更新继续进行。
- 主安装源（primary）校验保持严格不变。
- 删除因此不再被引用的 `Assert-TrustedSecondarySource` / `Assert-PackagedApplicationPayload`。

## 验证

- `node scripts/check-windows-installer-syntax.cjs`：全部 PowerShell 文件语法通过。
- 用临时目录复现真实故障场景（有效主安装 + 仅含 `Kun.exe`、缺少 `resources\app.asar` 的失效旧安装目录）运行 `Prepare`：
  - 修复前：Prepare 抛错中止（与日志一致）。
  - 修复后：Prepare 成功，stale mask = `2`，旧目录文件未被改动。
- 对照组：完全不含 Kun 标识的 primary 源仍会正确中止（严格性未放松）。
- 未运行 `scripts/smoke-windows-installer.ps1`（需要打包好的安装器与一次性 Windows 账户），建议 CI 执行。