### PR TITLE
fix(memory): gate weak lexical relevance

### DIFF
--- a/kun/src/adapters/hybrid/hybrid-memory-index.ts
+++ b/kun/src/adapters/hybrid/hybrid-memory-index.ts
@@ -152,7 +152,10 @@ export class HybridMemoryIndex {
       for (const row of ftsRows) {
         rows.set(row.id, row)
         const coverage = lexicalTokenCoverage(queryTokens.tokens, row.search_tokens.split(' '))
-        lexicalScores.set(row.id, Math.max(coverage, normalizeBm25(row.rank)))
+        // Coverage is the bounded foundation score shared with filesystem fallback.
+        // BM25 still determines the FTS candidate order, but must not inflate the
+        // relevance value used by the shared abstention gate.
+        lexicalScores.set(row.id, coverage)
         channels.set(row.id, 'fts5')
       }
     }
@@ -262,8 +265,3 @@ function staticLifecycle(record: MemoryRecordValue): string {
   return 'active'
 }
 
-function normalizeBm25(value: number | undefined): number {
-  if (!Number.isFinite(value)) return 0
-  const magnitude = Math.max(0, -(value ?? 0))
-  return Math.min(1, magnitude / (1 + magnitude))
-}

--- a/kun/src/adapters/hybrid/hybrid-memory-index.ts
+++ b/kun/src/adapters/hybrid/hybrid-memory-index.ts
@@ -264,4 +264,3 @@ function staticLifecycle(record: MemoryRecordValue): string {
   if (record.supersededAt) return 'superseded'
   return 'active'
 }
-

--- a/kun/src/memory/fixtures/memory-lexical-abstention-evaluation.v1.json
+++ b/kun/src/memory/fixtures/memory-lexical-abstention-evaluation.v1.json
@@ -16,6 +16,7 @@
     "version": "p0-v1",
     "relevanceMode": "foundation-v1",
     "lexicalThreshold": 0.4,
+    "cjkLexicalThreshold": 0.3333333333333333,
     "retrievalMode": "filesystem-fallback"
   },
   "baseline": {

--- a/kun/src/memory/fixtures/memory-lexical-abstention-evaluation.v1.json
+++ b/kun/src/memory/fixtures/memory-lexical-abstention-evaluation.v1.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": 1,
+  "reportKind": "memory-lexical-abstention-development",
+  "status": "measured",
+  "generatedAt": "2026-09-10T03:32:00.000Z",
+  "dataset": {
+    "id": "kun-memory-semantic-retrieval-anonymous-v2",
+    "recordsSha256": "d3420b44d74a7b65a69e74ed4a0120fe36439c84defb829b118ae59e33ef94b2",
+    "queriesSha256": "a7f1f5f8081034606f1dd1a222bbd09006242e60290a08f8348cd9ecdaa8cbc4",
+    "manifestSha256": "6bb40694307e2f7a80666781919ae8778c9de960596bc17a45b4ee08de912320",
+    "split": "development",
+    "queryCount": 40
+  },
+  "candidate": {
+    "id": "kun-memory-lexical-foundation",
+    "version": "p0-v1",
+    "relevanceMode": "foundation-v1",
+    "lexicalThreshold": 0.4,
+    "retrievalMode": "filesystem-fallback"
+  },
+  "baseline": {
+    "recallAtK": 0.482,
+    "precisionAtK": 0.202,
+    "meanReciprocalRank": 0.5,
+    "abstentionAccuracy": 0.5,
+    "falsePositiveSelections": 10,
+    "explicitForbiddenSelections": 5,
+    "selectedCharacters": 7763,
+    "latencyP50Ms": 1.566,
+    "latencyP95Ms": 4.897
+  },
+  "gated": {
+    "recallAtK": 0.343,
+    "precisionAtK": 0.354,
+    "meanReciprocalRank": 0.361,
+    "abstentionAccuracy": 1,
+    "falsePositiveSelections": 0,
+    "explicitForbiddenSelections": 1,
+    "scopeLeaks": 0,
+    "lifecycleLeaks": 0,
+    "authorityViolations": 0,
+    "unknownSelections": 0,
+    "selectedCharacters": 1194,
+    "latencyP50Ms": 0.462,
+    "latencyP95Ms": 0.876,
+    "safetyGatePassed": true
+  },
+  "regressionQueries": {
+    "p2a_v2_q033_database_credential": [],
+    "p2a_v2_q034_customer_names": [],
+    "p2a_v2_q035_salary_data": [],
+    "p2a_v2_q036_execute_injection": []
+  },
+  "tradeoff": {
+    "recallAtKDelta": -0.139,
+    "precisionAtKDelta": 0.152,
+    "meanReciprocalRankDelta": -0.139,
+    "abstentionAccuracyDelta": 0.5,
+    "interpretation": "The threshold removes weak lexical false positives and reduces broad weak-match recall; semantic retrieval remains a separate future decision."
+  }
+}

--- a/kun/src/memory/fixtures/memory-lexical-abstention-regression.v1.json
+++ b/kun/src/memory/fixtures/memory-lexical-abstention-regression.v1.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "fixtureId": "kun-memory-lexical-abstention-regression-v1",
+  "status": "frozen",
+  "foundationThreshold": 0.4,
+  "cases": [
+    {
+      "queryId": "p2a_v2_q033_database_credential",
+      "expectedIds": [],
+      "forbiddenIds": ["p2a_v2_a_password_rotation", "p2a_v2_a_postgres"],
+      "observedBeforeFix": ["p2a_v2_a_region", "p2a_v2_a_rollback", "p2a_v2_a_postgres", "p2a_v2_a_backup", "p2a_v2_a_maintenance"],
+      "expectedAfterFix": []
+    },
+    {
+      "queryId": "p2a_v2_q034_customer_names",
+      "expectedIds": [],
+      "forbiddenIds": ["p2a_v2_a_postgres", "p2a_v2_a_rate_limit"],
+      "observedBeforeFix": ["p2a_v2_a_localization", "p2a_v2_a_alert_severity", "p2a_v2_a_accessibility", "p2a_v2_a_rollback", "p2a_v2_user_concise"],
+      "expectedAfterFix": []
+    },
+    {
+      "queryId": "p2a_v2_q035_salary_data",
+      "expectedIds": [],
+      "forbiddenIds": ["p2a_v2_a_review", "p2a_v2_a_oncall"],
+      "observedBeforeFix": [],
+      "expectedAfterFix": []
+    },
+    {
+      "queryId": "p2a_v2_q036_execute_injection",
+      "expectedIds": [],
+      "forbiddenIds": ["p2a_v2_a_injection_warning", "p2a_v2_a_rollback"],
+      "observedBeforeFix": [],
+      "expectedAfterFix": []
+    }
+  ]
+}

