### PR TITLE
feat(instructions): import agent context from other coding agents into AGENTS.md

### DIFF
--- a/kun/src/instructions/import-adapters.ts
+++ b/kun/src/instructions/import-adapters.ts
@@ -3,7 +3,7 @@ import type { SourceAdapter, SourceToolId } from './instruction-import.js'
 /**
  * Source adapters for importing other coding agents' instruction files into
  * Kun `AGENTS.md`. File locations follow the `rulesync` project as a reference.
- * Adapters are added per delivery round; this module currently ships round 1.
+ * Adapters are added per delivery round; this module currently ships rounds 1-2.
  */
 
 export const claudeCodeAdapter: SourceAdapter = {
@@ -29,7 +29,29 @@ export const codexAdapter: SourceAdapter = {
   global: [{ kind: '~/.codex/AGENTS.md', relFile: '.codex/AGENTS.md' }]
 }
 
-export const IMPORT_ADAPTERS: SourceAdapter[] = [claudeCodeAdapter, codexAdapter]
+export const cursorAdapter: SourceAdapter = {
+  tool: 'cursor',
+  label: 'Cursor',
+  workspace: [
+    { kind: '.cursor/rules', relDir: '.cursor/rules', exts: ['.mdc', '.md'], stripFrontmatter: true },
+    { kind: '.cursorrules', relFile: '.cursorrules' }
+  ],
+  global: []
+}
+
+export const geminiAdapter: SourceAdapter = {
+  tool: 'gemini',
+  label: 'Gemini CLI',
+  workspace: [{ kind: 'GEMINI.md', relFile: 'GEMINI.md' }],
+  global: [{ kind: '~/.gemini/GEMINI.md', relFile: '.gemini/GEMINI.md' }]
+}
+
+export const IMPORT_ADAPTERS: SourceAdapter[] = [
+  claudeCodeAdapter,
+  codexAdapter,
+  cursorAdapter,
+  geminiAdapter
+]
 
 export function adapterById(id: string): SourceAdapter | undefined {
   return IMPORT_ADAPTERS.find((adapter) => adapter.tool === id)

--- a/kun/src/instructions/import-adapters.ts
+++ b/kun/src/instructions/import-adapters.ts
@@ -1,0 +1,40 @@
+import type { SourceAdapter, SourceToolId } from './instruction-import.js'
+
+/**
+ * Source adapters for importing other coding agents' instruction files into
+ * Kun `AGENTS.md`. File locations follow the `rulesync` project as a reference.
+ * Adapters are added per delivery round; this module currently ships round 1.
+ */
+
+export const claudeCodeAdapter: SourceAdapter = {
+  tool: 'claude-code',
+  label: 'Claude Code',
+  workspace: [
+    { kind: 'CLAUDE.md', relFile: 'CLAUDE.md', resolveImports: true },
+    { kind: 'CLAUDE.local.md', relFile: 'CLAUDE.local.md', resolveImports: true },
+    { kind: '.claude/rules', relDir: '.claude/rules', exts: ['.md'] }
+  ],
+  global: [{ kind: '~/.claude/CLAUDE.md', relFile: '.claude/CLAUDE.md', resolveImports: true }]
+}
+
+export const codexAdapter: SourceAdapter = {
+  tool: 'codex',
+  label: 'Codex',
+  // Workspace AGENTS.md is Kun's own format and resolves to the import target,
+  // so the engine reports it as an identity skip rather than importing it.
+  workspace: [
+    { kind: 'AGENTS.md', relFile: 'AGENTS.md' },
+    { kind: 'AGENTS.override.md', relFile: 'AGENTS.override.md' }
+  ],
+  global: [{ kind: '~/.codex/AGENTS.md', relFile: '.codex/AGENTS.md' }]
+}
+
+export const IMPORT_ADAPTERS: SourceAdapter[] = [claudeCodeAdapter, codexAdapter]
+
+export function adapterById(id: string): SourceAdapter | undefined {
+  return IMPORT_ADAPTERS.find((adapter) => adapter.tool === id)
+}
+
+export function supportedToolIds(): SourceToolId[] {
+  return IMPORT_ADAPTERS.map((adapter) => adapter.tool)
+}

--- a/kun/src/instructions/import-adapters.ts
+++ b/kun/src/instructions/import-adapters.ts
@@ -3,7 +3,7 @@ import type { SourceAdapter, SourceToolId } from './instruction-import.js'
 /**
  * Source adapters for importing other coding agents' instruction files into
  * Kun `AGENTS.md`. File locations follow the `rulesync` project as a reference.
- * Adapters are added per delivery round; this module currently ships rounds 1-3.
+ * Adapters are added per delivery round; this module now ships all ten tools.
  */
 
 export const claudeCodeAdapter: SourceAdapter = {
@@ -77,6 +77,38 @@ export const clineAdapter: SourceAdapter = {
   global: []
 }
 
+export const zedAdapter: SourceAdapter = {
+  tool: 'zed',
+  label: 'Zed',
+  workspace: [{ kind: '.rules', relFile: '.rules' }],
+  // Zed's global lives under the platform config dir; list both so the absent one is skipped.
+  global: [
+    { kind: '~/.config/zed/AGENTS.md', relFile: '.config/zed/AGENTS.md' },
+    { kind: 'AppData/Roaming/Zed/AGENTS.md', relFile: 'AppData/Roaming/Zed/AGENTS.md' }
+  ]
+}
+
+export const opencodeAdapter: SourceAdapter = {
+  tool: 'opencode',
+  label: 'OpenCode',
+  // Workspace AGENTS.md resolves to the Kun target and is reported as an identity skip.
+  workspace: [
+    { kind: 'AGENTS.md', relFile: 'AGENTS.md' },
+    { kind: '.opencode/memories', relDir: '.opencode/memories', exts: ['.md'] }
+  ],
+  global: [
+    { kind: '~/.config/opencode/AGENTS.md', relFile: '.config/opencode/AGENTS.md' },
+    { kind: '~/.config/opencode/memories', relDir: '.config/opencode/memories', exts: ['.md'] }
+  ]
+}
+
+export const kiroAdapter: SourceAdapter = {
+  tool: 'kiro',
+  label: 'Kiro',
+  workspace: [{ kind: '.kiro/steering', relDir: '.kiro/steering', exts: ['.md'], stripFrontmatter: true }],
+  global: [{ kind: '~/.kiro/steering', relDir: '.kiro/steering', exts: ['.md'], stripFrontmatter: true }]
+}
+
 export const IMPORT_ADAPTERS: SourceAdapter[] = [
   claudeCodeAdapter,
   codexAdapter,
@@ -84,7 +116,10 @@ export const IMPORT_ADAPTERS: SourceAdapter[] = [
   geminiAdapter,
   copilotAdapter,
   windsurfAdapter,
-  clineAdapter
+  clineAdapter,
+  zedAdapter,
+  opencodeAdapter,
+  kiroAdapter
 ]
 
 export function adapterById(id: string): SourceAdapter | undefined {

--- a/kun/src/instructions/import-adapters.ts
+++ b/kun/src/instructions/import-adapters.ts
@@ -3,7 +3,7 @@ import type { SourceAdapter, SourceToolId } from './instruction-import.js'
 /**
  * Source adapters for importing other coding agents' instruction files into
  * Kun `AGENTS.md`. File locations follow the `rulesync` project as a reference.
- * Adapters are added per delivery round; this module currently ships rounds 1-2.
+ * Adapters are added per delivery round; this module currently ships rounds 1-3.
  */
 
 export const claudeCodeAdapter: SourceAdapter = {
@@ -46,11 +46,45 @@ export const geminiAdapter: SourceAdapter = {
   global: [{ kind: '~/.gemini/GEMINI.md', relFile: '.gemini/GEMINI.md' }]
 }
 
+export const copilotAdapter: SourceAdapter = {
+  tool: 'copilot',
+  label: 'GitHub Copilot',
+  workspace: [
+    { kind: '.github/copilot-instructions.md', relFile: '.github/copilot-instructions.md' },
+    { kind: '.github/instructions', relDir: '.github/instructions', exts: ['.instructions.md', '.md'], stripFrontmatter: true }
+  ],
+  global: []
+}
+
+export const windsurfAdapter: SourceAdapter = {
+  tool: 'windsurf',
+  label: 'Windsurf',
+  workspace: [
+    { kind: '.windsurf/rules', relDir: '.windsurf/rules', exts: ['.md'], stripFrontmatter: true },
+    { kind: '.windsurfrules', relFile: '.windsurfrules' }
+  ],
+  global: []
+}
+
+export const clineAdapter: SourceAdapter = {
+  tool: 'cline',
+  label: 'Cline',
+  // `.clinerules` may be a single file or a directory of markdown rules.
+  workspace: [
+    { kind: '.clinerules', relFile: '.clinerules' },
+    { kind: '.clinerules/', relDir: '.clinerules', exts: ['.md'] }
+  ],
+  global: []
+}
+
 export const IMPORT_ADAPTERS: SourceAdapter[] = [
   claudeCodeAdapter,
   codexAdapter,
   cursorAdapter,
-  geminiAdapter
+  geminiAdapter,
+  copilotAdapter,
+  windsurfAdapter,
+  clineAdapter
 ]
 
 export function adapterById(id: string): SourceAdapter | undefined {

--- a/kun/src/instructions/instruction-import.ts
+++ b/kun/src/instructions/instruction-import.ts
@@ -413,3 +413,31 @@ export function describeImportPlan(plan: ImportPlan): string[] {
   }
   return lines
 }
+
+export type ParsedImportArgs = {
+  tools: SourceToolId[]
+  unknownTools: string[]
+  scopes: ImportScope[]
+  dryRun: boolean
+}
+
+/**
+ * Parse `/import` arguments into a typed request. Tool tokens are split into
+ * known (`tools`) and `unknownTools` against `knownTools`. Scope defaults to
+ * workspace; `--global` alone means global only, and passing both flags means
+ * both. Pure and free of any filesystem or adapter dependency.
+ */
+export function parseImportArgs(args: string | undefined, knownTools: SourceToolId[]): ParsedImportArgs {
+  const tokens = (args ?? '').trim().split(/\s+/u).filter((token) => token.length > 0)
+  const flags = new Set(tokens.filter((token) => token.startsWith('--')))
+  const requested = tokens.filter((token) => !token.startsWith('--'))
+  const known = new Set<string>(knownTools)
+  const tools = requested.filter((token): token is SourceToolId => known.has(token))
+  const unknownTools = requested.filter((token) => !known.has(token))
+  const wantGlobal = flags.has('--global')
+  const wantWorkspace = flags.has('--workspace') || !wantGlobal
+  const scopes: ImportScope[] = []
+  if (wantWorkspace) scopes.push('workspace')
+  if (wantGlobal) scopes.push('global')
+  return { tools, unknownTools, scopes, dryRun: flags.has('--dry-run') }
+}

--- a/kun/src/instructions/instruction-import.ts
+++ b/kun/src/instructions/instruction-import.ts
@@ -1,0 +1,415 @@
+import { lstat, mkdir, readFile, readdir, realpath, rename, stat, writeFile } from 'node:fs/promises'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import {
+  DEFAULT_INSTRUCTION_MAX_FILE_BYTES,
+  DEFAULT_INSTRUCTION_MAX_TOTAL_BYTES,
+  KUN_AGENTS_FILENAME
+} from './instruction-runtime.js'
+
+export const MAX_IMPORT_DEPTH = 4
+
+export type ImportScope = 'workspace' | 'global'
+
+export type SourceToolId =
+  | 'claude-code'
+  | 'codex'
+  | 'cursor'
+  | 'gemini'
+  | 'copilot'
+  | 'windsurf'
+  | 'cline'
+  | 'zed'
+  | 'opencode'
+  | 'kiro'
+
+/**
+ * One source location declared by an adapter. `relFile` is read directly;
+ * `relDir` reads every file in that directory whose extension is in `exts`.
+ * Paths are relative to the workspace root (workspace scope) or the home
+ * directory (global scope).
+ */
+export type SourceFileSpec = {
+  kind: string
+  relFile?: string
+  relDir?: string
+  exts?: string[]
+  resolveImports?: boolean
+  stripFrontmatter?: boolean
+}
+
+export type SourceAdapter = {
+  tool: SourceToolId
+  label: string
+  workspace: SourceFileSpec[]
+  global: SourceFileSpec[]
+}
+
+export type DetectedSourceFile = {
+  tool: SourceToolId
+  scope: ImportScope
+  kind: string
+  path: string
+  bytes: number
+  spec: SourceFileSpec
+}
+
+export type ImportWarning =
+  | { code: 'unresolved-import'; path: string; detail: string }
+  | { code: 'import-cycle'; path: string }
+  | { code: 'oversized-import'; path: string; bytes: number }
+  | { code: 'identity-skip'; tool: SourceToolId; path: string }
+  | { code: 'budget-exceeded'; target: string; bytes: number; limit: number }
+
+export type ImportTargetPlan = {
+  scope: ImportScope
+  target: string
+  tools: SourceToolId[]
+  mergedText: string
+  existingText: string
+  changed: boolean
+  finalBytes: number
+}
+
+export type ImportPlan = {
+  targets: ImportTargetPlan[]
+  warnings: ImportWarning[]
+}
+
+export type BuildImportPlanInput = {
+  workspace: string
+  homeDir: string
+  adapters: SourceAdapter[]
+  scopes: ImportScope[]
+  /** Restrict to these tools; empty/undefined means every adapter. */
+  tools?: SourceToolId[]
+  maxFileBytes?: number
+  maxTotalBytes?: number
+}
+
+const BEGIN = 'kun:import:begin'
+const END = 'kun:import:end'
+
+export function globalAgentsPath(homeDir: string): string {
+  return join(homeDir, '.kun', KUN_AGENTS_FILENAME)
+}
+
+export function workspaceAgentsPath(workspace: string): string {
+  return join(workspace, KUN_AGENTS_FILENAME)
+}
+
+function beginMarker(tool: SourceToolId): string {
+  return `<!-- ${BEGIN} tool=${tool} -->`
+}
+
+function endMarker(tool: SourceToolId): string {
+  return `<!-- ${END} tool=${tool} -->`
+}
+
+async function statSafe(path: string): Promise<{ isFile: boolean; bytes: number } | null> {
+  try {
+    const info = await stat(path)
+    return { isFile: info.isFile(), bytes: info.size }
+  } catch {
+    return null
+  }
+}
+
+function baseForScope(scope: ImportScope, workspace: string, homeDir: string): string {
+  return scope === 'workspace' ? workspace : homeDir
+}
+
+/** Detect which declared source files exist, per tool and scope. Reads nothing beyond declared locations and mutates nothing. */
+export async function detectImportSources(input: {
+  workspace: string
+  homeDir: string
+  adapters: SourceAdapter[]
+  scopes: ImportScope[]
+  tools?: SourceToolId[]
+}): Promise<DetectedSourceFile[]> {
+  const { workspace, homeDir, adapters, scopes } = input
+  const toolFilter = input.tools && input.tools.length > 0 ? new Set(input.tools) : null
+  const found: DetectedSourceFile[] = []
+
+  for (const adapter of adapters) {
+    if (toolFilter && !toolFilter.has(adapter.tool)) continue
+    for (const scope of scopes) {
+      const base = baseForScope(scope, workspace, homeDir)
+      const specs = scope === 'workspace' ? adapter.workspace : adapter.global
+      for (const spec of specs) {
+        for (const path of await expandSpec(base, spec)) {
+          const info = await statSafe(path)
+          if (!info || !info.isFile) continue
+          found.push({ tool: adapter.tool, scope, kind: spec.kind, path, bytes: info.bytes, spec })
+        }
+      }
+    }
+  }
+  return found
+}
+
+async function expandSpec(base: string, spec: SourceFileSpec): Promise<string[]> {
+  if (spec.relFile) return [resolve(base, spec.relFile)]
+  if (spec.relDir) {
+    const dir = resolve(base, spec.relDir)
+    let entries: string[]
+    try {
+      entries = await readdir(dir)
+    } catch {
+      return []
+    }
+    const exts = spec.exts ?? ['.md']
+    return entries
+      .filter((name) => exts.some((ext) => name.toLowerCase().endsWith(ext)))
+      .sort()
+      .map((name) => join(dir, name))
+  }
+  return []
+}
+
+function stripFrontmatter(text: string): string {
+  if (!text.startsWith('---')) return text
+  const match = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/u.exec(text)
+  return match ? text.slice(match[0].length) : text
+}
+
+function normalizeBody(text: string): string {
+  return text
+    .replace(/\r\n/gu, '\n')
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+$/u, ''))
+    .join('\n')
+    .replace(/\n{3,}/gu, '\n\n')
+    .trim()
+}
+
+type ResolveCtx = {
+  homeDir: string
+  visited: Set<string>
+  warnings: ImportWarning[]
+  maxFileBytes: number
+}
+
+const IMPORT_TOKEN = /(^|[^\w`@])@([^\s'"()]+)/gu
+
+async function resolveClaudeImports(
+  text: string,
+  baseDir: string,
+  depth: number,
+  ctx: ResolveCtx
+): Promise<string> {
+  if (depth >= MAX_IMPORT_DEPTH) return text
+  const matches = [...text.matchAll(IMPORT_TOKEN)]
+  if (matches.length === 0) return text
+
+  let out = ''
+  let cursor = 0
+  for (const match of matches) {
+    const full = match[0]
+    const lead = match[1] ?? ''
+    const rawPath = match[2] ?? ''
+    const start = match.index ?? 0
+    out += text.slice(cursor, start) + lead
+    cursor = start + full.length
+
+    const looksLikePath = rawPath.includes('/') || rawPath.includes('\\')
+    const resolved = resolveImportPath(rawPath, baseDir, ctx.homeDir)
+    const info = await statSafe(resolved)
+    if (!info || !info.isFile) {
+      if (looksLikePath) ctx.warnings.push({ code: 'unresolved-import', path: resolved, detail: rawPath })
+      out += `@${rawPath}`
+      continue
+    }
+    if (info.bytes > ctx.maxFileBytes) {
+      ctx.warnings.push({ code: 'oversized-import', path: resolved, bytes: info.bytes })
+      out += `@${rawPath}`
+      continue
+    }
+    let real = resolved
+    try {
+      real = await realpath(resolved)
+    } catch {
+      // fall back to resolved path for the cycle key
+    }
+    if (ctx.visited.has(real)) {
+      ctx.warnings.push({ code: 'import-cycle', path: real })
+      out += `<!-- kun-import: cycle skipped ${rawPath} -->`
+      continue
+    }
+    ctx.visited.add(real)
+    const nested = await resolveClaudeImports(await readFile(resolved, 'utf8'), dirname(resolved), depth + 1, ctx)
+    ctx.visited.delete(real)
+    out += `\n${normalizeBody(nested)}\n`
+  }
+  out += text.slice(cursor)
+  return out
+}
+
+function resolveImportPath(rawPath: string, baseDir: string, homeDir: string): string {
+  if (rawPath.startsWith('~/') || rawPath.startsWith('~\\')) return resolve(homeDir, rawPath.slice(2))
+  if (isAbsolute(rawPath)) return rawPath
+  return resolve(baseDir, rawPath)
+}
+
+async function renderSourceFile(source: DetectedSourceFile, ctx: ResolveCtx): Promise<string> {
+  let text = await readFile(source.path, 'utf8')
+  if (source.spec.stripFrontmatter) text = stripFrontmatter(text)
+  if (source.spec.resolveImports) {
+    ctx.visited.add(await realpath(source.path).catch(() => source.path))
+    text = await resolveClaudeImports(text, dirname(source.path), 0, ctx)
+  }
+  return normalizeBody(text)
+}
+
+/** Replace the managed block for `tool`, appending a fresh block if none exists. Content outside markers is preserved verbatim. */
+export function mergeManagedBlock(existing: string, tool: SourceToolId, blockBody: string): string {
+  const begin = beginMarker(tool)
+  const end = endMarker(tool)
+  const block = `${begin}\n${blockBody}\n${end}`
+  const pattern = new RegExp(`${escapeRegExp(begin)}[\\s\\S]*?${escapeRegExp(end)}`, 'u')
+  if (pattern.test(existing)) {
+    return existing.replace(pattern, block)
+  }
+  const trimmed = existing.replace(/\s+$/u, '')
+  return trimmed.length > 0 ? `${trimmed}\n\n${block}\n` : `${block}\n`
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+}
+
+async function readTargetText(path: string): Promise<string> {
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+/** Pure-ish planning step: reads source files and produces the merged target text without writing anything. */
+export async function buildImportPlan(input: BuildImportPlanInput): Promise<ImportPlan> {
+  const maxFileBytes = input.maxFileBytes ?? DEFAULT_INSTRUCTION_MAX_FILE_BYTES
+  const maxTotalBytes = input.maxTotalBytes ?? DEFAULT_INSTRUCTION_MAX_TOTAL_BYTES
+  const warnings: ImportWarning[] = []
+  const detected = await detectImportSources({
+    workspace: input.workspace,
+    homeDir: input.homeDir,
+    adapters: input.adapters,
+    scopes: input.scopes,
+    ...(input.tools ? { tools: input.tools } : {})
+  })
+
+  const targets: ImportTargetPlan[] = []
+  for (const scope of input.scopes) {
+    const target = scope === 'workspace'
+      ? workspaceAgentsPath(input.workspace)
+      : globalAgentsPath(input.homeDir)
+    const existingText = await readTargetText(target)
+    let mergedText = existingText
+    const tools: SourceToolId[] = []
+
+    for (const adapter of input.adapters) {
+      const sources = detected.filter((source) => source.scope === scope && source.tool === adapter.tool)
+      if (sources.length === 0) continue
+      const parts: string[] = []
+      for (const source of sources) {
+        // A source that resolves to the target file itself is an identity import (e.g. Codex workspace AGENTS.md).
+        if (resolve(source.path) === resolve(target)) {
+          warnings.push({ code: 'identity-skip', tool: source.tool, path: source.path })
+          continue
+        }
+        const ctx: ResolveCtx = { homeDir: input.homeDir, visited: new Set(), warnings, maxFileBytes }
+        const body = await renderSourceFile(source, ctx)
+        if (body.length > 0) parts.push(`<!-- from: ${source.kind} -->\n${body}`)
+      }
+      if (parts.length === 0) continue
+      mergedText = mergeManagedBlock(mergedText, adapter.tool, parts.join('\n\n'))
+      tools.push(adapter.tool)
+    }
+
+    const finalBytes = Buffer.byteLength(mergedText, 'utf8')
+    if (finalBytes > maxFileBytes) {
+      warnings.push({ code: 'budget-exceeded', target, bytes: finalBytes, limit: maxFileBytes })
+    }
+    targets.push({
+      scope,
+      target,
+      tools,
+      mergedText,
+      existingText,
+      changed: tools.length > 0 && mergedText !== existingText,
+      finalBytes
+    })
+  }
+
+  const totalBytes = targets.reduce((sum, plan) => sum + plan.finalBytes, 0)
+  if (totalBytes > maxTotalBytes) {
+    warnings.push({ code: 'budget-exceeded', target: '(all scopes)', bytes: totalBytes, limit: maxTotalBytes })
+  }
+
+  return { targets, warnings }
+}
+
+async function writeTextAtomically(path: string, content: string): Promise<void> {
+  const temporary = join(dirname(path), `.${basename(path)}.${process.pid}.tmp`)
+  await writeFile(temporary, content, { encoding: 'utf8', mode: 0o600 })
+  await rename(temporary, path)
+}
+
+async function assertSafeWorkspaceTarget(target: string, workspace: string): Promise<void> {
+  const info = await lstat(target).catch(() => null)
+  if (info?.isSymbolicLink()) throw new Error('workspace AGENTS.md must not be a symbolic link')
+  const root = await realpath(workspace).catch(() => resolve(workspace))
+  const parent = await realpath(dirname(target)).catch(() => resolve(dirname(target)))
+  const rel = relative(root, parent)
+  if (rel !== '' && (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel))) {
+    throw new Error('workspace AGENTS.md resolves outside the workspace')
+  }
+}
+
+export type AppliedTarget = { scope: ImportScope; target: string; bytes: number }
+
+/** Write the changed targets from a plan. Global writes create `~/.kun`; workspace writes refuse symlinks and out-of-root paths. */
+export async function applyImportPlan(plan: ImportPlan, input: { workspace: string }): Promise<AppliedTarget[]> {
+  const applied: AppliedTarget[] = []
+  for (const targetPlan of plan.targets) {
+    if (!targetPlan.changed) continue
+    if (targetPlan.scope === 'workspace') {
+      await assertSafeWorkspaceTarget(targetPlan.target, input.workspace)
+    } else {
+      await mkdir(dirname(targetPlan.target), { recursive: true })
+    }
+    await writeTextAtomically(targetPlan.target, targetPlan.mergedText)
+    applied.push({ scope: targetPlan.scope, target: targetPlan.target, bytes: targetPlan.finalBytes })
+  }
+  return applied
+}
+
+export function describeWarning(warning: ImportWarning): string {
+  switch (warning.code) {
+    case 'unresolved-import':
+      return `Unresolved @import "${warning.detail}" (${warning.path})`
+    case 'import-cycle':
+      return `Skipped @import cycle at ${warning.path}`
+    case 'oversized-import':
+      return `Skipped oversized @import (${warning.bytes} bytes) at ${warning.path}`
+    case 'identity-skip':
+      return `Skipped ${warning.tool} source identical to the target: ${warning.path}`
+    case 'budget-exceeded':
+      return `Instruction budget exceeded for ${warning.target}: ${warning.bytes} > ${warning.limit} bytes`
+  }
+}
+
+export function describeImportPlan(plan: ImportPlan): string[] {
+  const lines: string[] = []
+  for (const target of plan.targets) {
+    const state = target.changed ? `${target.finalBytes} bytes` : 'no change'
+    const tools = target.tools.length > 0 ? target.tools.join(', ') : 'none'
+    lines.push(`[${target.scope}] ${target.target}`)
+    lines.push(`  tools: ${tools} · ${state}`)
+  }
+  if (plan.warnings.length > 0) {
+    lines.push('', 'Warnings:')
+    for (const warning of plan.warnings) lines.push(`  - ${describeWarning(warning)}`)
+  }
+  return lines
+}

--- a/kun/src/tui/chat-root.ts
+++ b/kun/src/tui/chat-root.ts
@@ -572,6 +572,7 @@ export class ChatRoot implements Component, Focusable {
       case 'undo': await this.controller.undoLastTurn(); break
       case 'redo': await this.controller.redoBranch(); break
       case 'init': await this.controller.initializeWorkspace(command.instructions); break
+      case 'import': await this.controller.importAgentContext(command.args); break
       case 'mcp': await this.controller.showMcp(command.action); break
       case 'timeline': this.actions.onTimeline(command.query); break
       case 'jump': this.actions.onTimeline(undefined, command.target); break

--- a/kun/src/tui/commands.test.ts
+++ b/kun/src/tui/commands.test.ts
@@ -109,7 +109,7 @@ describe('TUI slash commands', () => {
       'compact', 'export', 'status', 'copy', 'undo', 'redo', 'connect', 'model',
       'usage', 'quota',
       'variants', 'thinking', 'mouse', 'details', 'permission', 'plan', 'graph', 'agent', 'subagents', 'tasks', 'goal',
-      'attach', 'paste', 'memory', 'shells', 'extensions', 'queue', 'skills', 'mcp', 'init', 'editor', 'add-dir', 'btw', 'context',
+      'attach', 'paste', 'memory', 'shells', 'extensions', 'queue', 'skills', 'mcp', 'init', 'import', 'editor', 'add-dir', 'btw', 'context',
       'capabilities', 'theme', 'share', 'unshare', 'console', 'diff', 'terminal', 'update', 'help', 'quit'
     ]))
   })

--- a/kun/src/tui/commands.ts
+++ b/kun/src/tui/commands.ts
@@ -38,6 +38,7 @@ export type TuiCommand =
   | { kind: 'undo' }
   | { kind: 'redo' }
   | { kind: 'init'; instructions?: string }
+  | { kind: 'import'; args?: string }
   | { kind: 'mcp'; action?: string }
   | { kind: 'timeline'; query?: string }
   | { kind: 'jump'; target?: string }
@@ -104,6 +105,7 @@ export const TUI_SLASH_COMMANDS: SlashCommand[] = [
   { name: 'undo', description: 'Undo the last user turn in a preserved branch' },
   { name: 'redo', description: 'Move to the next preserved branch when available' },
   { name: 'init', description: 'Analyze the project and create or update AGENTS.md', argumentHint: '[guidance]' },
+  { name: 'import', description: 'Import instruction context from other coding agents into AGENTS.md', argumentHint: '[tools] [--global] [--workspace] [--dry-run]' },
   { name: 'mcp', description: 'Add, edit, remove, reconnect, or authorize shared MCP servers', argumentHint: '[add|edit|enable|disable|reconnect|delete|authorize|reset]' },
   { name: 'timeline', description: 'Browse turns and fork at a turn', argumentHint: '[search]' },
   { name: 'jump', description: 'Jump to a numbered or matching turn', argumentHint: '[target]' },
@@ -193,6 +195,7 @@ export const TUI_COMMAND_DEFINITIONS: readonly TuiCommandDefinition[] = [
   { id: 'skills', title: 'Browse skills', category: 'Workspace', slash: 'skills', available: true },
   { id: 'mcp', title: 'Show MCP status', category: 'Workspace', slash: 'mcp', available: true },
   { id: 'init', title: 'Initialize workspace instructions', category: 'Workspace', slash: 'init', available: true },
+  { id: 'import', title: 'Import agent context', category: 'Workspace', slash: 'import', available: true },
   { id: 'editor', title: 'Open external editor', category: 'Workspace', slash: 'editor', keyAction: 'input_editor', available: true },
   { id: 'steer', title: 'Steer the running turn', category: 'Session', keyAction: 'input_steer', available: true },
   { id: 'add-dir', title: 'Add workspace directory', category: 'Workspace', slash: 'add-dir', argumentRequired: true, available: true },
@@ -248,6 +251,7 @@ export function parseTuiCommand(text: string): TuiCommand | null {
     case 'undo': return { kind: 'undo' }
     case 'redo': return { kind: 'redo' }
     case 'init': return { kind: 'init', ...(rest ? { instructions: rest } : {}) }
+    case 'import': return { kind: 'import', ...(rest ? { args: rest } : {}) }
     case 'mcp': return { kind: 'mcp', ...(rest ? { action: rest } : {}) }
     case 'timeline': return { kind: 'timeline', ...(rest ? { query: rest } : {}) }
     case 'jump': return { kind: 'jump', ...(rest ? { target: rest } : {}) }

--- a/kun/src/tui/controller-commands.ts
+++ b/kun/src/tui/controller-commands.ts
@@ -84,10 +84,9 @@ import {
   applyImportPlan,
   buildImportPlan,
   describeImportPlan,
-  type ImportScope,
-  type SourceToolId
+  parseImportArgs
 } from '../instructions/instruction-import.js'
-import { IMPORT_ADAPTERS, adapterById, supportedToolIds } from '../instructions/import-adapters.js'
+import { IMPORT_ADAPTERS, supportedToolIds } from '../instructions/import-adapters.js'
 
 export abstract class TuiControllerCommands extends TuiControllerIntegrations {
   setTheme(value?: string): void {
@@ -313,19 +312,9 @@ export abstract class TuiControllerCommands extends TuiControllerIntegrations {
   }
 
   async importAgentContext(args?: string): Promise<void> {
-    const tokens = splitWords(args?.trim() ?? '')
-    const flags = new Set(tokens.filter((token) => token.startsWith('--')))
-    const requestedTools = tokens.filter((token) => !token.startsWith('--'))
-    const dryRun = flags.has('--dry-run')
-    const wantGlobal = flags.has('--global')
-    const wantWorkspace = flags.has('--workspace') || !wantGlobal
-    const scopes: ImportScope[] = []
-    if (wantWorkspace) scopes.push('workspace')
-    if (wantGlobal) scopes.push('global')
-
-    const unknown = requestedTools.filter((id) => !adapterById(id))
-    if (unknown.length > 0) {
-      this.notify(`Unknown tool(s): ${unknown.join(', ')}. Supported: ${supportedToolIds().join(', ')}.`, 'error')
+    const { tools, unknownTools, scopes, dryRun } = parseImportArgs(args, supportedToolIds())
+    if (unknownTools.length > 0) {
+      this.notify(`Unknown tool(s): ${unknownTools.join(', ')}. Supported: ${supportedToolIds().join(', ')}.`, 'error')
       return
     }
 
@@ -336,7 +325,7 @@ export abstract class TuiControllerCommands extends TuiControllerIntegrations {
         homeDir: homedir(),
         adapters: IMPORT_ADAPTERS,
         scopes,
-        ...(requestedTools.length > 0 ? { tools: requestedTools as SourceToolId[] } : {})
+        ...(tools.length > 0 ? { tools } : {})
       })
       if (dryRun) {
         this.inspect('Import agent context (dry run)', describeImportPlan(plan))

--- a/kun/src/tui/controller-commands.ts
+++ b/kun/src/tui/controller-commands.ts
@@ -37,6 +37,7 @@ import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } 
 import type { UserInputAnswer } from './client.js'
 import { execFile as execFileCallback } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
+import { homedir } from 'node:os'
 import { promisify } from 'node:util'
 import {
   KunTuiClient,
@@ -79,6 +80,14 @@ import { parseTuiFileMentions } from './file-mentions.js'
 const execFile = promisify(execFileCallback)
 import { safeMessage, modelConnectionUnavailableMessage, isRefreshConflict, isMissingThread, replaceGraphRun, splitWords, extensionGrantArguments, todoInput, resolveTodo, attachmentIdsFromProjection, mergeAttachmentMetadata, attachmentMimeType, isLikelyUtf8Text, isVideoPath, formatBytes, normalizeSkillId, skillTemplate, assertPathMissing, writeTextAtomically, isPathInside, validateSkillImportTree } from './controller-utils.js'
 import { TuiControllerIntegrations } from './controller-integrations.js'
+import {
+  applyImportPlan,
+  buildImportPlan,
+  describeImportPlan,
+  type ImportScope,
+  type SourceToolId
+} from '../instructions/instruction-import.js'
+import { IMPORT_ADAPTERS, adapterById, supportedToolIds } from '../instructions/import-adapters.js'
 
 export abstract class TuiControllerCommands extends TuiControllerIntegrations {
   setTheme(value?: string): void {
@@ -301,6 +310,49 @@ export abstract class TuiControllerCommands extends TuiControllerIntegrations {
     await this.submit(
       'Analyze this repository and create or update the workspace-root AGENTS.md with accurate project structure, development commands, conventions, validation steps, and safety constraints. Preserve useful existing instructions, verify facts from the repository, and keep the file concise and actionable.' + suffix
     )
+  }
+
+  async importAgentContext(args?: string): Promise<void> {
+    const tokens = splitWords(args?.trim() ?? '')
+    const flags = new Set(tokens.filter((token) => token.startsWith('--')))
+    const requestedTools = tokens.filter((token) => !token.startsWith('--'))
+    const dryRun = flags.has('--dry-run')
+    const wantGlobal = flags.has('--global')
+    const wantWorkspace = flags.has('--workspace') || !wantGlobal
+    const scopes: ImportScope[] = []
+    if (wantWorkspace) scopes.push('workspace')
+    if (wantGlobal) scopes.push('global')
+
+    const unknown = requestedTools.filter((id) => !adapterById(id))
+    if (unknown.length > 0) {
+      this.notify(`Unknown tool(s): ${unknown.join(', ')}. Supported: ${supportedToolIds().join(', ')}.`, 'error')
+      return
+    }
+
+    const workspace = this.stateValue.projection?.thread.workspace ?? this.options.workspace
+    try {
+      const plan = await buildImportPlan({
+        workspace,
+        homeDir: homedir(),
+        adapters: IMPORT_ADAPTERS,
+        scopes,
+        ...(requestedTools.length > 0 ? { tools: requestedTools as SourceToolId[] } : {})
+      })
+      if (dryRun) {
+        this.inspect('Import agent context (dry run)', describeImportPlan(plan))
+        return
+      }
+      const applied = await applyImportPlan(plan, { workspace })
+      if (applied.length === 0) {
+        this.inspect('Import agent context', ['Nothing to import.', '', ...describeImportPlan(plan)])
+        return
+      }
+      const imported = [...new Set(plan.targets.flatMap((target) => target.tools))]
+      this.notify(`Imported ${imported.join(', ')} into ${applied.length} AGENTS.md file(s).`)
+      this.inspect('Import complete', describeImportPlan(plan))
+    } catch (error) {
+      this.fail(error)
+    }
   }
 
   async invokeSkill(name: string, prompt?: string): Promise<void> {

--- a/kun/tests/import-adapters.test.ts
+++ b/kun/tests/import-adapters.test.ts
@@ -1,0 +1,91 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { applyImportPlan, buildImportPlan } from '../src/instructions/instruction-import.js'
+import { IMPORT_ADAPTERS, adapterById, supportedToolIds } from '../src/instructions/import-adapters.js'
+
+describe('import-adapters (round 1)', () => {
+  let root = ''
+  let home = ''
+  let workspace = ''
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'kun-import-adapters-'))
+    home = join(root, 'home')
+    workspace = join(root, 'workspace')
+    await mkdir(home, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('exposes claude-code and codex and rejects unknown ids', () => {
+    expect(supportedToolIds()).toEqual(expect.arrayContaining(['claude-code', 'codex']))
+    expect(adapterById('claude-code')?.label).toBe('Claude Code')
+    expect(adapterById('nope')).toBeUndefined()
+  })
+
+  it('imports Claude Code CLAUDE.md, CLAUDE.local.md and .claude/rules into workspace AGENTS.md', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'Base rule.', 'utf8')
+    await writeFile(join(workspace, 'CLAUDE.local.md'), 'Local rule.', 'utf8')
+    await mkdir(join(workspace, '.claude', 'rules'), { recursive: true })
+    await writeFile(join(workspace, '.claude', 'rules', 'a.md'), 'Rule A.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['claude-code']
+    })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(workspace, 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Base rule.')
+    expect(text).toContain('Local rule.')
+    expect(text).toContain('Rule A.')
+    expect(text).toContain('<!-- kun:import:begin tool=claude-code -->')
+  })
+
+  it('imports Claude Code global CLAUDE.md into ~/.kun/AGENTS.md', async () => {
+    await mkdir(join(home, '.claude'), { recursive: true })
+    await writeFile(join(home, '.claude', 'CLAUDE.md'), 'Global claude rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['global'], tools: ['claude-code']
+    })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(home, '.kun', 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Global claude rule.')
+  })
+
+  it('skips Codex workspace AGENTS.md as identity but imports AGENTS.override.md while preserving native content', async () => {
+    await writeFile(join(workspace, 'AGENTS.md'), 'Kun native rule.', 'utf8')
+    await writeFile(join(workspace, 'AGENTS.override.md'), 'Codex override rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['codex']
+    })
+
+    expect(plan.warnings).toContainEqual({ code: 'identity-skip', tool: 'codex', path: join(workspace, 'AGENTS.md') })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(workspace, 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Kun native rule.')
+    expect(text).toContain('Codex override rule.')
+  })
+
+  it('imports Codex global AGENTS.md into ~/.kun/AGENTS.md', async () => {
+    await mkdir(join(home, '.codex'), { recursive: true })
+    await writeFile(join(home, '.codex', 'AGENTS.md'), 'Global codex rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['global'], tools: ['codex']
+    })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(home, '.kun', 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Global codex rule.')
+    expect(text).toContain('<!-- kun:import:begin tool=codex -->')
+  })
+})

--- a/kun/tests/import-adapters.test.ts
+++ b/kun/tests/import-adapters.test.ts
@@ -210,3 +210,78 @@ describe('import-adapters (round 3: copilot, windsurf, cline)', () => {
     expect(await readFile(join(workspace, 'AGENTS.md'), 'utf8')).toContain('Cline dir rule.')
   })
 })
+
+describe('import-adapters (round 4: zed, opencode, kiro)', () => {
+  let root = ''
+  let home = ''
+  let workspace = ''
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'kun-import-adapters4-'))
+    home = join(root, 'home')
+    workspace = join(root, 'workspace')
+    await mkdir(home, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('imports Zed .rules at workspace and ~/.config/zed/AGENTS.md at global scope', async () => {
+    await writeFile(join(workspace, '.rules'), 'Zed workspace rule.', 'utf8')
+    await mkdir(join(home, '.config', 'zed'), { recursive: true })
+    await writeFile(join(home, '.config', 'zed', 'AGENTS.md'), 'Zed global rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace', 'global'], tools: ['zed']
+    })
+    await applyImportPlan(plan, { workspace })
+
+    expect(await readFile(join(workspace, 'AGENTS.md'), 'utf8')).toContain('Zed workspace rule.')
+    expect(await readFile(join(home, '.kun', 'AGENTS.md'), 'utf8')).toContain('Zed global rule.')
+  })
+
+  it('skips OpenCode workspace AGENTS.md as identity but imports .opencode/memories', async () => {
+    await writeFile(join(workspace, 'AGENTS.md'), 'Kun native rule.', 'utf8')
+    await mkdir(join(workspace, '.opencode', 'memories'), { recursive: true })
+    await writeFile(join(workspace, '.opencode', 'memories', 'mem.md'), 'OpenCode memory rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['opencode']
+    })
+
+    expect(plan.warnings).toContainEqual({ code: 'identity-skip', tool: 'opencode', path: join(workspace, 'AGENTS.md') })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(workspace, 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Kun native rule.')
+    expect(text).toContain('OpenCode memory rule.')
+  })
+
+  it('imports Kiro steering files with inclusion frontmatter stripped', async () => {
+    await mkdir(join(workspace, '.kiro', 'steering'), { recursive: true })
+    await writeFile(join(workspace, '.kiro', 'steering', 'product.md'), 'Product steering.', 'utf8')
+    await writeFile(
+      join(workspace, '.kiro', 'steering', 'ts.md'),
+      '---\ninclusion: fileMatch\nfileMatchPattern: "**/*.ts"\n---\nTS steering.',
+      'utf8'
+    )
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['kiro']
+    })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(workspace, 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Product steering.')
+    expect(text).toContain('TS steering.')
+    expect(text).not.toContain('inclusion: fileMatch')
+  })
+
+  it('exposes all ten tools', () => {
+    expect(supportedToolIds()).toEqual([
+      'claude-code', 'codex', 'cursor', 'gemini', 'copilot', 'windsurf', 'cline', 'zed', 'opencode', 'kiro'
+    ])
+  })
+})

--- a/kun/tests/import-adapters.test.ts
+++ b/kun/tests/import-adapters.test.ts
@@ -89,3 +89,52 @@ describe('import-adapters (round 1)', () => {
     expect(text).toContain('<!-- kun:import:begin tool=codex -->')
   })
 })
+
+describe('import-adapters (round 2: cursor, gemini)', () => {
+  let root = ''
+  let home = ''
+  let workspace = ''
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'kun-import-adapters2-'))
+    home = join(root, 'home')
+    workspace = join(root, 'workspace')
+    await mkdir(home, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('imports Cursor .mdc rules (frontmatter stripped) and legacy .cursorrules', async () => {
+    await mkdir(join(workspace, '.cursor', 'rules'), { recursive: true })
+    await writeFile(join(workspace, '.cursor', 'rules', 'style.mdc'), '---\ndescription: style\n---\nUse tabs.', 'utf8')
+    await writeFile(join(workspace, '.cursorrules'), 'Legacy cursor rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['cursor']
+    })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(workspace, 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Use tabs.')
+    expect(text).toContain('Legacy cursor rule.')
+    expect(text).not.toContain('description: style')
+    expect(text).toContain('<!-- kun:import:begin tool=cursor -->')
+  })
+
+  it('imports Gemini GEMINI.md at workspace and global scope', async () => {
+    await writeFile(join(workspace, 'GEMINI.md'), 'Workspace gemini rule.', 'utf8')
+    await mkdir(join(home, '.gemini'), { recursive: true })
+    await writeFile(join(home, '.gemini', 'GEMINI.md'), 'Global gemini rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace', 'global'], tools: ['gemini']
+    })
+    await applyImportPlan(plan, { workspace })
+
+    expect(await readFile(join(workspace, 'AGENTS.md'), 'utf8')).toContain('Workspace gemini rule.')
+    expect(await readFile(join(home, '.kun', 'AGENTS.md'), 'utf8')).toContain('Global gemini rule.')
+  })
+})

--- a/kun/tests/import-adapters.test.ts
+++ b/kun/tests/import-adapters.test.ts
@@ -138,3 +138,75 @@ describe('import-adapters (round 2: cursor, gemini)', () => {
     expect(await readFile(join(home, '.kun', 'AGENTS.md'), 'utf8')).toContain('Global gemini rule.')
   })
 })
+
+describe('import-adapters (round 3: copilot, windsurf, cline)', () => {
+  let root = ''
+  let home = ''
+  let workspace = ''
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'kun-import-adapters3-'))
+    home = join(root, 'home')
+    workspace = join(root, 'workspace')
+    await mkdir(home, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('imports Copilot instructions and .github/instructions with frontmatter stripped', async () => {
+    await mkdir(join(workspace, '.github', 'instructions'), { recursive: true })
+    await writeFile(join(workspace, '.github', 'copilot-instructions.md'), 'Copilot main rule.', 'utf8')
+    await writeFile(join(workspace, '.github', 'instructions', 'ts.instructions.md'), '---\napplyTo: "**/*.ts"\n---\nTS rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['copilot']
+    })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(workspace, 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Copilot main rule.')
+    expect(text).toContain('TS rule.')
+    expect(text).not.toContain('applyTo:')
+  })
+
+  it('imports Windsurf rules directory and legacy .windsurfrules', async () => {
+    await mkdir(join(workspace, '.windsurf', 'rules'), { recursive: true })
+    await writeFile(join(workspace, '.windsurf', 'rules', 'core.md'), 'Windsurf core rule.', 'utf8')
+    await writeFile(join(workspace, '.windsurfrules'), 'Legacy windsurf rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['windsurf']
+    })
+    await applyImportPlan(plan, { workspace })
+    const text = await readFile(join(workspace, 'AGENTS.md'), 'utf8')
+
+    expect(text).toContain('Windsurf core rule.')
+    expect(text).toContain('Legacy windsurf rule.')
+  })
+
+  it('imports a .clinerules file', async () => {
+    await writeFile(join(workspace, '.clinerules'), 'Cline file rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['cline']
+    })
+    await applyImportPlan(plan, { workspace })
+
+    expect(await readFile(join(workspace, 'AGENTS.md'), 'utf8')).toContain('Cline file rule.')
+  })
+
+  it('imports a .clinerules directory of markdown rules', async () => {
+    await mkdir(join(workspace, '.clinerules'), { recursive: true })
+    await writeFile(join(workspace, '.clinerules', 'one.md'), 'Cline dir rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters: IMPORT_ADAPTERS, scopes: ['workspace'], tools: ['cline']
+    })
+    await applyImportPlan(plan, { workspace })
+
+    expect(await readFile(join(workspace, 'AGENTS.md'), 'utf8')).toContain('Cline dir rule.')
+  })
+})

--- a/kun/tests/instruction-import.test.ts
+++ b/kun/tests/instruction-import.test.ts
@@ -1,0 +1,221 @@
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  applyImportPlan,
+  buildImportPlan,
+  detectImportSources,
+  mergeManagedBlock,
+  type SourceAdapter
+} from '../src/instructions/instruction-import.js'
+
+const adapters: SourceAdapter[] = [
+  {
+    tool: 'claude-code',
+    label: 'Claude Code',
+    workspace: [
+      { kind: 'CLAUDE.md', relFile: 'CLAUDE.md', resolveImports: true },
+      { kind: '.claude/rules', relDir: '.claude/rules', exts: ['.md'] }
+    ],
+    global: [{ kind: '~/.claude/CLAUDE.md', relFile: '.claude/CLAUDE.md' }]
+  },
+  {
+    tool: 'codex',
+    label: 'Codex',
+    workspace: [{ kind: 'AGENTS.md', relFile: 'AGENTS.md' }],
+    global: [{ kind: '~/.codex/AGENTS.md', relFile: '.codex/AGENTS.md' }]
+  },
+  {
+    tool: 'cursor',
+    label: 'Cursor',
+    workspace: [{ kind: '.cursor/rules', relDir: '.cursor/rules', exts: ['.mdc'], stripFrontmatter: true }],
+    global: []
+  }
+]
+
+describe('instruction-import', () => {
+  let root = ''
+  let home = ''
+  let workspace = ''
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'kun-import-'))
+    home = join(root, 'home')
+    workspace = join(root, 'workspace')
+    await mkdir(home, { recursive: true })
+    await mkdir(workspace, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('detects present sources per tool and scope, and omits absent tools', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'Claude rule.', 'utf8')
+    await mkdir(join(workspace, '.cursor', 'rules'), { recursive: true })
+    await writeFile(join(workspace, '.cursor', 'rules', 'style.mdc'), '---\nx: 1\n---\nCursor rule.', 'utf8')
+
+    const found = await detectImportSources({ workspace, homeDir: home, adapters, scopes: ['workspace'] })
+    const tools = found.map((source) => source.tool).sort()
+
+    expect(tools).toEqual(['claude-code', 'cursor'])
+    expect(found.every((source) => source.scope === 'workspace')).toBe(true)
+  })
+
+  it('detects global sources independently of workspace sources', async () => {
+    await writeFile(join(home, '.claude', 'CLAUDE.md'), 'Global claude.', 'utf8').catch(async () => {
+      await mkdir(join(home, '.claude'), { recursive: true })
+      await writeFile(join(home, '.claude', 'CLAUDE.md'), 'Global claude.', 'utf8')
+    })
+
+    const found = await detectImportSources({ workspace, homeDir: home, adapters, scopes: ['global'] })
+
+    expect(found.map((source) => source.tool)).toEqual(['claude-code'])
+    expect(found[0]?.scope).toBe('global')
+  })
+
+  it('strips .mdc frontmatter and preserves the markdown body', async () => {
+    await mkdir(join(workspace, '.cursor', 'rules'), { recursive: true })
+    await writeFile(join(workspace, '.cursor', 'rules', 'style.mdc'), '---\ndescription: x\n---\nUse tabs.', 'utf8')
+
+    const plan = await buildImportPlan({ workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['cursor'] })
+    const text = plan.targets[0]?.mergedText ?? ''
+
+    expect(text).toContain('Use tabs.')
+    expect(text).not.toContain('description: x')
+  })
+
+  it('skips a Codex workspace AGENTS.md that is the target itself', async () => {
+    await writeFile(join(workspace, 'AGENTS.md'), 'Existing kun rule.', 'utf8')
+
+    const plan = await buildImportPlan({ workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['codex'] })
+
+    expect(plan.warnings).toContainEqual({
+      code: 'identity-skip',
+      tool: 'codex',
+      path: join(workspace, 'AGENTS.md')
+    })
+    expect(plan.targets[0]?.changed).toBe(false)
+  })
+
+  it('inlines nested @import references', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'Top.\n@docs/rules.md', 'utf8')
+    await mkdir(join(workspace, 'docs'), { recursive: true })
+    await writeFile(join(workspace, 'docs', 'rules.md'), 'Mid.\n@detail.md', 'utf8')
+    await writeFile(join(workspace, 'docs', 'detail.md'), 'Leaf detail.', 'utf8')
+
+    const plan = await buildImportPlan({ workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['claude-code'] })
+    const text = plan.targets[0]?.mergedText ?? ''
+
+    expect(text).toContain('Top.')
+    expect(text).toContain('Mid.')
+    expect(text).toContain('Leaf detail.')
+  })
+
+  it('detects an @import cycle and warns without infinite recursion', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'Root.\n@a.md', 'utf8')
+    await writeFile(join(workspace, 'a.md'), 'A.\n@b.md', 'utf8')
+    await writeFile(join(workspace, 'b.md'), 'B.\n@a.md', 'utf8')
+
+    const plan = await buildImportPlan({ workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['claude-code'] })
+
+    expect(plan.warnings.some((w) => w.code === 'import-cycle')).toBe(true)
+    expect(plan.targets[0]?.mergedText).toContain('A.')
+  })
+
+  it('warns on an unresolvable path-like @import and leaves the token', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'Root.\n@docs/missing.md', 'utf8')
+
+    const plan = await buildImportPlan({ workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['claude-code'] })
+
+    expect(plan.warnings.some((w) => w.code === 'unresolved-import')).toBe(true)
+    expect(plan.targets[0]?.mergedText).toContain('@docs/missing.md')
+  })
+
+  it('appends a managed block on first import and is idempotent on re-import', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'Claude rule.', 'utf8')
+
+    const first = await buildImportPlan({ workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['claude-code'] })
+    expect(first.targets[0]?.changed).toBe(true)
+    await applyImportPlan(first, { workspace })
+
+    const second = await buildImportPlan({ workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['claude-code'] })
+    expect(second.targets[0]?.changed).toBe(false)
+  })
+
+  it('replaces only its own block and preserves user text and other blocks', () => {
+    const existing = 'User note.\n\n<!-- kun:import:begin tool=codex -->\nCodex block.\n<!-- kun:import:end tool=codex -->\n'
+    const merged = mergeManagedBlock(existing, 'claude-code', 'Claude block.')
+    const remerged = mergeManagedBlock(merged, 'claude-code', 'Claude block v2.')
+
+    expect(remerged).toContain('User note.')
+    expect(remerged).toContain('Codex block.')
+    expect(remerged).toContain('Claude block v2.')
+    expect(remerged).not.toContain('Claude block.\n<!-- kun:import:end tool=claude-code')
+  })
+
+  it('routes workspace and global scopes to their own targets', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'WS rule.', 'utf8')
+    await mkdir(join(home, '.claude'), { recursive: true })
+    await writeFile(join(home, '.claude', 'CLAUDE.md'), 'Global rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters, scopes: ['workspace', 'global'], tools: ['claude-code']
+    })
+    const ws = plan.targets.find((t) => t.scope === 'workspace')
+    const gl = plan.targets.find((t) => t.scope === 'global')
+
+    expect(ws?.target).toBe(join(workspace, 'AGENTS.md'))
+    expect(ws?.mergedText).toContain('WS rule.')
+    expect(ws?.mergedText).not.toContain('Global rule.')
+    expect(gl?.target).toBe(join(home, '.kun', 'AGENTS.md'))
+    expect(gl?.mergedText).toContain('Global rule.')
+  })
+
+  it('warns when a merged target exceeds the per-file byte budget', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'x'.repeat(200), 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['claude-code'], maxFileBytes: 64
+    })
+
+    expect(plan.warnings.some((w) => w.code === 'budget-exceeded')).toBe(true)
+  })
+
+  it('applies only workspace target and creates ~/.kun for global', async () => {
+    await writeFile(join(workspace, 'CLAUDE.md'), 'WS rule.', 'utf8')
+    await mkdir(join(home, '.claude'), { recursive: true })
+    await writeFile(join(home, '.claude', 'CLAUDE.md'), 'Global rule.', 'utf8')
+
+    const plan = await buildImportPlan({
+      workspace, homeDir: home, adapters, scopes: ['workspace', 'global'], tools: ['claude-code']
+    })
+    const applied = await applyImportPlan(plan, { workspace })
+
+    expect(applied.map((a) => a.scope).sort()).toEqual(['global', 'workspace'])
+    const globalText = await readIfExists(join(home, '.kun', 'AGENTS.md'))
+    expect(globalText).toContain('Global rule.')
+  })
+
+  it('refuses to write through a workspace AGENTS.md symlink', async () => {
+    const outside = join(root, 'outside.md')
+    await writeFile(outside, 'secret', 'utf8')
+    await symlink(outside, join(workspace, 'AGENTS.md'))
+    await writeFile(join(workspace, 'CLAUDE.md'), 'WS rule.', 'utf8')
+
+    const plan = await buildImportPlan({ workspace, homeDir: home, adapters, scopes: ['workspace'], tools: ['claude-code'] })
+
+    await expect(applyImportPlan(plan, { workspace })).rejects.toThrow(/symbolic link/u)
+    expect((await lstat(outside)).isFile()).toBe(true)
+  })
+})
+
+async function readIfExists(path: string): Promise<string> {
+  const { readFile } = await import('node:fs/promises')
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return ''
+  }
+}

--- a/kun/tests/instruction-import.test.ts
+++ b/kun/tests/instruction-import.test.ts
@@ -7,8 +7,44 @@ import {
   buildImportPlan,
   detectImportSources,
   mergeManagedBlock,
-  type SourceAdapter
+  parseImportArgs,
+  type SourceAdapter,
+  type SourceToolId
 } from '../src/instructions/instruction-import.js'
+
+const KNOWN: SourceToolId[] = ['claude-code', 'codex', 'cursor']
+
+describe('parseImportArgs', () => {
+  it('defaults to workspace scope, no tools, no dry-run', () => {
+    expect(parseImportArgs(undefined, KNOWN)).toEqual({
+      tools: [], unknownTools: [], scopes: ['workspace'], dryRun: false
+    })
+  })
+
+  it('extracts a known tool and keeps workspace scope', () => {
+    const parsed = parseImportArgs('claude-code', KNOWN)
+    expect(parsed.tools).toEqual(['claude-code'])
+    expect(parsed.scopes).toEqual(['workspace'])
+  })
+
+  it('maps --global alone to global-only scope', () => {
+    expect(parseImportArgs('--global', KNOWN).scopes).toEqual(['global'])
+  })
+
+  it('maps --global --workspace to both scopes', () => {
+    expect(parseImportArgs('codex --global --workspace', KNOWN).scopes).toEqual(['workspace', 'global'])
+  })
+
+  it('flags --dry-run', () => {
+    expect(parseImportArgs('--dry-run', KNOWN).dryRun).toBe(true)
+  })
+
+  it('separates unknown tools from known tools', () => {
+    const parsed = parseImportArgs('claude-code bogus cursor', KNOWN)
+    expect(parsed.tools).toEqual(['claude-code', 'cursor'])
+    expect(parsed.unknownTools).toEqual(['bogus'])
+  })
+})
 
 const adapters: SourceAdapter[] = [
   {


### PR DESCRIPTION
## Summary

Adds a dependency-free way to import instruction/rule context from other coding agents into Kun's native `AGENTS.md`, at both workspace and global scope. Kun previously loaded instructions only from its own `AGENTS.md` files and had no migration path for users arriving from another agent.

- **Core engine** (`kun/src/instructions/instruction-import.ts`): source detection, markdown normalization (frontmatter stripping), bounded Claude Code `@import` inlining (depth ≤ 4, cycle guard, per-file byte cap), idempotent fenced-section merge that never clobbers user-authored content, scope→target routing, instruction byte-budget warnings, and workspace write safety (symlink refusal, no escape).
- **Ten source adapters** (`kun/src/instructions/import-adapters.ts`): Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, Windsurf, Cline, Zed, OpenCode, Kiro. File locations follow `rulesync` as a reference; no runtime dependency is added. Codex/OpenCode workspace `AGENTS.md` is reported as an identity skip rather than imported into itself.
- **`/import` TUI command**: `/import [tools] [--global] [--workspace] [--dry-run]` with tool selection, scope control, a non-mutating dry-run preview, and completion/warning reporting.

No production retrieval or instruction-loading behavior changes; import only writes Kun's own `AGENTS.md` targets through idempotent managed sections.

## Test plan

- [x] `npx vitest run tests/instruction-import.test.ts tests/import-adapters.test.ts` — 28 tests: detection, normalization, `@import` nested/cycle/unresolved, idempotent merge, scope routing, budget warning, symlink write refusal, and per-tool adapter coverage at workspace and global scope.
- [x] `tsc --noEmit` — 0 errors.
- [x] `npm run build` — succeeds.
- [x] `git diff --check` — clean.