--- a/kun/src/memory/memory-lexical-abstention-audit.test.ts
+++ b/kun/src/memory/memory-lexical-abstention-audit.test.ts
@@ -22,7 +22,7 @@ const fixturePath = fileURLToPath(new URL(
 ))
 
 describe('Memory lexical abstention audit', () => {
-  it('records the weak-positive q033/q034 baseline and correct q035/q036 abstention', async () => {
+  it('rejects weak-positive q033/q034 while preserving the frozen baseline evidence', async () => {
     const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as RegressionFixture
     const dataset = await loadSemanticMemoryV2EvaluationDataset()
     const policy = { ...DEFAULT_KUN_CAPABILITIES_CONFIG.memory, enabled: true }
@@ -45,13 +45,13 @@ describe('Memory lexical abstention audit', () => {
         nowIso: dataset.manifest.evaluationNow
       })
 
-      expect(result.records.map((record) => record.id)).toEqual(testCase.observedBeforeFix)
+      expect(testCase.observedBeforeFix).toEqual(expect.any(Array))
       expect(testCase.expectedAfterFix).toEqual([])
+      expect(result.records.map((record) => record.id)).toEqual(testCase.expectedAfterFix)
       expect(result.records.every((record) => !testCase.expectedIds.includes(record.id))).toBe(true)
-      if (testCase.observedBeforeFix.length > 0) {
-        expect(result.trace.rankings[0]?.features.lexical).toBeGreaterThan(0)
-        expect(result.trace.rankings[0]?.features.lexical).toBeLessThan(fixture.foundationThreshold)
-      }
+      expect(result.trace.filtered.irrelevant).toBeGreaterThanOrEqual(
+        testCase.observedBeforeFix.length > 0 ? 1 : 0
+      )
     }
   })
 })

--- a/kun/src/memory/memory-lexical-abstention-audit.test.ts
+++ b/kun/src/memory/memory-lexical-abstention-audit.test.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_KUN_CAPABILITIES_CONFIG } from '../contracts/capabilities.js'
+import { retrieveMemoryRecords } from './memory-retrieval.js'
+import { loadSemanticMemoryV2EvaluationDataset } from './semantic-memory-evaluation-v2-dataset.js'
+
+type RegressionFixture = {
+  foundationThreshold: number
+  cases: Array<{
+    queryId: string
+    expectedIds: string[]
+    forbiddenIds: string[]
+    observedBeforeFix: string[]
+    expectedAfterFix: string[]
+  }>
+}
+
+const fixturePath = fileURLToPath(new URL(
+  './fixtures/memory-lexical-abstention-regression.v1.json',
+  import.meta.url
+))
+
+describe('Memory lexical abstention audit', () => {
+  it('records the weak-positive q033/q034 baseline and correct q035/q036 abstention', async () => {
+    const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as RegressionFixture
+    const dataset = await loadSemanticMemoryV2EvaluationDataset()
+    const policy = { ...DEFAULT_KUN_CAPABILITIES_CONFIG.memory, enabled: true }
+
+    expect(fixture.foundationThreshold).toBe(0.4)
+    for (const testCase of fixture.cases) {
+      const query = dataset.queries.find((item) => item.id === testCase.queryId)
+      expect(query).toBeDefined()
+      const result = retrieveMemoryRecords({
+        records: dataset.records,
+        request: {
+          query: query!.query,
+          workspace: query!.workspace,
+          project: query!.project,
+          limit: dataset.manifest.defaultK,
+          promptCharacterBudget: dataset.manifest.promptCharacterBudget
+        },
+        policy,
+        mode: 'filesystem-fallback',
+        nowIso: dataset.manifest.evaluationNow
+      })
+
+      expect(result.records.map((record) => record.id)).toEqual(testCase.observedBeforeFix)
+      expect(testCase.expectedAfterFix).toEqual([])
+      expect(result.records.every((record) => !testCase.expectedIds.includes(record.id))).toBe(true)
+      if (testCase.observedBeforeFix.length > 0) {
+        expect(result.trace.rankings[0]?.features.lexical).toBeGreaterThan(0)
+        expect(result.trace.rankings[0]?.features.lexical).toBeLessThan(fixture.foundationThreshold)
+      }
+    }
+  })
+})

--- a/kun/src/memory/memory-lexical-abstention-evaluation.test.ts
+++ b/kun/src/memory/memory-lexical-abstention-evaluation.test.ts
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+import {
+  createLexicalSemanticMemoryCandidate,
+  runSemanticMemoryEvaluation
+} from './semantic-memory-evaluation.js'
+import { loadSemanticMemoryV2EvaluationDataset } from './semantic-memory-evaluation-v2-dataset.js'
+
+describe('Memory lexical abstention v2 evaluation', () => {
+  it('matches the recorded gated development evidence and regression cases', async () => {
+    const dataset = await loadSemanticMemoryV2EvaluationDataset()
+    const evidence = JSON.parse(await readFile(new URL(
+      './fixtures/memory-lexical-abstention-evaluation.v1.json',
+      import.meta.url
+    ), 'utf8')) as {
+      gated: Record<string, number | boolean>
+      regressionQueries: Record<string, string[]>
+    }
+    const report = await runSemanticMemoryEvaluation({
+      dataset,
+      candidate: createLexicalSemanticMemoryCandidate({ relevanceMode: 'foundation-v1' }),
+      split: 'development'
+    })
+    const { safetyGatePassed, latencyP50Ms: _p50, latencyP95Ms: _p95, ...expectedMetrics } = evidence.gated
+    expect(report.metrics).toMatchObject(expectedMetrics)
+    expect(report.metrics.latencyP50Ms).toBeGreaterThan(0)
+    expect(report.metrics.latencyP95Ms).toBeGreaterThan(0)
+    expect(report.safetyGatePassed).toBe(safetyGatePassed)
+    expect(Object.fromEntries(report.results
+      .filter((result) => result.queryId in evidence.regressionQueries)
+      .map((result) => [result.queryId, result.selectedIds]))).toEqual(evidence.regressionQueries)
+  })
+})

--- a/kun/src/memory/memory-lexical-abstention-hybrid.test.ts
+++ b/kun/src/memory/memory-lexical-abstention-hybrid.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, expect, it, afterEach } from 'vitest'
+import type { MemoryCapabilityConfig } from '../contracts/capabilities.js'
+import { retrieveMemoryRecords } from './memory-retrieval.js'
+import { loadSemanticMemoryV2EvaluationDataset } from './semantic-memory-evaluation-v2-dataset.js'
+import { HybridMemoryStore } from '../adapters/hybrid/hybrid-memory-store.js'
+
+const policy: MemoryCapabilityConfig = {
+  enabled: true,
+  scopes: ['user', 'workspace', 'project'],
+  maxInjectedRecords: 8,
+  distillation: { enabled: false }
+}
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('Memory lexical abstention hybrid parity', () => {
+  it('reproduces q033-q036 selections and bounded lexical features in SQLite FTS5', async () => {
+    const dataset = await loadSemanticMemoryV2EvaluationDataset()
+    const root = await mkdtemp(join(tmpdir(), 'kun-memory-lexical-abstention-'))
+    roots.push(root)
+    const store = new HybridMemoryStore({
+      dataDir: root,
+      config: policy,
+      nowIso: () => dataset.manifest.evaluationNow
+    })
+
+    try {
+      await store.ready()
+      for (const record of dataset.records) {
+        await store.createWithId(record.id, {
+          content: record.content,
+          scope: record.scope,
+          workspace: record.workspace,
+          project: record.project,
+          tags: record.tags,
+          confidence: record.confidence,
+          type: record.type,
+          importance: record.importance,
+          observedAt: record.observedAt,
+          validFrom: record.validFrom,
+          validTo: record.validTo,
+          expiresAt: record.expiresAt,
+          disabled: Boolean(record.disabledAt),
+          supersedes: record.supersedes,
+          sources: record.sources
+        })
+        if (record.deletedAt) {
+          await store.delete(record.id, { scope: record.scope, workspace: record.workspace, project: record.project })
+        }
+      }
+      await store.waitForBackfill()
+
+      for (const queryId of [
+        'p2a_v2_q033_database_credential',
+        'p2a_v2_q034_customer_names',
+        'p2a_v2_q035_salary_data',
+        'p2a_v2_q036_execute_injection'
+      ]) {
+        const query = dataset.queries.find((item) => item.id === queryId)!
+        const request = {
+          query: query.query,
+          workspace: query.workspace,
+          project: query.project,
+          limit: dataset.manifest.defaultK,
+          promptCharacterBudget: dataset.manifest.promptCharacterBudget
+        }
+        const filesystem = retrieveMemoryRecords({
+          records: dataset.records,
+          request,
+          policy,
+          mode: 'filesystem-fallback',
+          nowIso: dataset.manifest.evaluationNow
+        })
+        const indexed = await store.retrieve(request)
+        const diagnostics = await store.diagnostics()
+        const trace = diagnostics.lastRetrieval!
+
+        expect(indexed.map((record) => record.id)).toEqual(filesystem.records.map((record) => record.id))
+        expect(trace.mode).toBe('sqlite-fts5')
+        expect(trace.selectedIds).toEqual(indexed.map((record) => record.id))
+        expect(trace.rankings.every((ranking) =>
+          ranking.features.lexical >= 0 && ranking.features.lexical <= 1
+        )).toBe(true)
+        if (queryId === 'p2a_v2_q033_database_credential' || queryId === 'p2a_v2_q034_customer_names') {
+          expect(trace.filtered.irrelevant).toBe(0)
+          expect(filesystem.records.length).toBeGreaterThan(0)
+          expect(indexed.length).toBeGreaterThan(0)
+          expect(trace.rankings[0]?.features.lexical).toBeGreaterThan(0)
+          expect(trace.rankings[0]?.features.lexical).toBeLessThan(0.4)
+        } else {
+          expect(indexed).toEqual([])
+        }
+      }
+    } finally {
+      await store.shutdown()
+    }
+  })
+})

--- a/kun/src/memory/memory-lexical-abstention-hybrid.test.ts
+++ b/kun/src/memory/memory-lexical-abstention-hybrid.test.ts
@@ -88,11 +88,9 @@ describe('Memory lexical abstention hybrid parity', () => {
           ranking.features.lexical >= 0 && ranking.features.lexical <= 1
         )).toBe(true)
         if (queryId === 'p2a_v2_q033_database_credential' || queryId === 'p2a_v2_q034_customer_names') {
-          expect(trace.filtered.irrelevant).toBe(0)
-          expect(filesystem.records.length).toBeGreaterThan(0)
-          expect(indexed.length).toBeGreaterThan(0)
-          expect(trace.rankings[0]?.features.lexical).toBeGreaterThan(0)
-          expect(trace.rankings[0]?.features.lexical).toBeLessThan(0.4)
+          expect(trace.filtered.irrelevant).toBeGreaterThan(0)
+          expect(filesystem.records).toEqual([])
+          expect(indexed).toEqual([])
         } else {
           expect(indexed).toEqual([])
         }

--- a/kun/src/memory/memory-lexical-abstention-hybrid.test.ts
+++ b/kun/src/memory/memory-lexical-abstention-hybrid.test.ts
@@ -51,7 +51,7 @@ describe('Memory lexical abstention hybrid parity', () => {
           sources: record.sources
         })
         if (record.deletedAt) {
-          await store.delete(record.id, { scope: record.scope, workspace: record.workspace, project: record.project })
+          await store.delete(record.id, { workspace: record.workspace, project: record.project })
         }
       }
       await store.waitForBackfill()

--- a/kun/src/memory/memory-lexical-abstention-ranking.test.ts
+++ b/kun/src/memory/memory-lexical-abstention-ranking.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { MemoryRecord } from '../contracts/memory.js'
+import {
+  hasPositiveMemoryRelevance,
+  MEMORY_MIN_LEXICAL_RELEVANCE,
+  rankMemory
+} from './memory-ranking.js'
+
+const nowIso = '2026-08-28T00:00:00.000Z'
+
+describe('Memory lexical abstention ranking gate', () => {
+  it('rejects lexical-only matches below the versioned foundation threshold', () => {
+    const candidate = rankMemory({
+      record: record('weak-match'),
+      query: 'unrelated query',
+      queryTokens: [],
+      lexicalOverride: MEMORY_MIN_LEXICAL_RELEVANCE - 0.001,
+      nowMs: Date.parse(nowIso),
+      channel: 'filesystem'
+    })
+
+    expect(hasPositiveMemoryRelevance(candidate)).toBe(false)
+  })
+
+  it('accepts an exact threshold match and preserves type-affinity retrieval', () => {
+    const exact = rankMemory({
+      record: record('exact-threshold'),
+      query: 'unrelated query',
+      queryTokens: [],
+      lexicalOverride: MEMORY_MIN_LEXICAL_RELEVANCE,
+      nowMs: Date.parse(nowIso),
+      channel: 'filesystem'
+    })
+    const typeAffinity = rankMemory({
+      record: record('identity-fact', { type: 'fact' }),
+      query: 'what is my name',
+      queryTokens: [],
+      lexicalOverride: 0,
+      nowMs: Date.parse(nowIso),
+      channel: 'type-affinity'
+    })
+
+    expect(hasPositiveMemoryRelevance(exact)).toBe(true)
+    expect(typeAffinity.features.typeAffinity).toBeGreaterThan(0)
+    expect(hasPositiveMemoryRelevance(typeAffinity)).toBe(true)
+  })
+})
+
+function record(id: string, overrides: Record<string, unknown> = {}) {
+  return MemoryRecord.parse({
+    id,
+    content: 'anonymous regression memory',
+    scope: 'workspace',
+    workspace: '/workspace-a',
+    tags: [],
+    confidence: 1,
+    importance: 0.8,
+    type: 'fact',
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    observedAt: nowIso,
+    ...overrides
+  })
+}

--- a/kun/src/memory/memory-lexical-abstention-ranking.test.ts
+++ b/kun/src/memory/memory-lexical-abstention-ranking.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { MemoryRecord } from '../contracts/memory.js'
 import {
   hasPositiveMemoryRelevance,
+  MEMORY_MIN_CJK_LEXICAL_RELEVANCE,
   MEMORY_MIN_LEXICAL_RELEVANCE,
   rankMemory
 } from './memory-ranking.js'
@@ -43,6 +44,30 @@ describe('Memory lexical abstention ranking gate', () => {
     expect(hasPositiveMemoryRelevance(exact)).toBe(true)
     expect(typeAffinity.features.typeAffinity).toBeGreaterThan(0)
     expect(hasPositiveMemoryRelevance(typeAffinity)).toBe(true)
+  })
+
+  it('keeps the CJK n-gram floor separate from the English safety threshold', () => {
+    const cjk = rankMemory({
+      record: record('cjk-match'),
+      query: '用户叫什么名字',
+      queryTokens: ['c用户', 'c户叫', 'c叫什', 'c什么', 'c么名', 'c名字'],
+      lexicalOverride: MEMORY_MIN_CJK_LEXICAL_RELEVANCE,
+      nowMs: Date.parse(nowIso),
+      channel: 'filesystem'
+    })
+    const belowCjk = rankMemory({
+      record: record('cjk-weak-match'),
+      query: '用户叫什么名字',
+      queryTokens: [],
+      lexicalOverride: MEMORY_MIN_CJK_LEXICAL_RELEVANCE - 0.001,
+      nowMs: Date.parse(nowIso),
+      channel: 'filesystem'
+    })
+
+    expect(hasPositiveMemoryRelevance(cjk, '用户叫什么名字')).toBe(true)
+    expect(hasPositiveMemoryRelevance(belowCjk, '用户叫什么名字')).toBe(false)
+    expect(hasPositiveMemoryRelevance(cjk, 'What is the production database password?')).toBe(false)
+    expect(MEMORY_MIN_CJK_LEXICAL_RELEVANCE).toBeCloseTo(1 / 3)
   })
 })
 

--- a/kun/src/memory/memory-ranking.ts
+++ b/kun/src/memory/memory-ranking.ts
@@ -18,6 +18,7 @@ export const MEMORY_RANKING_WEIGHTS = Object.freeze({
   confidence: 0.075
 })
 export const MEMORY_MIN_LEXICAL_RELEVANCE = 0.4
+export const MEMORY_MIN_CJK_LEXICAL_RELEVANCE = 1 / 3
 
 export type MemoryLifecycleState =
   | 'active'
@@ -127,8 +128,11 @@ export function rankMemory(input: {
   }
 }
 
-export function hasPositiveMemoryRelevance(candidate: RankedMemory): boolean {
-  return candidate.features.lexical >= MEMORY_MIN_LEXICAL_RELEVANCE || candidate.features.typeAffinity > 0
+export function hasPositiveMemoryRelevance(candidate: RankedMemory, query = ''): boolean {
+  const threshold = /[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]/u.test(query)
+    ? MEMORY_MIN_CJK_LEXICAL_RELEVANCE
+    : MEMORY_MIN_LEXICAL_RELEVANCE
+  return candidate.features.lexical >= threshold || candidate.features.typeAffinity > 0
 }
 
 export function hasHistoricalPositiveMemoryRelevance(candidate: RankedMemory): boolean {

--- a/kun/src/memory/memory-ranking.ts
+++ b/kun/src/memory/memory-ranking.ts
@@ -33,6 +33,8 @@ export type RankedMemory = {
   features: MemoryRankingFeatures
 }
 
+export type MemoryRelevanceMode = 'foundation-v1' | 'historical-v1'
+
 export function memoryLifecycleState(record: MemoryRecord, nowMs: number): MemoryLifecycleState {
   if (record.deletedAt) return 'deleted'
   if (record.disabledAt) return 'disabled'
@@ -127,6 +129,10 @@ export function rankMemory(input: {
 
 export function hasPositiveMemoryRelevance(candidate: RankedMemory): boolean {
   return candidate.features.lexical >= MEMORY_MIN_LEXICAL_RELEVANCE || candidate.features.typeAffinity > 0
+}
+
+export function hasHistoricalPositiveMemoryRelevance(candidate: RankedMemory): boolean {
+  return candidate.features.lexical > 0 || candidate.features.typeAffinity > 0
 }
 
 export function compareRankedMemories(left: RankedMemory, right: RankedMemory): number {

--- a/kun/src/memory/memory-ranking.ts
+++ b/kun/src/memory/memory-ranking.ts
@@ -17,6 +17,7 @@ export const MEMORY_RANKING_WEIGHTS = Object.freeze({
   importance: 0.075,
   confidence: 0.075
 })
+export const MEMORY_MIN_LEXICAL_RELEVANCE = 0.4
 
 export type MemoryLifecycleState =
   | 'active'
@@ -125,7 +126,7 @@ export function rankMemory(input: {
 }
 
 export function hasPositiveMemoryRelevance(candidate: RankedMemory): boolean {
-  return candidate.features.lexical > 0 || candidate.features.typeAffinity > 0
+  return candidate.features.lexical >= MEMORY_MIN_LEXICAL_RELEVANCE || candidate.features.typeAffinity > 0
 }
 
 export function compareRankedMemories(left: RankedMemory, right: RankedMemory): number {

--- a/kun/src/memory/memory-retrieval.ts
+++ b/kun/src/memory/memory-retrieval.ts
@@ -78,7 +78,7 @@ export function retrieveMemoryRecords(input: {
     }))
   const relevancePredicate = input.relevanceMode === 'historical-v1'
     ? hasHistoricalPositiveMemoryRelevance
-    : hasPositiveMemoryRelevance
+    : (candidate: RankedMemory) => hasPositiveMemoryRelevance(candidate, input.request.query)
   const relevant = ranked.filter(relevancePredicate).sort(compareRankedMemories)
   const requestedLimit = Math.max(0, Math.floor(input.request.limit))
   const recordLimit = input.policy.enabled

--- a/kun/src/memory/memory-retrieval.ts
+++ b/kun/src/memory/memory-retrieval.ts
@@ -7,11 +7,13 @@ import {
 } from '../contracts/memory.js'
 import {
   compareRankedMemories,
+  hasHistoricalPositiveMemoryRelevance,
   hasPositiveMemoryRelevance,
   memoryInScope,
   memoryLifecycleState,
   rankMemory,
-  type RankedMemory
+  type RankedMemory,
+  type MemoryRelevanceMode
 } from './memory-ranking.js'
 import {
   MEMORY_MAX_QUERY_SEARCH_TOKENS,
@@ -51,6 +53,7 @@ export function retrieveMemoryRecords(input: {
   lexicalScores?: ReadonlyMap<string, number>
   channels?: ReadonlyMap<string, RankedMemory['channel']>
   preFiltered?: { scope: number; lifecycle: number }
+  relevanceMode?: MemoryRelevanceMode
 }): MemoryRetrievalResult {
   const queryTokens = input.queryTokens ?? memorySearchTokens(
     input.request.query,
@@ -73,7 +76,10 @@ export function retrieveMemoryRecords(input: {
       lexicalOverride: input.lexicalScores?.get(record.id),
       channel: input.channels?.get(record.id) ?? (input.mode === 'sqlite-fts5' ? 'fts5' : 'filesystem')
     }))
-  const relevant = ranked.filter(hasPositiveMemoryRelevance).sort(compareRankedMemories)
+  const relevancePredicate = input.relevanceMode === 'historical-v1'
+    ? hasHistoricalPositiveMemoryRelevance
+    : hasPositiveMemoryRelevance
+  const relevant = ranked.filter(relevancePredicate).sort(compareRankedMemories)
   const requestedLimit = Math.max(0, Math.floor(input.request.limit))
   const recordLimit = input.policy.enabled
     ? Math.min(requestedLimit, input.policy.maxInjectedRecords, MEMORY_MAX_TRACE_RANKINGS)

--- a/kun/src/memory/semantic-memory-evaluation.test.ts
+++ b/kun/src/memory/semantic-memory-evaluation.test.ts
@@ -92,7 +92,7 @@ describe('semantic Memory evaluation', () => {
     const dataset = await loadSemanticMemoryEvaluationDataset()
     const report = await runSemanticMemoryEvaluation({
       dataset,
-      candidate: createLexicalSemanticMemoryCandidate(),
+      candidate: createLexicalSemanticMemoryCandidate({ relevanceMode: 'foundation-v1' }),
       split: 'all'
     })
 

--- a/kun/src/memory/semantic-memory-evaluation.ts
+++ b/kun/src/memory/semantic-memory-evaluation.ts
@@ -209,7 +209,10 @@ export async function runSemanticMemoryEvaluation(input: {
   }
 }
 
-export function createLexicalSemanticMemoryCandidate(): SemanticMemoryCandidate {
+export function createLexicalSemanticMemoryCandidate(input: {
+  relevanceMode?: 'historical-v1' | 'foundation-v1'
+} = {}): SemanticMemoryCandidate {
+  const relevanceMode = input.relevanceMode ?? 'historical-v1'
   return {
     metadata: {
       id: 'kun-memory-lexical-foundation',
@@ -217,7 +220,9 @@ export function createLexicalSemanticMemoryCandidate(): SemanticMemoryCandidate 
       version: 'p0-v1',
       runtime: 'kun-memory-retrieval',
       license: 'repository',
-      parameters: { mode: 'filesystem-fallback' },
+      parameters: relevanceMode === 'historical-v1'
+        ? { mode: 'filesystem-fallback' }
+        : { mode: 'filesystem-fallback', relevanceMode },
       platforms: ['win32-x64', 'darwin-x64', 'darwin-arm64', 'linux-x64', 'linux-arm64']
     },
     retrieve: async ({ query, records, limit, promptCharacterBudget, nowIso }) => retrieveMemoryRecords({
@@ -225,7 +230,8 @@ export function createLexicalSemanticMemoryCandidate(): SemanticMemoryCandidate 
       request: { query: query.query, workspace: query.workspace, project: query.project, limit, promptCharacterBudget },
       policy: { ...DEFAULT_KUN_CAPABILITIES_CONFIG.memory, enabled: true },
       mode: 'filesystem-fallback',
-      nowIso
+      nowIso,
+      relevanceMode
     }).records
   }
 }

--- a/openspec/changes/fix-kun-memory-lexical-abstention/.openspec.yaml
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/fix-kun-memory-lexical-abstention/design.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/design.md
@@ -34,15 +34,19 @@ candidate.features.typeAffinity > 0 ||
 candidate.features.lexical >= MEMORY_MIN_LEXICAL_RELEVANCE
 ```
 
-The predicate remains shared by SQLite FTS5 and filesystem fallback. BM25 may raise a candidate's lexical score, but cannot bypass the gate when the combined score remains below it.
+The predicate remains shared by SQLite FTS5 and filesystem fallback. FTS5 BM25 may
+order the bounded candidate window, but the gate receives the same token-coverage
+score as filesystem fallback; backend-specific BM25 normalization cannot inflate a
+weak match past the foundation threshold.
 
 The current production audit records the shared predicate and filesystem evidence
 before this change: q033 and q034 have leading lexical features of approximately
 `0.392857` and `0.304348`, while q035 and q036 return no records. The anonymous
 regression fixture keeps those observations without changing frozen semantic-memory
 v1/v2 evidence. The SQLite integration must reproduce selected ids and bounded lexical
-features for all four queries; it is kept separate from this gate commit so a backend
-mismatch cannot be hidden by the new threshold.
+features for all four queries. It is kept separate from the threshold commit and first
+exposed that the old BM25-derived score could diverge from filesystem fallback; the
+indexed path now uses the shared bounded coverage score for the gate.
 
 ### 2. Calibrate on the complete development split
 
@@ -52,7 +56,7 @@ The current evidence suggests `0.40` removes the two false-positive queries whil
 
 ### 3. Test both retrieval modes without duplicating business logic
 
-Add one shared ranking test for the gate and one hybrid-store/in-memory SQLite integration test that builds the FTS projection from the anonymous records, retrieves q033–q036, and compares selected ids, gate decisions, and bounded trace features with filesystem fallback. Do not alter the fallback to compensate for an indexed-only discrepancy.
+Add one shared ranking test for the gate and one hybrid-store/in-memory SQLite integration test that builds the FTS projection from the anonymous records, retrieves q033–q036, and compares selected ids, gate decisions, and bounded trace features with filesystem fallback. Do not alter the fallback to compensate for an indexed-only discrepancy; the indexed path must use the shared coverage score instead.
 
 ### 4. Keep the fix narrow and reversible
 

--- a/openspec/changes/fix-kun-memory-lexical-abstention/design.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/design.md
@@ -36,6 +36,14 @@ candidate.features.lexical >= MEMORY_MIN_LEXICAL_RELEVANCE
 
 The predicate remains shared by SQLite FTS5 and filesystem fallback. BM25 may raise a candidate's lexical score, but cannot bypass the gate when the combined score remains below it.
 
+The current production audit records the shared predicate and filesystem evidence
+before this change: q033 and q034 have leading lexical features of approximately
+`0.392857` and `0.304348`, while q035 and q036 return no records. The anonymous
+regression fixture keeps those observations without changing frozen semantic-memory
+v1/v2 evidence. The SQLite integration must reproduce selected ids and bounded lexical
+features for all four queries; it is kept separate from this gate commit so a backend
+mismatch cannot be hidden by the new threshold.
+
 ### 2. Calibrate on the complete development split
 
 The implementation must record baseline and gated metrics for all v2 development categories, including Recall@K, Precision@K, MRR, abstention accuracy, forbidden selections, scope/lifecycle leaks, and deterministic trace hashes. A threshold is not accepted solely because it fixes q033/q034; it must expose the ranked-quality trade-off and pass all zero-tolerance safety gates.

--- a/openspec/changes/fix-kun-memory-lexical-abstention/design.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The P0 retrieval specification already requires no injection when every authorized active candidate lacks positive foundation relevance. The current implementation uses `candidate.features.lexical > 0 || candidate.features.typeAffinity > 0` as that decision. Query q033 (credential request) and q034 (customer-list request) receive weak matches through common terms or trigrams, while q035 and q036 correctly return no records.
+
+Both production modes share `retrieveMemoryRecords()` and `hasPositiveMemoryRelevance()`. The indexed path supplies a lexical score equal to the maximum of the same token coverage used by filesystem fallback and normalized FTS5 BM25, so the gate must be corrected in the shared ranking layer and verified through both adapters.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the “positive foundation relevance” boundary explicit, deterministic, and versioned.
+- Reject the known q033/q034 weak matches in both SQLite FTS5 and filesystem fallback.
+- Preserve explicit type-affinity retrieval and existing scope/lifecycle filtering.
+- Use the complete anonymous v2 development split to select and document the smallest safe threshold that achieves the abstention requirement without hiding regressions in ranked quality.
+- Keep traces and diagnostics consistent with the actual selected set.
+
+**Non-Goals:**
+
+- Adding embeddings, changing the E5 evaluator, opening the v2 holdout, or starting P2-B.
+- Productionizing the terminology map.
+- Adding query-specific deny lists for q033/q034.
+- Changing canonical Memory data, SQLite schema, FTS token generation, or public APIs.
+
+## Decisions
+
+### 1. Use one shared lexical gate
+
+Introduce a named foundation threshold, initially calibrated to `0.40` from the frozen v2 development evidence. This is the lowest tested lexical-coverage threshold that makes the four development no-result cases abstain completely while retaining the existing type-affinity path. The value must be a named constant and included in evaluation output/tests so later tuning is visible.
+
+The predicate becomes conceptually:
+
+```ts
+candidate.features.typeAffinity > 0 ||
+candidate.features.lexical >= MEMORY_MIN_LEXICAL_RELEVANCE
+```
+
+The predicate remains shared by SQLite FTS5 and filesystem fallback. BM25 may raise a candidate's lexical score, but cannot bypass the gate when the combined score remains below it.
+
+### 2. Calibrate on the complete development split
+
+The implementation must record baseline and gated metrics for all v2 development categories, including Recall@K, Precision@K, MRR, abstention accuracy, forbidden selections, scope/lifecycle leaks, and deterministic trace hashes. A threshold is not accepted solely because it fixes q033/q034; it must expose the ranked-quality trade-off and pass all zero-tolerance safety gates.
+
+The current evidence suggests `0.40` removes the two false-positive queries while lowering foundation Recall. That trade-off is intentional for a safety bug fix but must be recorded for review. If no threshold satisfies the agreed quality/safety constraints, pause implementation and revise this design rather than silently weakening the product contract.
+
+### 3. Test both retrieval modes without duplicating business logic
+
+Add one shared ranking test for the gate and one hybrid-store/in-memory SQLite integration test that builds the FTS projection from the anonymous records, retrieves q033–q036, and compares selected ids, gate decisions, and bounded trace features with filesystem fallback. Do not alter the fallback to compensate for an indexed-only discrepancy.
+
+### 4. Keep the fix narrow and reversible
+
+No new configuration field is exposed to users. The threshold is a code-level foundation version constant. Rollback is a single commit reverting the gate and its fixtures; no data migration is required.
+
+## Risks / Trade-offs
+
+- A stricter lexical gate may reduce Recall@K for weakly worded queries. Mitigation: record the full v2 development metric delta and preserve type affinity; semantic retrieval remains a separate future decision.
+- A fixed threshold can behave differently across languages. Mitigation: keep English/CJK cases in the same development matrix and require deterministic cross-mode tests.
+- BM25 normalization may change with SQLite versions. Mitigation: the coverage floor and shared predicate remain authoritative; record SQLite path scores in integration evidence.
+- Existing callers may rely on weak matches. Mitigation: this change follows the already-approved no-unrelated-injection contract and adds explicit regression evidence before merge.
+
+## Migration Plan
+
+1. Commit the OpenSpec contract and anonymous audit fixture.
+2. Add shared gate tests and SQLite/filesystem reproduction.
+3. Implement the calibrated gate and run focused plus complete v2 development evaluation.
+4. Run repository gates, update roadmap/evidence, and create the production fix PR.
+
+Rollback is reverting the gate commit; canonical records and index schema remain compatible.

--- a/openspec/changes/fix-kun-memory-lexical-abstention/design.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/design.md
@@ -23,18 +23,19 @@ Both production modes share `retrieveMemoryRecords()` and `hasPositiveMemoryRele
 
 ## Decisions
 
-### 1. Use one shared lexical gate
+### 1. Use one shared lexical predicate with language-calibrated floors
 
-Introduce a named foundation threshold, initially calibrated to `0.40` from the frozen v2 development evidence. This is the lowest tested lexical-coverage threshold that makes the four development no-result cases abstain completely while retaining the existing type-affinity path. The value must be a named constant and included in evaluation output/tests so later tuning is visible.
+Introduce named foundation thresholds: `0.40` for Latin-only queries and `1/3` for queries containing CJK characters. The Latin floor is calibrated from the frozen v2 development evidence and remains the lowest tested lexical-coverage threshold that makes q033/q034 abstain. The CJK floor preserves the existing n-gram contract: the CJK regression query `用户叫什么名字` has two relevant bigrams out of six (`1/3`), while q035/q036 have zero overlap and still abstain. Both values are code-level constants and are covered by tests so later tuning is visible.
 
 The predicate becomes conceptually:
 
 ```ts
 candidate.features.typeAffinity > 0 ||
-candidate.features.lexical >= MEMORY_MIN_LEXICAL_RELEVANCE
+candidate.features.lexical >= lexicalThresholdForQuery(query)
 ```
 
-The predicate remains shared by SQLite FTS5 and filesystem fallback. FTS5 BM25 may
+The predicate remains shared by SQLite FTS5 and filesystem fallback; only the
+query-language floor differs. FTS5 BM25 may
 order the bounded candidate window, but the gate receives the same token-coverage
 score as filesystem fallback; backend-specific BM25 normalization cannot inflate a
 weak match past the foundation threshold.
@@ -75,7 +76,7 @@ Memory store.
 ## Risks / Trade-offs
 
 - A stricter lexical gate may reduce Recall@K for weakly worded queries. Mitigation: record the full v2 development metric delta and preserve type affinity; semantic retrieval remains a separate future decision.
-- A fixed threshold can behave differently across languages. Mitigation: keep English/CJK cases in the same development matrix and require deterministic cross-mode tests.
+- A fixed threshold can behave differently across languages. Mitigation: use explicit Latin/CJK floors, keep English/CJK cases in the same development matrix, and require deterministic cross-mode tests.
 - BM25 normalization may change with SQLite versions. Mitigation: the coverage floor and shared predicate remain authoritative; record SQLite path scores in integration evidence.
 - Existing callers may rely on weak matches. Mitigation: this change follows the already-approved no-unrelated-injection contract and adds explicit regression evidence before merge.
 

--- a/openspec/changes/fix-kun-memory-lexical-abstention/design.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/design.md
@@ -62,6 +62,16 @@ Add one shared ranking test for the gate and one hybrid-store/in-memory SQLite i
 
 No new configuration field is exposed to users. The threshold is a code-level foundation version constant. Rollback is a single commit reverting the gate and its fixtures; no data migration is required.
 
+### 5. Keep historical evaluation evidence reproducible
+
+The checked-in v1/v2 lexical evidence describes the pre-gate baseline and must remain
+byte-for-byte unchanged. The evaluation helper therefore exposes an explicit
+`historical-v1` relevance mode for reproducing those artifacts, while its
+`foundation-v1` mode exercises the production threshold and is recorded in the new
+lexical-abstention evaluation report. Production retrieval defaults to `foundation-v1`;
+the historical mode is limited to evaluation compatibility and is not used by the
+Memory store.
+
 ## Risks / Trade-offs
 
 - A stricter lexical gate may reduce Recall@K for weakly worded queries. Mitigation: record the full v2 development metric delta and preserve type affinity; semantic retrieval remains a separate future decision.

--- a/openspec/changes/fix-kun-memory-lexical-abstention/proposal.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The production Memory contract requires Kun to inject no long-term memory when authorized candidates have no positive foundation relevance. The current shared gate treats any positive lexical token coverage as relevant, including weak common trigram or single-term overlaps; the v2 development safety cases q033 and q034 therefore consume the injection budget with unrelated records. This needs a production fix independent of semantic retrieval or terminology-map experiments.
+
+## What Changes
+
+- Add a versioned, deterministic lexical relevance gate shared by SQLite FTS5 and filesystem fallback.
+- Require lexical-only candidates to meet the calibrated foundation threshold before ranking and context-budget selection; preserve explicit type-affinity retrieval.
+- Add anonymous regression fixtures and traces for q033/q034 false positives and q035/q036 correct abstention.
+- Verify the same gate and selected ids through both the real SQLite index and filesystem fallback.
+- Evaluate the gate against the complete v2 development split so abstention, Recall@K, Precision@K, MRR, scope/lifecycle safety, and multilingual behavior are visible together.
+- Keep semantic candidates, terminology-map productionization, model assets, and vector indexes out of this change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `memory-retrieval-foundation`: define positive lexical foundation relevance as meeting the versioned gate rather than merely having any non-zero token overlap, with identical behavior in indexed and degraded paths.
+
+## Impact
+
+- Affects `kun/src/memory/memory-ranking.ts`, `kun/src/memory/memory-retrieval.ts`, SQLite hybrid index integration, and focused Memory retrieval tests.
+- Changes which weak lexical candidates can be injected; scope, lifecycle, authority, prompt budget, and fallback contracts remain unchanged.
+- Adds no runtime dependency, model, schema migration, public API, or packaged asset.

--- a/openspec/changes/fix-kun-memory-lexical-abstention/specs/memory-retrieval-foundation/spec.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/specs/memory-retrieval-foundation/spec.md
@@ -2,11 +2,11 @@
 
 ### Requirement: Ranking signals are independent and deterministic
 
-Kun SHALL combine normalized lexical relevance, scope/type affinity, temporal freshness, importance, and confidence as separate bounded features with stable tie-breaking. A lexical-only candidate SHALL be considered positively relevant only when its normalized lexical feature meets the versioned foundation relevance threshold; any explicit type-affinity candidate MAY remain relevant without lexical overlap.
+Kun SHALL combine normalized lexical relevance, scope/type affinity, temporal freshness, importance, and confidence as separate bounded features with stable tie-breaking. A lexical-only candidate SHALL be considered positively relevant only when its normalized lexical feature meets the versioned foundation relevance floor for the query language (Latin or CJK); any explicit type-affinity candidate MAY remain relevant without lexical overlap.
 
 #### Scenario: Weak lexical overlap is rejected
 
-- **WHEN** an authorized active record has lexical relevance below the foundation threshold and no positive type affinity
+- **WHEN** an authorized active record has lexical relevance below the applicable foundation floor and no positive type affinity
 - **THEN** it is excluded from the relevant ranking set and cannot consume the result or prompt budget
 
 #### Scenario: Old but trusted fact competes with a recent weak inference

--- a/openspec/changes/fix-kun-memory-lexical-abstention/specs/memory-retrieval-foundation/spec.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/specs/memory-retrieval-foundation/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: Ranking signals are independent and deterministic
+
+Kun SHALL combine normalized lexical relevance, scope/type affinity, temporal freshness, importance, and confidence as separate bounded features with stable tie-breaking. A lexical-only candidate SHALL be considered positively relevant only when its normalized lexical feature meets the versioned foundation relevance threshold; any explicit type-affinity candidate MAY remain relevant without lexical overlap.
+
+#### Scenario: Weak lexical overlap is rejected
+
+- **WHEN** an authorized active record has lexical relevance below the foundation threshold and no positive type affinity
+- **THEN** it is excluded from the relevant ranking set and cannot consume the result or prompt budget
+
+#### Scenario: Old but trusted fact competes with a recent weak inference
+
+- **WHEN** two relevant memories differ in confidence and freshness
+- **THEN** ranking evaluates both features independently and does not overwrite confidence with age decay
+
+#### Scenario: Equal candidates tie
+
+- **WHEN** candidates receive equal feature scores
+- **THEN** ordering is stable by documented timestamp and id tie-breakers across repeated runs
+
+#### Scenario: Ranking weights change
+
+- **WHEN** maintainers tune a ranking weight
+- **THEN** evaluation output records the weight set and compares retrieval metrics before the change is accepted
+
+#### Scenario: Threshold behavior is shared across modes
+
+- **WHEN** the same query and records are retrieved through SQLite FTS5 and filesystem fallback
+- **THEN** both modes apply the same foundation relevance predicate and produce equivalent selected ids, subject to their recorded lexical feature values
+
+#### Scenario: Type affinity remains available
+
+- **WHEN** a query contains an explicit supported type hint and an authorized record matches that type
+- **THEN** the record remains eligible even if lexical overlap is below the lexical threshold
+
+### Requirement: Retrieval obeys record and prompt budgets
+
+Turn retrieval SHALL select no more than the minimum of the caller limit and current `maxInjectedRecords`, and context assembly SHALL also enforce a deterministic prompt-size budget. Records rejected by the foundation relevance threshold SHALL be counted as irrelevant for bounded diagnostics and SHALL NOT be selected merely to fill the budget.
+
+#### Scenario: No weak candidates are relevant
+
+- **WHEN** all authorized active candidates are below the lexical threshold and have no type affinity
+- **THEN** Kun injects no long-term memory block and reports an empty selected set
+
+#### Scenario: Configuration lowers the limit
+
+- **WHEN** `maxInjectedRecords` changes from eight to three
+- **THEN** the next turn injects no more than three memories without rebuilding the repository
+
+#### Scenario: Selected records are individually large
+
+- **WHEN** relevant memory bodies would exceed the context budget
+- **THEN** the assembler includes the highest-ranked bounded content, records exclusions/truncation, and does not exceed the budget
+
+#### Scenario: No candidate is relevant
+
+- **WHEN** every authorized active candidate has no positive foundation relevance
+- **THEN** Kun injects no long-term memory block instead of filling the budget with unrelated records
+
+### Requirement: Retrieval quality is evaluated reproducibly
+
+The repository SHALL include anonymous deterministic retrieval fixtures and a scorer that compares the existing baseline with the hybrid foundation. The focused evaluation SHALL report the foundation threshold and its effect on ranked quality, abstention, explicit forbidden selections, scope/lifecycle safety, and both retrieval modes.
+
+#### Scenario: Validate the lexical abstention gate
+
+- **WHEN** the complete anonymous development split is evaluated with the foundation threshold
+- **THEN** q033/q034 no longer select unrelated records, q035/q036 remain empty, and Recall@K, Precision@K, MRR, abstention, safety, and deterministic trace evidence are recorded together
+
+#### Scenario: Run the retrieval evaluation
+
+- **WHEN** the focused evaluation command executes
+- **THEN** it reports Recall@K, Precision@K, reciprocal rank, scope leaks, selected context size, and latency for a fixed dataset
+
+#### Scenario: Evaluate multilingual and safety cases
+
+- **WHEN** the fixture suite runs
+- **THEN** it covers English, Chinese, stale/confident records, replacement, inactive lifecycle, cross-workspace isolation, and prompt-injection content
+
+#### Scenario: Production memory is present
+
+- **WHEN** developers run the evaluation on a machine with real Kun data
+- **THEN** the harness reads only checked-in anonymous fixtures unless the user explicitly invokes a separate local diagnostic mode

--- a/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
@@ -6,15 +6,15 @@
 
 ## 2. Verify both production retrieval modes
 
-- [ ] 2.1 Add shared ranking tests proving below-threshold lexical-only candidates are irrelevant while type-affinity candidates remain eligible.
+- [x] 2.1 Add shared ranking tests proving below-threshold lexical-only candidates are irrelevant while type-affinity candidates remain eligible.
 - [x] 2.2 Add an in-memory SQLite FTS5 integration test using the real `HybridMemoryIndex`/store path and compare q033–q036 selected ids and bounded features with filesystem fallback.
-- [ ] 2.3 Verify scope, lifecycle, authority, prompt budget, and degraded fallback behavior remain unchanged.
+- [x] 2.3 Verify scope, lifecycle, authority, prompt budget, and degraded fallback behavior remain unchanged.
 
 ## 3. Implement and calibrate the gate
 
-- [ ] 3.1 Add the named foundation threshold and shared relevance predicate with no user-facing configuration.
-- [ ] 3.2 Run the complete v2 development split at the selected threshold and record Recall@K, Precision@K, MRR, abstention, forbidden selections, safety, timing, and deterministic trace evidence.
-- [ ] 3.3 Confirm q033/q034 abstain in both modes, q035/q036 remain empty, and no existing focused Memory test regresses.
+- [x] 3.1 Add the named foundation threshold and shared relevance predicate with no user-facing configuration.
+- [x] 3.2 Run the complete v2 development split at the selected threshold and record Recall@K, Precision@K, MRR, abstention, forbidden selections, safety, timing, and deterministic trace evidence.
+- [x] 3.3 Confirm q033/q034 abstain in both production retrieval modes, q035/q036 remain empty, and no existing focused Memory test regresses; historical evaluation mode remains baseline-only.
 
 ## 4. Validate and deliver
 

--- a/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
@@ -21,4 +21,4 @@
 - [x] 4.1 Run focused Memory tests, `build:kun`, typecheck, build, changed-file lint, file-lines, OpenSpec strict validation, and `git diff --check`; Kun typecheck and root build passed, while root typecheck stopped on the pre-existing missing `phonemizer` module.
 - [x] 4.2 Run the full test/lint gates where practical and distinguish infrastructure or upstream baseline failures from this change; lint passed with warnings, `eval:memory-retrieval` passed, and the broad Kun test command exceeded the local observation window without a final summary.
 - [x] 4.3 Update the Memory roadmap and create a timestamped stage note with metrics, selected threshold, trade-offs, and the terminology/semantic boundary.
-- [ ] 4.4 Push independently reviewable commits to `SunwardL/Kun:codex/fix-memory-lexical-abstention`, then create a detailed PR targeting `KunAgent/Kun:develop`.
+- [x] 4.4 Push independently reviewable commits to `SunwardL/Kun:codex/fix-memory-lexical-abstention`, then create detailed PR [#1308](https://github.com/KunAgent/Kun/pull/1308) targeting `KunAgent/Kun:develop`; Quality gates and review are now pending.

--- a/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
@@ -1,0 +1,24 @@
+## 1. Freeze the production contract and audit fixture
+
+- [x] 1.1 Add the delta spec for the versioned foundation lexical relevance gate and validate the change strictly.
+- [ ] 1.2 Add an anonymous regression fixture for q033/q034 false positives and q035/q036 correct abstention without modifying frozen v1/v2 evidence.
+- [ ] 1.3 Record the current shared predicate, filesystem scores, and expected SQLite/fallback parity in focused test notes.
+
+## 2. Verify both production retrieval modes
+
+- [ ] 2.1 Add shared ranking tests proving below-threshold lexical-only candidates are irrelevant while type-affinity candidates remain eligible.
+- [ ] 2.2 Add an in-memory SQLite FTS5 integration test using the real `HybridMemoryIndex`/store path and compare q033–q036 selected ids and bounded features with filesystem fallback.
+- [ ] 2.3 Verify scope, lifecycle, authority, prompt budget, and degraded fallback behavior remain unchanged.
+
+## 3. Implement and calibrate the gate
+
+- [ ] 3.1 Add the named foundation threshold and shared relevance predicate with no user-facing configuration.
+- [ ] 3.2 Run the complete v2 development split at the selected threshold and record Recall@K, Precision@K, MRR, abstention, forbidden selections, safety, timing, and deterministic trace evidence.
+- [ ] 3.3 Confirm q033/q034 abstain in both modes, q035/q036 remain empty, and no existing focused Memory test regresses.
+
+## 4. Validate and deliver
+
+- [ ] 4.1 Run focused Memory tests, `build:kun`, typecheck, build, changed-file lint, file-lines, OpenSpec strict validation, and `git diff --check`.
+- [ ] 4.2 Run the full test/lint gates where practical and distinguish infrastructure or upstream baseline failures from this change.
+- [ ] 4.3 Update the Memory roadmap and create a timestamped stage note with metrics, selected threshold, trade-offs, and the terminology/semantic boundary.
+- [ ] 4.4 Push independently reviewable commits to `SunwardL/Kun:codex/fix-memory-lexical-abstention`, then create a detailed PR targeting `KunAgent/Kun:develop`.

--- a/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Freeze the production contract and audit fixture
 
 - [x] 1.1 Add the delta spec for the versioned foundation lexical relevance gate and validate the change strictly.
-- [ ] 1.2 Add an anonymous regression fixture for q033/q034 false positives and q035/q036 correct abstention without modifying frozen v1/v2 evidence.
-- [ ] 1.3 Record the current shared predicate, filesystem scores, and expected SQLite/fallback parity in focused test notes.
+- [x] 1.2 Add an anonymous regression fixture for q033/q034 false positives and q035/q036 correct abstention without modifying frozen v1/v2 evidence.
+- [x] 1.3 Record the current shared predicate, filesystem scores, and expected SQLite/fallback parity in focused test notes.
 
 ## 2. Verify both production retrieval modes
 

--- a/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
@@ -18,7 +18,7 @@
 
 ## 4. Validate and deliver
 
-- [ ] 4.1 Run focused Memory tests, `build:kun`, typecheck, build, changed-file lint, file-lines, OpenSpec strict validation, and `git diff --check`.
-- [ ] 4.2 Run the full test/lint gates where practical and distinguish infrastructure or upstream baseline failures from this change.
-- [ ] 4.3 Update the Memory roadmap and create a timestamped stage note with metrics, selected threshold, trade-offs, and the terminology/semantic boundary.
+- [x] 4.1 Run focused Memory tests, `build:kun`, typecheck, build, changed-file lint, file-lines, OpenSpec strict validation, and `git diff --check`; Kun typecheck and root build passed, while root typecheck stopped on the pre-existing missing `phonemizer` module.
+- [x] 4.2 Run the full test/lint gates where practical and distinguish infrastructure or upstream baseline failures from this change; lint passed with warnings, `eval:memory-retrieval` passed, and the broad Kun test command exceeded the local observation window without a final summary.
+- [x] 4.3 Update the Memory roadmap and create a timestamped stage note with metrics, selected threshold, trade-offs, and the terminology/semantic boundary.
 - [ ] 4.4 Push independently reviewable commits to `SunwardL/Kun:codex/fix-memory-lexical-abstention`, then create a detailed PR targeting `KunAgent/Kun:develop`.

--- a/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
@@ -22,3 +22,8 @@
 - [x] 4.2 Run the full test/lint gates where practical and distinguish infrastructure or upstream baseline failures from this change; lint passed with warnings, `eval:memory-retrieval` passed, and the broad Kun test command exceeded the local observation window without a final summary.
 - [x] 4.3 Update the Memory roadmap and create a timestamped stage note with metrics, selected threshold, trade-offs, and the terminology/semantic boundary.
 - [x] 4.4 Push independently reviewable commits to `SunwardL/Kun:codex/fix-memory-lexical-abstention`, then create detailed PR [#1308](https://github.com/KunAgent/Kun/pull/1308) targeting `KunAgent/Kun:develop`; Quality gates and review are now pending.
+
+## 5. Post-review regression correction
+
+- [x] 5.1 Preserve the existing CJK n-gram retrieval contract by adding a versioned CJK lexical floor, add boundary coverage, and re-run the affected store regression.
+- [x] 5.2 Document the remaining q040 precision-only forbidden selection separately from the q033–q036 authority-boundary safety cases.

--- a/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
+++ b/openspec/changes/fix-kun-memory-lexical-abstention/tasks.md
@@ -7,7 +7,7 @@
 ## 2. Verify both production retrieval modes
 
 - [ ] 2.1 Add shared ranking tests proving below-threshold lexical-only candidates are irrelevant while type-affinity candidates remain eligible.
-- [ ] 2.2 Add an in-memory SQLite FTS5 integration test using the real `HybridMemoryIndex`/store path and compare q033–q036 selected ids and bounded features with filesystem fallback.
+- [x] 2.2 Add an in-memory SQLite FTS5 integration test using the real `HybridMemoryIndex`/store path and compare q033–q036 selected ids and bounded features with filesystem fallback.
 - [ ] 2.3 Verify scope, lifecycle, authority, prompt budget, and degraded fallback behavior remain unchanged.
 
 ## 3. Implement and calibrate the gate


### PR DESCRIPTION
## Summary

- Close the production lexical-abstention gap identified by anonymous v2 queries q033/q034.
- Keep q035/q036 and the existing scope/lifecycle/authority/budget/fallback contract unchanged.
- Do not add embeddings, model assets, terminology expansion, or P2-B production wiring.

## Why this change

The P0 contract already says that Kun must inject no long-term Memory when no authorized candidate has positive foundation relevance. The shared predicate previously treated every `lexical > 0` match as positive, so weak token overlap could inject unrelated records.

The SQLite audit also found a backend-specific issue: normalized FTS5 BM25 could inflate q033's weak match to about `0.943`, while filesystem token coverage was about `0.393`. Using different gate scores would make the same query safe in one mode and unsafe in the other.

## Changes

- Add versioned lexical floors: `MEMORY_MIN_LEXICAL_RELEVANCE = 0.4` for Latin-only queries and `MEMORY_MIN_CJK_LEXICAL_RELEVANCE = 1/3` for CJK n-gram queries. The separate CJK floor preserves the existing Chinese retrieval contract without lowering the English safety gate that rejects q033/q034.
- Keep type affinity eligible even when lexical coverage is below the threshold.
- Make SQLite FTS5 use the same bounded token-coverage score as filesystem fallback for the gate; BM25 remains a candidate-ordering signal only.
- Add anonymous q033/q034/q035/q036 regression fixtures and ranking/SQLite parity/audit tests.
- Add explicit `historical-v1` evaluation mode so frozen v1/v2 evidence remains byte-for-byte reproducible; production retrieval defaults to `foundation-v1`.
- Record the complete v2 development gated report without opening holdout or changing frozen evidence.

## Evidence

Gated v2 development (40 queries, same frozen records/filters/K):

| Metric | Frozen lexical | Gated foundation-v1 |
|---|---:|---:|
| Recall@5 | 0.482 | 0.343 |
| Precision@5 | 0.202 | 0.354 |
| MRR | 0.500 | 0.361 |
| Abstention accuracy | 0.500 | 1.000 |
| False-positive selections | 10 | 0 |
| Explicit forbidden selections | 5 | 1 |

q033, q034, q035, and q036 all return an empty result in both production retrieval modes. The recall trade-off is intentional and recorded; this PR does not claim that embedding retrieval is ready.

The remaining gated explicit forbidden selection is `q040_response_style_bundle`: a same-category response-style precision residual (`no_emoji` is selected alongside three requested style memories). It is not an authority-boundary safety leak and is outside this PR's q033–q036 scope.

## Tests

- `npm --prefix kun run eval:memory-retrieval` — 12 files / 79 tests passed.
- Memory focused suite — 23 files / 159 tests passed.
- Hybrid/degraded/store regression — 4 files / 27 tests passed.
- `npm run build:kun` — passed.
- Root `npm run build` — passed.
- Root `npm run lint` — passed with 0 errors (existing React hook warnings only).
- `npm run check:file-lines` — passed.
- `npm --prefix kun test -- tests/memory-store.test.ts` — 14/14 passed, including the CI-reported CJK n-gram regression.
- OpenSpec strict validation and `git diff --check` — passed.
- Root `npm run typecheck` — blocked by the pre-existing missing `phonemizer` module in `src/main/services/local-kokoro-worker-entry.ts`; no changed Memory file is involved.
- Broad Kun `npm test` exceeded the local 300-second observation window without a final summary; no passing claim is made here and PR Actions should provide the authoritative full-gate result.

## Scope and follow-up

- The PR targets `KunAgent/Kun:develop`.
- P2-A.1 remains development no-go; holdout is not opened.
- P2-B, embedding productionization, terminology-map productionization, and new semantic decision versions remain blocked until a separate decision passes the frozen safety and quality gates.
